### PR TITLE
feat: consolidate language mapping and add editor improvements

### DIFF
--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -8,10 +8,11 @@ import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import 'github-markdown-css';
 import { Button } from '@/components/ui/button';
-import { Copy, Check, Loader2, Code, Eye, SplitSquareHorizontal, Rows } from 'lucide-react';
+import { Copy, Check, Loader2, Code, Eye, SplitSquareHorizontal, Rows, WrapText } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { MonacoEditor, MonacoDiffEditor } from '@/components/MonacoEditor';
 import { COPY_FEEDBACK_DURATION_MS } from '@/lib/constants';
+import { getShikiLanguage } from '@/lib/languageMapping';
 
 interface EditorState {
   cursorPosition?: { line: number; column: number };
@@ -30,75 +31,6 @@ interface CodeViewerProps {
   initialCursorPosition?: { line: number; column: number };
   /** Initial scroll position to restore */
   initialScrollPosition?: { top: number; left: number };
-}
-
-// Map file extensions to shiki language identifiers
-function getLanguage(filename: string): string {
-  const ext = filename.split('.').pop()?.toLowerCase() || '';
-  const name = filename.toLowerCase();
-
-  // Special files
-  if (name === 'dockerfile' || name.endsWith('.dockerfile')) return 'dockerfile';
-  if (name === 'makefile') return 'makefile';
-  if (name === '.gitignore' || name === '.dockerignore') return 'ignore';
-
-  const langMap: Record<string, string> = {
-    // JavaScript/TypeScript
-    js: 'javascript',
-    jsx: 'jsx',
-    ts: 'typescript',
-    tsx: 'tsx',
-    mjs: 'javascript',
-    cjs: 'javascript',
-    // Web
-    html: 'html',
-    htm: 'html',
-    css: 'css',
-    scss: 'scss',
-    sass: 'sass',
-    less: 'less',
-    // Data/Config
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    toml: 'toml',
-    xml: 'xml',
-    // Documentation
-    md: 'markdown',
-    mdx: 'mdx',
-    // Programming languages
-    go: 'go',
-    py: 'python',
-    rb: 'ruby',
-    rs: 'rust',
-    java: 'java',
-    kt: 'kotlin',
-    kts: 'kotlin',
-    swift: 'swift',
-    c: 'c',
-    h: 'c',
-    cpp: 'cpp',
-    cc: 'cpp',
-    hpp: 'cpp',
-    cs: 'csharp',
-    php: 'php',
-    // Shell
-    sh: 'bash',
-    bash: 'bash',
-    zsh: 'zsh',
-    ps1: 'powershell',
-    // SQL
-    sql: 'sql',
-    // Others
-    graphql: 'graphql',
-    gql: 'graphql',
-    prisma: 'prisma',
-    env: 'dotenv',
-    lock: 'text',
-    txt: 'text',
-  };
-
-  return langMap[ext] || 'text';
 }
 
 function isMarkdownFile(filename: string): boolean {
@@ -122,10 +54,11 @@ export function CodeViewer({
   const [lineCount, setLineCount] = useState(0);
   const [viewMode, setViewMode] = useState<'code' | 'rendered'>('code');
   const [diffViewMode, setDiffViewMode] = useState<'split' | 'unified'>('split');
+  const [wordWrap, setWordWrap] = useState(false);
 
   const isMarkdown = isMarkdownFile(filename);
   const isDiffMode = typeof oldContent === 'string';
-  const language = getLanguage(filename);
+  const language = getShikiLanguage(filename);
 
   useEffect(() => {
     // Monaco handles diff mode highlighting
@@ -244,6 +177,15 @@ export function CodeViewer({
             <Button
               variant="ghost"
               size="icon"
+              className={cn('h-5 w-5 text-muted-foreground', wordWrap && 'bg-muted')}
+              onClick={() => setWordWrap(!wordWrap)}
+              title={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}
+            >
+              <WrapText className="w-2.5 h-2.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
               className="h-5 w-5 text-muted-foreground"
               onClick={handleCopy}
             >
@@ -264,6 +206,7 @@ export function CodeViewer({
             filename={filename}
             readOnly={true}
             sideBySide={diffViewMode === 'split'}
+            wordWrap={wordWrap}
           />
         </div>
       </div>
@@ -291,12 +234,21 @@ export function CodeViewer({
               title={viewMode === 'code' ? 'Show rendered' : 'Show code'}
             >
               {viewMode === 'code' ? (
-                <Eye className="w-1 h-1" />
+                <Eye className="w-2.5 h-2.5" />
               ) : (
-                <Code className="w-1 h-1" />
+                <Code className="w-2.5 h-2.5" />
               )}
             </Button>
           )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn('h-5 w-5 text-muted-foreground', wordWrap && 'bg-muted')}
+            onClick={() => setWordWrap(!wordWrap)}
+            title={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}
+          >
+            <WrapText className="w-2.5 h-2.5" />
+          </Button>
           <Button
             variant="ghost"
             size="icon"
@@ -304,9 +256,9 @@ export function CodeViewer({
             onClick={handleCopy}
           >
             {copied ? (
-              <Check className="w-1 h-1 text-green-500" />
+              <Check className="w-2.5 h-2.5 text-green-500" />
             ) : (
-              <Copy className="w-1 h-1" />
+              <Copy className="w-2.5 h-2.5" />
             )}
           </Button>
         </div>
@@ -331,6 +283,7 @@ export function CodeViewer({
             content={content}
             filename={filename}
             readOnly={true}
+            wordWrap={wordWrap}
             onStateChange={onStateChange}
             initialCursorPosition={initialCursorPosition}
             initialScrollPosition={initialScrollPosition}
@@ -339,6 +292,7 @@ export function CodeViewer({
           // For all other code files, use Monaco
           <MonacoEditor
             content={content}
+            wordWrap={wordWrap}
             filename={filename}
             readOnly={true}
             onStateChange={onStateChange}

--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -5,76 +5,8 @@ import Editor, { DiffEditor, OnMount, OnChange } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
 import { Loader2 } from 'lucide-react';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { registerMonacoTheme, getThemeById } from '@/lib/monacoThemes';
-
-// Map file extensions to Monaco language identifiers
-function getMonacoLanguage(filename: string): string {
-  const ext = filename.split('.').pop()?.toLowerCase() || '';
-  const name = filename.toLowerCase();
-
-  // Special files
-  if (name === 'dockerfile' || name.endsWith('.dockerfile')) return 'dockerfile';
-  if (name === 'makefile') return 'makefile';
-  if (name === '.gitignore' || name === '.dockerignore') return 'plaintext';
-
-  const langMap: Record<string, string> = {
-    // JavaScript/TypeScript
-    js: 'javascript',
-    jsx: 'javascript',
-    ts: 'typescript',
-    tsx: 'typescript',
-    mjs: 'javascript',
-    cjs: 'javascript',
-    // Web
-    html: 'html',
-    htm: 'html',
-    css: 'css',
-    scss: 'scss',
-    sass: 'scss',
-    less: 'less',
-    // Data/Config
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    toml: 'plaintext',
-    xml: 'xml',
-    // Documentation
-    md: 'markdown',
-    mdx: 'markdown',
-    // Programming languages
-    go: 'go',
-    py: 'python',
-    rb: 'ruby',
-    rs: 'rust',
-    java: 'java',
-    kt: 'kotlin',
-    kts: 'kotlin',
-    swift: 'swift',
-    c: 'c',
-    h: 'c',
-    cpp: 'cpp',
-    cc: 'cpp',
-    hpp: 'cpp',
-    cs: 'csharp',
-    php: 'php',
-    // Shell
-    sh: 'shell',
-    bash: 'shell',
-    zsh: 'shell',
-    ps1: 'powershell',
-    // SQL
-    sql: 'sql',
-    // Others
-    graphql: 'graphql',
-    gql: 'graphql',
-    prisma: 'plaintext',
-    env: 'plaintext',
-    lock: 'plaintext',
-    txt: 'plaintext',
-  };
-
-  return langMap[ext] || 'plaintext';
-}
+import { registerMonacoTheme } from '@/lib/monacoThemes';
+import { getMonacoLanguage } from '@/lib/languageMapping';
 
 interface EditorState {
   cursorPosition?: { line: number; column: number };
@@ -85,6 +17,7 @@ interface MonacoEditorProps {
   content: string;
   filename: string;
   readOnly?: boolean;
+  wordWrap?: boolean;
   onChange?: (content: string) => void;
   onStateChange?: (state: EditorState) => void;
   initialCursorPosition?: { line: number; column: number };
@@ -95,6 +28,7 @@ export function MonacoEditor({
   content,
   filename,
   readOnly = false,
+  wordWrap = false,
   onChange,
   onStateChange,
   initialCursorPosition,
@@ -103,12 +37,15 @@ export function MonacoEditor({
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const language = getMonacoLanguage(filename);
   const editorTheme = useSettingsStore((s) => s.editorTheme);
-  const [activeTheme, setActiveTheme] = useState<string>(editorTheme);
+  const [activeTheme, setActiveTheme] = useState<string | null>(null);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   // Register custom theme when editorTheme changes
+  // Only show loading spinner on initial load to prevent flash when switching themes
   useEffect(() => {
     registerMonacoTheme(editorTheme).then((themeId) => {
       setActiveTheme(themeId);
+      setIsInitialLoad(false);
     });
   }, [editorTheme]);
 
@@ -163,6 +100,21 @@ export function MonacoEditor({
     };
   }, [onStateChange]);
 
+  // Dispose editor on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (editorRef.current) {
+        editorRef.current.dispose();
+        editorRef.current = null;
+      }
+    };
+  }, []);
+
+  // Show loading state only on initial theme registration
+  if (isInitialLoad || !activeTheme) {
+    return <EditorLoading />;
+  }
+
   return (
     <Editor
       height="100%"
@@ -185,7 +137,7 @@ export function MonacoEditor({
         renderLineHighlight: readOnly ? 'none' : 'line',
         cursorStyle: readOnly ? 'block' : 'line',
         cursorBlinking: readOnly ? 'solid' : 'blink',
-        wordWrap: 'off',
+        wordWrap: wordWrap ? 'on' : 'off',
         folding: true,
         foldingStrategy: 'indentation',
         showFoldingControls: 'mouseover',
@@ -199,11 +151,18 @@ export function MonacoEditor({
         overviewRulerBorder: false,
         hideCursorInOverviewRuler: true,
         contextmenu: !readOnly,
-        quickSuggestions: false,
-        suggestOnTriggerCharacters: false,
-        acceptSuggestionOnEnter: 'off',
-        tabCompletion: 'off',
-        parameterHints: { enabled: false },
+        // Enable find widget (Cmd/Ctrl+F)
+        find: {
+          addExtraSpaceOnTop: false,
+          autoFindInSelection: 'multiline',
+          seedSearchStringFromSelection: 'selection',
+        },
+        // Enable IntelliSense features for editable editors
+        quickSuggestions: !readOnly,
+        suggestOnTriggerCharacters: !readOnly,
+        acceptSuggestionOnEnter: readOnly ? 'off' : 'on',
+        tabCompletion: readOnly ? 'off' : 'on',
+        parameterHints: { enabled: !readOnly },
       }}
     />
   );
@@ -215,6 +174,7 @@ interface MonacoDiffEditorProps {
   filename: string;
   readOnly?: boolean;
   sideBySide?: boolean;
+  wordWrap?: boolean;
 }
 
 export function MonacoDiffEditor({
@@ -223,16 +183,20 @@ export function MonacoDiffEditor({
   filename,
   readOnly = true,
   sideBySide = true,
+  wordWrap = false,
 }: MonacoDiffEditorProps) {
   const language = getMonacoLanguage(filename);
   const editorRef = useRef<editor.IStandaloneDiffEditor | null>(null);
   const editorTheme = useSettingsStore((s) => s.editorTheme);
-  const [activeTheme, setActiveTheme] = useState<string>(editorTheme);
+  const [activeTheme, setActiveTheme] = useState<string | null>(null);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   // Register custom theme when editorTheme changes
+  // Only show loading spinner on initial load to prevent flash when switching themes
   useEffect(() => {
     registerMonacoTheme(editorTheme).then((themeId) => {
       setActiveTheme(themeId);
+      setIsInitialLoad(false);
     });
   }, [editorTheme]);
 
@@ -243,8 +207,39 @@ export function MonacoDiffEditor({
     }
   }, [sideBySide]);
 
+  // Update diff editor content when props change
+  // Note: This only syncs content, not language. If the filename changes to a different
+  // language, the model language won't update since Monaco models are tied to their
+  // language at creation. In practice, this component is typically used with a fixed
+  // filename within a single mount lifecycle, so this is acceptable.
+  useEffect(() => {
+    if (editorRef.current) {
+      const modifiedEditor = editorRef.current.getModifiedEditor();
+      const originalEditor = editorRef.current.getOriginalEditor();
+      const modifiedModel = modifiedEditor.getModel();
+      const originalModel = originalEditor.getModel();
+
+      if (modifiedModel && modifiedModel.getValue() !== newContent) {
+        modifiedModel.setValue(newContent);
+      }
+      if (originalModel && originalModel.getValue() !== oldContent) {
+        originalModel.setValue(oldContent);
+      }
+    }
+  }, [oldContent, newContent]);
+
   const handleMount = useCallback((editor: editor.IStandaloneDiffEditor) => {
     editorRef.current = editor;
+  }, []);
+
+  // Dispose editor on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (editorRef.current) {
+        editorRef.current.dispose();
+        editorRef.current = null;
+      }
+    };
   }, []);
 
   // Memoize options to prevent unnecessary re-renders
@@ -263,7 +258,8 @@ export function MonacoDiffEditor({
     enableSplitViewResizing: true,
     renderIndicators: true,
     renderOverviewRuler: false,
-    diffWordWrap: 'off' as const,
+    diffWordWrap: (wordWrap ? 'on' : 'off') as 'on' | 'off',
+    wordWrap: (wordWrap ? 'on' : 'off') as 'on' | 'off',
     scrollbar: {
       vertical: 'auto' as const,
       horizontal: 'auto' as const,
@@ -272,7 +268,12 @@ export function MonacoDiffEditor({
     },
     overviewRulerBorder: false,
     contextmenu: false,
-  }), [readOnly, sideBySide]);
+  }), [readOnly, sideBySide, wordWrap]);
+
+  // Show loading state only on initial theme registration
+  if (isInitialLoad || !activeTheme) {
+    return <EditorLoading />;
+  }
 
   return (
     <DiffEditor
@@ -300,4 +301,4 @@ function EditorLoading() {
 }
 
 // Re-export the language detection function for use elsewhere
-export { getMonacoLanguage };
+export { getMonacoLanguage } from '@/lib/languageMapping';

--- a/src/lib/languageMapping.ts
+++ b/src/lib/languageMapping.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared language mapping for Monaco editor and Shiki syntax highlighting.
+ * Provides consistent language detection across the codebase.
+ */
+
+interface LanguageMapping {
+  monaco: string;
+  shiki: string;
+}
+
+// Extension to language mapping
+const extensionMap: Record<string, LanguageMapping> = {
+  // JavaScript/TypeScript
+  js: { monaco: 'javascript', shiki: 'javascript' },
+  jsx: { monaco: 'javascript', shiki: 'jsx' },
+  ts: { monaco: 'typescript', shiki: 'typescript' },
+  tsx: { monaco: 'typescript', shiki: 'tsx' },
+  mjs: { monaco: 'javascript', shiki: 'javascript' },
+  cjs: { monaco: 'javascript', shiki: 'javascript' },
+  // Web
+  html: { monaco: 'html', shiki: 'html' },
+  htm: { monaco: 'html', shiki: 'html' },
+  css: { monaco: 'css', shiki: 'css' },
+  scss: { monaco: 'scss', shiki: 'scss' },
+  sass: { monaco: 'scss', shiki: 'sass' },
+  less: { monaco: 'less', shiki: 'less' },
+  // Data/Config
+  json: { monaco: 'json', shiki: 'json' },
+  yaml: { monaco: 'yaml', shiki: 'yaml' },
+  yml: { monaco: 'yaml', shiki: 'yaml' },
+  toml: { monaco: 'plaintext', shiki: 'toml' },
+  xml: { monaco: 'xml', shiki: 'xml' },
+  // Documentation
+  md: { monaco: 'markdown', shiki: 'markdown' },
+  mdx: { monaco: 'markdown', shiki: 'mdx' },
+  // Programming languages
+  go: { monaco: 'go', shiki: 'go' },
+  py: { monaco: 'python', shiki: 'python' },
+  rb: { monaco: 'ruby', shiki: 'ruby' },
+  rs: { monaco: 'rust', shiki: 'rust' },
+  java: { monaco: 'java', shiki: 'java' },
+  kt: { monaco: 'kotlin', shiki: 'kotlin' },
+  kts: { monaco: 'kotlin', shiki: 'kotlin' },
+  swift: { monaco: 'swift', shiki: 'swift' },
+  c: { monaco: 'c', shiki: 'c' },
+  h: { monaco: 'c', shiki: 'c' },
+  cpp: { monaco: 'cpp', shiki: 'cpp' },
+  cc: { monaco: 'cpp', shiki: 'cpp' },
+  hpp: { monaco: 'cpp', shiki: 'cpp' },
+  cs: { monaco: 'csharp', shiki: 'csharp' },
+  php: { monaco: 'php', shiki: 'php' },
+  // Shell
+  sh: { monaco: 'shell', shiki: 'bash' },
+  bash: { monaco: 'shell', shiki: 'bash' },
+  zsh: { monaco: 'shell', shiki: 'zsh' },
+  ps1: { monaco: 'powershell', shiki: 'powershell' },
+  // SQL
+  sql: { monaco: 'sql', shiki: 'sql' },
+  // Others
+  graphql: { monaco: 'graphql', shiki: 'graphql' },
+  gql: { monaco: 'graphql', shiki: 'graphql' },
+  prisma: { monaco: 'plaintext', shiki: 'prisma' },
+  env: { monaco: 'plaintext', shiki: 'dotenv' },
+  lock: { monaco: 'plaintext', shiki: 'text' },
+  txt: { monaco: 'plaintext', shiki: 'text' },
+};
+
+const defaultMapping: LanguageMapping = { monaco: 'plaintext', shiki: 'text' };
+
+/**
+ * Get language identifiers for a given filename.
+ * @param filename - The filename to detect language for
+ * @returns Object with monaco and shiki language identifiers
+ */
+export function getLanguageFromFilename(filename: string): LanguageMapping {
+  const ext = filename.split('.').pop()?.toLowerCase() || '';
+  const name = filename.toLowerCase();
+
+  // Special files
+  if (name === 'dockerfile' || name.endsWith('.dockerfile')) {
+    return { monaco: 'dockerfile', shiki: 'dockerfile' };
+  }
+  if (name === 'makefile') {
+    return { monaco: 'makefile', shiki: 'makefile' };
+  }
+  if (name === '.gitignore' || name === '.dockerignore') {
+    return { monaco: 'plaintext', shiki: 'ignore' };
+  }
+
+  return extensionMap[ext] || defaultMapping;
+}
+
+/**
+ * Get Monaco editor language identifier for a filename.
+ * @param filename - The filename to detect language for
+ * @returns Monaco language identifier string
+ */
+export function getMonacoLanguage(filename: string): string {
+  return getLanguageFromFilename(filename).monaco;
+}
+
+/**
+ * Get Shiki syntax highlighter language identifier for a filename.
+ * @param filename - The filename to detect language for
+ * @returns Shiki language identifier string
+ */
+export function getShikiLanguage(filename: string): string {
+  return getLanguageFromFilename(filename).shiki;
+}


### PR DESCRIPTION
## Summary

Consolidates duplicate language mapping logic into a shared utility and adds several editor improvements. Extracts language detection for both Monaco and Shiki, adds word wrap toggle, fixes icon sizing, prevents memory leaks, and improves theme loading UX.

## Changes

- Language mapping consolidation into `src/lib/languageMapping.ts`
- Word wrap toggle feature for code and diff viewers
- Icon size fixes for better visibility
- Editor memory leak prevention via cleanup on unmount
- Improved theme loading to prevent spinner flash on theme switches
- IntelliSense and find widget enablement for editable editors

## Test Plan

- Verify word wrap toggle works in both split and unified diff views
- Confirm theme switching doesn't flash loading spinner
- Test find widget (Cmd/Ctrl+F) on editable editors
- Validate language highlighting for various file types

🤖 Generated with [Claude Code](https://claude.com/claude-code)