### PR TITLE
Add diff editor enhancements: overview ruler and auto-scroll

### DIFF
--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -230,6 +230,19 @@ export function MonacoDiffEditor({
 
   const handleMount = useCallback((editor: editor.IStandaloneDiffEditor) => {
     editorRef.current = editor;
+
+    // Scroll to the first change after the diff is computed
+    // Use a small delay to ensure diff computation is complete
+    setTimeout(() => {
+      const lineChanges = editor.getLineChanges();
+      if (lineChanges && lineChanges.length > 0) {
+        const firstChange = lineChanges[0];
+        // Use the modified line number (right side) for positioning
+        const targetLine = firstChange.modifiedStartLineNumber || firstChange.originalStartLineNumber || 1;
+        const modifiedEditor = editor.getModifiedEditor();
+        modifiedEditor.revealLineInCenter(targetLine);
+      }
+    }, 50);
   }, []);
 
   // Dispose editor on unmount to prevent memory leaks
@@ -257,7 +270,7 @@ export function MonacoDiffEditor({
     useInlineViewWhenSpaceIsLimited: false, // Prevent auto-switch to unified based on width
     enableSplitViewResizing: true,
     renderIndicators: true,
-    renderOverviewRuler: false,
+    renderOverviewRuler: true,
     diffWordWrap: (wordWrap ? 'on' : 'off') as 'on' | 'off',
     wordWrap: (wordWrap ? 'on' : 'off') as 'on' | 'off',
     scrollbar: {


### PR DESCRIPTION
## Summary
- Enable the overview ruler (scrollbar markers) showing green/red highlights for additions and deletions in the Monaco diff editor
- Auto-scroll to the first change when opening a diff file from the changes panel

## Implementation Details
- Set `renderOverviewRuler: true` in MonacoDiffEditor options to enable scrollbar markers
- Added `handleMount` callback that scrolls to the first diff change after a brief delay to ensure diff computation is complete
- Uses Monaco's `getLineChanges()` API to find the first change and `revealLineInCenter()` to scroll to it

## Test Plan
- [ ] Open a changed file from the changes panel
- [ ] Verify the diff editor scrolls to the first change automatically
- [ ] Verify green (additions) and red (deletions) markers appear in the scrollbar area

## Notes
The 50ms delay in auto-scroll ensures Monaco has finished computing the diff before we try to access line changes.