### PR TITLE
Implement session name cache to optimize session creation

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -76,12 +76,13 @@ func (m *SessionLockManager) Unlock(path string) {
 }
 
 type Handlers struct {
-	store           *store.SQLiteStore
-	repoManager     *git.RepoManager
-	worktreeManager *git.WorktreeManager
-	agentManager    *agent.Manager
-	sessionLocks    *SessionLockManager
-	fileSizeConfig  FileSizeConfig
+	store            *store.SQLiteStore
+	repoManager      *git.RepoManager
+	worktreeManager  *git.WorktreeManager
+	agentManager     *agent.Manager
+	sessionLocks     *SessionLockManager
+	sessionNameCache *SessionNameCache
+	fileSizeConfig   FileSizeConfig
 }
 
 // writeJSON writes data as JSON response, logging any encoding errors
@@ -94,13 +95,20 @@ func writeJSON(w http.ResponseWriter, data interface{}) {
 }
 
 func NewHandlers(s *store.SQLiteStore, am *agent.Manager) *Handlers {
+	// Initialize session name cache with workspaces directory
+	// Cache initializes lazily on first use
+	workspacesDir, err := git.WorkspacesBaseDir()
+	if err != nil {
+		log.Printf("[handlers] Warning: failed to get workspaces base directory: %v (session name cache will be disabled)", err)
+	}
 	return &Handlers{
-		store:           s,
-		repoManager:     git.NewRepoManager(),
-		worktreeManager: git.NewWorktreeManager(),
-		agentManager:    am,
-		sessionLocks:    NewSessionLockManager(),
-		fileSizeConfig:  LoadFileSizeConfig(),
+		store:            s,
+		repoManager:      git.NewRepoManager(),
+		worktreeManager:  git.NewWorktreeManager(),
+		agentManager:     am,
+		sessionLocks:     NewSessionLockManager(),
+		sessionNameCache: NewSessionNameCache(workspacesDir),
+		fileSizeConfig:   LoadFileSizeConfig(),
 	}
 }
 
@@ -282,15 +290,11 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 		// Atomic session name generation with retry loop
 		const maxRetries = 5
 		for attempt := 0; attempt < maxRetries; attempt++ {
-			// Scan filesystem for existing session directories
-			existingNames := []string{}
-			entries, err := os.ReadDir(workspacesDir)
-			if err == nil {
-				for _, entry := range entries {
-					if entry.IsDir() {
-						existingNames = append(existingNames, entry.Name())
-					}
-				}
+			// Get existing names from cache (initializes on first call)
+			existingNames, err := h.sessionNameCache.GetAll()
+			if err != nil {
+				writeInternalError(w, "failed to get existing session names", err)
+				return
 			}
 
 			// Generate candidate name
@@ -301,11 +305,14 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 			if err == nil {
 				sessionName = candidateName
 				sessionPath = path
+				// Add to cache after successful creation
+				h.sessionNameCache.Add(sessionName)
 				break
 			}
 
 			if errors.Is(err, git.ErrDirectoryExists) {
-				// Name collision - retry with fresh name
+				// Name collision (external change or race) - add to cache and retry
+				h.sessionNameCache.Add(candidateName)
 				continue
 			}
 
@@ -330,6 +337,8 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		sessionPath = path
+		// Add to cache after successful creation
+		h.sessionNameCache.Add(sessionName)
 	}
 
 	// Generate or use provided branch name
@@ -345,7 +354,8 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	// Create git worktree in the atomically created directory
 	worktreePath, branchName, baseCommitSHA, err := h.worktreeManager.CreateInExistingDir(ctx, repo.Path, sessionPath, branchName)
 	if err != nil {
-		// Rollback: remove the atomically created directory
+		// Rollback: remove the atomically created directory and cache entry
+		h.sessionNameCache.Remove(sessionName)
 		if removeErr := os.RemoveAll(sessionPath); removeErr != nil {
 			log.Printf("[handlers] Warning: failed to rollback session directory %s: %v", sessionPath, removeErr)
 		}
@@ -358,6 +368,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if rollback {
 			fmt.Printf("[handlers] Rolling back worktree creation due to failure: %s\n", worktreePath)
+			h.sessionNameCache.Remove(sessionName)
 			session.DeleteMetadata(sessionID)
 			// Use background context for cleanup - the original request context may be cancelled
 			h.worktreeManager.RemoveAtPath(context.Background(), repo.Path, worktreePath, branchName)
@@ -576,6 +587,9 @@ func (h *Handlers) DeleteSession(w http.ResponseWriter, r *http.Request) {
 
 			// Remove the git worktree using absolute path
 			h.worktreeManager.RemoveAtPath(ctx, repo.Path, sess.WorktreePath, sess.Branch)
+
+			// Remove from session name cache
+			h.sessionNameCache.Remove(sess.Name)
 		}
 	}
 

--- a/backend/server/session_cache.go
+++ b/backend/server/session_cache.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// SessionNameCache provides an in-memory cache for existing session directory names.
+// It eliminates the need for filesystem scans on every session creation by maintaining
+// a synchronized map of lowercase session names.
+//
+// Thread-safety: All methods are safe for concurrent use.
+// Initialization: Lazy-loaded from filesystem on first GetAll() call.
+// Invalidation: Automatic via Add() and Remove() methods.
+//
+// Staleness: This cache may become stale if sessions are created or deleted externally
+// (outside this process). The session creation logic handles this gracefully via retry
+// loops that detect ErrDirectoryExists collisions and update the cache accordingly.
+// For most use cases, this eventual consistency is acceptable since the cache is primarily
+// an optimization to avoid filesystem scans, not a source of truth.
+type SessionNameCache struct {
+	mu            sync.RWMutex
+	names         map[string]bool // lowercase name -> exists
+	initialized   bool
+	workspacesDir string
+}
+
+// NewSessionNameCache creates a new cache instance for the given workspaces directory.
+// The cache is not initialized until the first call to GetAll().
+func NewSessionNameCache(workspacesDir string) *SessionNameCache {
+	return &SessionNameCache{
+		names:         make(map[string]bool),
+		workspacesDir: workspacesDir,
+	}
+}
+
+// Initialize loads existing session directory names from the filesystem.
+// This is called automatically by GetAll() if the cache is not initialized.
+// Returns any error from reading the directory.
+func (c *SessionNameCache) Initialize() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.initialized {
+		return nil
+	}
+
+	entries, err := os.ReadDir(c.workspacesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Directory doesn't exist yet - that's fine, start with empty cache
+			c.initialized = true
+			return nil
+		}
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			c.names[strings.ToLower(entry.Name())] = true
+		}
+	}
+
+	c.initialized = true
+	return nil
+}
+
+// Add registers a session name in the cache (case-insensitive).
+// Call this after successfully creating a session directory.
+func (c *SessionNameCache) Add(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.names[strings.ToLower(name)] = true
+}
+
+// Remove unregisters a session name from the cache (case-insensitive).
+// Call this after successfully deleting a session directory.
+func (c *SessionNameCache) Remove(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.names, strings.ToLower(name))
+}
+
+// Contains checks if a session name exists in the cache (case-insensitive).
+func (c *SessionNameCache) Contains(name string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.names[strings.ToLower(name)]
+}
+
+// GetAll returns all cached session names.
+// Initializes the cache from filesystem on first call.
+// Returns the list of names and any initialization error.
+func (c *SessionNameCache) GetAll() ([]string, error) {
+	c.mu.RLock()
+	initialized := c.initialized
+	c.mu.RUnlock()
+
+	if !initialized {
+		if err := c.Initialize(); err != nil {
+			return nil, err
+		}
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	result := make([]string, 0, len(c.names))
+	for name := range c.names {
+		result = append(result, name)
+	}
+	return result, nil
+}

--- a/backend/server/session_cache_test.go
+++ b/backend/server/session_cache_test.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestSessionNameCache_AddAndContains(t *testing.T) {
+	cache := NewSessionNameCache("")
+	cache.initialized = true // Skip filesystem initialization
+
+	cache.Add("Tokyo")
+	cache.Add("Osaka")
+
+	if !cache.Contains("tokyo") {
+		t.Error("Expected cache to contain 'tokyo' (case-insensitive)")
+	}
+	if !cache.Contains("TOKYO") {
+		t.Error("Expected cache to contain 'TOKYO' (case-insensitive)")
+	}
+	if !cache.Contains("osaka") {
+		t.Error("Expected cache to contain 'osaka'")
+	}
+	if cache.Contains("kyoto") {
+		t.Error("Did not expect cache to contain 'kyoto'")
+	}
+}
+
+func TestSessionNameCache_Remove(t *testing.T) {
+	cache := NewSessionNameCache("")
+	cache.initialized = true
+
+	cache.Add("Tokyo")
+	cache.Add("Osaka")
+
+	cache.Remove("TOKYO") // Case-insensitive remove
+
+	if cache.Contains("tokyo") {
+		t.Error("Did not expect cache to contain 'tokyo' after removal")
+	}
+	if !cache.Contains("osaka") {
+		t.Error("Expected cache to still contain 'osaka'")
+	}
+}
+
+func TestSessionNameCache_GetAll(t *testing.T) {
+	cache := NewSessionNameCache("")
+	cache.initialized = true
+
+	cache.Add("Tokyo")
+	cache.Add("Osaka")
+	cache.Add("Kyoto")
+
+	names, err := cache.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll returned error: %v", err)
+	}
+
+	if len(names) != 3 {
+		t.Errorf("Expected 3 names, got %d", len(names))
+	}
+
+	// Names are stored in lowercase
+	nameMap := make(map[string]bool)
+	for _, name := range names {
+		nameMap[name] = true
+	}
+
+	if !nameMap["tokyo"] {
+		t.Error("Expected 'tokyo' in GetAll result")
+	}
+	if !nameMap["osaka"] {
+		t.Error("Expected 'osaka' in GetAll result")
+	}
+	if !nameMap["kyoto"] {
+		t.Error("Expected 'kyoto' in GetAll result")
+	}
+}
+
+func TestSessionNameCache_InitializeFromFilesystem(t *testing.T) {
+	// Create temp directory with some session directories
+	tempDir := t.TempDir()
+
+	// Create some directories
+	os.Mkdir(filepath.Join(tempDir, "tokyo"), 0755)
+	os.Mkdir(filepath.Join(tempDir, "osaka"), 0755)
+	// Create a file (should be ignored)
+	os.WriteFile(filepath.Join(tempDir, "not-a-session.txt"), []byte("test"), 0644)
+
+	cache := NewSessionNameCache(tempDir)
+
+	names, err := cache.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll returned error: %v", err)
+	}
+
+	if len(names) != 2 {
+		t.Errorf("Expected 2 names (directories only), got %d", len(names))
+	}
+
+	if !cache.Contains("tokyo") {
+		t.Error("Expected cache to contain 'tokyo'")
+	}
+	if !cache.Contains("osaka") {
+		t.Error("Expected cache to contain 'osaka'")
+	}
+}
+
+func TestSessionNameCache_InitializeNonExistentDir(t *testing.T) {
+	cache := NewSessionNameCache("/nonexistent/path/to/workspaces")
+
+	names, err := cache.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll should not return error for nonexistent dir: %v", err)
+	}
+
+	if len(names) != 0 {
+		t.Errorf("Expected empty names list, got %d", len(names))
+	}
+}
+
+func TestSessionNameCache_ConcurrentAccess(t *testing.T) {
+	cache := NewSessionNameCache("")
+	cache.initialized = true
+
+	var wg sync.WaitGroup
+	numGoroutines := 100
+
+	// Concurrent adds
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			cache.Add("session-" + string(rune('a'+n%26)))
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			cache.Contains("session-" + string(rune('a'+n%26)))
+			cache.GetAll()
+		}(i)
+	}
+
+	// Concurrent removes
+	for i := 0; i < numGoroutines/2; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			cache.Remove("session-" + string(rune('a'+n%26)))
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Should not panic or deadlock
+}


### PR DESCRIPTION
Optimize session creation by eliminating redundant filesystem scans through an in-memory session name cache. The cache is lazy-initialized, thread-safe, and automatically maintained during session lifecycle operations.

Key improvements:
- Replaces repeated `os.ReadDir()` calls with cached lookups
- Proper rollback handling ensures cache consistency on failures
- Comprehensive test coverage including concurrent access patterns

Fixes #74