### PR TITLE
Fix worktree name truncation in sidebar

### DIFF
--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -670,7 +670,7 @@ function SortableWorkspaceItem({
                             ) : (
                               <GitBranch className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
                             )}
-                            <span className="text-sm font-medium truncate flex-1">
+                            <span className="text-sm font-medium truncate min-w-0 flex-shrink">
                               {session.branch || session.name}
                             </span>
                             {/* Pinned indicator - fade out on hover */}
@@ -678,10 +678,10 @@ function SortableWorkspaceItem({
                               <Pin className="h-2.5 w-2.5 text-primary shrink-0 group-hover:opacity-0 transition-opacity" />
                             )}
                             {/* Git line stats badge and actions container */}
-                            <div className="relative shrink-0 flex items-center">
+                            <div className="relative shrink-0 flex items-center min-w-[80px]">
                               {/* Stats - fade out on hover */}
                               {hasStats && (
-                                <span className="text-[11px] px-2 py-0.5 rounded border border-emerald-500/40 font-mono tabular-nums group-hover:opacity-0 transition-opacity">
+                                <span className="text-[11px] px-2 py-0.5 rounded border border-emerald-500/40 font-mono tabular-nums group-hover:opacity-0 transition-opacity whitespace-nowrap">
                                   <span className="text-emerald-400">+{session.stats!.additions}</span>
                                   <span className="text-red-400 ml-1">-{session.stats!.deletions}</span>
                                 </span>


### PR DESCRIPTION
## Summary
- Fixes truncation issue where long worktree/branch names push the git line stats badge off the visible area in the left sidebar
- Ensures proper text truncation with ellipsis for long names while keeping stats visible
- Adds minimum width reservation for the stats badge container

## Changes
- Updated branch name span styling from `truncate flex-1` to `truncate min-w-0 flex-shrink` for proper text overflow handling
- Added `min-w-[80px]` to stats/actions container to reserve space for the stats badge
- Added `whitespace-nowrap` to stats badge to prevent unwanted text wrapping

## Test plan
- [x] Test with short worktree names (stats should display normally)
- [x] Test with very long worktree names (name should truncate with ellipsis, stats stay visible)
- [x] Verify hover states still work (pin/archive buttons appear on hover)
- [x] Check responsive behavior when resizing sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)