### PR TITLE
fix: resolve file tab loading issues and markdown preview scrolling

### DIFF
--- a/src/components/ChangesPanel.tsx
+++ b/src/components/ChangesPanel.tsx
@@ -90,6 +90,9 @@ export function ChangesPanel() {
 
     openFileTab(newTab);
 
+    // Always set loading state for existing tabs (e.g., restored from persistence without content)
+    updateFileTab(tabId, { isLoading: true });
+
     // Fetch file content
     try {
       const fileData = await getRepoFileContent(selectedWorkspaceId, path);
@@ -143,6 +146,9 @@ export function ChangesPanel() {
     };
 
     openFileTab(newTab);
+
+    // Always set loading state for existing tabs (e.g., restored from persistence without content)
+    updateFileTab(tabId, { isLoading: true });
 
     // Fetch diff
     try {

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -369,10 +369,10 @@ export function CodeViewer({
       <div className="flex-1 overflow-hidden min-h-0">
         {isMarkdown && viewMode === 'rendered' ? (
           <div
-            className="p-6 min-h-full overflow-auto overscroll-contain"
+            className="h-full overflow-auto overscroll-contain"
             data-color-mode={resolvedTheme === 'dark' ? 'dark' : 'light'}
           >
-            <div className="markdown-body !bg-transparent px-4">
+            <div className="markdown-body !bg-transparent px-6 py-5">
               <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
                 {content}
               </ReactMarkdown>

--- a/src/components/ConversationArea.tsx
+++ b/src/components/ConversationArea.tsx
@@ -52,6 +52,7 @@ import { SystemInfoCard } from '@/components/SystemInfoCard';
 import { MarkdownPre, MarkdownCode } from '@/components/MarkdownCodeBlock';
 import type { Message, VerificationResult, FileChange } from '@/lib/types';
 import { COPY_FEEDBACK_DURATION_MS } from '@/lib/constants';
+import { getRepoFileContent, getSessionFileDiff } from '@/lib/api';
 
 interface ConversationAreaProps {
   children?: React.ReactNode;
@@ -198,9 +199,53 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     selectFileTab(null); // Deselect file tab when selecting conversation
   };
 
-  const handleSelectFileTab = (id: string) => {
+  const handleSelectFileTab = useCallback(async (id: string) => {
     selectFileTab(id);
-  };
+
+    // Find the tab and check if it needs content loaded
+    const tab = fileTabs.find((t) => t.id === id);
+    if (!tab || tab.isLoading) return;
+
+    // For regular file view without content, load it
+    if (tab.viewMode !== 'diff' && !tab.content && !tab.isBinary && !tab.isTooLarge) {
+      updateFileTab(id, { isLoading: true });
+      try {
+        const fileData = await getRepoFileContent(tab.workspaceId, tab.path);
+        updateFileTab(id, {
+          content: fileData.content,
+          originalContent: fileData.content,
+          isLoading: false,
+        });
+      } catch (error) {
+        console.error('Failed to load file:', error);
+        updateFileTab(id, {
+          content: `// Error loading file: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          isLoading: false,
+        });
+      }
+    }
+
+    // For diff view without diff content, load it
+    if (tab.viewMode === 'diff' && !tab.diff && !tab.isBinary && !tab.isTooLarge && tab.sessionId) {
+      updateFileTab(id, { isLoading: true });
+      try {
+        const diffData = await getSessionFileDiff(tab.workspaceId, tab.sessionId, tab.path);
+        updateFileTab(id, {
+          diff: {
+            oldContent: diffData.oldContent ?? '',
+            newContent: diffData.newContent ?? '',
+          },
+          isLoading: false,
+        });
+      } catch (error) {
+        console.error('Failed to load diff:', error);
+        updateFileTab(id, {
+          content: `// Error loading diff: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          isLoading: false,
+        });
+      }
+    }
+  }, [fileTabs, selectFileTab, updateFileTab]);
 
   const handleCloseFileTab = (id: string, e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/hooks/useTabPersistence.ts
+++ b/src/hooks/useTabPersistence.ts
@@ -58,8 +58,10 @@ export function useTabPersistence() {
             tabs.map(tabToDTO).sort((a, b) => a.id.localeCompare(b.id))
           );
 
-          // Select the first tab if none is selected
-          if (!selectedFileTabId && tabs.length > 0) {
+          // Only auto-select the first tab on initial workspace load
+          // Use useAppStore.getState() to get current value without stale closure
+          const currentSelectedTabId = useAppStore.getState().selectedFileTabId;
+          if (currentSelectedTabId === null && tabs.length > 0) {
             selectFileTab(tabs[0].id);
           }
         }
@@ -71,7 +73,9 @@ export function useTabPersistence() {
     };
 
     loadTabs();
-  }, [selectedWorkspaceId, setFileTabs, selectFileTab, selectedFileTabId]);
+    // Note: Only depend on selectedWorkspaceId - we don't want to re-run this effect
+    // when selectedFileTabId changes (e.g., when user clicks a conversation tab)
+  }, [selectedWorkspaceId, setFileTabs, selectFileTab]);
 
   // Save tabs when they change (debounced)
   const saveTabs = useCallback(async () => {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -456,10 +456,17 @@ streamingState: cleanedStreamingState,
     const existing = state.fileTabs.find((t) => t.id === tab.id);
 
     if (existing) {
-      // Tab already open - just select it and update lastAccessedAt
+      // Tab already open - select it, update lastAccessedAt, and merge new properties
+      // This allows setting isLoading: true when re-opening a tab that needs content loaded
       return {
         fileTabs: state.fileTabs.map((t) =>
-          t.id === tab.id ? { ...t, lastAccessedAt: now } : t
+          t.id === tab.id
+            ? {
+                ...t,
+                ...tab, // Merge incoming properties (e.g., isLoading: true)
+                lastAccessedAt: now,
+              }
+            : t
         ),
         selectedFileTabId: tab.id,
       };


### PR DESCRIPTION
## Summary

- Fix file tabs showing "Empty file" on first click instead of loading content
- Fix conversation tabs incorrectly showing "Empty file" after clicking (regression from tab persistence)
- Fix markdown preview not scrolling when content exceeds viewport
- Improve markdown preview padding for better readability

## Changes

### File Tab Loading (`appStore.ts`, `ChangesPanel.tsx`, `ConversationArea.tsx`)
- Modified `openFileTab` to merge incoming properties (like `isLoading: true`) for existing tabs
- Added explicit `isLoading` state update when opening files from the Changes panel
- Added on-demand content loading in `handleSelectFileTab` for tabs restored from persistence without content

### Conversation Tab Fix (`useTabPersistence.ts`)
- Removed `selectedFileTabId` from the effect's dependency array - it was causing the effect to re-run when selecting a conversation (which sets `selectedFileTabId` to `null`)
- Used `useAppStore.getState()` to get current tab selection state without stale closure issues

### Markdown Preview (`CodeViewer.tsx`)
- Changed `min-h-full` to `h-full` on the scroll container to properly constrain height and enable scrolling
- Adjusted padding from outer container to inner `markdown-body` div for proper scroll behavior

## Test plan

- [ ] Open a file from "All Files" panel - should load content on first click
- [ ] Click on a conversation tab - should show conversation content, not "Empty file"
- [ ] Open a markdown file and click the preview button - should be able to scroll the rendered content
- [ ] Switch between file tabs and conversation tabs multiple times - should work consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)