### PR TITLE
fix: use get() in selectSession to avoid stale closure bug

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -366,13 +366,9 @@ export default function Home() {
           selectWorkspace(mappedWorkspaces[0].id);
           const firstSession = allSessions.find(s => s.workspaceId === mappedWorkspaces[0].id);
           if (firstSession) {
-            selectSession(firstSession.id);
-            // Select existing conversation or create a new one if none exists
+            // Create a placeholder conversation if none exist for this session
             const sessionConvs = allConversations.filter(c => c.sessionId === firstSession.id);
-            if (sessionConvs.length > 0) {
-              selectConversation(sessionConvs[0].id);
-            } else {
-              // Create a placeholder conversation only if none exist
+            if (sessionConvs.length === 0) {
               const convId = `conv-${firstSession.id}`;
               addConversation({
                 id: convId,
@@ -385,8 +381,9 @@ export default function Home() {
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString(),
               });
-              selectConversation(convId);
             }
+            // selectSession auto-selects the first conversation for the session
+            selectSession(firstSession.id);
           }
         }
       } catch (error) {
@@ -397,7 +394,7 @@ export default function Home() {
     }
 
     loadData();
-  }, [backendConnected, repoToWorkspace, sessionToWorktreeSession, conversationToConversation, setWorkspaces, setSessions, setConversations, selectWorkspace, selectSession, addConversation, selectConversation]);
+  }, [backendConnected, repoToWorkspace, sessionToWorktreeSession, conversationToConversation, setWorkspaces, setSessions, setConversations, selectWorkspace, selectSession, addConversation]);
 
   // Menu action handlers
   const handleNewSession = useCallback(async () => {

--- a/src/components/AddWorkspaceModal.tsx
+++ b/src/components/AddWorkspaceModal.tsx
@@ -27,7 +27,7 @@ export function AddWorkspaceModal({ isOpen, onClose }: AddWorkspaceModalProps) {
   const [path, setPath] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const { addWorkspace, selectWorkspace, addSession, selectSession, addConversation, selectConversation } = useAppStore();
+  const { addWorkspace, selectWorkspace, addSession, selectSession, addConversation } = useAppStore();
   const { expandWorkspace } = useSettingsStore();
 
   useEffect(() => {
@@ -97,9 +97,6 @@ export function AddWorkspaceModal({ isOpen, onClose }: AddWorkspaceModalProps) {
 
       expandWorkspace(workspace.id);
       selectSession(session.id);
-      if (conversations.length > 0) {
-        selectConversation(conversations[0].id);
-      }
 
       setPath('');
       onClose();

--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -108,7 +108,6 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
     selectSession,
     addSession,
     addConversation,
-    selectConversation,
     reorderWorkspaces,
     archiveSession,
     updateSession,
@@ -217,12 +216,9 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
       // Expand the workspace if not already
       expandWorkspace(workspaceId);
 
-      // Select the new session and first conversation
+      // Select the new session (selectSession auto-selects first conversation)
       selectWorkspace(workspaceId);
       selectSession(session.id);
-      if (conversations.length > 0) {
-        selectConversation(conversations[0].id);
-      }
     } catch (error) {
       console.error('Failed to create session:', error);
     }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -355,9 +355,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       fileTabs: [],
     };
   }),
-  selectSession: (id) => set((state) => {
-    // When switching sessions, find the first conversation for this session
-    // File tabs persist in store but UI only shows tabs for current session
+  selectSession: (id) => {
+    // NOTE: This intentionally uses get() instead of set((state) => ...) pattern.
+    // Using get() ensures we read the latest state, avoiding stale closure issues
+    // when called immediately after other store updates like addConversation.
+    const state = get();
     const sessionConversations = state.conversations.filter(c => c.sessionId === id);
     const firstConversation = sessionConversations[0];
 
@@ -368,13 +370,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       ? state.selectedFileTabId
       : visibleTabs[0]?.id || null;
 
-    return {
+    set({
       selectedSessionId: id,
       selectedConversationId: firstConversation?.id || null,
       selectedFileTabId: newSelectedTabId,
-      // fileTabs remain unchanged - UI filters by session
-    };
-  }),
+    });
+  },
   archiveSession: (id) => set((state) => {
     const session = state.sessions.find((s) => s.id === id);
 


### PR DESCRIPTION
Fixes the stale closure bug in selectSession where calling it immediately after addConversation would use outdated state and fail to select the newly added conversation. Switching to get() ensures we always read the latest store state.

Also removes redundant selectConversation calls from call sites since selectSession now automatically selects the first conversation for a session.

**Changes:**
- Modified selectSession to use get() for latest state
- Removed manual selectConversation calls from page.tsx, AddWorkspaceModal.tsx, and WorkspaceSidebar.tsx
- Updated dependency array to remove selectConversation

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>