### PR TITLE
fix: resolve race condition when stopping processes concurrently

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -316,7 +316,9 @@ func (m *Manager) SendConversationMessage(convID, message string) error {
 	proc, ok := m.convProcesses[convID]
 	m.mu.RUnlock()
 
-	if !ok || !proc.IsRunning() {
+	// Check if process exists, hasn't been stopped, and is running.
+	// IsStopped() catches explicit stops; IsRunning() catches natural exits.
+	if !ok || proc.IsStopped() || !proc.IsRunning() {
 		// Process not running, need to restart it
 		conv, err := m.store.GetConversation(ctx, convID)
 		if err != nil {
@@ -381,7 +383,7 @@ func (m *Manager) RewindConversationFiles(convID, checkpointUuid string) error {
 	proc, ok := m.convProcesses[convID]
 	m.mu.RUnlock()
 
-	if !ok || !proc.IsRunning() {
+	if !ok || proc.IsStopped() || !proc.IsRunning() {
 		return fmt.Errorf("conversation process not running: %s", convID)
 	}
 
@@ -395,7 +397,7 @@ func (m *Manager) SetConversationPlanMode(convID string, enabled bool) error {
 	proc, ok := m.convProcesses[convID]
 	m.mu.RUnlock()
 
-	if !ok || !proc.IsRunning() {
+	if !ok || proc.IsStopped() || !proc.IsRunning() {
 		return fmt.Errorf("conversation process not running: %s", convID)
 	}
 
@@ -410,20 +412,27 @@ func (m *Manager) SetConversationPlanMode(convID string, enabled bool) error {
 // StopConversation stops a running conversation
 func (m *Manager) StopConversation(convID string) {
 	ctx := context.Background()
+
 	m.mu.Lock()
 	proc, ok := m.convProcesses[convID]
-	if !ok || !proc.IsRunning() {
+	if !ok {
 		m.mu.Unlock()
 		return
 	}
-	// Remove from map to prevent concurrent stop attempts
+	// Remove from map to prevent new lookups finding this process
 	delete(m.convProcesses, convID)
 	m.mu.Unlock()
 
-	// Now safe to stop without holding lock
+	// Send graceful stop signal first (best effort, may fail if process already exited)
 	proc.SendStop()
-	proc.Stop()
 
+	// TryStop atomically claims ownership of the stop operation.
+	// Returns false if another goroutine already stopped this process.
+	if !proc.TryStop() {
+		return // Another goroutine is handling the stop
+	}
+
+	// Update status only if we performed the stop
 	if err := m.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
 		c.Status = models.ConversationStatusIdle
 		c.UpdatedAt = time.Now()
@@ -653,18 +662,24 @@ func (m *Manager) SpawnAgent(repoPath, repoID, task string) (*models.Agent, erro
 
 func (m *Manager) StopAgent(agentID string) {
 	ctx := context.Background()
+
 	m.mu.Lock()
 	proc, ok := m.processes[agentID]
 	if !ok {
 		m.mu.Unlock()
 		return
 	}
-	// Remove from map to prevent concurrent stop attempts
+	// Remove from map to prevent new lookups finding this process
 	delete(m.processes, agentID)
 	m.mu.Unlock()
 
-	// Now safe to stop without holding lock
-	proc.Stop()
+	// TryStop atomically claims ownership of the stop operation.
+	// Returns false if another goroutine already stopped this process.
+	if !proc.TryStop() {
+		return // Another goroutine is handling the stop
+	}
+
+	// Update status only if we performed the stop
 	if err := m.store.UpdateAgentStatus(ctx, agentID, models.StatusError); err != nil {
 		log.Printf("[manager] failed to update agent status on stop: %v", err)
 	}

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -327,6 +328,120 @@ func TestManager_ConcurrentGetProcess(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		<-done
 	}
+}
+
+func TestManager_ConcurrentStopConversation(t *testing.T) {
+	manager, s := setupTestManager(t)
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	// Manually insert a process into the map
+	proc := NewProcess("test", t.TempDir(), "conv-1")
+	manager.mu.Lock()
+	manager.convProcesses["conv-1"] = proc
+	manager.mu.Unlock()
+
+	// Track status updates - should only happen once
+	var statusUpdateCount int
+	var mu sync.Mutex
+	manager.SetConversationStatusHandler(func(convID, status string) {
+		mu.Lock()
+		statusUpdateCount++
+		mu.Unlock()
+	})
+
+	// Concurrent stop calls should not panic and should update status only once
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.StopConversation("conv-1")
+		}()
+	}
+	wg.Wait()
+
+	// Status should be updated exactly once (only one goroutine wins TryStop)
+	mu.Lock()
+	count := statusUpdateCount
+	mu.Unlock()
+	assert.Equal(t, 1, count, "status should be updated exactly once")
+
+	// Process should be removed from map
+	assert.Nil(t, manager.GetConversationProcess("conv-1"))
+}
+
+func TestManager_ConcurrentStopAgent(t *testing.T) {
+	manager, s := setupTestManager(t)
+
+	// Create test data
+	createTestRepo(t, s, "repo-1")
+
+	// Manually insert a process into the legacy processes map
+	proc := NewProcess("agent-1", t.TempDir(), "")
+	manager.mu.Lock()
+	manager.processes["agent-1"] = proc
+	manager.mu.Unlock()
+
+	// Track status updates - should only happen once
+	var statusUpdateCount int
+	var mu sync.Mutex
+	manager.SetStatusHandler(func(agentID string, status models.AgentStatus) {
+		mu.Lock()
+		statusUpdateCount++
+		mu.Unlock()
+	})
+
+	// Concurrent stop calls should not panic and should update status only once
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.StopAgent("agent-1")
+		}()
+	}
+	wg.Wait()
+
+	// Status should be updated exactly once (only one goroutine wins TryStop)
+	mu.Lock()
+	count := statusUpdateCount
+	mu.Unlock()
+	assert.Equal(t, 1, count, "status should be updated exactly once")
+
+	// Process should be removed from map
+	assert.Nil(t, manager.GetProcess("agent-1"))
+}
+
+func TestManager_ConcurrentStopAndGet(t *testing.T) {
+	manager, s := setupTestManager(t)
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	// Manually insert a process
+	proc := NewProcess("test", t.TempDir(), "conv-1")
+	manager.mu.Lock()
+	manager.convProcesses["conv-1"] = proc
+	manager.mu.Unlock()
+
+	// Concurrent reads and stops should not cause race conditions
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			manager.GetConversationProcess("conv-1")
+		}()
+		go func() {
+			defer wg.Done()
+			manager.StopConversation("conv-1")
+		}()
+	}
+	wg.Wait()
 }
 
 // ============================================================================

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -48,6 +48,7 @@ type Process struct {
 	done           chan struct{}
 	mu             sync.Mutex
 	running        bool
+	stopped        bool // Prevents double-stop race conditions
 	exitErr        error
 }
 
@@ -357,13 +358,40 @@ func (p *Process) sendInput(msg InputMessage) error {
 	return nil
 }
 
-func (p *Process) Stop() {
-	p.mu.Lock()
+// doStopLocked performs the actual stop cleanup. Must be called with p.mu held.
+func (p *Process) doStopLocked() {
 	if p.stdin != nil {
 		p.stdin.Close()
+		p.stdin = nil
 	}
-	p.mu.Unlock()
 	p.cancel()
+}
+
+// Stop stops the process. Safe to call multiple times (idempotent).
+func (p *Process) Stop() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.stopped {
+		return // Already stopped, no-op
+	}
+	p.stopped = true
+	p.doStopLocked()
+}
+
+// TryStop attempts to stop the process and returns true if this call performed
+// the stop, false if the process was already stopped by another goroutine.
+// Use this when you need to know if you "own" the stop operation.
+func (p *Process) TryStop() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.stopped {
+		return false // Someone else stopped it
+	}
+	p.stopped = true
+	p.doStopLocked()
+	return true
 }
 
 func (p *Process) Output() <-chan string {
@@ -378,6 +406,13 @@ func (p *Process) IsRunning() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.running
+}
+
+// IsStopped returns true if the process has been stopped.
+func (p *Process) IsStopped() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.stopped
 }
 
 func (p *Process) ExitError() error {

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -189,6 +190,83 @@ func TestProcess_Stop(t *testing.T) {
 
 	// Stop should not panic even when not running
 	p.Stop()
+}
+
+func TestProcess_Stop_Idempotent(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+
+	// Multiple Stop calls should not panic
+	p.Stop()
+	p.Stop()
+	p.Stop()
+
+	assert.True(t, p.IsStopped())
+}
+
+func TestProcess_TryStop(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+
+	// First TryStop should succeed
+	result1 := p.TryStop()
+	assert.True(t, result1)
+	assert.True(t, p.IsStopped())
+
+	// Second TryStop should return false
+	result2 := p.TryStop()
+	assert.False(t, result2)
+}
+
+func TestProcess_IsStopped(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+
+	assert.False(t, p.IsStopped())
+
+	p.Stop()
+
+	assert.True(t, p.IsStopped())
+}
+
+func TestProcess_ConcurrentStop(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+
+	// Concurrent Stop calls should not panic or cause race conditions
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.Stop()
+		}()
+	}
+	wg.Wait()
+
+	assert.True(t, p.IsStopped())
+}
+
+func TestProcess_ConcurrentTryStop(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+
+	// Only one TryStop should succeed
+	var wg sync.WaitGroup
+	successCount := 0
+	var mu sync.Mutex
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if p.TryStop() {
+				mu.Lock()
+				successCount++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Exactly one goroutine should have succeeded
+	assert.Equal(t, 1, successCount)
+	assert.True(t, p.IsStopped())
 }
 
 func TestInputMessage_Marshal(t *testing.T) {


### PR DESCRIPTION
Fixes concurrent stop attempts that could cause multiple status updates or panic from double-close on stdin.

**Changes:**
- Add `stopped` flag to prevent double-stop race conditions
- Implement TryStop() to atomically claim stop ownership
- Extract common cleanup into doStopLocked() helper
- Add IsStopped() check in message send/rewind/plan methods
- Add comprehensive concurrent stop tests with 100 goroutines

**Testing:** All tests pass with `-race` flag enabled.