### PR TITLE
refactor: replace dotfile whitelist with blocklist for file tree

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -1198,22 +1198,21 @@ func buildFileTree(basePath, relativePath string, maxDepth, currentDepth int) ([
 	var dirs, files []os.DirEntry
 	for _, entry := range entries {
 		name := entry.Name()
-		// Skip hidden files except important ones
-		if strings.HasPrefix(name, ".") {
-			// Allow these hidden files/dirs
-			allowed := map[string]bool{
-				".github": true, ".vscode": true, ".husky": true,
-				".gitignore": true, ".dockerignore": true, ".env": true,
-				".env.example": true, ".env.local": true, ".prettierrc": true,
-				".prettierignore": true, ".eslintrc": true, ".editorconfig": true,
-				".nvmrc": true, ".npmrc": true, ".yarnrc": true,
-			}
-			if !allowed[name] && !strings.HasPrefix(name, ".env") {
-				continue
-			}
+
+		// Skip known junk/cache files and OS-specific hidden files
+		blocked := map[string]bool{
+			".DS_Store": true, ".localized": true, ".Trash": true,
+			".DocumentRevisions-V100": true, ".Spotlight-V100": true,
+			".TemporaryItems": true, ".fseventsd": true, ".VolumeIcon.icns": true,
+			".AppleDouble": true, ".LSOverride": true, "._*": true,
+			"Thumbs.db": true, "desktop.ini": true, ".git": true,
 		}
-		// Skip node_modules and other large dirs
-		if name == "node_modules" || name == "vendor" || name == ".git" ||
+		if blocked[name] || strings.HasPrefix(name, "._") {
+			continue
+		}
+
+		// Skip large build/dependency directories
+		if name == "node_modules" || name == "vendor" ||
 			name == "dist" || name == "build" || name == "__pycache__" ||
 			name == "target" || name == ".next" || name == "out" {
 			continue

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -714,6 +714,68 @@ func TestListSessionFiles_SessionNotFound(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "session not found")
 }
 
+func TestListSessionFiles_DotfileFiltering(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	createTestRepo(t, s, "ws-1", "/path/to/repo")
+	_, worktreePath := createTestSessionWithWorktree(t, s, "sess-1", "ws-1")
+
+	// Create legitimate config dotfiles that should be shown
+	writeFile(t, worktreePath, ".mcp.json", `{"mcpServers":{}}`)
+	writeFile(t, worktreePath, ".gitignore", "node_modules")
+	writeFile(t, worktreePath, ".env.example", "KEY=value")
+	writeFile(t, worktreePath, ".prettierrc", `{}`)
+	writeFile(t, worktreePath, ".babelrc", `{}`)
+	writeFile(t, worktreePath, ".eslintrc.json", `{}`)
+
+	// Create OS junk files that should be filtered out
+	writeFile(t, worktreePath, ".DS_Store", "junk")
+	writeFile(t, worktreePath, ".localized", "junk")
+	writeFile(t, worktreePath, "._hidden", "junk")
+
+	// Create normal files
+	writeFile(t, worktreePath, "README.md", "readme")
+	writeFile(t, worktreePath, "package.json", `{}`)
+
+	req := httptest.NewRequest("GET", "/api/sessions/sess-1/files", nil)
+	req = withChiContext(req, map[string]string{"sessionId": "sess-1"})
+	w := httptest.NewRecorder()
+
+	h.ListSessionFiles(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response []map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Convert response to map for easier checking
+	fileMap := make(map[string]bool)
+	for _, file := range response {
+		name, ok := file["name"].(string)
+		if ok {
+			fileMap[name] = true
+		}
+	}
+
+	// Verify legitimate config dotfiles are included
+	assert.True(t, fileMap[".mcp.json"], ".mcp.json should be included")
+	assert.True(t, fileMap[".gitignore"], ".gitignore should be included")
+	assert.True(t, fileMap[".env.example"], ".env.example should be included")
+	assert.True(t, fileMap[".prettierrc"], ".prettierrc should be included")
+	assert.True(t, fileMap[".babelrc"], ".babelrc should be included")
+	assert.True(t, fileMap[".eslintrc.json"], ".eslintrc.json should be included")
+
+	// Verify OS junk files are excluded
+	assert.False(t, fileMap[".DS_Store"], ".DS_Store should be excluded")
+	assert.False(t, fileMap[".localized"], ".localized should be excluded")
+	assert.False(t, fileMap["._hidden"], "._hidden should be excluded")
+
+	// Verify normal files are included
+	assert.True(t, fileMap["README.md"], "README.md should be included")
+	assert.True(t, fileMap["package.json"], "package.json should be included")
+}
+
 // ============================================================================
 // JSON Response Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

- Changed file tree filtering from whitelist to blocklist approach
- `.mcp.json` and other config files now visible in file tree
- Only filters out known junk files (.DS_Store, ._*, etc.)

## Problem

The file tree used a whitelist approach that only showed a hardcoded list of "important" dotfiles. This meant `.mcp.json` and many other legitimate config files (`.babelrc`, `.swcrc`, `.releaserc`, etc.) were hidden from users, making it difficult to discover and manage MCP server configurations.

## Solution

Replaced the whitelist with a blocklist that:
- Shows all files by default, including all dotfiles
- Only filters out known OS junk/cache files:
  - macOS: `.DS_Store`, `.localized`, `._*` files, `.Spotlight-V100`, etc.
  - Windows: `Thumbs.db`, `desktop.ini`
  - Still excludes `.git` directory and large build directories

## Benefits

- Important config files like `.mcp.json` are now visible
- No need to maintain a growing whitelist as new tools/configs emerge
- More predictable and transparent behavior for users
- All legitimate dotfiles are shown

## Test plan

- [x] Added comprehensive test `TestListSessionFiles_DotfileFiltering`
- [x] Verified legitimate dotfiles (.mcp.json, .babelrc, etc.) are included
- [x] Verified OS junk files are excluded
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)