### PR TITLE
Move Create PR button to right sidebar

### DIFF
--- a/src/components/ChangesPanel.tsx
+++ b/src/components/ChangesPanel.tsx
@@ -279,6 +279,19 @@ export function ChangesPanel() {
           <Eye className="h-3.5 w-3.5" />
           Review
         </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'h-7 text-xs gap-1.5 border border-transparent transition-colors',
+            hasActivePR && 'text-green-600 dark:text-green-400 hover:border-green-500/50 hover:bg-green-500/10',
+            hasConflictOrFailure && 'text-red-600 dark:text-red-400 hover:border-red-500/50 hover:bg-red-500/10',
+            !hasActivePR && !hasConflictOrFailure && 'text-primary hover:border-primary/50 hover:bg-primary/10'
+          )}
+        >
+          <GitPullRequest className="h-3.5 w-3.5" />
+          Create PR
+        </Button>
         <Button variant="ghost" size="icon" className="h-7 w-7">
           <MoreVertical className="h-3.5 w-3.5" />
         </Button>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -15,7 +15,6 @@ import {
   GitBranch,
   ChevronDown,
   ExternalLink,
-  GitPullRequest,
   Terminal,
   FolderOpen,
   Code,
@@ -148,12 +147,6 @@ export function TopBar({
       <div className="text-xs text-muted-foreground font-mono px-2">
         {formatCost(totalCost)}
       </div>
-
-      {/* Create PR Button */}
-      <Button variant="ghost" size="sm" className="h-7 gap-1.5 text-xs text-primary border border-transparent hover:border-primary/50 hover:bg-primary/10 transition-colors mr-1">
-        <GitPullRequest className="h-3.5 w-3.5" />
-        Create PR
-      </Button>
 
       {/* Toggle Right Sidebar Button - only shown when sidebar is hidden */}
       {!showRightSidebar && onToggleRightSidebar && (


### PR DESCRIPTION
## Summary
Move the Create PR button from the main TopBar to the right sidebar topbar, positioning it next to the Review button.

## Changes
- Removed Create PR button from TopBar.tsx
- Added Create PR button to ChangesPanel.tsx right sidebar with matching dynamic styling
- Button inherits green/red/primary color states based on PR status

## Testing
Visual inspection confirms the button appears in the correct location with proper styling.