### PR TITLE
refactor: scope terminal instances to sessions instead of workspaces

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -227,6 +227,11 @@ export default function Home() {
 
   const { expandWorkspace } = useSettingsStore();
 
+  // Computed: selected session for terminal and other uses
+  const selectedSession = selectedSessionId
+    ? sessions.find((s) => s.id === selectedSessionId)
+    : null;
+
   // Connect WebSocket for real-time updates (only when backend is connected)
   useWebSocket(backendConnected);
 
@@ -904,7 +909,7 @@ export default function Home() {
 
               {/* Bottom Terminal - always mounted to preserve PTY session */}
               {showBottomTerminal && <ResizableHandle />}
-              {selectedWorkspaceId && (
+              {selectedSession && (
                 <ResizablePanel
                   id="bottom-terminal"
                   defaultSize={showBottomTerminal ? "150px" : "0px"}
@@ -915,8 +920,8 @@ export default function Home() {
                   <div className={showBottomTerminal ? 'h-full' : 'h-0 overflow-hidden'}>
                     <ErrorBoundary section="Terminal">
                       <BottomTerminal
-                        workspaceId={selectedWorkspaceId}
-                        workspacePath={workspaces.find((w) => w.id === selectedWorkspaceId)?.path || ''}
+                        sessionId={selectedSession.id}
+                        workspacePath={selectedSession.worktreePath}
                         onHide={() => setShowBottomTerminal(false)}
                       />
                     </ErrorBoundary>

--- a/src/components/BottomTerminal.tsx
+++ b/src/components/BottomTerminal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { X, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -20,13 +20,13 @@ const Terminal = dynamic(
 );
 
 interface BottomTerminalProps {
-  workspaceId: string;
+  sessionId: string;
   workspacePath: string;
   onHide: () => void;
 }
 
-export function BottomTerminal({ workspaceId, workspacePath, onHide }: BottomTerminalProps) {
-  // Use optimized selector scoped to this workspace
+export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTerminalProps) {
+  // Use optimized selector scoped to this session
   const {
     instances,
     activeId,
@@ -34,19 +34,24 @@ export function BottomTerminal({ workspaceId, workspacePath, onHide }: BottomTer
     closeTerminal,
     setActiveTerminal,
     markTerminalExited,
-  } = useTerminalState(workspaceId);
+  } = useTerminalState(sessionId);
   const canCreateMore = instances.length < 5;
+
+  // Ref to track if we've already created a terminal for this session
+  // Prevents React Strict Mode from creating duplicate terminals
+  const createdRef = useRef<string | null>(null);
 
   // Auto-create first terminal when panel is shown and no terminals exist
   useEffect(() => {
-    if (instances.length === 0) {
-      createTerminal(workspaceId);
+    if (instances.length === 0 && createdRef.current !== sessionId) {
+      createdRef.current = sessionId;
+      createTerminal(sessionId);
     }
-  }, [workspaceId, instances.length, createTerminal]);
+  }, [sessionId, instances.length, createTerminal]);
 
   const handleCreateTerminal = () => {
     if (canCreateMore) {
-      createTerminal(workspaceId);
+      createTerminal(sessionId);
     }
   };
 
@@ -54,10 +59,10 @@ export function BottomTerminal({ workspaceId, workspacePath, onHide }: BottomTer
     e.stopPropagation();
     // If this is the last terminal, hide the panel
     if (instances.length === 1) {
-      closeTerminal(workspaceId, terminalId);
+      closeTerminal(sessionId, terminalId);
       onHide();
     } else {
-      closeTerminal(workspaceId, terminalId);
+      closeTerminal(sessionId, terminalId);
     }
   };
 
@@ -74,7 +79,7 @@ export function BottomTerminal({ workspaceId, workspacePath, onHide }: BottomTer
           {instances.map((terminal) => (
             <button
               key={terminal.id}
-              onClick={() => setActiveTerminal(workspaceId, terminal.id)}
+              onClick={() => setActiveTerminal(sessionId, terminal.id)}
               className={cn(
                 'flex items-center gap-1 px-2 py-1 text-xs rounded-sm shrink-0',
                 'hover:bg-accent/50 transition-colors',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -427,10 +427,10 @@ export interface TerminalSession {
   status: 'idle' | 'active' | 'closed';
 }
 
-// Terminal instance for bottom panel terminals (per workspace)
+// Terminal instance for bottom panel terminals (per session)
 export interface TerminalInstance {
-  id: string;           // "workspaceId-term-slotNumber"
-  workspaceId: string;
+  id: string;           // "sessionId-term-slotNumber"
+  sessionId: string;
   slotNumber: number;   // 1-5
   status: 'active' | 'exited';
 }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -77,9 +77,9 @@ interface AppState {
   agentTodos: { [conversationId: string]: AgentTodoItem[] };
   customTodos: { [sessionId: string]: CustomTodoItem[] };
 
-  // Terminal instances (bottom panel terminals per workspace)
-  terminalInstances: Record<string, TerminalInstance[]>; // keyed by workspaceId
-  activeTerminalId: Record<string, string | null>;       // keyed by workspaceId
+  // Terminal instances (bottom panel terminals per session)
+  terminalInstances: Record<string, TerminalInstance[]>; // keyed by sessionId
+  activeTerminalId: Record<string, string | null>;       // keyed by sessionId
 
   // MCP servers state
   mcpServers: McpServerStatus[];
@@ -175,9 +175,9 @@ interface AppState {
   deleteCustomTodo: (sessionId: string, todoId: string) => void;
 
   // Terminal instance actions (bottom panel)
-  createTerminal: (workspaceId: string) => TerminalInstance | null;
-  closeTerminal: (workspaceId: string, terminalId: string) => void;
-  setActiveTerminal: (workspaceId: string, terminalId: string) => void;
+  createTerminal: (sessionId: string) => TerminalInstance | null;
+  closeTerminal: (sessionId: string, terminalId: string) => void;
+  setActiveTerminal: (sessionId: string, terminalId: string) => void;
   markTerminalExited: (terminalId: string) => void;
 
   // MCP servers actions
@@ -255,17 +255,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       delete cleanedAgentTodos[convId];
     }
 
-    // Clean up custom todos and session outputs for all sessions
+    // Clean up custom todos, session outputs, and terminal instances for all sessions
     const cleanedCustomTodos = { ...state.customTodos };
     const cleanedSessionOutputs = { ...state.sessionOutputs };
+    const cleanedTerminalInstances = { ...state.terminalInstances };
+    const cleanedActiveTerminalId = { ...state.activeTerminalId };
     for (const sessionId of workspaceSessionIds) {
       delete cleanedCustomTodos[sessionId];
       delete cleanedSessionOutputs[sessionId];
+      delete cleanedTerminalInstances[sessionId];
+      delete cleanedActiveTerminalId[sessionId];
     }
-
-    // Clean up terminal instances
-    const { [id]: _terminals, ...remainingTerminalInstances } = state.terminalInstances;
-    const { [id]: _activeTerminal, ...remainingActiveTerminalId } = state.activeTerminalId;
 
     return {
       workspaces: state.workspaces.filter((w) => w.id !== id),
@@ -284,8 +284,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       agentTodos: cleanedAgentTodos,
       customTodos: cleanedCustomTodos,
       sessionOutputs: cleanedSessionOutputs,
-      terminalInstances: remainingTerminalInstances,
-      activeTerminalId: remainingActiveTerminalId,
+      terminalInstances: cleanedTerminalInstances,
+      activeTerminalId: cleanedActiveTerminalId,
       selectedFileTabId: null,
       fileTabs: [],
     };
@@ -895,11 +895,11 @@ updateFileTabContent: (id, content) => set((state) => ({
   })),
 
   // Terminal instance actions (bottom panel)
-  createTerminal: (workspaceId) => {
+  createTerminal: (sessionId) => {
     const state = get();
-    const existing = state.terminalInstances[workspaceId] || [];
+    const existing = state.terminalInstances[sessionId] || [];
 
-    // Max 5 terminals per workspace
+    // Max 5 terminals per session
     if (existing.length >= 5) return null;
 
     // Find lowest available slot (1-5)
@@ -908,8 +908,8 @@ updateFileTabContent: (id, content) => set((state) => ({
     while (usedSlots.has(slot) && slot <= 5) slot++;
 
     const terminal: TerminalInstance = {
-      id: `${workspaceId}-term-${slot}-${Date.now()}`,
-      workspaceId,
+      id: `${sessionId}-term-${slot}-${Date.now()}`,
+      sessionId,
       slotNumber: slot,
       status: 'active',
     };
@@ -917,24 +917,24 @@ updateFileTabContent: (id, content) => set((state) => ({
     set({
       terminalInstances: {
         ...state.terminalInstances,
-        [workspaceId]: [...existing, terminal],
+        [sessionId]: [...existing, terminal],
       },
       activeTerminalId: {
         ...state.activeTerminalId,
-        [workspaceId]: terminal.id,
+        [sessionId]: terminal.id,
       },
     });
 
     return terminal;
   },
 
-  closeTerminal: (workspaceId, terminalId) => {
+  closeTerminal: (sessionId, terminalId) => {
     const state = get();
-    const existing = state.terminalInstances[workspaceId] || [];
+    const existing = state.terminalInstances[sessionId] || [];
     const filtered = existing.filter(t => t.id !== terminalId);
-    const wasActive = state.activeTerminalId[workspaceId] === terminalId;
+    const wasActive = state.activeTerminalId[sessionId] === terminalId;
 
-    let newActiveId = state.activeTerminalId[workspaceId];
+    let newActiveId = state.activeTerminalId[sessionId];
     if (wasActive && filtered.length > 0) {
       // Select next available or last
       const closedIndex = existing.findIndex(t => t.id === terminalId);
@@ -947,20 +947,20 @@ updateFileTabContent: (id, content) => set((state) => ({
     set({
       terminalInstances: {
         ...state.terminalInstances,
-        [workspaceId]: filtered,
+        [sessionId]: filtered,
       },
       activeTerminalId: {
         ...state.activeTerminalId,
-        [workspaceId]: newActiveId,
+        [sessionId]: newActiveId,
       },
     });
   },
 
-  setActiveTerminal: (workspaceId, terminalId) => {
+  setActiveTerminal: (sessionId, terminalId) => {
     set({
       activeTerminalId: {
         ...get().activeTerminalId,
-        [workspaceId]: terminalId,
+        [sessionId]: terminalId,
       },
     });
   },

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -17,7 +17,7 @@
 
 import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from './appStore';
-import type { Message, AgentTodoItem, CustomTodoItem } from '@/lib/types';
+import type { Message, AgentTodoItem, CustomTodoItem, TerminalInstance } from '@/lib/types';
 
 // Stable empty arrays to avoid creating new references
 // Using readonly to prevent accidental mutations
@@ -25,7 +25,7 @@ const EMPTY_MESSAGES: readonly Message[] = [];
 const EMPTY_TOOLS: readonly unknown[] = []; // ActiveTool is internal to appStore
 const EMPTY_AGENT_TODOS: readonly AgentTodoItem[] = [];
 const EMPTY_CUSTOM_TODOS: readonly CustomTodoItem[] = [];
-const EMPTY_TERMINAL_INSTANCES: readonly unknown[] = [];
+const EMPTY_TERMINAL_INSTANCES: readonly TerminalInstance[] = [];
 
 // ============================================================================
 // Conversation State
@@ -188,14 +188,14 @@ export const useSelectedIds = () =>
 // ============================================================================
 
 /**
- * Terminal instances for a specific workspace.
+ * Terminal instances for a specific session.
  * Use in: BottomTerminal
  */
-export const useTerminalState = (workspaceId: string | null) =>
+export const useTerminalState = (sessionId: string | null) =>
   useAppStore(
     useShallow((s) => ({
-      instances: workspaceId ? s.terminalInstances[workspaceId] ?? EMPTY_TERMINAL_INSTANCES : EMPTY_TERMINAL_INSTANCES,
-      activeId: workspaceId ? s.activeTerminalId[workspaceId] : null,
+      instances: sessionId ? s.terminalInstances[sessionId] ?? EMPTY_TERMINAL_INSTANCES : EMPTY_TERMINAL_INSTANCES,
+      activeId: sessionId ? s.activeTerminalId[sessionId] : null,
       createTerminal: s.createTerminal,
       closeTerminal: s.closeTerminal,
       setActiveTerminal: s.setActiveTerminal,


### PR DESCRIPTION
Terminal management is now keyed by sessionId instead of workspaceId to align with the worktree-based architecture where each session has its own independent terminal state and working directory. Added a defensive ref to prevent React Strict Mode from creating duplicate terminals. Fixed a potential issue where the terminal could open in an unexpected directory by ensuring the panel only renders when the selected session exists.

- Refactored all terminal state management from workspace-level to session-level
- Added React Strict Mode guard to prevent duplicate terminal creation
- Improved type safety by properly typing EMPTY_TERMINAL_INSTANCES
- Updated cleanup logic to correctly remove terminal instances per session