### PR TITLE
feat: add git line stats badge to session cards in sidebar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import { useWebSocket } from '@/hooks/useWebSocket';
 import { useTabPersistence } from '@/hooks/useTabPersistence';
 import { useAutoSave } from '@/hooks/useAutoSave';
 import { useFileWatcher } from '@/hooks/useFileWatcher';
-import { listRepos, listSessions, listConversations, createSession, createConversation, deleteConversation, addRepo, type RepoDTO, type SessionDTO, type ConversationDTO, type MessageDTO } from '@/lib/api';
+import { listRepos, listSessions, listConversations, createSession, createConversation, deleteConversation, addRepo, getSessionChanges, type RepoDTO, type SessionDTO, type ConversationDTO, type MessageDTO } from '@/lib/api';
 import { WorkspaceSidebar } from '@/components/WorkspaceSidebar';
 import { WorkspaceManagement } from '@/components/WorkspaceManagement';
 import { SettingsPage } from '@/components/SettingsPage';
@@ -302,7 +302,29 @@ export default function Home() {
         const allSessions = sessionResults.flatMap(sessions =>
           sessions.map(s => sessionToWorktreeSession(s))
         );
-        setSessions(allSessions);
+
+        // Fetch file changes for all sessions to compute stats
+        const sessionsWithStats = await Promise.all(
+          allSessions.map(async (session) => {
+            try {
+              const changes = await getSessionChanges(session.workspaceId, session.id);
+              if (changes && changes.length > 0) {
+                const stats = changes.reduce(
+                  (acc, change) => ({
+                    additions: acc.additions + change.additions,
+                    deletions: acc.deletions + change.deletions,
+                  }),
+                  { additions: 0, deletions: 0 }
+                );
+                return { ...session, stats };
+              }
+            } catch {
+              // Ignore errors fetching changes
+            }
+            return session;
+          })
+        );
+        setSessions(sessionsWithStats);
 
         // Fetch conversations for all sessions in parallel
         const conversationResults = await Promise.all(

--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -572,40 +572,43 @@ function SortableWorkspaceItem({
                         <span className="text-sm font-medium truncate flex-1">
                           {session.branch || session.name}
                         </span>
-                        {/* Pinned indicator - hidden on hover */}
+                        {/* Pinned indicator - fade out on hover */}
                         {session.pinned && (
-                          <Pin className="h-2.5 w-2.5 text-primary shrink-0 group-hover:hidden" />
+                          <Pin className="h-2.5 w-2.5 text-primary shrink-0 group-hover:opacity-0 transition-opacity" />
                         )}
-                        {/* Stats - hidden on hover */}
-                        {hasStats && (
-                          <span className="text-[10px] shrink-0 group-hover:hidden">
-                            <span className="text-green-500">+{session.stats!.additions}</span>
-                            <span className="text-red-500 ml-1">-{session.stats!.deletions}</span>
-                          </span>
-                        )}
-                        {/* Actions - shown on hover */}
-                        <div className="hidden group-hover:flex items-center gap-1 shrink-0">
-                          <button
-                            className={cn(
-                              "p-0.5 rounded hover:bg-sidebar-accent hover:text-foreground",
-                              session.pinned ? "text-primary" : "text-muted-foreground"
-                            )}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onPinSession(session.id);
-                            }}
-                          >
-                            <Pin className="h-2.5 w-2.5" />
-                          </button>
-                          <button
-                            className="p-0.5 rounded hover:bg-sidebar-accent text-muted-foreground hover:text-foreground"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onArchiveSession(session.id);
-                            }}
-                          >
-                            <Archive className="h-2.5 w-2.5" />
-                          </button>
+                        {/* Git line stats badge and actions container */}
+                        <div className="relative shrink-0 flex items-center">
+                          {/* Stats - fade out on hover */}
+                          {hasStats && (
+                            <span className="text-[11px] px-2 py-0.5 rounded border border-emerald-500/40 font-mono tabular-nums group-hover:opacity-0 transition-opacity">
+                              <span className="text-emerald-400">+{session.stats!.additions}</span>
+                              <span className="text-red-400 ml-1">-{session.stats!.deletions}</span>
+                            </span>
+                          )}
+                          {/* Actions - positioned absolutely to avoid layout shift */}
+                          <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                            <button
+                              className={cn(
+                                "p-0.5 rounded hover:bg-sidebar-accent hover:text-foreground",
+                                session.pinned ? "text-primary" : "text-muted-foreground"
+                              )}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onPinSession(session.id);
+                              }}
+                            >
+                              <Pin className="h-2.5 w-2.5" />
+                            </button>
+                            <button
+                              className="p-0.5 rounded hover:bg-sidebar-accent text-muted-foreground hover:text-foreground"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onArchiveSession(session.id);
+                              }}
+                            >
+                              <Archive className="h-2.5 w-2.5" />
+                            </button>
+                          </div>
                         </div>
                       </div>
                       {/* Second line: session name · PR info · status */}


### PR DESCRIPTION
## Summary
- Computes session stats (additions/deletions) from file changes when loading sessions
- Displays stats in a bordered pill badge with emerald/red colors matching the design reference
- Uses opacity transitions and absolute positioning for hover actions to prevent layout jiggle

## Test plan
- [ ] Verify stats badge appears for sessions with file changes (dirty worktrees)
- [ ] Verify badge shows correct format: `+N -M` with green additions and red deletions
- [ ] Verify hover behavior is smooth without layout shift/jiggle
- [ ] Verify sessions without changes don't show the badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)