### PR TITLE
fix: improve signal handler cleanup robustness

### DIFF
--- a/agent-runner/dist/index.js
+++ b/agent-runner/dist/index.js
@@ -78,6 +78,11 @@ let rl = null;
 let queryRef = null;
 // Track current session ID
 let currentSessionId = undefined;
+// Module-level references for cleanup
+let abortControllerRef = null;
+// Shutdown state
+let isShuttingDown = false;
+let cleanupCalled = false;
 // Close readline interface if it exists
 function closeReadline() {
     if (rl) {
@@ -378,6 +383,7 @@ const hooks = {
 // ============================================================================
 async function main() {
     const abortController = new AbortController();
+    abortControllerRef = abortController;
     emit({
         type: "ready",
         conversationId,
@@ -729,19 +735,48 @@ function handleMessage(message) {
         }
     }
 }
+// Async cleanup function for graceful shutdown
+async function cleanup(reason) {
+    // Idempotency guard - prevent duplicate cleanup
+    if (cleanupCalled)
+        return;
+    cleanupCalled = true;
+    // 1. Signal abort to cancel pending operations
+    if (abortControllerRef) {
+        abortControllerRef.abort();
+    }
+    // 2. Interrupt the query if active
+    if (queryRef) {
+        try {
+            await queryRef.interrupt();
+        }
+        catch {
+            // Ignore errors during shutdown
+        }
+    }
+    // 3. Close readline
+    closeReadline();
+    // 4. Emit shutdown event
+    emit({ type: "shutdown", reason });
+}
 // Handle graceful shutdown
 process.on("SIGTERM", () => {
-    closeReadline();
-    emit({ type: "shutdown", reason: "SIGTERM" });
-    process.exit(0);
+    if (isShuttingDown)
+        return;
+    isShuttingDown = true;
+    cleanup("SIGTERM").finally(() => process.exit(0));
 });
 process.on("SIGINT", () => {
-    closeReadline();
-    emit({ type: "shutdown", reason: "SIGINT" });
-    process.exit(0);
+    if (isShuttingDown)
+        return;
+    isShuttingDown = true;
+    cleanup("SIGINT").finally(() => process.exit(0));
 });
-main().catch((err) => {
-    closeReadline();
+main().catch(async (err) => {
+    if (isShuttingDown)
+        return;
+    isShuttingDown = true;
+    await cleanup("error");
     emit({ type: "error", message: `Unhandled error: ${err}` });
     process.exit(1);
 });

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -132,6 +132,13 @@ let queryRef: Query | null = null;
 // Track current session ID
 let currentSessionId: string | undefined = undefined;
 
+// Module-level references for cleanup
+let abortControllerRef: AbortController | null = null;
+
+// Shutdown state
+let isShuttingDown = false;
+let cleanupCalled = false;
+
 // Close readline interface if it exists
 function closeReadline(): void {
   if (rl) {
@@ -477,6 +484,7 @@ const hooks = {
 
 async function main(): Promise<void> {
   const abortController = new AbortController();
+  abortControllerRef = abortController;
 
   emit({
     type: "ready",
@@ -846,21 +854,50 @@ function handleMessage(message: SDKMessage): void {
   }
 }
 
+// Async cleanup function for graceful shutdown
+async function cleanup(reason: string): Promise<void> {
+  // Idempotency guard - prevent duplicate cleanup
+  if (cleanupCalled) return;
+  cleanupCalled = true;
+
+  // 1. Signal abort to cancel pending operations
+  if (abortControllerRef) {
+    abortControllerRef.abort();
+  }
+
+  // 2. Interrupt the query if active
+  if (queryRef) {
+    try {
+      await queryRef.interrupt();
+    } catch {
+      // Ignore errors during shutdown
+    }
+  }
+
+  // 3. Close readline
+  closeReadline();
+
+  // 4. Emit shutdown event
+  emit({ type: "shutdown", reason });
+}
+
 // Handle graceful shutdown
 process.on("SIGTERM", () => {
-  closeReadline();
-  emit({ type: "shutdown", reason: "SIGTERM" });
-  process.exit(0);
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  cleanup("SIGTERM").finally(() => process.exit(0));
 });
 
 process.on("SIGINT", () => {
-  closeReadline();
-  emit({ type: "shutdown", reason: "SIGINT" });
-  process.exit(0);
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  cleanup("SIGINT").finally(() => process.exit(0));
 });
 
-main().catch((err) => {
-  closeReadline();
+main().catch(async (err) => {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  await cleanup("error");
   emit({ type: "error", message: `Unhandled error: ${err}` });
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
Fixes a race condition in the agent-runner signal handlers where cleanup() could be called twice concurrently from different handlers (SIGTERM, SIGINT, or main error). Added an isShuttingDown flag checked by all callers and an idempotency guard inside cleanup() itself.

## Changes
- Prevents duplicate shutdown events and resource cleanup
- Centralizes cleanup logic for AbortController, query interruption, readline closure, and shutdown emission
- Uses async cleanup with proper error handling during shutdown

## Test Plan
- Manually test graceful shutdown with SIGTERM/SIGINT
- Verify no duplicate shutdown events are emitted
- Confirm all cleanup operations complete before process exit