### PR TITLE
fix: flush text buffer before tool transitions to prevent batched text

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -594,6 +594,9 @@ function handleMessage(message: SDKMessage): void {
               content: (block as { type: "thinking"; thinking: string }).thinking,
             });
           } else if (block.type === "tool_use") {
+            // Flush any buffered text before tool starts
+            flushBlockBuffer();
+
             // Tool use started
             activeTools.set(block.id, {
               tool: block.name,
@@ -656,6 +659,9 @@ function handleMessage(message: SDKMessage): void {
           if (block.type === "tool_result") {
             const toolInfo = activeTools.get(block.tool_use_id);
             if (toolInfo) {
+              // Flush any buffered text before tool ends
+              flushBlockBuffer();
+
               const duration = Date.now() - toolInfo.startTime;
               // Determine success from content
               const isError = block.is_error === true;


### PR DESCRIPTION
## Summary

Fixes text appearing all at once instead of streaming character-by-character after tool calls complete. The text buffer now flushes at tool boundaries (tool_start and tool_end) to ensure smooth streaming throughout the conversation.

## Changes

- Added `flushBlockBuffer()` call before `tool_start` event emission
- Added `flushBlockBuffer()` call before `tool_end` event emission
- Text now streams smoothly before, during, and after tool execution instead of accumulating and dumping in batches

## Testing

Run `make dev` and start a conversation with multiple tool calls (e.g., "List files in this directory"). Verify that text streams character-by-character consistently, not in batches after tools complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)