### PR TITLE
Fix file picker dual selection for keyboard and mouse

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -18,19 +18,39 @@ import {
 
 type CommandDialogVariant = "centered" | "spotlight"
 
+// Context for tracking mouse hover separately from keyboard selection
+const CommandHoverContext = React.createContext<{
+  hoveredValue: string | null
+  setHoveredValue: (value: string | null) => void
+}>({
+  hoveredValue: null,
+  setHoveredValue: () => {},
+})
+
 function Command({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive>) {
+  const [hoveredValue, setHoveredValue] = React.useState<string | null>(null)
+
+  const contextValue = React.useMemo(() => ({
+    hoveredValue,
+    setHoveredValue,
+  }), [hoveredValue])
+
   return (
-    <CommandPrimitive
-      data-slot="command"
-      className={cn(
-        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
-        className
-      )}
-      {...props}
-    />
+    <CommandHoverContext.Provider value={contextValue}>
+      <CommandPrimitive
+        data-slot="command"
+        className={cn(
+          "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+          className
+        )}
+        // Disable cmdk's pointer selection - we handle mouse hover separately
+        disablePointerSelection
+        {...props}
+      />
+    </CommandHoverContext.Provider>
   )
 }
 
@@ -214,13 +234,44 @@ function CommandSeparator({
 
 function CommandItem({
   className,
+  value,
+  onSelect,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  const { hoveredValue, setHoveredValue } = React.useContext(CommandHoverContext)
+  const isHovered = value !== undefined && hoveredValue === value
+
+  const handleMouseEnter = React.useCallback(() => {
+    if (value !== undefined) {
+      setHoveredValue(value)
+    }
+  }, [value, setHoveredValue])
+
+  const handleMouseLeave = React.useCallback(() => {
+    setHoveredValue(null)
+  }, [setHoveredValue])
+
+  // Handle click - this triggers onSelect for the hovered item
+  const handleClick = React.useCallback(() => {
+    onSelect?.(value ?? "")
+  }, [onSelect, value])
+
   return (
     <CommandPrimitive.Item
       data-slot="command-item"
+      data-hovered={isHovered ? "true" : undefined}
+      value={value}
+      onSelect={onSelect}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onClick={handleClick}
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // Base styles
+        "[&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // Mouse hover - subtle styling (comes first so keyboard selection can override)
+        "data-[hovered=true]:bg-muted",
+        // Keyboard selection - prominent styling (comes last to take precedence)
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Implement separate tracking for keyboard selection and mouse hover in the command palette
- Keyboard selection uses prominent styling (`bg-accent`) and responds to Enter key
- Mouse hover uses subtle styling (`bg-muted`) and responds to click
- Uses `disablePointerSelection` to prevent mouse from hijacking keyboard selection


https://github.com/user-attachments/assets/e59f7c11-aead-4cc2-81d1-98e20b091117



## Implementation Details
- Added `CommandHoverContext` to track hovered item separately from cmdk's keyboard selection
- `CommandItem` now tracks mouse enter/leave and applies `data-hovered` attribute
- Click handler explicitly calls `onSelect` for the hovered item
- Styling order ensures keyboard selection takes visual precedence over hover

## Test Plan
- [ ] Open file picker with Cmd+P
- [ ] Type to search and use arrow keys to navigate - keyboard selection should be prominent
- [ ] Move mouse over different items - should show subtle hover highlight
- [ ] Press Enter - should open the keyboard-selected file
- [ ] Click an item - should open the clicked file (even if different from keyboard selection)

## Notes
Similar approach to VS Code's command palette behavior.