### PR TITLE
fix: use in-memory SQLite for tests to prevent database pollution

### DIFF
--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -21,19 +20,13 @@ import (
 func setupTestManager(t *testing.T) (*Manager, *store.SQLiteStore) {
 	t.Helper()
 
-	// Create temp directory for HOME
-	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-
-	sqliteStore, err := store.NewSQLiteStore()
+	sqliteStore, err := store.NewSQLiteStoreInMemory()
 	require.NoError(t, err)
 
 	worktreeManager := git.NewWorktreeManager()
 
 	t.Cleanup(func() {
 		sqliteStore.Close()
-		os.Setenv("HOME", origHome)
 	})
 
 	manager := NewManager(sqliteStore, worktreeManager)

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -871,6 +872,12 @@ func TestCreateSession_DuplicateUserProvidedName(t *testing.T) {
 	// Create a real git repo
 	repoPath := createTestGitRepo(t)
 	repo := createTestRepo(t, s, "ws-1", repoPath)
+
+	// Clean up test session directory after test
+	t.Cleanup(func() {
+		workspacesDir, _ := git.WorkspacesBaseDir()
+		os.RemoveAll(filepath.Join(workspacesDir, "my-session"))
+	})
 
 	// Create first session with explicit name
 	body, _ := json.Marshal(CreateSessionRequest{Name: "my-session"})

--- a/backend/server/router_test.go
+++ b/backend/server/router_test.go
@@ -18,7 +18,7 @@ func setupTestRouter(t *testing.T) (http.Handler, *store.SQLiteStore) {
 	t.Helper()
 
 	// Create in-memory store
-	s, err := store.NewSQLiteStore()
+	s, err := store.NewSQLiteStoreInMemory()
 	require.NoError(t, err)
 	t.Cleanup(func() { s.Close() })
 

--- a/backend/server/testhelpers_test.go
+++ b/backend/server/testhelpers_test.go
@@ -22,17 +22,11 @@ import (
 func setupTestHandlers(t *testing.T) (*Handlers, *store.SQLiteStore) {
 	t.Helper()
 
-	// Create temp directory for HOME
-	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-
-	sqliteStore, err := store.NewSQLiteStore()
+	sqliteStore, err := store.NewSQLiteStoreInMemory()
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		sqliteStore.Close()
-		os.Setenv("HOME", origHome)
 	})
 
 	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil)
@@ -45,12 +39,7 @@ func setupTestHandlers(t *testing.T) (*Handlers, *store.SQLiteStore) {
 func setupTestHandlersWithAgentManager(t *testing.T) (*Handlers, *store.SQLiteStore, *agent.Manager) {
 	t.Helper()
 
-	// Create temp directory for HOME
-	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-
-	sqliteStore, err := store.NewSQLiteStore()
+	sqliteStore, err := store.NewSQLiteStoreInMemory()
 	require.NoError(t, err)
 
 	worktreeManager := git.NewWorktreeManager()
@@ -58,7 +47,6 @@ func setupTestHandlersWithAgentManager(t *testing.T) (*Handlers, *store.SQLiteSt
 
 	t.Cleanup(func() {
 		sqliteStore.Close()
-		os.Setenv("HOME", origHome)
 	})
 
 	handlers := NewHandlers(sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil)

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -69,6 +69,29 @@ func NewSQLiteStore() (*SQLiteStore, error) {
 	return s, nil
 }
 
+// NewSQLiteStoreInMemory creates an in-memory SQLite store for testing
+func NewSQLiteStoreInMemory() (*SQLiteStore, error) {
+	db, err := sql.Open("sqlite", ":memory:?_pragma=foreign_keys(1)")
+	if err != nil {
+		return nil, err
+	}
+
+	// Single connection for in-memory databases
+	db.SetMaxOpenConns(1)
+
+	s := &SQLiteStore{
+		db:     db,
+		dbPath: ":memory:",
+	}
+
+	if err := s.initSchema(); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	return s, nil
+}
+
 // Close closes the database connection
 func (s *SQLiteStore) Close() error {
 	return s.db.Close()


### PR DESCRIPTION
## Summary
- Add `NewSQLiteStoreInMemory()` function for isolated test databases
- Update all test helpers to use in-memory store instead of real database
- Remove HOME environment override hacks that weren't fully isolating tests
- Add proper cleanup for session directory in duplicate name test

## Problem
Tests were using `NewSQLiteStore()` which writes to `~/.chatml/chatml.db`. This caused test data to pollute the production database, resulting in fake workspaces like "001 >" appearing in the UI.

## Solution
Created an in-memory SQLite constructor for tests that:
- Creates a `:memory:` database that doesn't persist
- Sets single connection (required for in-memory SQLite)
- Initializes schema just like the production store

## Test plan
- [x] All backend tests pass: `go test ./...`
- [x] Build succeeds: `go build ./...`
- [x] Tests are properly isolated (no database pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)