### PR TITLE
feat: improve GitHub OAuth flow with state management and timeout

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -188,8 +188,11 @@ pub fn run() {
                     for url in urls {
                         if url.scheme() == "chatml" && url.host_str() == Some("oauth") {
                             log::info!("Received OAuth callback URL: {}", url);
-                            // Emit to frontend for handling
+                            // Emit to frontend for handling and focus the window
                             if let Some(window) = app_handle.get_webview_window("main") {
+                                // Show and focus the window so user sees the result
+                                let _ = window.show();
+                                let _ = window.set_focus();
                                 let _ = window.emit("oauth-callback", url.to_string());
                             }
                         }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useAuthStore } from '@/stores/authStore';
 import { OnboardingScreen } from '@/components/OnboardingScreen';
-import { initAuth, listenForOAuthCallback } from '@/lib/auth';
+import { initAuth, listenForOAuthCallback, OAUTH_TIMEOUT_MS } from '@/lib/auth';
 import { isTauri, safeListen, closeWindow, openFolderDialog } from '@/lib/tauri';
 import { CloseTabConfirmDialog } from '@/components/CloseTabConfirmDialog';
 import { CloseFileConfirmDialog } from '@/components/CloseFileConfirmDialog';
@@ -130,7 +130,14 @@ export default function Home() {
   const confirmCloseActiveTab = useSettingsStore((s) => s.confirmCloseActiveTab);
   const { showBottomTerminal, setShowBottomTerminal, zenMode, setZenMode } = useSettingsStore();
 
-  const { isLoading: authLoading, isAuthenticated, setAuthenticated, setError } = useAuthStore();
+  const {
+    isLoading: authLoading,
+    isAuthenticated,
+    oauthState,
+    setAuthenticated,
+    completeOAuth,
+    failOAuth,
+  } = useAuthStore();
 
   // Initialize auth on mount
   useEffect(() => {
@@ -141,10 +148,11 @@ export default function Home() {
       try {
         unlistenOAuth = await listenForOAuthCallback(
           (result) => {
+            completeOAuth();
             setAuthenticated(true, result.user);
           },
           (error) => {
-            setError(error.message);
+            failOAuth(error.message);
           }
         );
       } catch {
@@ -165,7 +173,18 @@ export default function Home() {
     return () => {
       if (unlistenOAuth) unlistenOAuth();
     };
-  }, [setAuthenticated, setError]);
+  }, [setAuthenticated, completeOAuth, failOAuth]);
+
+  // OAuth timeout - fail if pending for too long
+  useEffect(() => {
+    if (oauthState !== 'pending') return;
+
+    const timeoutId = setTimeout(() => {
+      failOAuth('Authentication timed out. Please try again.');
+    }, OAUTH_TIMEOUT_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [oauthState, failOAuth]);
 
   // Use refs to avoid changing useEffect dependency array sizes
   const showBottomTerminalRef = useRef(showBottomTerminal);

--- a/src/components/OnboardingScreen.tsx
+++ b/src/components/OnboardingScreen.tsx
@@ -1,32 +1,54 @@
 // src/components/OnboardingScreen.tsx
 'use client';
 
-import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { GlassCard } from '@/components/ui/glass-card';
-import { Github, Loader2 } from 'lucide-react';
-import { startOAuthFlow } from '@/lib/auth';
+import { Github, Loader2, X, RefreshCw } from 'lucide-react';
+import { startOAuthFlow, cancelOAuthFlow } from '@/lib/auth';
 import { useAuthStore } from '@/stores/authStore';
 
 export function OnboardingScreen() {
-  const [isConnecting, setIsConnecting] = useState(false);
-  const { error, setError, setAuthenticated } = useAuthStore();
+  const {
+    oauthState,
+    oauthError,
+    startOAuth,
+    cancelOAuth,
+    setAuthenticated,
+  } = useAuthStore();
+
+  const isConnecting = oauthState === 'pending';
+  const hasError = oauthState === 'error';
 
   const handleSignIn = async () => {
-    setIsConnecting(true);
-    setError(null);
+    startOAuth();
 
     try {
       await startOAuthFlow();
       // OAuth callback will be handled by listener in page.tsx
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start sign in');
-      setIsConnecting(false);
+      // Only fail if we're still in pending state (not cancelled)
+      if (useAuthStore.getState().oauthState === 'pending') {
+        useAuthStore.getState().failOAuth(
+          err instanceof Error ? err.message : 'Failed to start sign in'
+        );
+      }
     }
+  };
+
+  const handleCancel = () => {
+    cancelOAuthFlow();
+    cancelOAuth();
+  };
+
+  const handleRetry = () => {
+    // Clear error and start fresh
+    cancelOAuth();
+    handleSignIn();
   };
 
   const handleSkip = () => {
     // Skip authentication for development - sets a placeholder user
+    cancelOAuthFlow(); // Clear any pending state
     setAuthenticated(true, {
       login: 'local-dev',
       name: 'Local Developer',
@@ -71,39 +93,74 @@ export function OnboardingScreen() {
             Enterprise AI Orchestration
           </p>
 
-          {/* Sign in button with gradient */}
-          <Button
-            size="lg"
-            onClick={handleSignIn}
-            disabled={isConnecting}
-            className="h-12 px-8 text-base bg-gradient-to-r from-primary to-purple-500 hover:from-primary/90 hover:to-purple-500/90 shadow-lg shadow-primary/25 transition-all duration-200 active:scale-[0.98]"
-          >
-            {isConnecting ? (
-              <>
-                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-                Connecting...
-              </>
-            ) : (
-              <>
+          {/* Action buttons */}
+          <div className="flex flex-col items-center gap-3 w-full">
+            {/* Error state: show error and retry button */}
+            {hasError && (
+              <div className="flex flex-col items-center gap-3 w-full animate-slide-up-fade">
+                <div className="flex items-center gap-2 text-sm text-destructive bg-destructive/10 px-4 py-2 rounded-lg">
+                  <X className="h-4 w-4 shrink-0" />
+                  <span>{oauthError}</span>
+                </div>
+                <Button
+                  size="lg"
+                  onClick={handleRetry}
+                  className="h-12 px-8 text-base bg-gradient-to-r from-primary to-purple-500 hover:from-primary/90 hover:to-purple-500/90 shadow-lg shadow-primary/25 transition-all duration-200 active:scale-[0.98]"
+                >
+                  <RefreshCw className="mr-2 h-5 w-5" />
+                  Try Again
+                </Button>
+              </div>
+            )}
+
+            {/* Pending state: show spinner and cancel button */}
+            {isConnecting && (
+              <div className="flex flex-col items-center gap-3 w-full">
+                <Button
+                  size="lg"
+                  disabled
+                  className="h-12 px-8 text-base bg-gradient-to-r from-primary to-purple-500 shadow-lg shadow-primary/25"
+                >
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                  Waiting for GitHub...
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleCancel}
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Cancel
+                </Button>
+                <p className="text-xs text-muted-foreground text-center">
+                  Complete authorization in your browser, then return here.
+                </p>
+              </div>
+            )}
+
+            {/* Idle state: show sign in button */}
+            {!isConnecting && !hasError && (
+              <Button
+                size="lg"
+                onClick={handleSignIn}
+                className="h-12 px-8 text-base bg-gradient-to-r from-primary to-purple-500 hover:from-primary/90 hover:to-purple-500/90 shadow-lg shadow-primary/25 transition-all duration-200 active:scale-[0.98]"
+              >
                 <Github className="mr-2 h-5 w-5" />
                 Sign in with GitHub
-              </>
+              </Button>
             )}
-          </Button>
+          </div>
 
-          {/* Skip button for development */}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleSkip}
-            className="text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Skip for now
-          </Button>
-
-          {/* Error message */}
-          {error && (
-            <p className="text-sm text-destructive animate-slide-up-fade">{error}</p>
+          {/* Skip button for development - only show when not connecting */}
+          {!isConnecting && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleSkip}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Skip for now
+            </Button>
           )}
 
           {/* Footer */}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -49,11 +49,48 @@ function generateState(): string {
 // Store state temporarily for verification
 let pendingOAuthState: string | null = null;
 
+// OAuth timeout duration (2 minutes)
+export const OAUTH_TIMEOUT_MS = 120000;
+
+/**
+ * Get user-friendly error message for GitHub OAuth errors
+ */
+function getOAuthErrorMessage(error: string, description: string | null): string {
+  switch (error) {
+    case 'access_denied':
+      return 'You declined to authorize ChatML. Click "Sign in" to try again.';
+    case 'redirect_uri_mismatch':
+      return 'OAuth configuration error. The redirect URL is not registered with GitHub.';
+    case 'application_suspended':
+      return 'This application has been suspended. Please contact support.';
+    case 'incorrect_client_credentials':
+      return 'OAuth configuration error. Please contact support.';
+    default:
+      return description || `GitHub authorization failed: ${error}`;
+  }
+}
+
+/**
+ * Check if an OAuth flow is currently pending
+ */
+export function isOAuthPending(): boolean {
+  return pendingOAuthState !== null;
+}
+
+/**
+ * Cancel any pending OAuth flow
+ * Clears the stored state so callbacks will be rejected
+ */
+export function cancelOAuthFlow(): void {
+  pendingOAuthState = null;
+}
+
 /**
  * Start the GitHub OAuth flow
  * Opens browser to GitHub authorization page
  */
 export async function startOAuthFlow(): Promise<void> {
+  // Clear any previous pending state
   pendingOAuthState = generateState();
 
   const params = new URLSearchParams({
@@ -82,15 +119,28 @@ export async function startOAuthFlow(): Promise<void> {
  */
 export async function handleOAuthCallback(url: string): Promise<{ token: string; user: GitHubUser }> {
   const parsed = new URL(url);
+
+  // Check for GitHub error response FIRST (e.g., user denied access)
+  const error = parsed.searchParams.get('error');
+  const errorDescription = parsed.searchParams.get('error_description');
+
+  if (error) {
+    pendingOAuthState = null; // Clear state on error
+    const message = getOAuthErrorMessage(error, errorDescription);
+    throw new Error(message);
+  }
+
   const code = parsed.searchParams.get('code');
   const state = parsed.searchParams.get('state');
 
   if (!code) {
-    throw new Error('No authorization code received');
+    pendingOAuthState = null;
+    throw new Error('No authorization code received from GitHub.');
   }
 
   if (state !== pendingOAuthState) {
-    throw new Error('State mismatch - possible CSRF attack');
+    pendingOAuthState = null;
+    throw new Error('Security error: state mismatch. Please try again.');
   }
 
   pendingOAuthState = null;
@@ -104,7 +154,7 @@ export async function handleOAuthCallback(url: string): Promise<{ token: string;
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`OAuth exchange failed: ${text}`);
+    throw new Error(`Failed to complete authentication: ${text}`);
   }
 
   return res.json();

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,17 +2,30 @@
 import { create } from 'zustand';
 import type { GitHubUser } from '@/lib/auth';
 
+// OAuth flow states
+export type OAuthState = 'idle' | 'pending' | 'error';
+
 interface AuthState {
   isLoading: boolean;
   isAuthenticated: boolean;
   user: GitHubUser | null;
   error: string | null;
 
+  // OAuth flow state
+  oauthState: OAuthState;
+  oauthError: string | null;
+
   // Actions
   setLoading: (loading: boolean) => void;
   setAuthenticated: (authenticated: boolean, user?: GitHubUser | null) => void;
   setError: (error: string | null) => void;
   reset: () => void;
+
+  // OAuth actions
+  startOAuth: () => void;
+  completeOAuth: () => void;
+  failOAuth: (error: string) => void;
+  cancelOAuth: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -21,6 +34,10 @@ export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   error: null,
 
+  // OAuth starts idle
+  oauthState: 'idle',
+  oauthError: null,
+
   setLoading: (isLoading) => set({ isLoading }),
 
   setAuthenticated: (isAuthenticated, user = null) => set({
@@ -28,6 +45,8 @@ export const useAuthStore = create<AuthState>((set) => ({
     user,
     isLoading: false,
     error: null,
+    oauthState: 'idle',
+    oauthError: null,
   }),
 
   setError: (error) => set({
@@ -40,5 +59,28 @@ export const useAuthStore = create<AuthState>((set) => ({
     isAuthenticated: false,
     user: null,
     error: null,
+    oauthState: 'idle',
+    oauthError: null,
+  }),
+
+  // OAuth flow actions
+  startOAuth: () => set({
+    oauthState: 'pending',
+    oauthError: null,
+  }),
+
+  completeOAuth: () => set({
+    oauthState: 'idle',
+    oauthError: null,
+  }),
+
+  failOAuth: (error) => set({
+    oauthState: 'error',
+    oauthError: error,
+  }),
+
+  cancelOAuth: () => set({
+    oauthState: 'idle',
+    oauthError: null,
   }),
 }));


### PR DESCRIPTION
## Summary
- Add comprehensive OAuth state management (idle/pending/error) with Zustand store
- Implement timeout protection (2 minutes) to prevent stuck states
- Provide user-friendly error messages with retry capability
- Add cancel functionality for pending OAuth flows
- Improve UX by showing/focusing window on OAuth callback

Removes local state management in favor of centralized store-driven approach for better consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)