### PR TITLE
feat: add theme splash background color to prevent flash on startup

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "resizable": true,
         "fullscreen": false,
         "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "hiddenTitle": true,
+        "backgroundColor": "#141414"
       }
     ],
     "security": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { GeistSans } from "geist/font/sans";
 import "@fontsource/instrument-serif/400.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { ThemeScript } from "@/components/ThemeScript";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -16,6 +17,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
       <body className={GeistSans.className}>
         <ThemeProvider
           attribute="class"

--- a/src/components/ThemeScript.tsx
+++ b/src/components/ThemeScript.tsx
@@ -1,0 +1,45 @@
+/**
+ * ThemeScript - Prevents flash of wrong theme on app startup
+ *
+ * This component renders an inline script that runs synchronously in the <head>
+ * before CSS is parsed. It reads the theme preference from localStorage and
+ * immediately applies the correct class and background color to prevent any
+ * visible flash.
+ */
+export function ThemeScript() {
+  const script = `
+(function() {
+  // Must match next-themes storageKey (default: 'theme')
+  var STORAGE_KEY = 'theme';
+  // Must match globals.css: .dark --background and light theme --background
+  var DARK_BG = '#141414';
+  var LIGHT_BG = '#ffffff';
+
+  function getTheme() {
+    try {
+      var stored = localStorage.getItem(STORAGE_KEY);
+      if (stored === 'dark') return 'dark';
+      if (stored === 'light') return 'light';
+    } catch (e) {}
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  var theme = getTheme();
+  var html = document.documentElement;
+
+  if (theme === 'dark') {
+    html.classList.add('dark');
+    html.style.backgroundColor = DARK_BG;
+  } else {
+    html.classList.remove('dark');
+    html.style.backgroundColor = LIGHT_BG;
+  }
+})();
+`;
+
+  return (
+    <script
+      dangerouslySetInnerHTML={{ __html: script }}
+    />
+  );
+}


### PR DESCRIPTION
Prevents the flash of wrong theme color on app startup by applying the correct background immediately when the page loads.

The ThemeScript component runs synchronously in the <head> before CSS parsing to read theme preference from localStorage (or system preference as fallback) and apply the correct background color. This coordinates with the Tauri window backgroundColor setting to ensure consistent appearance from launch.

Includes detailed comments to maintain sync between the inline script constants and globals.css / next-themes configuration.

🤖 Generated with Claude Code