### PR TITLE
feat: add PKCE support for OAuth and improve signal handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,24 @@ deps:
 		npm install; \
 	fi
 
-# Build Go backend for current platform
+# Build Go backend for current platform (development - uses env vars at runtime)
 backend:
 	cd backend && go build -o ../src-tauri/binaries/chatml-backend-$(TARGET)
 
+# Build Go backend with embedded credentials (production - uses build-time vars)
+# Requires GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET env vars
+backend-release:
+	@if [ -z "$$GITHUB_CLIENT_ID" ]; then echo "Error: GITHUB_CLIENT_ID not set"; exit 1; fi
+	@if [ -z "$$GITHUB_CLIENT_SECRET" ]; then echo "Error: GITHUB_CLIENT_SECRET not set"; exit 1; fi
+	cd backend && go build -ldflags "\
+		-X 'github.com/chatml/chatml-backend/server.githubClientID=$$GITHUB_CLIENT_ID' \
+		-X 'github.com/chatml/chatml-backend/server.githubClientSecret=$$GITHUB_CLIENT_SECRET'" \
+		-o ../src-tauri/binaries/chatml-backend-$(TARGET)
+
 # Development mode (auto-installs deps if needed)
+# Trap SIGINT/SIGTERM to kill all child processes in the process group
 dev: deps backend
-	npm run tauri:dev
+	@trap 'kill 0' INT TERM; npm run tauri:dev & wait
 
 # Production build (auto-installs deps if needed)
 build: deps backend

--- a/backend/github/client.go
+++ b/backend/github/client.go
@@ -46,11 +46,15 @@ func NewClient(clientID, clientSecret string) *Client {
 }
 
 // ExchangeCode exchanges an OAuth code for an access token
-func (c *Client) ExchangeCode(ctx context.Context, code string) (string, error) {
+// If codeVerifier is provided, it's included for PKCE validation
+func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier string) (string, error) {
 	data := url.Values{}
 	data.Set("client_id", c.clientID)
 	data.Set("client_secret", c.clientSecret)
 	data.Set("code", code)
+	if codeVerifier != "" {
+		data.Set("code_verifier", codeVerifier)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST",
 		c.baseURL+"/login/oauth/access_token",

--- a/backend/github/client_test.go
+++ b/backend/github/client_test.go
@@ -30,7 +30,7 @@ func TestExchangeCode(t *testing.T) {
 	client := NewClient("test_client_id", "test_client_secret")
 	client.baseURL = server.URL // Override for testing
 
-	token, err := client.ExchangeCode(context.Background(), "test_code")
+	token, err := client.ExchangeCode(context.Background(), "test_code", "")
 	if err != nil {
 		t.Fatalf("ExchangeCode failed: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestExchangeCode_OAuthError(t *testing.T) {
 	client := NewClient("test_client_id", "test_client_secret")
 	client.baseURL = server.URL
 
-	_, err := client.ExchangeCode(context.Background(), "invalid_code")
+	_, err := client.ExchangeCode(context.Background(), "invalid_code", "")
 	if err == nil {
 		t.Fatal("Expected error for OAuth error response, got nil")
 	}
@@ -116,7 +116,7 @@ func TestExchangeCode_Non200Status(t *testing.T) {
 	client := NewClient("test_client_id", "test_client_secret")
 	client.baseURL = server.URL
 
-	_, err := client.ExchangeCode(context.Background(), "test_code")
+	_, err := client.ExchangeCode(context.Background(), "test_code", "")
 	if err == nil {
 		t.Fatal("Expected error for non-200 status, got nil")
 	}
@@ -151,7 +151,7 @@ func TestExchangeCode_VerifyRequest(t *testing.T) {
 	client := NewClient("test_client_id", "test_client_secret")
 	client.baseURL = server.URL
 
-	_, err := client.ExchangeCode(context.Background(), "test_code_123")
+	_, err := client.ExchangeCode(context.Background(), "test_code_123", "")
 	if err != nil {
 		t.Fatalf("ExchangeCode failed: %v", err)
 	}
@@ -170,5 +170,40 @@ func TestExchangeCode_VerifyRequest(t *testing.T) {
 	}
 	if !strings.Contains(receivedBody, "code=test_code_123") {
 		t.Errorf("Request body missing code, got: %s", receivedBody)
+	}
+}
+
+func TestExchangeCode_WithPKCE(t *testing.T) {
+	// Mock GitHub OAuth server that verifies PKCE code_verifier is included
+	var receivedBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login/oauth/access_token" {
+			body, _ := io.ReadAll(r.Body)
+			receivedBody = string(body)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_token": "gho_test_token",
+				"token_type":   "bearer",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient("test_client_id", "test_client_secret")
+	client.baseURL = server.URL
+
+	// Test with PKCE code verifier
+	_, err := client.ExchangeCode(context.Background(), "test_code", "test_verifier_abc123")
+	if err != nil {
+		t.Fatalf("ExchangeCode with PKCE failed: %v", err)
+	}
+
+	// Verify code_verifier is included in request
+	if !strings.Contains(receivedBody, "code_verifier=test_verifier_abc123") {
+		t.Errorf("Request body missing code_verifier, got: %s", receivedBody)
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,8 +5,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"syscall"
 	"time"
 
 	"github.com/chatml/chatml-backend/agent"
@@ -23,6 +25,10 @@ import (
 )
 
 func main() {
+	// Create root context that cancels on SIGINT/SIGTERM
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "9876"
@@ -39,7 +45,7 @@ func main() {
 
 	// Clean up orphaned worktrees from previous crashes or failed session creations
 	// Use a timeout to prevent startup from hanging indefinitely on git lock issues
-	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 30*time.Second)
 	if err := cleanup.CleanOrphanedWorktrees(cleanupCtx, s, wm); err != nil {
 		log.Printf("Warning: orphan cleanup failed: %v", err)
 		// Non-fatal - continue startup
@@ -87,7 +93,10 @@ func main() {
 				}
 			}()
 
-			ctx := context.Background()
+			// Check if we're shutting down
+			if ctx.Err() != nil {
+				return
+			}
 
 			// Extract display name from the new branch
 			newName := naming.ExtractSessionNameFromBranch(event.NewBranch)
@@ -137,10 +146,10 @@ func main() {
 		defer branchWatcher.Close()
 
 		// Initialize watches for existing sessions
-		repos, listErr := s.ListRepos(context.Background())
+		repos, listErr := s.ListRepos(ctx)
 		if listErr == nil {
 			for _, repo := range repos {
-				sessions, sessErr := s.ListSessions(context.Background(), repo.ID)
+				sessions, sessErr := s.ListSessions(ctx, repo.ID)
 				if sessErr != nil {
 					continue
 				}
@@ -159,8 +168,31 @@ func main() {
 
 	router := server.NewRouter(s, hub, agentMgr, ghClient, orch, branchWatcher)
 
-	log.Printf("ChatML backend starting on port %s", port)
-	if err := http.ListenAndServe(":"+port, router); err != nil {
-		log.Fatal(err)
+	// Create HTTP server with graceful shutdown support
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: router,
 	}
+
+	// Start server in goroutine
+	go func() {
+		log.Printf("ChatML backend starting on port %s", port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server error: %v", err)
+		}
+	}()
+
+	// Wait for shutdown signal
+	<-ctx.Done()
+	log.Println("Shutdown signal received, stopping server...")
+
+	// Give outstanding requests a short deadline to complete
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer shutdownCancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Server shutdown error: %v", err)
+	}
+
+	log.Println("Server stopped")
 }

--- a/backend/server/auth_handlers.go
+++ b/backend/server/auth_handlers.go
@@ -20,7 +20,8 @@ func NewAuthHandlers(ghClient *github.Client) *AuthHandlers {
 
 // GitHubCallbackRequest is the request body for OAuth callback
 type GitHubCallbackRequest struct {
-	Code string `json:"code"`
+	Code         string `json:"code"`
+	CodeVerifier string `json:"code_verifier,omitempty"` // PKCE code verifier
 }
 
 // GitHubCallbackResponse is the response for OAuth callback
@@ -54,8 +55,8 @@ func (h *AuthHandlers) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Exchange code for token
-	token, err := h.ghClient.ExchangeCode(r.Context(), req.Code)
+	// Exchange code for token (with PKCE verifier if provided)
+	token, err := h.ghClient.ExchangeCode(r.Context(), req.Code, req.CodeVerifier)
 	if err != nil {
 		writeBadGateway(w, "failed to exchange code", err)
 		return

--- a/backend/server/config.go
+++ b/backend/server/config.go
@@ -37,11 +37,29 @@ type GitHubConfig struct {
 	ClientSecret string
 }
 
-// LoadGitHubConfig loads GitHub OAuth config from environment variables
+// Build-time variables for GitHub OAuth (set via -ldflags)
+// Example: go build -ldflags "-X github.com/chatml/chatml-backend/server.githubClientID=xxx"
+var (
+	githubClientID     string
+	githubClientSecret string
+)
+
+// LoadGitHubConfig loads GitHub OAuth config.
+// Priority: environment variables > build-time embedded values
 func LoadGitHubConfig() GitHubConfig {
+	clientID := os.Getenv("GITHUB_CLIENT_ID")
+	if clientID == "" {
+		clientID = githubClientID
+	}
+
+	clientSecret := os.Getenv("GITHUB_CLIENT_SECRET")
+	if clientSecret == "" {
+		clientSecret = githubClientSecret
+	}
+
 	return GitHubConfig{
-		ClientID:     os.Getenv("GITHUB_CLIENT_ID"),
-		ClientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
 	}
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -39,15 +39,29 @@ export interface AuthStatus {
   user?: GitHubUser;
 }
 
-// Generate random state for CSRF protection
-function generateState(): string {
-  const array = new Uint8Array(32);
+// Generate random string for state/PKCE
+function generateRandomString(length: number): string {
+  const array = new Uint8Array(length);
   crypto.getRandomValues(array);
   return Array.from(array, b => b.toString(16).padStart(2, '0')).join('');
 }
 
-// Store state temporarily for verification (also in sessionStorage for persistence across refreshes)
+
+// Generate PKCE code challenge from verifier (S256 method)
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  // Base64url encode (no padding)
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+// Store state and verifier temporarily for verification
 let pendingOAuthState: string | null = null;
+let pendingCodeVerifier: string | null = null;
 
 // OAuth timeout duration (2 minutes)
 export const OAUTH_TIMEOUT_MS = 120000;
@@ -83,23 +97,35 @@ export function isOAuthPending(): boolean {
  */
 export function cancelOAuthFlow(): void {
   pendingOAuthState = null;
+  pendingCodeVerifier = null;
+  if (typeof window !== 'undefined') {
+    sessionStorage.removeItem('oauth_state');
+    sessionStorage.removeItem('oauth_code_verifier');
+  }
 }
 
-// Try to restore state from sessionStorage on module load
+// Try to restore state and verifier from sessionStorage on module load
 if (typeof window !== 'undefined') {
   pendingOAuthState = sessionStorage.getItem('oauth_state');
+  pendingCodeVerifier = sessionStorage.getItem('oauth_code_verifier');
 }
 
 /**
- * Start the GitHub OAuth flow
+ * Start the GitHub OAuth flow with PKCE
  * Opens browser to GitHub authorization page
  */
 export async function startOAuthFlow(): Promise<void> {
-  // Clear any previous pending state
-  pendingOAuthState = generateState();
-  // Persist state to sessionStorage in case app refreshes
+  // Generate state and PKCE code verifier (32 bytes = 64 hex chars, within 43-128 range)
+  pendingOAuthState = generateRandomString(32);
+  pendingCodeVerifier = generateRandomString(32);
+
+  // Generate code challenge from verifier
+  const codeChallenge = await generateCodeChallenge(pendingCodeVerifier);
+
+  // Persist to sessionStorage in case app refreshes
   if (typeof window !== 'undefined') {
     sessionStorage.setItem('oauth_state', pendingOAuthState);
+    sessionStorage.setItem('oauth_code_verifier', pendingCodeVerifier);
   }
 
   const params = new URLSearchParams({
@@ -107,6 +133,8 @@ export async function startOAuthFlow(): Promise<void> {
     redirect_uri: GITHUB_REDIRECT_URI,
     scope: GITHUB_SCOPES,
     state: pendingOAuthState,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
   });
 
   const authUrl = `https://github.com/login/oauth/authorize?${params}`;
@@ -162,17 +190,23 @@ export async function handleOAuthCallback(url: string): Promise<{ token: string;
     throw new Error('Security error: state mismatch. Please try again.');
   }
 
+  // Get the code verifier before clearing
+  const codeVerifier = pendingCodeVerifier ||
+    (typeof window !== 'undefined' ? sessionStorage.getItem('oauth_code_verifier') : null);
+
+  // Clear state and verifier
   pendingOAuthState = null;
-  // Clear from sessionStorage
+  pendingCodeVerifier = null;
   if (typeof window !== 'undefined') {
     sessionStorage.removeItem('oauth_state');
+    sessionStorage.removeItem('oauth_code_verifier');
   }
 
-  // Exchange code for token via backend
+  // Exchange code for token via backend (with PKCE verifier)
   const res = await fetch(`${API_BASE}/api/auth/github/callback`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code }),
+    body: JSON.stringify({ code, code_verifier: codeVerifier }),
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary

- Add PKCE (Proof Key for Code Exchange) to GitHub OAuth flow for enhanced security
- Add graceful shutdown with proper signal handling for clean CTRL+C exit
- Support build-time credential embedding for production builds

## Changes

### OAuth Security (PKCE)
- Frontend generates `code_verifier` and `code_challenge` (S256 method)
- Backend passes `code_verifier` to GitHub's token exchange endpoint
- Follows GitHub's best practices for public clients (desktop apps)

### Backend Signal Handling
- Use `signal.NotifyContext` for SIGINT/SIGTERM handling
- Graceful HTTP server shutdown with 2-second timeout
- Context cancellation propagates to all components

### Build System
- `make backend-release` - Production build with embedded GitHub credentials via ldflags
- `make dev` - Fixed signal propagation with trap for clean CTRL+C exit
- Priority: env vars > build-time embedded values (dev can still use .env)

## Test plan
- [x] Go tests pass (including new PKCE test)
- [x] Frontend builds successfully
- [ ] Manual test: `make dev` and CTRL+C exits cleanly
- [ ] Manual test: GitHub OAuth flow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)