### PR TITLE
Add draggable region to sign-in screen

### DIFF
--- a/src/components/OnboardingScreen.tsx
+++ b/src/components/OnboardingScreen.tsx
@@ -58,6 +58,8 @@ export function OnboardingScreen() {
 
   return (
     <div className="relative flex h-screen w-screen items-center justify-center bg-surface-0 overflow-hidden">
+      {/* Draggable region for window management */}
+      <div data-tauri-drag-region className="absolute top-0 left-0 right-0 h-11 z-50" />
       {/* Gradient background (static for performance) */}
       <div className="absolute inset-0 overflow-hidden">
         {/* Large blur orbs */}


### PR DESCRIPTION
## Summary
- Add draggable region to the top of the OnboardingScreen/sign-in page
- Allows users to move the window before authenticating

## Implementation Details
- Added `data-tauri-drag-region` div at the top of the OnboardingScreen component
- Consistent with other draggable regions in TopBar and SettingsPage (h-11 height)

## Test Plan
- [ ] Open app when not authenticated
- [ ] Drag window from the top area of the sign-in screen
- [ ] Verify window moves as expected