### PR TITLE
fix: position spotlight dialog closer to window topbar

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -87,7 +87,7 @@ function CommandDialog({
           <DialogPrimitive.Content
             data-slot="dialog-content"
             className={cn(
-              "fixed top-[10%] left-[50%] translate-x-[-50%] z-50",
+              "fixed top-[5%] left-[50%] translate-x-[-50%] z-50",
               "w-full max-w-xl",
               "bg-popover/95 backdrop-blur-xl",
               "border rounded-lg shadow-2xl",


### PR DESCRIPTION
Moves the spotlight dialog position from `top-[10%]` to `top-[5%]` for a more prominent, Spotlight/Alfred-style appearance closer to the window topbar.

Follow-up to #36.