### PR TITLE
feat: implement file size limits for SaveFile endpoint

### DIFF
--- a/backend/server/config.go
+++ b/backend/server/config.go
@@ -1,6 +1,10 @@
 package server
 
-import "os"
+import (
+	"log"
+	"os"
+	"strconv"
+)
 
 // AllowedOrigins defines the allowed origins for CORS and WebSocket connections.
 // These must be kept in sync to prevent security misconfigurations.
@@ -38,4 +42,26 @@ func LoadGitHubConfig() GitHubConfig {
 		ClientID:     os.Getenv("GITHUB_CLIENT_ID"),
 		ClientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
 	}
+}
+
+// FileSizeConfig holds file size limit configuration
+type FileSizeConfig struct {
+	MaxFileSizeBytes int64
+}
+
+// LoadFileSizeConfig loads file size config from environment variables.
+// Default: 50MB if CHATML_MAX_FILE_SIZE_MB is not set.
+func LoadFileSizeConfig() FileSizeConfig {
+	maxSize := int64(50 * 1024 * 1024) // 50MB default
+	if envSize := os.Getenv("CHATML_MAX_FILE_SIZE_MB"); envSize != "" {
+		mb, err := strconv.ParseInt(envSize, 10, 64)
+		if err != nil {
+			log.Printf("[config] Warning: invalid CHATML_MAX_FILE_SIZE_MB value %q (not a number), using default 50MB", envSize)
+		} else if mb <= 0 {
+			log.Printf("[config] Warning: invalid CHATML_MAX_FILE_SIZE_MB value %d (must be positive), using default 50MB", mb)
+		} else {
+			maxSize = mb * 1024 * 1024
+		}
+	}
+	return FileSizeConfig{MaxFileSizeBytes: maxSize}
 }

--- a/backend/server/errors.go
+++ b/backend/server/errors.go
@@ -14,12 +14,13 @@ type APIError struct {
 
 // Error codes for categorization
 const (
-	ErrCodeValidation   = "VALIDATION_ERROR"
-	ErrCodeNotFound     = "NOT_FOUND"
-	ErrCodeConflict     = "CONFLICT"
-	ErrCodeInternal     = "INTERNAL_ERROR"
-	ErrCodeUnauthorized = "UNAUTHORIZED"
-	ErrCodeBadGateway   = "BAD_GATEWAY"
+	ErrCodeValidation      = "VALIDATION_ERROR"
+	ErrCodeNotFound        = "NOT_FOUND"
+	ErrCodeConflict        = "CONFLICT"
+	ErrCodeInternal        = "INTERNAL_ERROR"
+	ErrCodeUnauthorized    = "UNAUTHORIZED"
+	ErrCodeBadGateway      = "BAD_GATEWAY"
+	ErrCodePayloadTooLarge = "PAYLOAD_TOO_LARGE"
 )
 
 // writeError writes a JSON error response and logs the internal error server-side
@@ -71,4 +72,9 @@ func writeUnauthorized(w http.ResponseWriter, msg string) {
 // writeBadGateway writes a 502 bad gateway error response for external service failures
 func writeBadGateway(w http.ResponseWriter, msg string, err error) {
 	writeError(w, http.StatusBadGateway, ErrCodeBadGateway, msg, err)
+}
+
+// writePayloadTooLarge writes a 413 payload too large error response
+func writePayloadTooLarge(w http.ResponseWriter, msg string) {
+	writeError(w, http.StatusRequestEntityTooLarge, ErrCodePayloadTooLarge, msg, nil)
 }

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -81,6 +81,7 @@ type Handlers struct {
 	worktreeManager *git.WorktreeManager
 	agentManager    *agent.Manager
 	sessionLocks    *SessionLockManager
+	fileSizeConfig  FileSizeConfig
 }
 
 // writeJSON writes data as JSON response, logging any encoding errors
@@ -99,6 +100,7 @@ func NewHandlers(s *store.SQLiteStore, am *agent.Manager) *Handlers {
 		worktreeManager: git.NewWorktreeManager(),
 		agentManager:    am,
 		sessionLocks:    NewSessionLockManager(),
+		fileSizeConfig:  LoadFileSizeConfig(),
 	}
 }
 
@@ -1369,6 +1371,13 @@ func (h *Handlers) SaveFile(w http.ResponseWriter, r *http.Request) {
 	var req SaveFileRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	// Check file size limit
+	maxSize := h.fileSizeConfig.MaxFileSizeBytes
+	if int64(len(req.Content)) > maxSize {
+		writePayloadTooLarge(w, fmt.Sprintf("file content exceeds maximum size of %d MB", maxSize/(1024*1024)))
 		return
 	}
 

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -830,3 +830,165 @@ func TestCreateSession_DuplicateUserProvidedName(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, w.Code)
 	assert.Contains(t, w.Body.String(), "already exists")
 }
+
+// ============================================================================
+// SaveFile Handler Tests (Issue #77 - File Size Limits)
+// ============================================================================
+
+func TestSaveFile_Success(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	repoPath := createTestGitRepo(t)
+	repo := createTestRepo(t, s, "ws-1", repoPath)
+
+	// Create a test file to save to (SaveFile only allows saving existing files)
+	writeFile(t, repoPath, "test.txt", "original content")
+
+	body, _ := json.Marshal(SaveFileRequest{
+		Path:    "test.txt",
+		Content: "updated content",
+	})
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/file/save", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": repo.ID})
+	w := httptest.NewRecorder()
+
+	h.SaveFile(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify file was updated
+	content, err := os.ReadFile(filepath.Join(repoPath, "test.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "updated content", string(content))
+}
+
+func TestSaveFile_ExceedsMaxSize(t *testing.T) {
+	// Set a small max file size for testing via env var BEFORE creating handlers
+	t.Setenv("CHATML_MAX_FILE_SIZE_MB", "1") // 1MB limit
+
+	h, s := setupTestHandlers(t)
+
+	repoPath := createTestGitRepo(t)
+	repo := createTestRepo(t, s, "ws-1", repoPath)
+
+	// Create a test file to save to
+	writeFile(t, repoPath, "test.txt", "original content")
+
+	// Create content larger than 1MB
+	largeContent := strings.Repeat("x", 2*1024*1024) // 2MB
+
+	body, _ := json.Marshal(SaveFileRequest{
+		Path:    "test.txt",
+		Content: largeContent,
+	})
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/file/save", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": repo.ID})
+	w := httptest.NewRecorder()
+
+	h.SaveFile(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+
+	var apiErr APIError
+	err := json.Unmarshal(w.Body.Bytes(), &apiErr)
+	require.NoError(t, err)
+	assert.Equal(t, ErrCodePayloadTooLarge, apiErr.Code)
+	assert.Contains(t, apiErr.Error, "exceeds maximum size")
+}
+
+func TestSaveFile_AtExactLimit(t *testing.T) {
+	// Set a small max file size for testing BEFORE creating handlers
+	t.Setenv("CHATML_MAX_FILE_SIZE_MB", "1") // 1MB limit
+
+	h, s := setupTestHandlers(t)
+
+	repoPath := createTestGitRepo(t)
+	repo := createTestRepo(t, s, "ws-1", repoPath)
+
+	// Create a test file to save to
+	writeFile(t, repoPath, "test.txt", "original content")
+
+	// Create content exactly at 1MB (should succeed)
+	exactContent := strings.Repeat("x", 1*1024*1024) // exactly 1MB
+
+	body, _ := json.Marshal(SaveFileRequest{
+		Path:    "test.txt",
+		Content: exactContent,
+	})
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/file/save", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": repo.ID})
+	w := httptest.NewRecorder()
+
+	h.SaveFile(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSaveFile_JustOverLimit(t *testing.T) {
+	// Set a small max file size for testing BEFORE creating handlers
+	t.Setenv("CHATML_MAX_FILE_SIZE_MB", "1") // 1MB limit
+
+	h, s := setupTestHandlers(t)
+
+	repoPath := createTestGitRepo(t)
+	repo := createTestRepo(t, s, "ws-1", repoPath)
+
+	// Create a test file to save to
+	writeFile(t, repoPath, "test.txt", "original content")
+
+	// Create content just over 1MB (should fail)
+	overContent := strings.Repeat("x", 1*1024*1024+1) // 1MB + 1 byte
+
+	body, _ := json.Marshal(SaveFileRequest{
+		Path:    "test.txt",
+		Content: overContent,
+	})
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/file/save", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": repo.ID})
+	w := httptest.NewRecorder()
+
+	h.SaveFile(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}
+
+func TestLoadFileSizeConfig_Default(t *testing.T) {
+	// Clear environment variable - t.Setenv with empty string then unset
+	t.Setenv("CHATML_MAX_FILE_SIZE_MB", "")
+
+	config := LoadFileSizeConfig()
+
+	// Default is 50MB
+	assert.Equal(t, int64(50*1024*1024), config.MaxFileSizeBytes)
+}
+
+func TestLoadFileSizeConfig_FromEnv(t *testing.T) {
+	t.Setenv("CHATML_MAX_FILE_SIZE_MB", "100")
+
+	config := LoadFileSizeConfig()
+
+	// Should be 100MB
+	assert.Equal(t, int64(100*1024*1024), config.MaxFileSizeBytes)
+}
+
+func TestLoadFileSizeConfig_InvalidEnv(t *testing.T) {
+	t.Setenv("CHATML_MAX_FILE_SIZE_MB", "invalid")
+
+	config := LoadFileSizeConfig()
+
+	// Should fall back to default (50MB)
+	assert.Equal(t, int64(50*1024*1024), config.MaxFileSizeBytes)
+}
+
+func TestLoadFileSizeConfig_ZeroValue(t *testing.T) {
+	t.Setenv("CHATML_MAX_FILE_SIZE_MB", "0")
+
+	config := LoadFileSizeConfig()
+
+	// Zero is invalid, should fall back to default (50MB)
+	assert.Equal(t, int64(50*1024*1024), config.MaxFileSizeBytes)
+}


### PR DESCRIPTION
## Summary

Implement configurable file size limits for the SaveFile endpoint to prevent excessively large file uploads. The feature includes a 50MB default limit that can be customized via the `CHATML_MAX_FILE_SIZE_MB` environment variable. Invalid or missing configuration values gracefully fall back to defaults with warning logs for debugging.

## Changes

- Add FileSizeConfig type to load and validate file size limits from environment
- Add 413 Payload Too Large error response handler
- Validate file content size in SaveFile handler before writing to disk
- Add comprehensive test coverage including boundary conditions
- Config is loaded once at server startup for optimal performance

## Test plan

- All new SaveFile tests pass (success, exceeds limit, exact limit, just over limit)
- Config loading tests verify default, valid env, invalid env, and zero value scenarios
- Full backend test suite passes without regression