### PR TITLE
fix: improve JSON parse error diagnostics in agent runner

### DIFF
--- a/agent-runner/dist/index.js
+++ b/agent-runner/dist/index.js
@@ -160,7 +160,13 @@ async function* createMessageStream() {
                 }
             }
             catch (err) {
-                emit({ type: "error", message: `Failed to parse input: ${err}` });
+                const errorMessage = err instanceof Error ? err.message : String(err);
+                emit({
+                    type: "json_parse_error",
+                    message: `Failed to parse input: ${errorMessage}`,
+                    rawInput: line.length > 1000 ? line.slice(0, 1000) + "...[truncated]" : line,
+                    errorDetails: errorMessage,
+                });
             }
         }
     }

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -224,7 +224,13 @@ async function* createMessageStream(): AsyncGenerator<SDKUserMessage> {
           } as SDKUserMessage;
         }
       } catch (err) {
-        emit({ type: "error", message: `Failed to parse input: ${err}` });
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        emit({
+          type: "json_parse_error",
+          message: `Failed to parse input: ${errorMessage}`,
+          rawInput: line.length > 1000 ? line.slice(0, 1000) + "...[truncated]" : line,
+          errorDetails: errorMessage,
+        });
       }
     }
   } finally {

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -102,6 +102,10 @@ type AgentEvent struct {
 
 	// Stderr data
 	Data string `json:"data,omitempty"`
+
+	// JSON parse error fields
+	RawInput     string `json:"rawInput,omitempty"`
+	ErrorDetails string `json:"errorDetails,omitempty"`
 }
 
 // McpServerStatus represents MCP server connection status
@@ -194,6 +198,7 @@ const (
 	EventTypeThinkingStart     = "thinking_start"
 	EventTypeCheckpointCreated = "checkpoint_created"
 	EventTypeFilesRewound      = "files_rewound"
+	EventTypeJsonParseError    = "json_parse_error"
 )
 
 // TodoItem represents a single todo item from the agent's TodoWrite tool

--- a/backend/agent/parser_test.go
+++ b/backend/agent/parser_test.go
@@ -188,6 +188,16 @@ func TestParseAgentLine_ValidJSON(t *testing.T) {
 				assert.Equal(t, []string{"err1", "err2"}, event.Errors)
 			},
 		},
+		{
+			name:         "json_parse_error",
+			input:        `{"type":"json_parse_error","message":"Failed to parse input: Unexpected token","rawInput":"{invalid json}","errorDetails":"Unexpected token"}`,
+			expectedType: EventTypeJsonParseError,
+			checkFields: func(t *testing.T, event *AgentEvent) {
+				assert.Equal(t, "Failed to parse input: Unexpected token", event.Message)
+				assert.Equal(t, "{invalid json}", event.RawInput)
+				assert.Equal(t, "Unexpected token", event.ErrorDetails)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -299,6 +309,7 @@ func TestAgentEvent_IsTerminalEvent(t *testing.T) {
 		{EventTypeInit, false},
 		{EventTypeNameSuggestion, false},
 		{EventTypeTodoUpdate, false},
+		{EventTypeJsonParseError, false}, // json_parse_error is NOT terminal - agent continues
 		{"text", false},
 		{"stderr", false},
 	}


### PR DESCRIPTION
Improves error handling when the agent receives malformed JSON input by providing more detailed diagnostics for debugging.

Changes:
- Replace generic 'error' event type with specific 'json_parse_error'
- Add rawInput field (truncated at 1000 chars) to capture problematic input
- Add errorDetails field with structured error information
- Properly extract error messages from Error objects vs other thrown values
- Mark json_parse_error as non-terminal so agent continues processing

Fixes Issue #85