### PR TITLE
Add repository menu with clone, quick start, and open options

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { isTauri, safeListen, closeWindow } from '@/lib/tauri';
+import { isTauri, safeListen, closeWindow, openFolderDialog } from '@/lib/tauri';
 import { CloseTabConfirmDialog } from '@/components/CloseTabConfirmDialog';
 import { useWebSocket } from '@/hooks/useWebSocket';
-import { listRepos, listSessions, listConversations, createSession, createConversation, deleteConversation, type RepoDTO, type SessionDTO, type ConversationDTO, type MessageDTO } from '@/lib/api';
+import { listRepos, listSessions, listConversations, createSession, createConversation, deleteConversation, addRepo, type RepoDTO, type SessionDTO, type ConversationDTO, type MessageDTO } from '@/lib/api';
 import { WorkspaceSidebar } from '@/components/WorkspaceSidebar';
 import { WorkspaceManagement } from '@/components/WorkspaceManagement';
 import { SettingsPage } from '@/components/SettingsPage';
@@ -16,6 +16,8 @@ import { ChatInput } from '@/components/ChatInput';
 import { ChangesPanel } from '@/components/ChangesPanel';
 import { BottomTerminal } from '@/components/BottomTerminal';
 import { AddWorkspaceModal } from '@/components/AddWorkspaceModal';
+import { CloneFromUrlDialog } from '@/components/CloneFromUrlDialog';
+import { QuickStartDialog } from '@/components/QuickStartDialog';
 import { UpdateChecker } from '@/components/UpdateChecker';
 import { BackendStatus } from '@/components/BackendStatus';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -37,6 +39,8 @@ export default function Home() {
   const [sidebarWidth, setSidebarWidth] = useState(250); // Default until measured
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const [pendingCloseConvId, setPendingCloseConvId] = useState<string | null>(null);
+  const [showCloneFromUrl, setShowCloneFromUrl] = useState(false);
+  const [showQuickStart, setShowQuickStart] = useState(false);
   const leftSidebarRef = useRef<HTMLDivElement>(null);
 
   const confirmCloseActiveTab = useSettingsStore((s) => s.confirmCloseActiveTab);
@@ -342,6 +346,32 @@ export default function Home() {
     }
   }, [pendingCloseConvId, doCloseTab]);
 
+  // Handle opening a project - directly opens folder dialog and adds the workspace
+  const handleOpenProject = useCallback(async () => {
+    const selectedPath = await openFolderDialog('Select Repository');
+    if (!selectedPath) return;
+
+    try {
+      // Call backend API to validate and add repo
+      const repo = await addRepo(selectedPath);
+
+      // Map to workspace and add to store
+      const workspace = {
+        id: repo.id,
+        name: repo.name,
+        path: repo.path,
+        defaultBranch: repo.branch,
+        createdAt: repo.createdAt,
+      };
+      useAppStore.getState().addWorkspace(workspace);
+      selectWorkspace(workspace.id);
+    } catch (error) {
+      // If it fails, fall back to showing the modal where user can see the error
+      console.error('Failed to add workspace directly:', error);
+      setShowAddWorkspace(true);
+    }
+  }, [selectWorkspace]);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -527,7 +557,9 @@ export default function Home() {
                 <div ref={leftSidebarRef} className="h-full">
                   <ErrorBoundary section="Sidebar">
                     <WorkspaceSidebar
-                      onAddWorkspace={() => setShowAddWorkspace(true)}
+                      onOpenProject={handleOpenProject}
+                      onCloneFromUrl={() => setShowCloneFromUrl(true)}
+                      onQuickStart={() => setShowQuickStart(true)}
                       onShowWorkspaceManagement={() => setShowWorkspaceManagement(true)}
                       onSessionSelected={() => setShowWorkspaceManagement(false)}
                       onOpenSettings={() => setShowSettings(true)}
@@ -628,6 +660,18 @@ export default function Home() {
         <AddWorkspaceModal
           isOpen={showAddWorkspace}
           onClose={() => setShowAddWorkspace(false)}
+        />
+
+        {/* Clone from URL Dialog */}
+        <CloneFromUrlDialog
+          isOpen={showCloneFromUrl}
+          onClose={() => setShowCloneFromUrl(false)}
+        />
+
+        {/* Quick Start Dialog */}
+        <QuickStartDialog
+          isOpen={showQuickStart}
+          onClose={() => setShowQuickStart(false)}
         />
 
         {/* Close Tab Confirmation Dialog */}

--- a/src/components/CloneFromUrlDialog.tsx
+++ b/src/components/CloneFromUrlDialog.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { openFolderDialog, getHomeDir } from '@/lib/tauri';
+
+interface CloneFromUrlDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// Validates common git URL formats: https://, git@, ssh://, git://
+function isValidGitUrl(url: string): boolean {
+  const gitUrlPattern = /^(https?:\/\/|git@|ssh:\/\/|git:\/\/).+/i;
+  return gitUrlPattern.test(url.trim());
+}
+
+export function CloneFromUrlDialog({ isOpen, onClose }: CloneFromUrlDialogProps) {
+  const [gitUrl, setGitUrl] = useState('');
+  const [cloneLocation, setCloneLocation] = useState('');
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const hasInitializedLocation = useRef(false);
+
+  // Fetch home directory once for default location
+  useEffect(() => {
+    if (!hasInitializedLocation.current) {
+      hasInitializedLocation.current = true;
+      getHomeDir().then((home) => {
+        if (home) {
+          setCloneLocation(home);
+        }
+      });
+    }
+  }, []);
+
+  const handleClose = () => {
+    setGitUrl('');
+    setUrlError(null);
+    // Intentionally preserve cloneLocation - users often clone to the same directory
+    onClose();
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // Validate git URL format
+    if (!isValidGitUrl(gitUrl)) {
+      setUrlError('Please enter a valid git URL (https://, git@, ssh://, or git://)');
+      return;
+    }
+
+    // TODO: Implement actual git clone via Tauri command
+    // For now, show a message that this feature is coming soon
+    alert('Clone repository feature coming soon!\n\nRepository: ' + gitUrl + '\nLocation: ' + cloneLocation);
+    handleClose();
+  };
+
+  const handleUrlChange = (value: string) => {
+    setGitUrl(value);
+    // Clear error when user starts typing
+    if (urlError) setUrlError(null);
+  };
+
+  const handleBrowse = async () => {
+    const selectedPath = await openFolderDialog('Select Clone Location');
+    if (selectedPath) {
+      setCloneLocation(selectedPath);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Clone from URL</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <label htmlFor="git-url" className="text-sm font-medium">Git URL</label>
+              <Input
+                id="git-url"
+                value={gitUrl}
+                onChange={(e) => handleUrlChange(e.target.value)}
+                placeholder="https://github.com/user/repo.git"
+                className={`font-mono text-sm ${urlError ? 'border-destructive' : ''}`}
+                autoFocus
+              />
+              {urlError && (
+                <p className="text-sm text-destructive">{urlError}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="clone-location" className="text-sm font-medium">Clone location</label>
+              <div className="flex gap-2">
+                <Input
+                  id="clone-location"
+                  value={cloneLocation}
+                  onChange={(e) => setCloneLocation(e.target.value)}
+                  placeholder="Select a location..."
+                  className="font-mono text-sm flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleBrowse}
+                >
+                  Browse...
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!gitUrl.trim() || !cloneLocation.trim()}>
+              Clone repository
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/QuickStartDialog.tsx
+++ b/src/components/QuickStartDialog.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { FileCode } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { openFolderDialog, getHomeDir } from '@/lib/tauri';
+
+interface QuickStartDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type Template = 'empty' | 'nextjs';
+
+// Generate a unique default project name with timestamp
+function generateDefaultName(): string {
+  const timestamp = Date.now().toString(36).slice(-4);
+  return `conductor-playground-${timestamp}`;
+}
+
+export function QuickStartDialog({ isOpen, onClose }: QuickStartDialogProps) {
+  const [name, setName] = useState(generateDefaultName);
+  const [location, setLocation] = useState('');
+  const [template, setTemplate] = useState<Template>('empty');
+  const hasInitializedLocation = useRef(false);
+
+  const canSubmit = name.trim() && location.trim();
+
+  // Fetch home directory once for default location
+  useEffect(() => {
+    if (!hasInitializedLocation.current) {
+      hasInitializedLocation.current = true;
+      getHomeDir().then((home) => {
+        if (home) {
+          setLocation(home);
+        }
+      });
+    }
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setName(generateDefaultName());
+    setTemplate('empty');
+    onClose();
+  }, [onClose]);
+
+  const handleSubmit = useCallback(async (e?: React.FormEvent) => {
+    e?.preventDefault();
+    if (!canSubmit) return;
+
+    // TODO: Implement actual project creation via Tauri command
+    // For now, show a message that this feature is coming soon
+    const templateName = template === 'nextjs' ? 'Next.js' : 'Empty';
+    alert(`Quick start feature coming soon!\n\nProject: ${name}\nLocation: ${location}\nTemplate: ${templateName}`);
+    handleClose();
+  }, [canSubmit, name, location, template, handleClose]);
+
+  // Keyboard shortcut: Cmd+Enter to submit
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.metaKey && e.key === 'Enter' && canSubmit) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, canSubmit, handleSubmit]);
+
+  const handleBrowse = async () => {
+    const selectedPath = await openFolderDialog('Select Location');
+    if (selectedPath) {
+      setLocation(selectedPath);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Quick start</DialogTitle>
+          <DialogDescription>
+            Conductor will create a new folder and GitHub repo for you.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <label htmlFor="project-name" className="text-sm font-medium">Name</label>
+              <Input
+                id="project-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="conductor-playground"
+                className="text-sm"
+                autoFocus
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="project-location" className="text-sm font-medium">Location</label>
+              <div className="flex gap-2">
+                <Input
+                  id="project-location"
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                  placeholder="Select a location..."
+                  className="font-mono text-sm flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleBrowse}
+                >
+                  Browse...
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <span className="text-sm font-medium">Template</span>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => setTemplate('empty')}
+                  className={cn(
+                    'flex items-center gap-3 px-4 py-3 rounded-lg border text-left transition-colors flex-1',
+                    template === 'empty'
+                      ? 'border-primary/50 bg-primary/5'
+                      : 'border-border hover:bg-accent/50'
+                  )}
+                >
+                  <div className="w-10 h-10 rounded-md bg-muted/50 flex items-center justify-center shrink-0">
+                    <FileCode className="w-5 h-5 text-muted-foreground" />
+                  </div>
+                  <div>
+                    <div className="text-sm font-medium">Empty</div>
+                    <div className="text-xs text-muted-foreground">Start from scratch</div>
+                  </div>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setTemplate('nextjs')}
+                  className={cn(
+                    'flex items-center gap-3 px-4 py-3 rounded-lg border text-left transition-colors flex-1',
+                    template === 'nextjs'
+                      ? 'border-primary/50 bg-primary/5'
+                      : 'border-border hover:bg-accent/50'
+                  )}
+                >
+                  <div className="w-10 h-10 rounded-md bg-muted/50 flex items-center justify-center shrink-0">
+                    <span className="text-lg font-bold text-muted-foreground">N</span>
+                  </div>
+                  <div>
+                    <div className="text-sm font-medium">Next.js</div>
+                    <div className="text-xs text-muted-foreground">TS, Tailwind, App Router</div>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              Create
+              <kbd className="ml-2 pointer-events-none inline-flex h-5 items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+                <span className="text-xs">&#8984;</span>&#8629;
+              </kbd>
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -53,6 +53,9 @@ import {
   AlertTriangle,
   Pin,
   PanelLeftClose,
+  Folder,
+  Globe,
+  SquarePlus,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Workspace, WorktreeSession, SetupInfo } from '@/lib/types';
@@ -68,14 +71,29 @@ function generateBranchName(): string {
 }
 
 interface WorkspaceSidebarProps {
-  onAddWorkspace: () => void;
+  onOpenProject: () => void;
+  onCloneFromUrl: () => void;
+  onQuickStart: () => void;
   onShowWorkspaceManagement?: () => void;
   onSessionSelected?: () => void;
   onOpenSettings?: () => void;
   onToggleSidebar?: () => void;
 }
 
-export function WorkspaceSidebar({ onAddWorkspace, onShowWorkspaceManagement, onSessionSelected, onOpenSettings, onToggleSidebar }: WorkspaceSidebarProps) {
+// Shared menu items for "Add repository" dropdown
+const ADD_REPO_MENU_ITEMS = [
+  { icon: Folder, label: 'Open project', key: 'open' },
+  { icon: Globe, label: 'Clone from URL', key: 'clone' },
+  { icon: SquarePlus, label: 'Quick start', key: 'quickstart' },
+] as const;
+
+export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, onShowWorkspaceManagement, onSessionSelected, onOpenSettings, onToggleSidebar }: WorkspaceSidebarProps) {
+  const menuHandlers = {
+    open: onOpenProject,
+    clone: onCloneFromUrl,
+    quickstart: onQuickStart,
+  };
+
   const {
     workspaces,
     sessions,
@@ -281,15 +299,26 @@ export function WorkspaceSidebar({ onAddWorkspace, onShowWorkspaceManagement, on
               <p className="text-xs text-muted-foreground/70 mt-1 mb-4">
                 Add a repository to get started
               </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="text-xs"
-                onClick={onAddWorkspace}
-              >
-                <Plus className="w-3.5 h-3.5 mr-1.5" />
-                Add repository
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-xs"
+                  >
+                    <Plus className="w-3.5 h-3.5 mr-1.5" />
+                    Add repository
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="center" className="w-48">
+                  {ADD_REPO_MENU_ITEMS.map((item) => (
+                    <DropdownMenuItem key={item.key} onClick={menuHandlers[item.key]}>
+                      <item.icon className="h-4 w-4" />
+                      {item.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           ) : (
             <DndContext
@@ -330,15 +359,26 @@ export function WorkspaceSidebar({ onAddWorkspace, onShowWorkspaceManagement, on
 
       {/* Footer */}
       <div className="p-2 border-t border-sidebar-border flex items-center gap-1">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="flex-1 justify-start gap-2 h-8 text-muted-foreground hover:text-foreground"
-          onClick={onAddWorkspace}
-        >
-          <Plus className="w-4 h-4" />
-          <span className="text-sm">Add repository</span>
-        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex-1 justify-start gap-2 h-8 text-muted-foreground hover:text-foreground"
+            >
+              <Plus className="w-4 h-4" />
+              <span className="text-sm">Add repository</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" side="top" className="w-48">
+            {ADD_REPO_MENU_ITEMS.map((item) => (
+              <DropdownMenuItem key={item.key} onClick={menuHandlers[item.key]}>
+                <item.icon className="h-4 w-4" />
+                {item.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
         <Button
           variant="ghost"
           size="icon"

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -94,6 +94,20 @@ export async function restartSidecar(): Promise<boolean> {
 }
 
 /**
+ * Get the user's home directory
+ */
+export async function getHomeDir(): Promise<string | null> {
+  if (!isTauri()) return null;
+  try {
+    const { homeDir } = await import('@tauri-apps/api/path');
+    return await homeDir();
+  } catch (e) {
+    console.error('Failed to get home directory', e);
+    return null;
+  }
+}
+
+/**
  * Open native folder picker dialog
  */
 export async function openFolderDialog(title?: string): Promise<string | null> {


### PR DESCRIPTION
## Summary
Implements a dropdown menu for adding repositories with three options: Open project, Clone from URL, and Quick start. Addresses all code review feedback including git URL validation, error handling, and improved UX.

## Changes
- **Clone from URL**: Git URL validation with error messaging, Coming Soon placeholder
- **Quick start**: Unique project names with timestamps, Coming Soon placeholder  
- **Open project**: Direct folder dialog integration with fallback to modal
- UI consistency: Cancel buttons added to both dialogs, location persistence

## Testing
All TypeScript types pass. Functionality marked for future backend implementation.