### PR TITLE
style: mute brand colors in sidebar header

### DIFF
--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -317,7 +317,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
 
       {/* Header - pl-20 gives space for macOS traffic lights */}
       <div data-tauri-drag-region className={cn("relative h-10 pl-20 pr-3 flex items-center justify-between border-b shrink-0", leftToolbarBg)}>
-        <span className="text-2xl font-extrabold"><span className="text-foreground">chat</span><span className="text-violet-500">ml</span></span>
+        <span className="text-2xl font-extrabold"><span className="text-muted-foreground">chat</span><span className="text-violet-400/80">ml</span></span>
         {onToggleSidebar && (
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- Mute "chat" text using `text-muted-foreground` instead of bright `text-foreground`
- Soften "ml" purple using `text-violet-400/80` instead of bright `text-violet-500`

Reduces visual distraction from the brand in the sidebar header.

## Test plan
- [ ] Verify brand text is visible but not distracting
- [ ] Check appearance in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)