### PR TITLE
feat: GitHub OAuth infrastructure for authentication onboarding

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,51 @@
-.PHONY: build dev backend clean
+.PHONY: build build-debug dev backend clean init deps install-debug
 
 # Get the Rust target triple for the current platform
 TARGET := $(shell rustc -vV | grep host | cut -d' ' -f2)
+
+# Install npm dependencies if node_modules is missing
+deps:
+	@if [ ! -d "node_modules" ]; then \
+		echo "Installing npm dependencies..."; \
+		npm install; \
+	fi
 
 # Build Go backend for current platform
 backend:
 	cd backend && go build -o ../src-tauri/binaries/chatml-backend-$(TARGET)
 
-# Development mode
-dev: backend
+# Development mode (auto-installs deps if needed)
+dev: deps backend
 	npm run tauri:dev
 
-# Production build
-build: backend
+# Production build (auto-installs deps if needed)
+build: deps backend
 	npm run tauri:build
+
+# Debug build (for testing deep links, OAuth, etc.)
+# Note: The updater plugin fails without a valid signing key, but we only need the .app bundle
+# We capture the exit code and only fail if both the build failed AND no .app was created
+build-debug: deps backend
+	@npm run tauri build -- --debug --bundles app; \
+	BUILD_EXIT=$$?; \
+	if [ ! -d src-tauri/target/debug/bundle/macos/chatml.app ]; then \
+		echo "Build failed - .app not created"; \
+		exit 1; \
+	fi; \
+	if [ $$BUILD_EXIT -ne 0 ]; then \
+		echo "Note: Build completed with warnings (exit code $$BUILD_EXIT), but .app bundle was created successfully"; \
+	fi
+
+# Install debug build to /Applications (enables deep link testing)
+install-debug: build-debug
+	@echo "Installing debug build to /Applications..."
+	@rm -rf /Applications/chatml.app
+	@cp -r src-tauri/target/debug/bundle/macos/chatml.app /Applications/
+	@echo "Installed! Run 'open /Applications/chatml.app' to test deep links"
+
+# Initialize fresh worktree - explicit setup command
+init: deps backend
+	@echo "Worktree initialized. Run 'make dev' to start development."
 
 # Clean build artifacts
 clean:

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -113,6 +113,14 @@ pub fn spawn_sidecar(app: &tauri::AppHandle, state: &Arc<AppState>) -> AppResult
         sidecar_command = sidecar_command.env("CHATML_DEV_ORIGIN", "http://localhost:3100");
     }
 
+    // Pass GitHub OAuth credentials to sidecar (if set)
+    if let Ok(client_id) = std::env::var("GITHUB_CLIENT_ID") {
+        sidecar_command = sidecar_command.env("GITHUB_CLIENT_ID", &client_id);
+    }
+    if let Ok(client_secret) = std::env::var("GITHUB_CLIENT_SECRET") {
+        sidecar_command = sidecar_command.env("GITHUB_CLIENT_SECRET", &client_secret);
+    }
+
     let (mut rx, child) = sidecar_command
         .spawn()
         .map_err(|e| AppError::Sidecar(format!("Failed to spawn sidecar: {}", e)))?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,6 +43,12 @@
     }
   },
   "plugins": {
+    "deep-link": {
+      "mobile": [],
+      "desktop": {
+        "schemes": ["chatml"]
+      }
+    },
     "updater": {
       "pubkey": "REPLACE_WITH_YOUR_PUBLIC_KEY",
       "endpoints": [


### PR DESCRIPTION
## Summary

Adds infrastructure for GitHub OAuth authentication flow, including deep-link scheme registration for callback handling and credential passthrough to the sidecar process.

## Changes

- Register `chatml://` deep-link scheme for OAuth callbacks
- Pass GitHub OAuth credentials to sidecar via environment variables
- Add `build-debug` and `install-debug` make targets for testing
- Improve Makefile with dependency management and workspace initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)