### PR TITLE
Move sessions to global workspace directory with city-based naming

### DIFF
--- a/backend/git/worktree.go
+++ b/backend/git/worktree.go
@@ -8,6 +8,15 @@ import (
 	"strings"
 )
 
+// WorkspacesBaseDir returns the base directory for session worktrees: ~/.chatml/workspaces
+func WorkspacesBaseDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".chatml", "workspaces"), nil
+}
+
 type WorktreeManager struct{}
 
 func NewWorktreeManager() *WorktreeManager {
@@ -19,9 +28,18 @@ func (wm *WorktreeManager) Create(repoPath, agentID string) (worktreePath string
 	return wm.CreateWithBranch(repoPath, agentID, branchName)
 }
 
-// CreateWithBranch creates a worktree with a custom branch name
-// Returns the worktree path, branch name, and the base commit SHA that the worktree was created from
+// CreateWithBranch creates a worktree with a custom branch name in the repo's .worktrees directory.
+// Returns the worktree path, branch name, and the base commit SHA that the worktree was created from.
+// Deprecated: Use CreateAtPath for new code - it allows specifying the worktree location.
 func (wm *WorktreeManager) CreateWithBranch(repoPath, worktreeID, branchName string) (worktreePath string, branch string, baseCommit string, err error) {
+	worktreesDir := filepath.Join(repoPath, ".worktrees")
+	worktreePath = filepath.Join(worktreesDir, worktreeID)
+	return wm.CreateAtPath(repoPath, worktreePath, branchName)
+}
+
+// CreateAtPath creates a worktree at a specific absolute path with a custom branch name.
+// Returns the worktree path, branch name, and the base commit SHA that the worktree was created from.
+func (wm *WorktreeManager) CreateAtPath(repoPath, worktreePath, branchName string) (string, string, string, error) {
 	// Capture current HEAD before creating the worktree - this is the base commit
 	cmd := exec.Command("git", "rev-parse", "HEAD")
 	cmd.Dir = repoPath
@@ -29,14 +47,13 @@ func (wm *WorktreeManager) CreateWithBranch(repoPath, worktreeID, branchName str
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to get current HEAD: %w", err)
 	}
-	baseCommit = strings.TrimSpace(string(out))
+	baseCommit := strings.TrimSpace(string(out))
 
-	worktreesDir := filepath.Join(repoPath, ".worktrees")
-	if err := os.MkdirAll(worktreesDir, 0755); err != nil {
-		return "", "", "", fmt.Errorf("failed to create worktrees dir: %w", err)
+	// Ensure parent directory exists
+	parentDir := filepath.Dir(worktreePath)
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
+		return "", "", "", fmt.Errorf("failed to create parent dir %s: %w", parentDir, err)
 	}
-
-	worktreePath = filepath.Join(worktreesDir, worktreeID)
 
 	cmd = exec.Command("git", "worktree", "add", "-b", branchName, worktreePath)
 	cmd.Dir = repoPath
@@ -52,10 +69,15 @@ func (wm *WorktreeManager) Remove(repoPath, agentID string) error {
 	return wm.RemoveByPath(repoPath, agentID, branchName)
 }
 
-// RemoveByPath removes a worktree by its ID and branch name
+// RemoveByPath removes a worktree by its ID and branch name from the repo's .worktrees directory.
+// Deprecated: Use RemoveAtPath for new code - it works with absolute worktree paths.
 func (wm *WorktreeManager) RemoveByPath(repoPath, worktreeID, branchName string) error {
 	worktreePath := filepath.Join(repoPath, ".worktrees", worktreeID)
+	return wm.RemoveAtPath(repoPath, worktreePath, branchName)
+}
 
+// RemoveAtPath removes a worktree at an absolute path and deletes its branch.
+func (wm *WorktreeManager) RemoveAtPath(repoPath, worktreePath, branchName string) error {
 	// Remove the worktree
 	cmd := exec.Command("git", "worktree", "remove", worktreePath, "--force")
 	cmd.Dir = repoPath
@@ -79,11 +101,15 @@ func (wm *WorktreeManager) List(repoPath string) ([]string, error) {
 		return nil, err
 	}
 
+	// Get the workspaces base directory to recognize new-style worktrees
+	workspacesDir, _ := WorkspacesBaseDir() // Ignore error, will just not match new-style
+
 	var worktrees []string
 	for _, line := range strings.Split(string(out), "\n") {
 		if strings.HasPrefix(line, "worktree ") {
 			path := strings.TrimPrefix(line, "worktree ")
-			if strings.Contains(path, ".worktrees") {
+			// Include old-style worktrees (in .worktrees dir) and new-style (in ~/.chatml/workspaces)
+			if strings.Contains(path, ".worktrees") || (workspacesDir != "" && strings.HasPrefix(path, workspacesDir)) {
 				worktrees = append(worktrees, path)
 			}
 		}

--- a/backend/naming/cities.go
+++ b/backend/naming/cities.go
@@ -1,0 +1,95 @@
+package naming
+
+// Cities contains world cities organized by region for session naming.
+// Future gamification can use these categories for rarity tiers:
+// - Capitals: common
+// - Major cities: uncommon
+// - Remote/obscure: rare
+// - Micronations/unusual: legendary
+var Cities = []string{
+	// North America
+	"seattle", "portland", "vancouver", "toronto", "montreal",
+	"boston", "chicago", "denver", "austin", "miami",
+	"phoenix", "detroit", "atlanta", "dallas", "houston",
+	"calgary", "winnipeg", "quebec", "ottawa", "halifax",
+	"juneau", "anchorage", "honolulu", "nashville", "memphis",
+
+	// Central America & Caribbean
+	"havana", "cancun", "guadalajara", "monterrey", "tijuana",
+	"panama", "belize", "kingston", "nassau", "bridgetown",
+
+	// South America
+	"bogota", "lima", "quito", "caracas", "santiago",
+	"buenos-aires", "montevideo", "asuncion", "la-paz", "sucre",
+	"brasilia", "rio", "sao-paulo", "medellin", "cartagena",
+	"cusco", "valparaiso", "ushuaia", "patagonia", "manaus",
+
+	// Western Europe
+	"london", "paris", "berlin", "amsterdam", "brussels",
+	"madrid", "barcelona", "lisbon", "porto", "dublin",
+	"edinburgh", "glasgow", "manchester", "birmingham", "leeds",
+	"lyon", "marseille", "nice", "bordeaux", "toulouse",
+	"munich", "frankfurt", "hamburg", "cologne", "stuttgart",
+	"milan", "rome", "florence", "venice", "naples",
+	"vienna", "zurich", "geneva", "bern", "basel",
+
+	// Northern Europe
+	"oslo", "stockholm", "copenhagen", "helsinki", "reykjavik",
+	"bergen", "gothenburg", "malmo", "turku", "tromso",
+	"akureyri", "rovaniemi", "tallinn", "riga", "vilnius",
+
+	// Eastern Europe
+	"moscow", "kyiv", "warsaw", "prague", "budapest",
+	"bucharest", "sofia", "belgrade", "zagreb", "ljubljana",
+	"bratislava", "krakow", "gdansk", "minsk", "chisinau",
+	"tbilisi", "yerevan", "baku", "odessa", "lviv",
+
+	// Middle East
+	"dubai", "abu-dhabi", "doha", "riyadh", "jeddah",
+	"tehran", "baghdad", "amman", "beirut", "damascus",
+	"jerusalem", "tel-aviv", "muscat", "kuwait", "manama",
+	"istanbul", "ankara", "izmir", "antalya", "cappadocia",
+
+	// South Asia
+	"mumbai", "delhi", "bangalore", "chennai", "kolkata",
+	"hyderabad", "pune", "ahmedabad", "jaipur", "goa",
+	"kathmandu", "colombo", "dhaka", "karachi", "lahore",
+	"islamabad", "kabul", "thimphu", "malé", "leh",
+
+	// Southeast Asia
+	"singapore", "bangkok", "hanoi", "saigon", "jakarta",
+	"kuala-lumpur", "manila", "yangon", "phnom-penh", "vientiane",
+	"bali", "phuket", "chiang-mai", "danang", "penang",
+	"brunei", "dili", "siem-reap", "luang-prabang", "boracay",
+
+	// East Asia
+	"tokyo", "osaka", "kyoto", "yokohama", "nagoya",
+	"seoul", "busan", "beijing", "shanghai", "guangzhou",
+	"shenzhen", "hong-kong", "macau", "taipei", "kaohsiung",
+	"sapporo", "fukuoka", "okinawa", "jeju", "xian",
+
+	// Central Asia
+	"almaty", "astana", "tashkent", "bishkek", "dushanbe",
+	"ashgabat", "samarkand", "bukhara", "khiva", "ulaanbaatar",
+
+	// Africa
+	"cairo", "casablanca", "marrakech", "tunis", "algiers",
+	"lagos", "accra", "abidjan", "dakar", "nairobi",
+	"addis-ababa", "kigali", "kampala", "dar-es-salaam", "zanzibar",
+	"cape-town", "johannesburg", "durban", "pretoria", "windhoek",
+	"luanda", "kinshasa", "douala", "libreville", "antananarivo",
+
+	// Oceania
+	"sydney", "melbourne", "brisbane", "perth", "adelaide",
+	"auckland", "wellington", "christchurch", "queenstown", "rotorua",
+	"fiji", "samoa", "tonga", "vanuatu", "tahiti",
+	"darwin", "cairns", "hobart", "canberra", "gold-coast",
+
+	// Remote & Unusual (future legendary tier)
+	"longyearbyen", "nuuk", "faroe", "svalbard", "mcmurdo",
+	"easter-island", "galapagos", "pitcairn", "tristan", "kerguelen",
+	"siberia", "yakutsk", "kamchatka", "vladivostok", "magadan",
+	"lhasa", "ladakh", "bhutan", "sikkim", "darjeeling",
+	"petra", "palmyra", "timbuktu", "machu-picchu", "angkor",
+	"bora-bora", "maldives", "seychelles", "mauritius", "reunion",
+}

--- a/backend/naming/generator.go
+++ b/backend/naming/generator.go
@@ -1,0 +1,58 @@
+package naming
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// GenerateSessionName returns a random city name for session naming.
+func GenerateSessionName() string {
+	idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(Cities))))
+	if err != nil {
+		// Fallback to first city if crypto/rand fails (extremely unlikely)
+		return Cities[0]
+	}
+	return Cities[idx.Int64()]
+}
+
+// GenerateUniqueSessionName generates a city name that doesn't conflict with existing names.
+// If the generated name already exists, it appends a short random suffix.
+func GenerateUniqueSessionName(existingNames []string) string {
+	// Build lookup set for O(1) collision checking
+	existing := make(map[string]bool, len(existingNames))
+	for _, name := range existingNames {
+		existing[strings.ToLower(name)] = true
+	}
+
+	// Try to find an unused city (up to 10 attempts)
+	for i := 0; i < 10; i++ {
+		name := GenerateSessionName()
+		if !existing[strings.ToLower(name)] {
+			return name
+		}
+	}
+
+	// All attempts collided - append a random suffix
+	baseName := GenerateSessionName()
+	suffix := generateSuffix()
+	return fmt.Sprintf("%s-%s", baseName, suffix)
+}
+
+// generateSuffix creates a short random alphanumeric suffix for collision handling.
+func generateSuffix() string {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	const length = 4
+
+	suffix := make([]byte, length)
+	for i := range suffix {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			suffix[i] = 'x' // Fallback character
+		} else {
+			suffix[i] = charset[idx.Int64()]
+		}
+	}
+	return string(suffix)
+}

--- a/backend/naming/generator_test.go
+++ b/backend/naming/generator_test.go
@@ -1,0 +1,119 @@
+package naming
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateSessionName(t *testing.T) {
+	name := GenerateSessionName()
+	if name == "" {
+		t.Error("GenerateSessionName returned empty string")
+	}
+
+	// Verify it's one of the cities
+	found := false
+	for _, city := range Cities {
+		if name == city {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GenerateSessionName returned %q which is not in Cities list", name)
+	}
+}
+
+func TestGenerateUniqueSessionName_NoCollision(t *testing.T) {
+	existingNames := []string{"tokyo", "london", "paris"}
+	name := GenerateUniqueSessionName(existingNames)
+
+	if name == "" {
+		t.Error("GenerateUniqueSessionName returned empty string")
+	}
+
+	// Should not match any existing name (case-insensitive)
+	nameLower := strings.ToLower(name)
+	for _, existing := range existingNames {
+		if nameLower == strings.ToLower(existing) {
+			// Could happen if all 10 attempts collide, but the suffix should make it unique
+			if !strings.Contains(name, "-") {
+				t.Errorf("GenerateUniqueSessionName returned %q which matches existing name %q", name, existing)
+			}
+		}
+	}
+}
+
+func TestGenerateUniqueSessionName_CaseInsensitive(t *testing.T) {
+	// Test that collision detection is case-insensitive
+	existingNames := []string{"TOKYO", "London", "PARIS"}
+
+	// Run multiple times to increase chance of collision
+	for i := 0; i < 100; i++ {
+		name := GenerateUniqueSessionName(existingNames)
+		nameLower := strings.ToLower(name)
+
+		// If it matches an existing name (case-insensitive), it must have a suffix
+		for _, existing := range existingNames {
+			if nameLower == strings.ToLower(existing) {
+				t.Errorf("GenerateUniqueSessionName returned %q which matches existing name %q (case-insensitive)", name, existing)
+			}
+		}
+	}
+}
+
+func TestGenerateUniqueSessionName_HighCollision(t *testing.T) {
+	// When all cities are taken, should append a suffix
+	existingNames := make([]string, len(Cities))
+	copy(existingNames, Cities)
+
+	name := GenerateUniqueSessionName(existingNames)
+
+	if name == "" {
+		t.Error("GenerateUniqueSessionName returned empty string")
+	}
+
+	// Should have a suffix (city-xxxx format)
+	if !strings.Contains(name, "-") {
+		t.Errorf("GenerateUniqueSessionName should append suffix when all cities are taken, got %q", name)
+	}
+
+	// Suffix should be 4 chars after the hyphen
+	parts := strings.Split(name, "-")
+	if len(parts) < 2 {
+		t.Errorf("Expected suffix format city-xxxx, got %q", name)
+		return
+	}
+	suffix := parts[len(parts)-1]
+	if len(suffix) != 4 {
+		t.Errorf("Expected 4-char suffix, got %q (%d chars)", suffix, len(suffix))
+	}
+}
+
+func TestGenerateSuffix(t *testing.T) {
+	suffix := generateSuffix()
+
+	if len(suffix) != 4 {
+		t.Errorf("generateSuffix should return 4 chars, got %d", len(suffix))
+	}
+
+	// Should only contain lowercase letters and digits
+	for _, c := range suffix {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+			t.Errorf("generateSuffix should only contain lowercase letters and digits, got %q", suffix)
+		}
+	}
+}
+
+func TestGenerateSuffix_Uniqueness(t *testing.T) {
+	// Generate multiple suffixes and verify they're not all the same
+	suffixes := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		suffixes[generateSuffix()] = true
+	}
+
+	// Should have generated multiple unique suffixes
+	if len(suffixes) < 10 {
+		t.Errorf("generateSuffix appears to not be random, only got %d unique suffixes in 100 attempts", len(suffixes))
+	}
+}

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -13,6 +13,8 @@ import (
 	"github.com/chatml/chatml-backend/agent"
 	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/models"
+	"github.com/chatml/chatml-backend/naming"
+	"github.com/chatml/chatml-backend/session"
 	"github.com/chatml/chatml-backend/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -168,10 +170,14 @@ func (h *Handlers) ListSessions(w http.ResponseWriter, r *http.Request) {
 }
 
 type CreateSessionRequest struct {
-	Name         string `json:"name"`
-	Branch       string `json:"branch"`
-	WorktreePath string `json:"worktreePath"`
-	Task         string `json:"task,omitempty"`
+	// Name is optional - if not provided, a city name will be auto-generated
+	Name string `json:"name,omitempty"`
+	// Branch is optional - if not provided, will be generated from the session name
+	Branch string `json:"branch,omitempty"`
+	// WorktreePath is deprecated - worktrees are now created at ~/.chatml/workspaces/{name}
+	WorktreePath string `json:"worktreePath,omitempty"`
+	// Task is an optional description of what this session is for
+	Task string `json:"task,omitempty"`
 }
 
 func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
@@ -196,18 +202,71 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	// Generate session ID
 	sessionID := uuid.New().String()
 
-	// Create git worktree for this session
-	worktreePath, branchName, baseCommitSHA, err := h.worktreeManager.CreateWithBranch(repo.Path, sessionID, req.Branch)
+	// Generate or use provided session name (city-based naming)
+	sessionName := req.Name
+	if sessionName == "" {
+		// Get workspaces base directory to check for existing directories
+		workspacesDir, err := git.WorkspacesBaseDir()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to get workspaces directory: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		// Scan filesystem for existing session directories (global collision check)
+		existingNames := []string{}
+		entries, err := os.ReadDir(workspacesDir)
+		if err == nil { // Directory might not exist yet
+			for _, entry := range entries {
+				if entry.IsDir() {
+					existingNames = append(existingNames, entry.Name())
+				}
+			}
+		}
+		sessionName = naming.GenerateUniqueSessionName(existingNames)
+	}
+
+	// Generate or use provided branch name
+	branchName := req.Branch
+	if branchName == "" {
+		branchName = fmt.Sprintf("session/%s", sessionName)
+	}
+
+	// Get workspaces base directory (~/.chatml/workspaces)
+	workspacesDir, err := git.WorkspacesBaseDir()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get workspaces directory: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Create git worktree at the new location
+	worktreePath, branchName, baseCommitSHA, err := h.worktreeManager.CreateAtPath(repo.Path, filepath.Join(workspacesDir, sessionName), branchName)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to create worktree: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	now := time.Now()
-	session := &models.Session{
+
+	// Write session metadata JSON file for portability
+	meta := &session.Metadata{
+		ID:            sessionID,
+		Name:          sessionName,
+		WorkspaceID:   workspaceID,
+		WorkspacePath: repo.Path,
+		Branch:        branchName,
+		BaseCommitSHA: baseCommitSHA,
+		CreatedAt:     now,
+		Task:          req.Task,
+	}
+	if err := session.WriteMetadata(worktreePath, meta); err != nil {
+		// Log but don't fail - metadata is supplementary
+		fmt.Printf("[handlers] Warning: failed to write session metadata: %v\n", err)
+	}
+
+	sess := &models.Session{
 		ID:            sessionID,
 		WorkspaceID:   workspaceID,
-		Name:          req.Name,
+		Name:          sessionName,
 		Branch:        branchName,
 		WorktreePath:  worktreePath,
 		BaseCommitSHA: baseCommitSHA,
@@ -218,7 +277,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 		UpdatedAt:     now,
 	}
 
-	if err := h.store.AddSession(ctx, session); err != nil {
+	if err := h.store.AddSession(ctx, sess); err != nil {
 		http.Error(w, fmt.Sprintf("failed to create session: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -227,7 +286,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	convID := uuid.New().String()[:8]
 	conv := &models.Conversation{
 		ID:          convID,
-		SessionID:   session.ID,
+		SessionID:   sess.ID,
 		Type:        models.ConversationTypeTask,
 		Name:        "Untitled",
 		Status:      models.ConversationStatusIdle,
@@ -251,8 +310,8 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 		Role:    "system",
 		Content: "",
 		SetupInfo: &models.SetupInfo{
-			SessionName:  session.Name,
-			BranchName:   session.Branch,
+			SessionName:  sess.Name,
+			BranchName:   sess.Branch,
 			OriginBranch: originBranch,
 		},
 		Timestamp: now,
@@ -262,7 +321,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, session)
+	writeJSON(w, sess)
 }
 
 func (h *Handlers) GetSession(w http.ResponseWriter, r *http.Request) {
@@ -364,20 +423,23 @@ func (h *Handlers) DeleteSession(w http.ResponseWriter, r *http.Request) {
 	sessionID := chi.URLParam(r, "sessionId")
 
 	// Get session to find workspace and worktree path
-	session, err := h.store.GetSession(ctx, sessionID)
+	sess, err := h.store.GetSession(ctx, sessionID)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("database error: %v", err), http.StatusInternalServerError)
 		return
 	}
-	if session != nil {
-		repo, err := h.store.GetRepo(ctx, session.WorkspaceID)
+	if sess != nil {
+		repo, err := h.store.GetRepo(ctx, sess.WorkspaceID)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("database error: %v", err), http.StatusInternalServerError)
 			return
 		}
-		if repo != nil && session.WorktreePath != "" {
-			// Remove the git worktree
-			h.worktreeManager.RemoveByPath(repo.Path, sessionID, session.Branch)
+		if repo != nil && sess.WorktreePath != "" {
+			// Delete session metadata file (if exists)
+			session.DeleteMetadata(sess.WorktreePath)
+
+			// Remove the git worktree using absolute path
+			h.worktreeManager.RemoveAtPath(repo.Path, sess.WorktreePath, sess.Branch)
 		}
 	}
 

--- a/backend/session/metadata.go
+++ b/backend/session/metadata.go
@@ -1,0 +1,87 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// MetadataFileName is the name of the session metadata file stored in each worktree.
+	// Uses a hidden filename (dot prefix) to avoid accidental git commits.
+	MetadataFileName = ".session.json"
+	// MetadataVersion is the current version of the metadata format
+	MetadataVersion = 1
+)
+
+// Metadata contains session information stored alongside the worktree for portability.
+// This supplements the SQLite database - the database is authoritative for queries,
+// but this file allows session recovery and provides portable session context.
+type Metadata struct {
+	Version       int       `json:"version"`
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	WorkspaceID   string    `json:"workspaceId"`
+	WorkspacePath string    `json:"workspacePath"` // Original repo path
+	Branch        string    `json:"branch"`
+	BaseCommitSHA string    `json:"baseCommitSha"`
+	CreatedAt     time.Time `json:"createdAt"`
+	Task          string    `json:"task,omitempty"`
+}
+
+// WriteMetadata writes session metadata to a JSON file in the worktree directory.
+func WriteMetadata(worktreePath string, meta *Metadata) error {
+	if meta.Version == 0 {
+		meta.Version = MetadataVersion
+	}
+
+	filePath := filepath.Join(worktreePath, MetadataFileName)
+
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal session metadata: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write session metadata to %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// ReadMetadata reads session metadata from a JSON file in the worktree directory.
+func ReadMetadata(worktreePath string) (*Metadata, error) {
+	filePath := filepath.Join(worktreePath, MetadataFileName)
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session metadata from %s: %w", filePath, err)
+	}
+
+	var meta Metadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal session metadata: %w", err)
+	}
+
+	return &meta, nil
+}
+
+// DeleteMetadata removes the session metadata file from the worktree directory.
+func DeleteMetadata(worktreePath string) error {
+	filePath := filepath.Join(worktreePath, MetadataFileName)
+
+	if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete session metadata at %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// MetadataExists checks if a session metadata file exists in the worktree directory.
+func MetadataExists(worktreePath string) bool {
+	filePath := filepath.Join(worktreePath, MetadataFileName)
+	_, err := os.Stat(filePath)
+	return err == nil
+}

--- a/backend/session/metadata_test.go
+++ b/backend/session/metadata_test.go
@@ -1,0 +1,204 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriteAndReadMetadata(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "session-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create metadata
+	now := time.Now().Truncate(time.Second) // Truncate for comparison
+	meta := &Metadata{
+		ID:            "test-session-id",
+		Name:          "tokyo",
+		WorkspaceID:   "workspace-123",
+		WorkspacePath: "/path/to/repo",
+		Branch:        "session/tokyo",
+		BaseCommitSHA: "abc123def456",
+		CreatedAt:     now,
+		Task:          "Fix the bug",
+	}
+
+	// Write metadata
+	if err := WriteMetadata(tmpDir, meta); err != nil {
+		t.Fatalf("WriteMetadata failed: %v", err)
+	}
+
+	// Verify file exists with correct name (hidden)
+	filePath := filepath.Join(tmpDir, MetadataFileName)
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Errorf("metadata file not created at %s", filePath)
+	}
+
+	// Read metadata back
+	readMeta, err := ReadMetadata(tmpDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata failed: %v", err)
+	}
+
+	// Verify all fields
+	if readMeta.Version != MetadataVersion {
+		t.Errorf("Version mismatch: got %d, want %d", readMeta.Version, MetadataVersion)
+	}
+	if readMeta.ID != meta.ID {
+		t.Errorf("ID mismatch: got %q, want %q", readMeta.ID, meta.ID)
+	}
+	if readMeta.Name != meta.Name {
+		t.Errorf("Name mismatch: got %q, want %q", readMeta.Name, meta.Name)
+	}
+	if readMeta.WorkspaceID != meta.WorkspaceID {
+		t.Errorf("WorkspaceID mismatch: got %q, want %q", readMeta.WorkspaceID, meta.WorkspaceID)
+	}
+	if readMeta.WorkspacePath != meta.WorkspacePath {
+		t.Errorf("WorkspacePath mismatch: got %q, want %q", readMeta.WorkspacePath, meta.WorkspacePath)
+	}
+	if readMeta.Branch != meta.Branch {
+		t.Errorf("Branch mismatch: got %q, want %q", readMeta.Branch, meta.Branch)
+	}
+	if readMeta.BaseCommitSHA != meta.BaseCommitSHA {
+		t.Errorf("BaseCommitSHA mismatch: got %q, want %q", readMeta.BaseCommitSHA, meta.BaseCommitSHA)
+	}
+	if !readMeta.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt mismatch: got %v, want %v", readMeta.CreatedAt, now)
+	}
+	if readMeta.Task != meta.Task {
+		t.Errorf("Task mismatch: got %q, want %q", readMeta.Task, meta.Task)
+	}
+}
+
+func TestWriteMetadata_SetsVersion(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "session-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create metadata without version
+	meta := &Metadata{
+		ID:   "test-id",
+		Name: "london",
+	}
+
+	if err := WriteMetadata(tmpDir, meta); err != nil {
+		t.Fatalf("WriteMetadata failed: %v", err)
+	}
+
+	readMeta, err := ReadMetadata(tmpDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata failed: %v", err)
+	}
+
+	if readMeta.Version != MetadataVersion {
+		t.Errorf("Version should be set to %d, got %d", MetadataVersion, readMeta.Version)
+	}
+}
+
+func TestReadMetadata_MissingFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "session-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	_, err = ReadMetadata(tmpDir)
+	if err == nil {
+		t.Error("ReadMetadata should fail for missing file")
+	}
+}
+
+func TestReadMetadata_CorruptFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "session-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write corrupt JSON
+	filePath := filepath.Join(tmpDir, MetadataFileName)
+	if err := os.WriteFile(filePath, []byte("not valid json{"), 0644); err != nil {
+		t.Fatalf("failed to write corrupt file: %v", err)
+	}
+
+	_, err = ReadMetadata(tmpDir)
+	if err == nil {
+		t.Error("ReadMetadata should fail for corrupt file")
+	}
+}
+
+func TestDeleteMetadata(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "session-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write metadata first
+	meta := &Metadata{ID: "test", Name: "paris"}
+	if err := WriteMetadata(tmpDir, meta); err != nil {
+		t.Fatalf("WriteMetadata failed: %v", err)
+	}
+
+	// Delete it
+	if err := DeleteMetadata(tmpDir); err != nil {
+		t.Fatalf("DeleteMetadata failed: %v", err)
+	}
+
+	// Verify file is gone
+	filePath := filepath.Join(tmpDir, MetadataFileName)
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Error("metadata file should be deleted")
+	}
+}
+
+func TestDeleteMetadata_MissingFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "session-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Should not error when file doesn't exist
+	if err := DeleteMetadata(tmpDir); err != nil {
+		t.Errorf("DeleteMetadata should not error for missing file: %v", err)
+	}
+}
+
+func TestMetadataExists(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "session-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Should not exist initially
+	if MetadataExists(tmpDir) {
+		t.Error("MetadataExists should return false for missing file")
+	}
+
+	// Write metadata
+	meta := &Metadata{ID: "test", Name: "berlin"}
+	if err := WriteMetadata(tmpDir, meta); err != nil {
+		t.Fatalf("WriteMetadata failed: %v", err)
+	}
+
+	// Should exist now
+	if !MetadataExists(tmpDir) {
+		t.Error("MetadataExists should return true after writing")
+	}
+}
+
+func TestMetadataFileName_IsHidden(t *testing.T) {
+	// Verify the filename starts with a dot (hidden file)
+	if MetadataFileName[0] != '.' {
+		t.Errorf("MetadataFileName should be a hidden file (start with dot), got %q", MetadataFileName)
+	}
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,16 +43,6 @@ import {
 // Pre-computed skeleton widths (avoids Math.random() during render)
 const SKELETON_WIDTHS = [72, 88, 65, 81];
 
-// Generate a random branch name for new sessions
-function generateBranchName(): string {
-  const adjectives = ['quick', 'bright', 'swift', 'calm', 'bold', 'keen', 'warm', 'cool'];
-  const nouns = ['fox', 'owl', 'bear', 'wolf', 'hawk', 'deer', 'lion', 'sage'];
-  const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
-  const noun = nouns[Math.floor(Math.random() * nouns.length)];
-  const num = Math.floor(Math.random() * 100);
-  return `${adj}-${noun}-${num}`;
-}
-
 // Loading skeleton for conversation area
 function ConversationSkeleton() {
   return (
@@ -398,20 +388,9 @@ export default function Home() {
   const handleNewSession = useCallback(async () => {
     if (!selectedWorkspaceId) return;
 
-    const workspace = workspaces.find((w) => w.id === selectedWorkspaceId);
-    if (!workspace) return;
-
     try {
-      // Generate a unique session name
-      const workspaceSessions = sessions.filter((s) => s.workspaceId === selectedWorkspaceId);
-      const sessionNumber = workspaceSessions.length + 1;
-      const branchName = `session-${sessionNumber}-${Date.now().toString(36)}`;
-
-      const newSession = await createSession(selectedWorkspaceId, {
-        name: `Session ${sessionNumber}`,
-        branch: branchName,
-        worktreePath: `${workspace.path}/.worktrees/${branchName}`,
-      });
+      // Backend generates city-based session name, branch, and worktree path
+      const newSession = await createSession(selectedWorkspaceId);
 
       // Add to store and select
       addSession({
@@ -546,13 +525,8 @@ export default function Home() {
       useAppStore.getState().addWorkspace(workspace);
       selectWorkspace(workspace.id);
 
-      // Auto-create first session for the new workspace
-      const branchName = generateBranchName();
-      const session = await createSession(workspace.id, {
-        name: branchName,
-        branch: branchName,
-        worktreePath: '',
-      });
+      // Auto-create first session for the new workspace (backend generates city-based name)
+      const session = await createSession(workspace.id);
 
       addSession({
         id: session.id,

--- a/src/components/AddWorkspaceModal.tsx
+++ b/src/components/AddWorkspaceModal.tsx
@@ -23,16 +23,6 @@ interface AddWorkspaceModalProps {
   onClose: () => void;
 }
 
-// Generate a random branch name for new sessions
-function generateBranchName(): string {
-  const adjectives = ['quick', 'bright', 'swift', 'calm', 'bold', 'keen', 'warm', 'cool'];
-  const nouns = ['fox', 'owl', 'bear', 'wolf', 'hawk', 'deer', 'lion', 'sage'];
-  const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
-  const noun = nouns[Math.floor(Math.random() * nouns.length)];
-  const num = Math.floor(Math.random() * 100);
-  return `${adj}-${noun}-${num}`;
-}
-
 export function AddWorkspaceModal({ isOpen, onClose }: AddWorkspaceModalProps) {
   const [path, setPath] = useState('');
   const [error, setError] = useState('');
@@ -67,13 +57,8 @@ export function AddWorkspaceModal({ isOpen, onClose }: AddWorkspaceModalProps) {
       addWorkspace(workspace);
       selectWorkspace(workspace.id);
 
-      // Auto-create first session for the new workspace
-      const branchName = generateBranchName();
-      const session = await createSessionApi(workspace.id, {
-        name: branchName,
-        branch: branchName,
-        worktreePath: '',
-      });
+      // Auto-create first session for the new workspace (backend generates city-based name)
+      const session = await createSessionApi(workspace.id);
 
       addSession({
         id: session.id,

--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -71,16 +71,6 @@ import { AgentSidebar } from './AgentSidebar';
 import { cn } from '@/lib/utils';
 import type { Workspace, WorktreeSession, SetupInfo } from '@/lib/types';
 
-// Generate a random branch name - moved outside component to avoid React purity warning
-function generateBranchName(): string {
-  const adjectives = ['quick', 'bright', 'swift', 'calm', 'bold', 'keen', 'warm', 'cool'];
-  const nouns = ['fox', 'owl', 'bear', 'wolf', 'hawk', 'deer', 'lion', 'sage'];
-  const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
-  const noun = nouns[Math.floor(Math.random() * nouns.length)];
-  const num = Math.floor(Math.random() * 100);
-  return `${adj}-${noun}-${num}`;
-}
-
 interface WorkspaceSidebarProps {
   onOpenProject: () => void;
   onCloneFromUrl: () => void;
@@ -184,15 +174,9 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
   };
 
   const handleCreateSession = async (workspaceId: string) => {
-    const branchName = generateBranchName();
-
     try {
-      // Create session via backend API (backend auto-creates "Untitled" conversation)
-      const session = await createSessionApi(workspaceId, {
-        name: branchName,
-        branch: branchName,
-        worktreePath: '', // Will be set when agent starts
-      });
+      // Create session via backend API (generates city-based name, branch, and worktree path)
+      const session = await createSessionApi(workspaceId);
 
       // Add to local store
       addSession({

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -178,7 +178,7 @@ export async function listSessions(workspaceId: string): Promise<SessionDTO[]> {
 
 export async function createSession(
   workspaceId: string,
-  data: { name: string; branch: string; worktreePath: string; task?: string }
+  data: { name?: string; branch?: string; worktreePath?: string; task?: string } = {}
 ): Promise<SessionDTO> {
   const res = await fetch(`${API_BASE}/api/repos/${workspaceId}/sessions`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Sessions now stored at `~/.chatml/workspaces/{city-name}` instead of per-repo `.worktrees` directories
- Backend generates memorable city names for sessions (200+ world cities) instead of frontend random strings
- Added session metadata files (`.session.json`) for portability and recovery
- Simplified frontend by moving session name/branch generation to backend

## Changes
- Global collision detection by scanning filesystem for existing session directories
- Backend now handles all session name, branch, and worktree path generation
- Case-insensitive collision handling with suffix fallback
- Removed duplicate name generation code from 3 frontend files

🤖 Generated with [Claude Code](https://claude.com/claude-code)