### PR TITLE
feat: add spotlight variant to command dialog

### DIFF
--- a/src/components/FilePicker.tsx
+++ b/src/components/FilePicker.tsx
@@ -167,13 +167,15 @@ export function FilePicker({ workspaceId, sessionId }: FilePickerProps) {
 
   return (
     <CommandDialog
+      variant="spotlight"
       open={open}
       onOpenChange={setOpen}
       title="Open File"
       description="Search for a file to open..."
+      showCloseButton={false}
     >
       <CommandInput placeholder="Search files..." />
-      <CommandList>
+      <CommandList className="max-h-[400px]">
         {isLoading ? (
           <div className="flex items-center justify-center py-6">
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -2,7 +2,8 @@
 
 import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
-import { SearchIcon } from "lucide-react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { SearchIcon, XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import {
@@ -10,8 +11,12 @@ import {
   DialogContent,
   DialogDescription,
   DialogHeader,
+  DialogOverlay,
+  DialogPortal,
   DialogTitle,
 } from "@/components/ui/dialog"
+
+type CommandDialogVariant = "centered" | "spotlight"
 
 function Command({
   className,
@@ -29,33 +34,95 @@ function Command({
   )
 }
 
+// Styles for centered (modal) command dialog
+const centeredCommandStyles = cn(
+  "[&_[cmdk-group-heading]]:text-muted-foreground",
+  "**:data-[slot=command-input-wrapper]:h-12",
+  "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium",
+  "[&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0",
+  "[&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5",
+  "[&_[cmdk-input]]:h-12",
+  "[&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3",
+  "[&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+)
+
+// Styles for spotlight (top-positioned) command dialog - more compact
+const spotlightCommandStyles = cn(
+  "[&_[cmdk-group-heading]]:text-muted-foreground",
+  "**:data-[slot=command-input-wrapper]:h-10",
+  "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+  "[&_[cmdk-group]]:px-1.5 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0",
+  "[&_[cmdk-input-wrapper]_svg]:h-4 [&_[cmdk-input-wrapper]_svg]:w-4",
+  "[&_[cmdk-input]]:h-10",
+  "[&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-1",
+  "[&_[cmdk-item]_svg]:h-4 [&_[cmdk-item]_svg]:w-4"
+)
+
 function CommandDialog({
   title = "Command Palette",
   description = "Search for a command to run...",
   children,
   className,
   showCloseButton = true,
+  variant = "centered",
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string
   description?: string
   className?: string
   showCloseButton?: boolean
+  variant?: CommandDialogVariant
 }) {
+  const isSpotlight = variant === "spotlight"
+
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
         <DialogTitle>{title}</DialogTitle>
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
-      <DialogContent
-        className={cn("overflow-hidden p-0", className)}
-        showCloseButton={showCloseButton}
-      >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-          {children}
-        </Command>
-      </DialogContent>
+      {isSpotlight ? (
+        <DialogPortal>
+          <DialogOverlay className="bg-transparent" />
+          <DialogPrimitive.Content
+            data-slot="dialog-content"
+            className={cn(
+              "fixed top-[10%] left-[50%] translate-x-[-50%] z-50",
+              "w-full max-w-xl",
+              "bg-popover/95 backdrop-blur-xl",
+              "border rounded-lg shadow-2xl",
+              "overflow-hidden p-0",
+              "data-[state=open]:animate-in data-[state=closed]:animate-out",
+              "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+              "data-[state=open]:slide-in-from-top-4 data-[state=closed]:slide-out-to-top-4",
+              "duration-200",
+              className
+            )}
+          >
+            <Command className={spotlightCommandStyles}>
+              {children}
+            </Command>
+            {showCloseButton && (
+              <DialogPrimitive.Close
+                data-slot="dialog-close"
+                className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-2 right-2 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+              >
+                <XIcon />
+                <span className="sr-only">Close</span>
+              </DialogPrimitive.Close>
+            )}
+          </DialogPrimitive.Content>
+        </DialogPortal>
+      ) : (
+        <DialogContent
+          className={cn("overflow-hidden p-0", className)}
+          showCloseButton={showCloseButton}
+        >
+          <Command className={centeredCommandStyles}>
+            {children}
+          </Command>
+        </DialogContent>
+      )}
     </Dialog>
   )
 }


### PR DESCRIPTION
Introduces a top-positioned, compact command dialog variant for file picker use cases. The spotlight variant features:

- Top-aligned positioning (10% from top) instead of center-aligned
- More compact styling with smaller icons and reduced padding
- Transparent overlay that doesn't dim the background
- Full close button support via showCloseButton prop
- Consistent data-slot attributes for selector compatibility

This change enables a modern, Spotlight/Alfred-style file picker experience while maintaining backward compatibility with the centered default variant.