### PR TITLE
feat: add file commit history panel with diff viewer

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -38,12 +39,13 @@ func NewRepoManager() *RepoManager {
 	return &RepoManager{}
 }
 
-// validateGitRef validates a git reference (branch, tag, commit SHA) to prevent command injection.
+// ValidateGitRef validates a git reference (branch, tag, commit SHA) to prevent command injection.
 // Valid refs contain only alphanumeric characters, hyphens, underscores, forward slashes, dots, and tildes.
 // Rejects refs starting with hyphen (could be interpreted as flags) or containing shell metacharacters.
+// Exported for use by handlers that need early validation with better error messages.
 var validGitRefPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-/~^@{}]*$`)
 
-func validateGitRef(ref string) error {
+func ValidateGitRef(ref string) error {
 	if ref == "" {
 		return fmt.Errorf("empty git ref")
 	}
@@ -84,7 +86,7 @@ func (rm *RepoManager) GetRepoName(path string) string {
 
 // GetFileAtRef returns the content of a file at a specific git ref (branch, tag, or commit)
 func (rm *RepoManager) GetFileAtRef(ctx context.Context, repoPath, ref, filePath string) (string, error) {
-	if err := validateGitRef(ref); err != nil {
+	if err := ValidateGitRef(ref); err != nil {
 		return "", fmt.Errorf("invalid ref: %w", err)
 	}
 	cmd, cancel := gitCmdWithContext(ctx, repoPath, "show", fmt.Sprintf("%s:%s", ref, filePath))
@@ -98,7 +100,7 @@ func (rm *RepoManager) GetFileAtRef(ctx context.Context, repoPath, ref, filePath
 
 // GetChangedFiles returns a list of files that have changed compared to a base ref
 func (rm *RepoManager) GetChangedFiles(ctx context.Context, repoPath, baseRef string) ([]string, error) {
-	if err := validateGitRef(baseRef); err != nil {
+	if err := ValidateGitRef(baseRef); err != nil {
 		return nil, fmt.Errorf("invalid base ref: %w", err)
 	}
 	cmd, cancel := gitCmdWithContext(ctx, repoPath, "diff", "--name-only", baseRef)
@@ -128,7 +130,7 @@ type FileChange struct {
 
 // GetChangedFilesWithStats returns files changed compared to a base ref with addition/deletion counts
 func (rm *RepoManager) GetChangedFilesWithStats(ctx context.Context, repoPath, baseRef string) ([]FileChange, error) {
-	if err := validateGitRef(baseRef); err != nil {
+	if err := ValidateGitRef(baseRef); err != nil {
 		return nil, fmt.Errorf("invalid base ref: %w", err)
 	}
 	// First get the diff stats
@@ -223,6 +225,99 @@ func (rm *RepoManager) GetUntrackedFiles(ctx context.Context, repoPath string) (
 	}
 
 	return untracked, nil
+}
+
+// FileCommit represents a commit that touched a specific file
+type FileCommit struct {
+	SHA       string    `json:"sha"`
+	ShortSHA  string    `json:"shortSha"`
+	Message   string    `json:"message"`
+	Author    string    `json:"author"`
+	Email     string    `json:"email"`
+	Timestamp time.Time `json:"timestamp"`
+	Additions int       `json:"additions"`
+	Deletions int       `json:"deletions"`
+}
+
+// GetFileCommitHistory returns the commit history for a specific file
+// Uses --follow to track file renames
+func (rm *RepoManager) GetFileCommitHistory(ctx context.Context, repoPath, filePath string) ([]FileCommit, error) {
+	// Build git log command with custom format
+	// Format: SHA|ShortSHA|AuthorName|AuthorEmail|Timestamp|Subject
+	args := []string{
+		"log",
+		"--follow",
+		"--pretty=format:%H|%h|%an|%ae|%aI|%s",
+		"--numstat",
+		"--",
+		filePath,
+	}
+
+	cmd, cancel := gitCmdWithContext(ctx, repoPath, args...)
+	defer cancel()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var commits []FileCommit
+	lines := strings.Split(string(out), "\n")
+
+	var current *FileCommit
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Check if this is a commit line (contains 5 pipes for our format)
+		if strings.Count(line, "|") == 5 {
+			// Save previous commit if exists
+			if current != nil {
+				commits = append(commits, *current)
+			}
+
+			parts := strings.SplitN(line, "|", 6)
+			if len(parts) != 6 {
+				continue
+			}
+
+			timestamp, _ := time.Parse(time.RFC3339, parts[4])
+			current = &FileCommit{
+				SHA:       parts[0],
+				ShortSHA:  parts[1],
+				Author:    parts[2],
+				Email:     parts[3],
+				Timestamp: timestamp,
+				Message:   parts[5],
+			}
+		} else if current != nil {
+			// Parse numstat line: additions deletions filename
+			// With --follow, renames may produce multiple stat lines per commit.
+			// We accumulate values to capture total changes for the file.
+			statParts := strings.Fields(line)
+			if len(statParts) >= 2 {
+				// Handle binary files (shown as "-")
+				if statParts[0] != "-" {
+					if additions, err := strconv.Atoi(statParts[0]); err == nil {
+						current.Additions += additions
+					}
+				}
+				if statParts[1] != "-" {
+					if deletions, err := strconv.Atoi(statParts[1]); err == nil {
+						current.Deletions += deletions
+					}
+				}
+			}
+		}
+	}
+
+	// Don't forget the last commit
+	if current != nil {
+		commits = append(commits, *current)
+	}
+
+	return commits, nil
 }
 
 // HasMergeConflicts checks if there are any merge conflicts in the repo
@@ -382,7 +477,7 @@ func (rm *RepoManager) getSyncStatus(ctx context.Context, repoPath, baseBranch s
 	}
 
 	// Validate base branch ref
-	if err := validateGitRef(baseBranch); err != nil {
+	if err := ValidateGitRef(baseBranch); err != nil {
 		return status, fmt.Errorf("invalid base branch: %w", err)
 	}
 

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -939,6 +939,105 @@ func (h *Handlers) GetSessionFileDiff(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, response)
 }
 
+// FileHistoryResponse represents the commit history for a file
+type FileHistoryResponse struct {
+	Commits []git.FileCommit `json:"commits"`
+	Total   int              `json:"total"`
+}
+
+// GetSessionFileHistory returns the commit history for a specific file in a session's worktree
+func (h *Handlers) GetSessionFileHistory(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sessionID := chi.URLParam(r, "sessionId")
+	session, err := h.store.GetSession(ctx, sessionID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if session == nil {
+		writeNotFound(w, "session")
+		return
+	}
+
+	filePath := r.URL.Query().Get("path")
+	if filePath == "" {
+		writeValidationError(w, "path parameter is required")
+		return
+	}
+
+	// Validate and clean the path to prevent directory traversal attacks
+	cleanPath, err := validatePath(session.WorktreePath, filePath)
+	if err != nil {
+		writeValidationError(w, "invalid path")
+		return
+	}
+
+	commits, err := h.repoManager.GetFileCommitHistory(ctx, session.WorktreePath, cleanPath)
+	if err != nil {
+		// Empty history is valid for new files
+		log.Printf("[handlers] Debug: failed to get file history for %s: %v (returning empty)", cleanPath, err)
+		commits = []git.FileCommit{}
+	}
+
+	writeJSON(w, FileHistoryResponse{
+		Commits: commits,
+		Total:   len(commits),
+	})
+}
+
+// GetSessionFileAtRef returns the content of a file at a specific git ref (commit SHA)
+func (h *Handlers) GetSessionFileAtRef(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sessionID := chi.URLParam(r, "sessionId")
+	session, err := h.store.GetSession(ctx, sessionID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if session == nil {
+		writeNotFound(w, "session")
+		return
+	}
+
+	filePath := r.URL.Query().Get("path")
+	if filePath == "" {
+		writeValidationError(w, "path parameter is required")
+		return
+	}
+
+	ref := r.URL.Query().Get("ref")
+	if ref == "" {
+		writeValidationError(w, "ref parameter is required")
+		return
+	}
+
+	// Validate ref format early for better error messages
+	if err := git.ValidateGitRef(ref); err != nil {
+		writeValidationError(w, "invalid commit reference format")
+		return
+	}
+
+	// Validate and clean the path to prevent directory traversal attacks
+	cleanPath, err := validatePath(session.WorktreePath, filePath)
+	if err != nil {
+		writeValidationError(w, "invalid path")
+		return
+	}
+
+	content, err := h.repoManager.GetFileAtRef(ctx, session.WorktreePath, ref, cleanPath)
+	if err != nil {
+		writeInternalError(w, "failed to read file at ref", err)
+		return
+	}
+
+	writeJSON(w, FileContentResponse{
+		Path:    cleanPath,
+		Name:    filepath.Base(cleanPath),
+		Content: content,
+		Size:    int64(len(content)),
+	})
+}
+
 type SendMessageRequest struct {
 	Content string `json:"content"`
 }

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -76,6 +76,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Get("/{id}/sessions/{sessionId}/git-status", h.GetSessionGitStatus)
 		r.Get("/{id}/sessions/{sessionId}/pr-status", h.GetSessionPRStatus)
 		r.Get("/{id}/sessions/{sessionId}/diff", h.GetSessionFileDiff)
+		r.Get("/{id}/sessions/{sessionId}/file-history", h.GetSessionFileHistory)
+		r.Get("/{id}/sessions/{sessionId}/file-at-ref", h.GetSessionFileAtRef)
 		r.Get("/{id}/sessions/{sessionId}/file", h.GetSessionFileContent)
 		r.Get("/{id}/sessions/{sessionId}/files", h.ListSessionFiles)
 		r.With(messageRateLimiter).Post("/{id}/sessions/{sessionId}/message", h.SendSessionMessage)

--- a/src/components/ChangesPanel.tsx
+++ b/src/components/ChangesPanel.tsx
@@ -18,6 +18,7 @@ import { usePRStatus } from '@/hooks/usePRStatus';
 import { McpServersPanel } from '@/components/McpServersPanel';
 import { PlansPanel } from '@/components/PlansPanel';
 import { ReviewPanel } from '@/components/ReviewPanel';
+import { FileHistoryPanel } from '@/components/FileHistoryPanel';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -648,6 +649,7 @@ export function ChangesPanel({
               {bottomTab === 'budget' && <BudgetStatusPanel />}
               {bottomTab === 'mcp' && <McpServersPanel />}
               {bottomTab === 'history' && <CheckpointTimeline />}
+              {bottomTab === 'file-history' && <FileHistoryPanel />}
             </div>
           </div>
         </ResizablePanel>
@@ -661,6 +663,7 @@ const BOTTOM_TABS_CONFIG: Record<AllBottomPanelTab, { label: string; alwaysVisib
   todos: { label: 'Tasks', alwaysVisible: true },
   plans: { label: 'Plans' },
   history: { label: 'Checkpoints' },
+  'file-history': { label: 'File History' },
   budget: { label: 'Budget' },
   mcp: { label: 'MCP' },
 };

--- a/src/components/FileHistoryPanel.tsx
+++ b/src/components/FileHistoryPanel.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useSelectedIds, useFileTabState } from '@/stores/selectors';
+import { EmptyState } from '@/components/ui/empty-state';
+import { GitCommitHorizontal, FileQuestion, Loader2 } from 'lucide-react';
+import {
+  getFileCommitHistory,
+  getFileAtCommit,
+  getSessionFileContent,
+  type FileCommitDTO,
+} from '@/lib/api';
+
+const ITEM_HEIGHT = 56; // Estimated height per commit row in pixels
+const OVERSCAN = 5; // Extra items to render above/below viewport
+
+/**
+ * Format a relative time string from an ISO timestamp.
+ */
+function formatRelativeTime(isoTimestamp: string): string {
+  try {
+    const date = new Date(isoTimestamp);
+    if (isNaN(date.getTime())) {
+      return 'unknown';
+    }
+
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+
+    return date.toLocaleDateString();
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function FileHistoryPanel() {
+  const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
+  const { fileTabs, selectedFileTabId, openFileTab, updateFileTab } = useFileTabState();
+
+  const [commits, setCommits] = useState<FileCommitDTO[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Virtual scroll state
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  // Track if component is mounted
+  const isMountedRef = useRef(false);
+
+  // Get current file from selected tab
+  const currentFileTab = useMemo(() => {
+    if (!selectedFileTabId || !selectedSessionId) return null;
+    return fileTabs.find((t) => t.id === selectedFileTabId && t.sessionId === selectedSessionId);
+  }, [fileTabs, selectedFileTabId, selectedSessionId]);
+
+  const currentFilePath = currentFileTab?.path;
+
+  // Fetch function that handles all state updates
+  const fetchHistory = useCallback(async () => {
+    if (!selectedWorkspaceId || !selectedSessionId || !currentFilePath) {
+      setCommits([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getFileCommitHistory(selectedWorkspaceId, selectedSessionId, currentFilePath);
+      if (isMountedRef.current) {
+        setCommits(data.commits);
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to load history');
+        setCommits([]);
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [selectedWorkspaceId, selectedSessionId, currentFilePath]);
+
+  // Fetch file history when file changes
+  useEffect(() => {
+    isMountedRef.current = true;
+    fetchHistory();
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, [fetchHistory]);
+
+  // Handle container resize
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerHeight(entry.contentRect.height);
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  // Handle scroll
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    setScrollTop(e.currentTarget.scrollTop);
+  }, []);
+
+  // Calculate virtual window
+  const { startIndex, endIndex, paddingTop, paddingBottom } = useMemo(() => {
+    const start = Math.max(0, Math.floor(scrollTop / ITEM_HEIGHT) - OVERSCAN);
+    const visibleCount = Math.ceil(containerHeight / ITEM_HEIGHT) + OVERSCAN * 2;
+    const end = Math.min(commits.length, start + visibleCount);
+
+    return {
+      startIndex: start,
+      endIndex: end,
+      paddingTop: start * ITEM_HEIGHT,
+      paddingBottom: Math.max(0, (commits.length - end) * ITEM_HEIGHT),
+    };
+  }, [scrollTop, containerHeight, commits.length]);
+
+  const visibleCommits = useMemo(
+    () => commits.slice(startIndex, endIndex),
+    [commits, startIndex, endIndex]
+  );
+
+  // Handle commit click - show diff
+  const handleCommitClick = useCallback(
+    async (commit: FileCommitDTO) => {
+      if (!selectedWorkspaceId || !selectedSessionId || !currentFilePath || !currentFileTab) return;
+
+      const tabId = `history-diff-${currentFilePath}-${commit.sha}`;
+      const filename = currentFilePath.split('/').pop() || currentFilePath;
+
+      // Open tab with loading state
+      openFileTab({
+        id: tabId,
+        workspaceId: selectedWorkspaceId,
+        sessionId: selectedSessionId,
+        path: currentFilePath,
+        name: `${filename} @ ${commit.shortSha}`,
+        isLoading: true,
+        viewMode: 'diff',
+      });
+
+      try {
+        // Fetch old content (at commit) and current content in parallel
+        const [oldContentResult, currentContentResult] = await Promise.all([
+          getFileAtCommit(selectedWorkspaceId, selectedSessionId, currentFilePath, commit.sha),
+          getSessionFileContent(selectedWorkspaceId, selectedSessionId, currentFilePath),
+        ]);
+
+        updateFileTab(tabId, {
+          diff: {
+            oldContent: oldContentResult.content,
+            newContent: currentContentResult.content,
+          },
+          isLoading: false,
+        });
+      } catch (err) {
+        updateFileTab(tabId, {
+          isLoading: false,
+          content: `// Error loading diff: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          viewMode: 'file',
+        });
+      }
+    },
+    [selectedWorkspaceId, selectedSessionId, currentFilePath, currentFileTab, openFileTab, updateFileTab]
+  );
+
+  // Empty states
+  if (!currentFilePath) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <EmptyState
+          icon={FileQuestion}
+          title="No file selected"
+          description="Select a file to view its commit history"
+        />
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <EmptyState icon={GitCommitHorizontal} title="Error loading history" description={error} />
+      </div>
+    );
+  }
+
+  if (commits.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <EmptyState
+          icon={GitCommitHorizontal}
+          title="No commit history"
+          description="This file has no git history yet"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="h-full overflow-auto" onScroll={handleScroll}>
+      <div style={{ height: commits.length * ITEM_HEIGHT }}>
+        <div style={{ paddingTop, paddingBottom }}>
+          {visibleCommits.map((commit) => (
+            <CommitRow key={commit.sha} commit={commit} onClick={() => handleCommitClick(commit)} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CommitRow({ commit, onClick }: { commit: FileCommitDTO; onClick: () => void }) {
+  const timeAgo = useMemo(() => formatRelativeTime(commit.timestamp), [commit.timestamp]);
+
+  return (
+    <div
+      className="flex items-start gap-2 px-2 py-1.5 hover:bg-surface-2 cursor-pointer group"
+      style={{ height: ITEM_HEIGHT }}
+      onClick={onClick}
+    >
+      <GitCommitHorizontal className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-medium truncate" title={commit.message}>
+          {commit.message}
+        </div>
+        <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+          <span className="font-mono">{commit.shortSha}</span>
+          <span className="truncate">{commit.author}</span>
+          <span>{timeAgo}</span>
+        </div>
+        {/* Always render stats line to maintain consistent ITEM_HEIGHT for virtual scroll */}
+        <div className="text-[11px] tabular-nums h-[14px]">
+          {commit.additions > 0 && <span className="text-text-success">+{commit.additions}</span>}
+          {commit.deletions > 0 && (
+            <span className="text-text-error ml-1">-{commit.deletions}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -266,6 +266,48 @@ export async function getGitStatus(workspaceId: string, sessionId: string): Prom
   return handleResponse<GitStatusDTO>(res);
 }
 
+// File commit history types
+export interface FileCommitDTO {
+  sha: string;
+  shortSha: string;
+  message: string;
+  author: string;
+  email: string;
+  timestamp: string;
+  additions: number;
+  deletions: number;
+}
+
+export interface FileHistoryResponse {
+  commits: FileCommitDTO[];
+  total: number;
+}
+
+export async function getFileCommitHistory(
+  workspaceId: string,
+  sessionId: string,
+  filePath: string
+): Promise<FileHistoryResponse> {
+  const params = new URLSearchParams({ path: filePath });
+  const res = await fetchWithAuth(
+    `${API_BASE}/api/repos/${workspaceId}/sessions/${sessionId}/file-history?${params.toString()}`
+  );
+  return handleResponse<FileHistoryResponse>(res);
+}
+
+export async function getFileAtCommit(
+  workspaceId: string,
+  sessionId: string,
+  filePath: string,
+  commitSha: string
+): Promise<FileContentDTO> {
+  const params = new URLSearchParams({ path: filePath, ref: commitSha });
+  const res = await fetchWithAuth(
+    `${API_BASE}/api/repos/${workspaceId}/sessions/${sessionId}/file-at-ref?${params.toString()}`
+  );
+  return handleResponse<FileContentDTO>(res);
+}
+
 // PR Details types
 export type CheckStatus = 'pending' | 'success' | 'failure' | 'none';
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -2,13 +2,13 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 // Bottom panel tab IDs that can be toggled (Tasks is always visible)
-export type BottomPanelTab = 'plans' | 'history' | 'budget' | 'mcp';
+export type BottomPanelTab = 'plans' | 'history' | 'budget' | 'mcp' | 'file-history';
 
 // All bottom panel tabs including the always-visible Tasks
 export type AllBottomPanelTab = 'todos' | BottomPanelTab;
 
 // Default tab order
-export const DEFAULT_BOTTOM_TAB_ORDER: AllBottomPanelTab[] = ['todos', 'plans', 'history', 'budget', 'mcp'];
+export const DEFAULT_BOTTOM_TAB_ORDER: AllBottomPanelTab[] = ['todos', 'plans', 'history', 'file-history', 'budget', 'mcp'];
 
 // Theme options
 export type ThemeOption = 'system' | 'light' | 'dark';


### PR DESCRIPTION
## Summary

Adds a new File History panel that displays commit history for selected files with the ability to view diffs between historical and current versions. The implementation includes security validations, virtual scrolling for performance, and handles edge cases like file renames.

## Changes

- **Backend**: New `GetFileCommitHistory()` method with `--follow` support for renames
- **Frontend**: Virtual-scrolled `FileHistoryPanel` component with relative time formatting  
- **API**: New endpoints for file history and content at specific commits
- **UI**: Integrated as new bottom panel tab

## Testing

- All Go tests pass (git: 5.8s, server: 6.7s)
- ESLint passes with no new warnings
- Code review issues addressed with improvements to error handling and validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)