### PR TITLE
fix: add readline cleanup on error exit in agent runner

### DIFF
--- a/agent-runner/dist/index.js
+++ b/agent-runner/dist/index.js
@@ -445,6 +445,7 @@ async function main() {
         emit({ type: "complete", sessionId: currentSessionId });
     }
     catch (err) {
+        closeReadline();
         emit({ type: "error", message: `${err}` });
         process.exit(1);
     }

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -551,6 +551,7 @@ async function main(): Promise<void> {
     flushBlockBuffer();
     emit({ type: "complete", sessionId: currentSessionId });
   } catch (err) {
+    closeReadline();
     emit({ type: "error", message: `${err}` });
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
Add readline cleanup on error exit in the agent runner to fix Issue #83.

When an error occurs during query execution, the readline interface is now properly closed before process.exit() to prevent resource leaks and terminal state issues.

## Changes
- Added `closeReadline()` call in main() catch block before process.exit()
- Aligns with cleanup patterns already in place for SIGTERM, SIGINT, and unhandled errors

## Testing
- Build passes without errors
- Code follows existing cleanup patterns in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)