### PR TITLE
fix: enable syntax highlighting in Monaco diff editor

### DIFF
--- a/src/components/MonacoEditor.tsx
+++ b/src/components/MonacoEditor.tsx
@@ -345,6 +345,8 @@ export function MonacoDiffEditor({
       language={language}
       original={oldContent}
       modified={newContent}
+      originalModelPath={`original://${filename}`}
+      modifiedModelPath={`modified://${filename}`}
       theme={activeTheme}
       loading={<EditorLoading />}
       onMount={handleMount}


### PR DESCRIPTION
## Summary
Add originalModelPath and modifiedModelPath props to DiffEditor component to fix model caching issues that prevented syntax highlighting from being applied in diff view.

## Test Plan
- Run `make dev` to start development server
- Open a code file in the code viewer (verify highlighting works)
- Switch to diff view for the same file
- Verify syntax highlighting appears in both original and modified panes
- Test with multiple file types: TypeScript, Go, Python, JSON

🤖 Generated with Claude Code