### PR TITLE
fix: remove hover scale and lift animations

### DIFF
--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -110,8 +110,7 @@ function FileTreeNode({ node, depth, onFileSelect }: FileTreeNodeProps) {
     <div>
       <div
         className={cn(
-          'flex items-center gap-1.5 py-0.5 px-1 hover:bg-accent/50 cursor-pointer text-xs rounded-sm',
-          'hover-scale',
+          'flex items-center gap-1.5 py-0.5 px-1 hover:bg-accent/50 cursor-pointer text-xs rounded-sm transition-colors',
           isHidden && 'text-muted-foreground/75'
         )}
         style={{ paddingLeft: `${depth * 12 + 4}px` }}

--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -605,7 +605,7 @@ function SortableWorkspaceItem({
                     <ContextMenuTrigger asChild>
                       <div
                         className={cn(
-                          'group flex items-start gap-2 px-2 py-2 rounded-md cursor-pointer my-0.5 hover-lift',
+                          'group flex items-start gap-2 px-2 py-2 rounded-md cursor-pointer my-0.5 transition-colors',
                           isSessionSelected
                             ? 'bg-sidebar-accent shadow-sm'
                             : 'hover:bg-sidebar-accent/50'


### PR DESCRIPTION
## Summary
Remove the hover-scale and hover-lift animations from FileTree and WorkspaceSidebar components that were causing a jiggle effect on hover.

## Changes
- Removed `hover-scale` class from file/folder items in All Files panel
- Removed `hover-lift` class from workspace session items in sidebar
- Replaced with `transition-colors` for smooth background transitions on hover

## Testing
Hover over items in All Files panel and workspaces list to verify smooth color transitions without scale/lift effects.