### PR TITLE
feat: set up macOS code signing and notarization for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,6 @@ jobs:
           - platform: macos-latest
             args: --target x86_64-apple-darwin
             target: x86_64-apple-darwin
-          - platform: ubuntu-22.04
-            args: ''
-            target: x86_64-unknown-linux-gnu
-          - platform: windows-latest
-            args: ''
-            target: x86_64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -77,16 +71,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install dependencies (Ubuntu)
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25'
           cache-dependency-path: backend/go.sum
 
       - name: Build Go backend (macOS ARM64)
@@ -101,19 +89,33 @@ jobs:
           cd backend
           GOOS=darwin GOARCH=amd64 go build -o ../src-tauri/binaries/chatml-backend-x86_64-apple-darwin ./cmd/chatml
 
-      - name: Build Go backend (Linux)
-        if: matrix.platform == 'ubuntu-22.04'
+      - name: Sign Go backend sidecar (macOS)
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
-          cd backend
-          GOOS=linux GOARCH=amd64 go build -o ../src-tauri/binaries/chatml-backend-x86_64-unknown-linux-gnu ./cmd/chatml
+          # Import certificate to keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
 
-      - name: Build Go backend (Windows)
-        if: matrix.platform == 'windows-latest'
-        run: |
-          cd backend
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          go build -o ../src-tauri/binaries/chatml-backend-x86_64-pc-windows-msvc.exe ./cmd/chatml
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          security import $RUNNER_TEMP/certificate.p12 -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # Sign the sidecar with hardened runtime
+          codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" \
+            --entitlements src-tauri/entitlements.plist \
+            src-tauri/binaries/chatml-backend-${{ matrix.target }}
+
+          # Cleanup keychain
+          security delete-keychain $KEYCHAIN_PATH
 
       - name: Install npm dependencies
         run: npm ci
@@ -122,8 +124,16 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Tauri update signing
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Apple code signing + notarization
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,14 +39,15 @@
     ],
     "createUpdaterArtifacts": true,
     "macOS": {
-      "minimumSystemVersion": "10.15"
+      "minimumSystemVersion": "10.15",
+      "entitlements": "entitlements.plist"
     }
   },
   "plugins": {
     "updater": {
-      "pubkey": "REPLACE_WITH_YOUR_PUBLIC_KEY",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcyQTNBMzJBNjQ0ODgwOEMKUldTTWdFaGtLcU9qY21ldENlYWZweHlKYWswTTdIeHJNNHNKMURaTnU1MzVzWGJqR3gwWlMrUDMK",
       "endpoints": [
-        "https://github.com/OWNER/chatml/releases/latest/download/latest.json"
+        "https://github.com/chatml/app/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"


### PR DESCRIPTION
## Summary
- Configures GitHub Actions for macOS code signing and notarization
- Signs Go backend sidecar with hardened runtime and entitlements
- Removes Linux and Windows build targets (macOS-only)
- Updates Tauri config with proper entitlements reference and updater pubkey

## Details
The release workflow now properly signs the native Go backend binary with Apple's code signing requirements, enabling notarization for App Store distribution. Only ARM64 and x86_64 macOS targets are built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)