### PR TITLE
ci: embed GitHub OAuth credentials in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,15 +79,27 @@ jobs:
 
       - name: Build Go backend (macOS ARM64)
         if: matrix.target == 'aarch64-apple-darwin'
+        env:
+          GITHUB_CLIENT_ID: ${{ secrets.OAUTH_GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_CLIENT_SECRET }}
         run: |
           cd backend
-          GOOS=darwin GOARCH=arm64 go build -o ../src-tauri/binaries/chatml-backend-aarch64-apple-darwin ./cmd/chatml
+          GOOS=darwin GOARCH=arm64 go build -ldflags "\
+            -X 'github.com/chatml/chatml-backend/server.githubClientID=$GITHUB_CLIENT_ID' \
+            -X 'github.com/chatml/chatml-backend/server.githubClientSecret=$GITHUB_CLIENT_SECRET'" \
+            -o ../src-tauri/binaries/chatml-backend-aarch64-apple-darwin .
 
       - name: Build Go backend (macOS x64)
         if: matrix.target == 'x86_64-apple-darwin'
+        env:
+          GITHUB_CLIENT_ID: ${{ secrets.OAUTH_GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_CLIENT_SECRET }}
         run: |
           cd backend
-          GOOS=darwin GOARCH=amd64 go build -o ../src-tauri/binaries/chatml-backend-x86_64-apple-darwin ./cmd/chatml
+          GOOS=darwin GOARCH=amd64 go build -ldflags "\
+            -X 'github.com/chatml/chatml-backend/server.githubClientID=$GITHUB_CLIENT_ID' \
+            -X 'github.com/chatml/chatml-backend/server.githubClientSecret=$GITHUB_CLIENT_SECRET'" \
+            -o ../src-tauri/binaries/chatml-backend-x86_64-apple-darwin .
 
       - name: Sign Go backend sidecar (macOS)
         env:
@@ -124,6 +136,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GitHub OAuth (embedded in frontend at build time)
+          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ secrets.OAUTH_GITHUB_CLIENT_ID }}
           # Tauri update signing
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}


### PR DESCRIPTION
## Summary

Embed GitHub OAuth credentials in production release builds so GitHub Sign In works in distributed app.

## Changes

- Add `OAUTH_GITHUB_CLIENT_ID` and `OAUTH_GITHUB_CLIENT_SECRET` to Go backend build via ldflags
- Add `NEXT_PUBLIC_GITHUB_CLIENT_ID` to frontend build environment
- Fix Go build path (`./cmd/chatml` → `.`)

## Required Setup

Add these secrets in **Settings → Secrets and variables → Actions**:

| Secret Name | Description |
|-------------|-------------|
| `OAUTH_GITHUB_CLIENT_ID` | GitHub OAuth App client ID |
| `OAUTH_GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret |

## Test plan
- [ ] Verify release workflow runs successfully with secrets configured
- [ ] Verify GitHub Sign In works in released app

🤖 Generated with [Claude Code](https://claude.com/claude-code)