### PR TITLE
feat: add planning mode approval UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -392,3 +392,22 @@
 .scrollbar-none::-webkit-scrollbar {
   display: none;
 }
+
+/* Plan approval border styling */
+.plan-approval-border {
+  position: relative;
+}
+
+.plan-approval-border::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 0.5rem;
+  border: 2px dashed #e8a89b;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.dark .plan-approval-border::before {
+  border-color: #c47d6d;
+}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, KeyboardEvent } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode } from '@/lib/api';
+import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, approvePlan } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -25,6 +25,8 @@ import {
   FolderSymlink,
   FileText,
   X,
+  EyeOff,
+  Loader2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { listenForFileDrop, listenForDragEnter, listenForDragLeave } from '@/lib/tauri';
@@ -45,6 +47,8 @@ export function ChatInput() {
   const [message, setMessage] = useState('');
   const [selectedModel, setSelectedModel] = useState(MODELS[0]);
   const [isSending, setIsSending] = useState(false);
+  const [isApproving, setIsApproving] = useState(false);
+  const [approvalError, setApprovalError] = useState<string | null>(null);
   const [thinkingEnabled, setThinkingEnabled] = useState(false);
   const [planModeEnabled, setPlanModeEnabled] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -74,6 +78,7 @@ export function ChatInput() {
     updateConversation,
     selectConversation,
     setStreaming,
+    setAwaitingPlanApproval,
   } = useAppStore();
 
   // Get current session and conversation
@@ -83,6 +88,11 @@ export function ChatInput() {
   // Check if currently streaming
   const isStreaming = selectedConversationId
     ? streamingState[selectedConversationId]?.isStreaming
+    : false;
+
+  // Check if awaiting plan approval
+  const awaitingPlanApproval = selectedConversationId
+    ? streamingState[selectedConversationId]?.awaitingPlanApproval
     : false;
 
   useEffect(() => {
@@ -171,6 +181,32 @@ export function ChatInput() {
     }
   }, [planModeEnabled, selectedConversationId, isStreaming]);
 
+  // Handle plan approval
+  const handleApprovePlan = useCallback(async () => {
+    if (!selectedConversationId || !awaitingPlanApproval || isApproving) return;
+
+    setIsApproving(true);
+    setApprovalError(null);
+    try {
+      await approvePlan(selectedConversationId);
+      // The WebSocket will clear awaitingPlanApproval when tool_end is received
+    } catch (error) {
+      console.error('Failed to approve plan:', error);
+      setApprovalError(error instanceof Error ? error.message : 'Failed to approve plan');
+    } finally {
+      setIsApproving(false);
+    }
+  }, [selectedConversationId, awaitingPlanApproval, isApproving]);
+
+  // Handle hand off - dismisses the approval UI locally without approving.
+  // The agent continues waiting; user can still send feedback via the input.
+  // This allows the user to hide the approval bar while composing a longer response.
+  const handleHandOff = useCallback(() => {
+    if (!selectedConversationId) return;
+    setAwaitingPlanApproval(selectedConversationId, false);
+    setApprovalError(null);
+  }, [selectedConversationId, setAwaitingPlanApproval]);
+
   // Global keyboard shortcuts
 
   useEffect(() => {
@@ -197,6 +233,7 @@ export function ChatInput() {
           toggleListening();
         }
       }
+      // Note: Cmd+Shift+Enter for plan approval is handled in handleKeyDown on the textarea
     };
 
     // Handle menu events from native Tauri menu
@@ -320,6 +357,13 @@ export function ChatInput() {
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // ⌘⇧↵ to approve plan
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && e.shiftKey && awaitingPlanApproval) {
+      e.preventDefault();
+      handleApprovePlan();
+      return;
+    }
+    // Regular Enter to submit (or send feedback when awaiting approval)
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit();
@@ -328,11 +372,54 @@ export function ChatInput() {
 
   return (
     <div className="pt-1 px-4 pb-4">
+      {/* Plan Approval Bar */}
+      {awaitingPlanApproval && (
+        <div className="space-y-1.5 mb-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">
+              Approve the plan (<kbd className="px-1 py-0.5 rounded bg-muted text-xs font-mono">⌘⇧↵</kbd>) or tell the AI what to do differently <kbd className="px-1 py-0.5 rounded bg-muted text-xs font-mono">↵</kbd>
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 text-xs text-muted-foreground"
+                onClick={handleHandOff}
+                disabled={isApproving}
+              >
+                <EyeOff className="h-3.5 w-3.5" />
+                Hand off
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                className="h-7 gap-1.5 text-xs bg-background hover:bg-muted"
+                onClick={handleApprovePlan}
+                disabled={isApproving}
+              >
+                {isApproving ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <>
+                    Approve
+                    <kbd className="px-1 py-0.5 rounded bg-muted text-[10px] font-mono">⌘⇧↵</kbd>
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+          {approvalError && (
+            <div className="text-xs text-destructive">{approvalError}</div>
+          )}
+        </div>
+      )}
+
       <div className={cn(
         'relative',
-        isStreaming && 'streaming-border'
+        isStreaming && !awaitingPlanApproval && 'streaming-border',
+        awaitingPlanApproval && 'plan-approval-border'
       )}>
-        {isStreaming && (
+        {isStreaming && !awaitingPlanApproval && (
           <svg className="streaming-border-svg">
             <rect
               x="1"
@@ -345,7 +432,8 @@ export function ChatInput() {
         )}
       <div className={cn(
         'rounded-lg border bg-muted/50',
-        isStreaming && 'border-transparent',
+        isStreaming && !awaitingPlanApproval && 'border-transparent',
+        awaitingPlanApproval && 'border-transparent',
         isDragOver && 'ring-2 ring-primary ring-offset-2 border-primary',
         isListening && 'shadow-[inset_0_4px_8px_-2px_rgba(16,185,129,0.15)]'
       )}>

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -76,6 +76,7 @@ export function useWebSocket(enabled: boolean = true) {
     setThinking,
     clearThinking,
     setPlanModeActive,
+    setAwaitingPlanApproval,
     addActiveTool,
     completeActiveTool,
     clearActiveTools,
@@ -169,6 +170,11 @@ export function useWebSocket(enabled: boolean = true) {
             params: event.params,
             startTime: Date.now(),
           });
+
+          // Detect ExitPlanMode tool - this means Claude wants plan approval
+          if (event.tool === 'ExitPlanMode') {
+            setAwaitingPlanApproval(conversationId, true);
+          }
         }
         break;
 
@@ -176,9 +182,18 @@ export function useWebSocket(enabled: boolean = true) {
         // Complete active tool with success/summary info
         // For Bash tools, also capture stdout/stderr
         if (event?.id) {
+          // Check tool name BEFORE completing (to avoid race condition with state update)
+          const activeTool = useAppStore.getState().activeTools[conversationId]?.find(t => t.id === event.id);
+          const isExitPlanMode = activeTool?.tool === 'ExitPlanMode';
+
           const stdout = event.stdout as string | undefined;
           const stderr = event.stderr as string | undefined;
           completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr);
+
+          // Clear awaiting plan approval when ExitPlanMode completes
+          if (isExitPlanMode) {
+            setAwaitingPlanApproval(conversationId, false);
+          }
         }
         break;
 
@@ -292,6 +307,7 @@ export function useWebSocket(enabled: boolean = true) {
     setThinking,
     clearThinking,
     setPlanModeActive,
+    setAwaitingPlanApproval,
     clearActiveTools,
     setAgentTodos,
     finalizeStreamingMessage,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -481,6 +481,17 @@ export async function setConversationPlanMode(convId: string, enabled: boolean):
   }
 }
 
+export async function approvePlan(convId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/conversations/${convId}/approve-plan`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(text || `HTTP ${res.status}`, res.status, text);
+  }
+}
+
 // File Tab DTOs and functions
 export interface FileTabDTO {
   id: string;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -35,6 +35,7 @@ interface StreamingState {
   isThinking: boolean;
   startTime?: number; // When streaming started (for elapsed time)
   planModeActive: boolean; // Whether plan mode is active for this conversation
+  awaitingPlanApproval: boolean; // Whether we're waiting for user to approve ExitPlanMode
 }
 
 interface ActiveTool {
@@ -155,6 +156,7 @@ interface AppState {
   setThinking: (conversationId: string, isThinking: boolean) => void;
   clearThinking: (conversationId: string) => void;
   setPlanModeActive: (conversationId: string, active: boolean) => void;
+  setAwaitingPlanApproval: (conversationId: string, awaiting: boolean) => void;
   addActiveTool: (conversationId: string, tool: ActiveTool) => void;
   completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string) => void;
   clearActiveTools: (conversationId: string) => void;
@@ -730,13 +732,22 @@ updateFileTabContent: (id, content) => set((state) => ({
         thinking: null,
         isThinking: false,
         planModeActive: state.streamingState[conversationId]?.planModeActive || false,
+        awaitingPlanApproval: false,
       },
     },
   })),
   clearStreamingText: (conversationId) => set((state) => ({
     streamingState: {
       ...state.streamingState,
-      [conversationId]: { text: '', isStreaming: false, error: null, thinking: null, isThinking: false, planModeActive: state.streamingState[conversationId]?.planModeActive || false },
+      [conversationId]: {
+        text: '',
+        isStreaming: false,
+        error: null,
+        thinking: null,
+        isThinking: false,
+        planModeActive: state.streamingState[conversationId]?.planModeActive || false,
+        awaitingPlanApproval: false,
+      },
     },
   })),
   appendThinkingText: (conversationId, text) => set((state) => ({
@@ -776,6 +787,7 @@ updateFileTabContent: (id, content) => set((state) => ({
         thinking: null,
         isThinking: false,
         planModeActive: state.streamingState[conversationId]?.planModeActive || false,
+        awaitingPlanApproval: state.streamingState[conversationId]?.awaitingPlanApproval || false,
       },
     },
   })),
@@ -790,6 +802,22 @@ updateFileTabContent: (id, content) => set((state) => ({
         thinking: state.streamingState[conversationId]?.thinking || null,
         isThinking: state.streamingState[conversationId]?.isThinking || false,
         planModeActive: active,
+        awaitingPlanApproval: state.streamingState[conversationId]?.awaitingPlanApproval || false,
+      },
+    },
+  })),
+  setAwaitingPlanApproval: (conversationId, awaiting) => set((state) => ({
+    streamingState: {
+      ...state.streamingState,
+      [conversationId]: {
+        ...state.streamingState[conversationId],
+        text: state.streamingState[conversationId]?.text || '',
+        isStreaming: state.streamingState[conversationId]?.isStreaming || false,
+        error: state.streamingState[conversationId]?.error || null,
+        thinking: state.streamingState[conversationId]?.thinking || null,
+        isThinking: state.streamingState[conversationId]?.isThinking || false,
+        planModeActive: state.streamingState[conversationId]?.planModeActive || false,
+        awaitingPlanApproval: awaiting,
       },
     },
   })),
@@ -829,6 +857,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       thinking: null,
       isThinking: false,
       planModeActive: streaming?.planModeActive || false,
+      awaitingPlanApproval: false,
     };
 
     // If no streaming text, just clear the state


### PR DESCRIPTION
## Summary

- Add `awaitingPlanApproval` state to track when user approval is needed for ExitPlanMode
- Detect ExitPlanMode tool call in WebSocket events and trigger approval UI
- Show approval bar above chat input with instructions and action buttons
- Support ⌘⇧↵ keyboard shortcut to approve the plan
- Add dashed pink border styling when awaiting approval
- Include loading state and error feedback on approval action
- Add `approvePlan` API function

## UI Details

When Claude calls the ExitPlanMode tool, an approval bar appears above the input:
- Instructions: "Approve the plan (⌘⇧↵) or tell the AI what to do differently ↵"
- **Hand off** button - dismisses the bar (user can still send feedback)
- **Approve** button - approves the plan with loading spinner

## Backend Required

The frontend calls `POST /api/conversations/{id}/approve-plan` which needs to be implemented in the backend to forward approval to the Claude SDK agent process.

## Test plan

- [ ] Verify ExitPlanMode detection triggers approval UI
- [ ] Test Approve button sends API request with loading state
- [ ] Test ⌘⇧↵ keyboard shortcut approves the plan
- [ ] Test Hand off button dismisses the approval bar
- [ ] Test error feedback displays when approval fails
- [ ] Verify dashed pink border appears during approval state
- [ ] Confirm approval UI is scoped per conversation (multiple chats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)