### PR TITLE
refactor: replace drag handle with letter avatar in workspace sidebar

### DIFF
--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -45,7 +45,6 @@ import {
   Terminal,
   Trash2,
   Copy,
-  GripVertical,
   Archive,
   Settings,
   CheckCircle2,
@@ -450,14 +449,11 @@ function SortableWorkspaceItem({
             )}
           >
             <div
-              className="cursor-grab active:cursor-grabbing text-muted-foreground/50 hover:text-muted-foreground"
+              className="w-6 h-6 rounded-md bg-primary/15 flex items-center justify-center text-[11px] font-semibold text-primary shrink-0 cursor-grab active:cursor-grabbing"
               {...attributes}
               {...listeners}
               onClick={(e) => e.stopPropagation()}
             >
-              <GripVertical className="w-3.5 h-3.5" />
-            </div>
-            <div className="w-6 h-6 rounded-md bg-primary/15 flex items-center justify-center text-[11px] font-semibold text-primary shrink-0">
               {getInitial(workspace.name)}
             </div>
             <span className="text-sm font-medium truncate">


### PR DESCRIPTION
## Summary
- Remove GripVertical drag handle icon from workspace list
- Move drag listeners to the letter avatar element
- Cleaner UI with letter avatar doubling as drag handle

## Test plan
- [ ] Verify workspaces can still be reordered by dragging the letter avatar
- [ ] Verify the letter avatar shows correct first letter of workspace name
- [ ] Verify cursor changes to grab/grabbing on the avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)