### PR TITLE
Remove glow animations from the app

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -601,14 +601,6 @@
   }
 }
 
-@keyframes glow-pulse {
-  0%, 100% {
-    box-shadow: 0 0 20px var(--primary);
-  }
-  50% {
-    box-shadow: 0 0 30px var(--primary), 0 0 60px var(--primary);
-  }
-}
 
 /* Animation Utility Classes */
 .animate-slide-up-fade {
@@ -643,23 +635,6 @@
   animation: gradient-shift 3s ease infinite;
 }
 
-.animate-glow-pulse {
-  animation: glow-pulse 2s ease-in-out infinite;
-}
-
-/* Destructive variant for glow-pulse */
-@keyframes glow-pulse-destructive {
-  0%, 100% {
-    box-shadow: 0 0 15px var(--destructive);
-  }
-  50% {
-    box-shadow: 0 0 25px var(--destructive), 0 0 40px var(--destructive);
-  }
-}
-
-.animate-glow-pulse-destructive {
-  animation: glow-pulse-destructive 1.5s ease-in-out infinite;
-}
 
 /* Stagger children animation */
 .stagger-children > * {
@@ -688,13 +663,6 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-.hover-glow {
-  transition: box-shadow 0.2s ease;
-}
-
-.hover-glow:hover {
-  box-shadow: 0 0 20px var(--primary);
-}
 
 .hover-scale {
   transition: transform 0.15s ease;
@@ -716,8 +684,6 @@
   .animate-thinking-pulse,
   .animate-shimmer,
   .animate-gradient-shift,
-  .animate-glow-pulse,
-  .animate-glow-pulse-destructive,
   .stagger-children > * {
     animation: none;
     opacity: 1;

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -569,7 +569,7 @@ export function ChatInput() {
             <Button
               size="icon"
               variant="destructive"
-              className="h-8 w-8 rounded-full animate-glow-pulse-destructive"
+              className="h-8 w-8 rounded-full"
               onClick={handleStop}
               aria-label="Stop agent"
             >

--- a/src/components/OnboardingScreen.tsx
+++ b/src/components/OnboardingScreen.tsx
@@ -74,12 +74,12 @@ export function OnboardingScreen() {
             Enterprise AI Orchestration
           </p>
 
-          {/* Sign in button with gradient and glow */}
+          {/* Sign in button with gradient */}
           <Button
             size="lg"
             onClick={handleSignIn}
             disabled={isConnecting}
-            className="h-12 px-8 text-base bg-gradient-to-r from-primary to-purple-500 hover:from-primary/90 hover:to-purple-500/90 shadow-lg shadow-primary/25 transition-all duration-200 active:scale-[0.98] hover-glow"
+            className="h-12 px-8 text-base bg-gradient-to-r from-primary to-purple-500 hover:from-primary/90 hover:to-purple-500/90 shadow-lg shadow-primary/25 transition-all duration-200 active:scale-[0.98]"
           >
             {isConnecting ? (
               <>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,8 +21,6 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
         gradient:
           "bg-gradient-to-r from-primary to-purple-500 text-primary-foreground hover:from-primary/90 hover:to-purple-500/90 shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/30",
-        glow:
-          "bg-primary text-primary-foreground hover:bg-primary/90 shadow-[0_0_15px_var(--primary)] hover:shadow-[0_0_25px_var(--primary)]",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -16,7 +16,6 @@ const cardVariants = cva(
       hover: {
         none: "",
         lift: "hover:translate-y-[-2px] hover:shadow-lg",
-        glow: "hover:border-primary/50 hover:shadow-[0_0_20px_-5px_var(--primary)]",
         scale: "hover:scale-[1.02]",
       },
     },

--- a/src/components/ui/glass-card.tsx
+++ b/src/components/ui/glass-card.tsx
@@ -10,12 +10,10 @@ const glassCardVariants = cva(
         default: "bg-card/80 border-border/50",
         elevated: "bg-card/90 border-border/60 shadow-lg",
         subtle: "bg-card/50 border-border/30",
-        glow: "bg-card/80 border-primary/30 shadow-[0_0_30px_-5px_var(--primary)]",
       },
       hover: {
         none: "",
         lift: "hover:translate-y-[-2px] hover:shadow-lg",
-        glow: "hover:border-primary/50 hover:shadow-[0_0_20px_-5px_var(--primary)]",
         scale: "hover:scale-[1.02]",
       },
       padding: {


### PR DESCRIPTION
## Summary
- Remove all glow-related animations and styles as they don't fit this type of application

## Implementation Details
- Removed `glow-pulse` and `glow-pulse-destructive` keyframes from globals.css
- Removed `.animate-glow-pulse`, `.animate-glow-pulse-destructive`, and `.hover-glow` utility classes
- Removed `animate-glow-pulse-destructive` from the stop button in ChatInput.tsx
- Removed `hover-glow` from the sign-in button in OnboardingScreen.tsx
- Removed `glow` variant from button.tsx
- Removed `glow` variant and `glow` hover option from card.tsx and glass-card.tsx
- Updated reduced motion media query to remove glow references

## Test Plan
- [ ] Verify the stop button in chat input still works and looks correct without glow
- [ ] Verify the sign-in button on onboarding screen looks correct without glow
- [ ] Verify no visual regressions in card components

## Notes
None of the removed glow variants were actively being used in the codebase.