### PR TITLE
feat: rename git branch when auto-naming sessions

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/models"
+	"github.com/chatml/chatml-backend/session"
 	"github.com/chatml/chatml-backend/store"
 	"github.com/google/uuid"
 )
@@ -459,10 +460,23 @@ func (m *Manager) GetConversationProcess(convID string) *Process {
 }
 
 // formatSessionName converts a human-readable name into a branch-friendly format.
-// Example: "Fix the login bug" -> "fix-login-bug"
+// Example: "Fix the login bug" -> "login-bug"
+// Returns empty string for generic/non-specific names that shouldn't be used.
 func formatSessionName(name string) string {
 	// Convert to lowercase
 	name = strings.ToLower(name)
+
+	// Remove generic phrases first (before word-level filtering)
+	genericPhrases := []string{
+		"explore session", "explore codebase", "explore the codebase",
+		"understand how", "understand the", "learn about", "look at",
+		"investigate the", "investigate how", "check out", "review the",
+		"examine the", "analyze the", "study the", "research the",
+		"get familiar", "familiarize with", "dive into",
+	}
+	for _, phrase := range genericPhrases {
+		name = strings.ReplaceAll(name, phrase, " ")
+	}
 
 	// Remove common filler words
 	fillerWords := []string{
@@ -470,6 +484,9 @@ func formatSessionName(name string) string {
 		"help", "implement", "create", "add", "update", "fix", "make", "build",
 		"i'll", "i will", "let me", "going to", "need to", "want to",
 		"you", "me", "your", "my", "this", "that", "some", "new",
+		"explore", "understand", "how", "works", "work", "does",
+		"codebase", "code", "base", "project", "repo", "repository",
+		"session", "task", "feature", "thing", "stuff",
 	}
 
 	// First pass: remove filler phrases
@@ -507,24 +524,35 @@ func formatSessionName(name string) string {
 		return ""
 	}
 
+	// Reject overly generic results
+	genericResults := map[string]bool{
+		"explore": true, "session": true, "codebase": true,
+		"understand": true, "how": true, "works": true,
+		"investigate": true, "analyze": true, "review": true,
+	}
+	if genericResults[result] {
+		return ""
+	}
+
 	return result
 }
 
 // tryAutoNameSession attempts to auto-name a session based on the first conversation's name suggestion.
 // It only updates the session name if the session hasn't been auto-named yet.
 // The name is formatted like a branch name (lowercase, hyphenated).
+// This also renames the git branch and updates the .session.json metadata file.
 func (m *Manager) tryAutoNameSession(ctx context.Context, sessionID, suggestedName string) {
-	session, err := m.store.GetSession(ctx, sessionID)
+	sess, err := m.store.GetSession(ctx, sessionID)
 	if err != nil {
 		log.Printf("[manager] failed to get session %s for auto-naming: %v", sessionID, err)
 		return
 	}
-	if session == nil {
+	if sess == nil {
 		return
 	}
 
 	// Skip if session has already been auto-named
-	if session.AutoNamed {
+	if sess.AutoNamed {
 		return
 	}
 
@@ -535,10 +563,22 @@ func (m *Manager) tryAutoNameSession(ctx context.Context, sessionID, suggestedNa
 		return
 	}
 
-	// Update session name and mark as auto-named
+	// Rename the git branch
+	oldBranchName := sess.Branch
+	newBranchName := fmt.Sprintf("session/%s", formattedName)
+
+	if err := m.worktreeManager.RenameBranch(sess.WorktreePath, oldBranchName, newBranchName); err != nil {
+		log.Printf("[manager] failed to rename branch for session %s: %v", sessionID, err)
+		// Continue anyway - the session name update is still useful
+	} else {
+		log.Printf("[manager] renamed branch for session %s: %q -> %q", sessionID, oldBranchName, newBranchName)
+	}
+
+	// Update session name, branch, and mark as auto-named
 	now := time.Now()
 	if err := m.store.UpdateSession(ctx, sessionID, func(s *models.Session) {
 		s.Name = formattedName
+		s.Branch = newBranchName
 		s.AutoNamed = true
 		s.UpdatedAt = now
 	}); err != nil {
@@ -546,13 +586,23 @@ func (m *Manager) tryAutoNameSession(ctx context.Context, sessionID, suggestedNa
 		return
 	}
 
+	// Update the .session.json metadata file
+	if meta, err := session.ReadMetadata(sess.WorktreePath); err == nil {
+		meta.Name = formattedName
+		meta.Branch = newBranchName
+		if err := session.WriteMetadata(sess.WorktreePath, meta); err != nil {
+			log.Printf("[manager] failed to update session metadata for %s: %v", sessionID, err)
+		}
+	}
+
 	log.Printf("[manager] auto-named session %s: %q (from %q)", sessionID, formattedName, suggestedName)
 
 	// Emit session event for WebSocket broadcast
 	if m.onSessionEvent != nil {
 		m.onSessionEvent(sessionID, map[string]interface{}{
-			"type": "session_name_update",
-			"name": formattedName,
+			"type":   "session_name_update",
+			"name":   formattedName,
+			"branch": newBranchName,
 		})
 	}
 }

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -395,8 +395,8 @@ func TestFormatSessionName(t *testing.T) {
 		},
 		{
 			name:     "already lowercase",
-			input:    "add session renaming feature",
-			expected: "session-renaming-feature",
+			input:    "add branch renaming logic",
+			expected: "branch-renaming-logic",
 		},
 		{
 			name:     "with punctuation",

--- a/backend/git/worktree.go
+++ b/backend/git/worktree.go
@@ -157,3 +157,14 @@ func (wm *WorktreeManager) Merge(repoPath, agentID string) error {
 
 	return nil
 }
+
+// RenameBranch renames a git branch. The command must be run from within the worktree
+// that has the branch checked out, as you cannot rename a branch from outside.
+func (wm *WorktreeManager) RenameBranch(worktreePath, oldBranchName, newBranchName string) error {
+	cmd := exec.Command("git", "branch", "-m", oldBranchName, newBranchName)
+	cmd.Dir = worktreePath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to rename branch: %s: %w", string(out), err)
+	}
+	return nil
+}

--- a/src/components/ChangesPanel.tsx
+++ b/src/components/ChangesPanel.tsx
@@ -232,6 +232,9 @@ export function ChangesPanel() {
   const currentSession = sessions.find((s) => s.id === selectedSessionId);
   const currentWorkspace = workspaces.find((w) => w.id === selectedWorkspaceId);
 
+  // Track branch for refetching changes when branch is renamed
+  const currentBranch = currentSession?.branch;
+
   // Determine top bar state
   const hasActivePR = currentSession?.prStatus === 'open';
   const hasConflictOrFailure = currentSession?.hasMergeConflict || currentSession?.hasCheckFailures;
@@ -266,7 +269,7 @@ export function ChangesPanel() {
     }
   }, [selectedTab, selectedWorkspaceId, selectedSessionId]);
 
-  // Fetch changes when session changes or tab switches to changes
+  // Fetch changes when session changes, tab switches to changes, or branch is renamed
   useEffect(() => {
     if (selectedTab === 'changes' && selectedWorkspaceId && selectedSessionId) {
       let cancelled = false;
@@ -281,7 +284,7 @@ export function ChangesPanel() {
         .finally(() => { if (!cancelled) setChangesLoading(false); });
       return () => { cancelled = true; };
     }
-  }, [selectedTab, selectedWorkspaceId, selectedSessionId]);
+  }, [selectedTab, selectedWorkspaceId, selectedSessionId, currentBranch]);
 
   // Listen for file change events and auto-refresh changes
   useEffect(() => {

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -372,7 +372,11 @@ export function useWebSocket(enabled: boolean = true) {
         if (data.type === 'session_name_update' && data.sessionId) {
           const payload = data.payload as Record<string, unknown> | undefined;
           if (payload?.name && typeof payload.name === 'string') {
-            updateSession(data.sessionId, { name: payload.name });
+            const updates: { name: string; branch?: string } = { name: payload.name };
+            if (payload?.branch && typeof payload.branch === 'string') {
+              updates.branch = payload.branch;
+            }
+            updateSession(data.sessionId, updates);
           }
           return;
         }


### PR DESCRIPTION
## Summary
- When a session is auto-named based on conversation context, the git branch is now also renamed (e.g., `session/bratislava` → `session/login-auth-fix`)
- Added filtering for generic names like "explore codebase", "understand how", etc. to prevent unhelpful branch names
- Updates the `.session.json` metadata file and broadcasts the new branch name via WebSocket

## Test plan
- [ ] Create a new session (gets random city name like `session/paris`)
- [ ] Start a conversation with a specific task (e.g., "fix the login button")
- [ ] Verify the branch gets renamed to something like `session/login-button`
- [ ] Verify generic tasks like "explore the codebase" don't trigger a rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)