### PR TITLE
fix: add timeout-based backpressure handling

### DIFF
--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -12,6 +12,13 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"time"
+)
+
+const (
+	// processOutputTimeout is how long to wait for buffer space before dropping
+	// a message from stdout/stderr. This gives slow consumers time to catch up.
+	processOutputTimeout = 5 * time.Second
 )
 
 // AgentRunnerPath can be set to override the default agent-runner location
@@ -226,8 +233,10 @@ func (p *Process) Start() error {
 		for scanner.Scan() {
 			select {
 			case p.output <- scanner.Text():
-			default:
-				log.Printf("[process:%s] Output buffer full, dropping stdout message", p.ID)
+				// Successfully queued
+			case <-time.After(processOutputTimeout):
+				// Buffer full after timeout - downstream reader is persistently slow
+				log.Printf("[process:%s] Output buffer full after %v timeout, dropping stdout message (slow reader)", p.ID, processOutputTimeout)
 			}
 		}
 	}()
@@ -239,8 +248,10 @@ func (p *Process) Start() error {
 		for scanner.Scan() {
 			select {
 			case p.output <- "[stderr] " + scanner.Text():
-			default:
-				log.Printf("[process:%s] Output buffer full, dropping stderr message", p.ID)
+				// Successfully queued
+			case <-time.After(processOutputTimeout):
+				// Buffer full after timeout - downstream reader is persistently slow
+				log.Printf("[process:%s] Output buffer full after %v timeout, dropping stderr message (slow reader)", p.ID, processOutputTimeout)
 			}
 		}
 	}()

--- a/backend/server/websocket.go
+++ b/backend/server/websocket.go
@@ -23,6 +23,10 @@ const (
 
 	// Send pings to client with this period (must be less than pongWait)
 	pingPeriod = (pongWait * 9) / 10
+
+	// broadcastTimeout is how long to wait for buffer space before dropping
+	// a broadcast message. This gives Hub.Run() time to catch up.
+	broadcastTimeout = 2 * time.Second
 )
 
 var upgrader = websocket.Upgrader{
@@ -53,6 +57,7 @@ type Client struct {
 type HubMetrics struct {
 	messagesDelivered     atomic.Uint64
 	messagesDropped       atomic.Uint64
+	messagesTimedOut      atomic.Uint64 // Messages dropped after timeout waiting for buffer space
 	clientsDropped        atomic.Uint64 // Clients disconnected due to slow consumption
 	broadcastBackpressure atomic.Uint64 // Times broadcast channel was near full
 	peakClients           atomic.Int64
@@ -65,6 +70,10 @@ func (m *HubMetrics) recordDelivered() {
 
 func (m *HubMetrics) recordDropped() {
 	m.messagesDropped.Add(1)
+}
+
+func (m *HubMetrics) recordTimedOut() {
+	m.messagesTimedOut.Add(1)
 }
 
 func (m *HubMetrics) recordClientDropped() {
@@ -104,7 +113,7 @@ type Hub struct {
 func NewHub() *Hub {
 	return &Hub{
 		clients:   make(map[*Client]bool),
-		broadcast: make(chan []byte, 256),
+		broadcast: make(chan []byte, 1024),
 		register:  make(chan *Client),
 		// Buffered to prevent eviction goroutines from blocking during
 		// high-churn scenarios or if the Hub is slow to process unregisters
@@ -187,14 +196,16 @@ func (h *Hub) Broadcast(event Event) BroadcastResult {
 		log.Printf("Broadcast channel high utilization: %d/%d", bufferUsage, bufferCapacity)
 	}
 
+	// Try to send with timeout to allow Hub.Run() to catch up
+	// This handles transient slowdowns gracefully instead of dropping immediately
 	select {
 	case h.broadcast <- data:
 		// Successfully queued
-	default:
-		// Channel full - this should now be rare with per-client buffers
+	case <-time.After(broadcastTimeout):
+		// Channel still full after timeout - reader is persistently slow
 		result.Delivered = false
-		h.metrics.recordDropped()
-		log.Printf("WARN: Broadcast channel full, event dropped: type=%s", event.Type)
+		h.metrics.recordTimedOut()
+		log.Printf("WARN: Broadcast channel full after %v timeout, event dropped: type=%s", broadcastTimeout, event.Type)
 	}
 
 	return result
@@ -304,6 +315,7 @@ func (h *Hub) GetStats() map[string]interface{} {
 	return map[string]interface{}{
 		"messagesDelivered":       h.metrics.messagesDelivered.Load(),
 		"messagesDropped":         h.metrics.messagesDropped.Load(),
+		"messagesTimedOut":        h.metrics.messagesTimedOut.Load(),
 		"clientsDropped":          h.metrics.clientsDropped.Load(),
 		"backpressureEvents":      h.metrics.broadcastBackpressure.Load(),
 		"currentClients":          h.metrics.currentClients.Load(),

--- a/backend/server/websocket_test.go
+++ b/backend/server/websocket_test.go
@@ -28,15 +28,15 @@ func TestNewHub(t *testing.T) {
 func TestNewHub_ChannelsInitialized(t *testing.T) {
 	hub := NewHub()
 
-	// Verify broadcast channel has buffer of 256
-	// We can verify this by sending 256 pre-serialized messages without blocking
+	// Verify broadcast channel has buffer of 1024
+	// We can verify this by sending 1024 pre-serialized messages without blocking
 	testData, _ := json.Marshal(Event{Type: "test"})
-	for i := 0; i < 256; i++ {
+	for i := 0; i < 1024; i++ {
 		select {
 		case hub.broadcast <- testData:
 			// OK - channel accepted the message
 		default:
-			t.Fatalf("Channel blocked after %d messages, expected buffer of 256", i)
+			t.Fatalf("Channel blocked after %d messages, expected buffer of 1024", i)
 		}
 	}
 }
@@ -74,13 +74,13 @@ func TestHub_Broadcast_Success(t *testing.T) {
 func TestHub_Broadcast_ChannelFull(t *testing.T) {
 	hub := NewHub()
 
-	// Fill the channel to capacity (256)
+	// Fill the channel to capacity (1024)
 	fillerData, _ := json.Marshal(Event{Type: "filler"})
-	for i := 0; i < 256; i++ {
+	for i := 0; i < 1024; i++ {
 		hub.broadcast <- fillerData
 	}
 
-	// Now broadcast should drop the event (non-blocking)
+	// Now broadcast should timeout and drop the event after 2 seconds
 	done := make(chan bool)
 	go func() {
 		result := hub.Broadcast(Event{Type: "dropped"})
@@ -90,13 +90,13 @@ func TestHub_Broadcast_ChannelFull(t *testing.T) {
 
 	select {
 	case <-done:
-		// Success - broadcast didn't block even with full channel
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Broadcast blocked when channel was full")
+		// Success - broadcast returned (after timeout)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Broadcast did not timeout after 2 seconds")
 	}
 
-	// Verify dropped message was recorded in metrics
-	assert.Equal(t, uint64(1), hub.metrics.messagesDropped.Load())
+	// Verify timed out message was recorded in metrics
+	assert.Equal(t, uint64(1), hub.metrics.messagesTimedOut.Load())
 }
 
 func TestHub_Broadcast_MultipleEvents(t *testing.T) {
@@ -129,9 +129,9 @@ func TestHub_Broadcast_MultipleEvents(t *testing.T) {
 func TestHub_Broadcast_Backpressure(t *testing.T) {
 	hub := NewHub()
 
-	// Fill channel to >75% capacity (193 messages, which is > 192 = 256*3/4) to trigger backpressure
+	// Fill channel to >75% capacity (769 messages, which is > 768 = 1024*3/4) to trigger backpressure
 	fillerData, _ := json.Marshal(Event{Type: "filler"})
-	for i := 0; i < 193; i++ {
+	for i := 0; i < 769; i++ {
 		hub.broadcast <- fillerData
 	}
 
@@ -317,7 +317,7 @@ func TestHub_GetStats(t *testing.T) {
 	assert.Equal(t, uint64(1), stats["messagesDropped"])
 	assert.Equal(t, int64(3), stats["currentClients"])
 	assert.Equal(t, int64(3), stats["peakClients"])
-	assert.Equal(t, 256, stats["broadcastBufferCapacity"])
+	assert.Equal(t, 1024, stats["broadcastBufferCapacity"])
 }
 
 // ============================================================================
@@ -460,4 +460,60 @@ func TestBroadcastResult_SuccessfulDelivery(t *testing.T) {
 
 	assert.True(t, result.Delivered)
 	assert.False(t, result.Backpressure)
+}
+
+// ============================================================================
+// Timeout Behavior Tests
+// ============================================================================
+
+func TestHub_Broadcast_TimeoutBehavior(t *testing.T) {
+	hub := NewHub()
+
+	// Fill the channel to capacity (1024)
+	fillerData, _ := json.Marshal(Event{Type: "filler"})
+	for i := 0; i < 1024; i++ {
+		hub.broadcast <- fillerData
+	}
+
+	// Measure how long broadcast takes when channel is full
+	start := time.Now()
+	result := hub.Broadcast(Event{Type: "timed_out"})
+	elapsed := time.Since(start)
+
+	// Should take approximately 2 seconds (the timeout duration)
+	assert.False(t, result.Delivered, "Event should not be delivered when channel full")
+	assert.GreaterOrEqual(t, elapsed, 2*time.Second, "Should wait at least 2 seconds before timing out")
+	assert.Less(t, elapsed, 3*time.Second, "Should not wait much longer than 2 seconds")
+
+	// Verify timeout metric was recorded
+	assert.Equal(t, uint64(1), hub.metrics.messagesTimedOut.Load())
+}
+
+func TestHub_Metrics_TimedOut(t *testing.T) {
+	hub := NewHub()
+
+	// Initial state should be zero
+	assert.Equal(t, uint64(0), hub.metrics.messagesTimedOut.Load())
+
+	// Record a timeout
+	hub.metrics.recordTimedOut()
+	assert.Equal(t, uint64(1), hub.metrics.messagesTimedOut.Load())
+
+	// Record another
+	hub.metrics.recordTimedOut()
+	assert.Equal(t, uint64(2), hub.metrics.messagesTimedOut.Load())
+}
+
+func TestHub_GetStats_IncludesTimedOut(t *testing.T) {
+	hub := NewHub()
+
+	// Record a timeout
+	hub.metrics.recordTimedOut()
+
+	stats := hub.GetStats()
+
+	// Verify messagesTimedOut is included in stats
+	timedOut, exists := stats["messagesTimedOut"]
+	assert.True(t, exists, "messagesTimedOut should be in stats")
+	assert.Equal(t, uint64(1), timedOut)
 }


### PR DESCRIPTION
## Summary
Replace immediate message dropping with graceful timeout-based degradation when WebSocket and process output buffers are full. This gives slow consumers time to catch up before messages are dropped.

## Changes
- Process output: 5-second timeout before dropping stdout/stderr messages
- WebSocket broadcast: 2-second timeout before dropping events
- Broadcast buffer: increased from 256 to 1024 to handle bursty workloads
- New metric: `messagesTimedOut` to track timeout-based drops separately

## Testing
All tests pass including race condition detection. New tests verify timeout behavior and timing accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)