### PR TITLE
feat: add PR dashboard with full-content layout

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -2395,3 +2395,183 @@ func (h *Handlers) GetSessionPRStatus(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, prDetails)
 }
+
+// PRDashboardItem represents a PR in the dashboard
+type PRDashboardItem struct {
+	// PR metadata
+	Number         int           `json:"number"`
+	Title          string        `json:"title"`
+	State          string        `json:"state"`
+	HTMLURL        string        `json:"htmlUrl"`
+	IsDraft        bool          `json:"isDraft"`
+	Mergeable      *bool         `json:"mergeable"`
+	MergeableState string        `json:"mergeableState"`
+	CheckStatus    string        `json:"checkStatus"`
+	CheckDetails   []interface{} `json:"checkDetails"`
+
+	// Branch info
+	Branch     string `json:"branch"`
+	BaseBranch string `json:"baseBranch"`
+
+	// Session info (if created from ChatML)
+	SessionID   string `json:"sessionId,omitempty"`
+	SessionName string `json:"sessionName,omitempty"`
+
+	// Workspace info
+	WorkspaceID   string `json:"workspaceId"`
+	WorkspaceName string `json:"workspaceName"`
+	RepoOwner     string `json:"repoOwner"`
+	RepoName      string `json:"repoName"`
+
+	// Counts for summary
+	ChecksTotal  int `json:"checksTotal"`
+	ChecksPassed int `json:"checksPassed"`
+	ChecksFailed int `json:"checksFailed"`
+}
+
+// ListPRs returns all PRs across workspaces with their status
+func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Optional workspace filter
+	workspaceID := r.URL.Query().Get("workspaceId")
+
+	// Get all repos (or specific repo if filtered)
+	var repos []*models.Repo
+	var err error
+
+	if workspaceID != "" {
+		repo, err := h.store.GetRepo(ctx, workspaceID)
+		if err != nil {
+			writeDBError(w, err)
+			return
+		}
+		if repo == nil {
+			writeNotFound(w, "workspace")
+			return
+		}
+		repos = []*models.Repo{repo}
+	} else {
+		repos, err = h.store.ListRepos(ctx)
+		if err != nil {
+			writeDBError(w, err)
+			return
+		}
+	}
+
+	// Collect all PRs
+	var prItems []PRDashboardItem
+
+	for _, repo := range repos {
+		// Get GitHub remote info for this repo
+		owner, repoName, err := h.repoManager.GetGitHubRemote(ctx, repo.Path)
+		if err != nil {
+			// Skip repos without GitHub remote
+			continue
+		}
+
+		// List sessions for this repo
+		sessions, err := h.store.ListSessions(ctx, repo.ID)
+		if err != nil {
+			continue
+		}
+
+		// Filter to sessions with PRs
+		for _, session := range sessions {
+			if session.PRStatus == "" || session.PRStatus == "none" || session.PRNumber == 0 {
+				continue
+			}
+
+			// Only include open PRs (for dashboard view)
+			if session.PRStatus != "open" {
+				continue
+			}
+
+			// Get PR details from GitHub
+			var prItem PRDashboardItem
+
+			if h.ghClient != nil {
+				prDetails, err := h.ghClient.GetPRDetails(ctx, owner, repoName, session.PRNumber)
+				if err == nil && prDetails != nil {
+					prItem = PRDashboardItem{
+						Number:         prDetails.Number,
+						Title:          prDetails.Title,
+						State:          prDetails.State,
+						HTMLURL:        prDetails.HTMLURL,
+						Mergeable:      prDetails.Mergeable,
+						MergeableState: prDetails.MergeableState,
+						CheckStatus:    string(prDetails.CheckStatus),
+						Branch:         session.Branch,
+						BaseBranch:     repo.Branch, // Default branch
+						SessionID:      session.ID,
+						SessionName:    session.Name,
+						WorkspaceID:    repo.ID,
+						WorkspaceName:  repo.Name,
+						RepoOwner:      owner,
+						RepoName:       repoName,
+					}
+
+					// Convert check details to interface slice
+					for _, check := range prDetails.CheckDetails {
+						prItem.CheckDetails = append(prItem.CheckDetails, check)
+					}
+
+					// Calculate counts
+					prItem.ChecksTotal = len(prDetails.CheckDetails)
+					for _, check := range prDetails.CheckDetails {
+						if check.Status == "completed" {
+							if check.Conclusion == "success" || check.Conclusion == "neutral" || check.Conclusion == "skipped" {
+								prItem.ChecksPassed++
+							} else {
+								prItem.ChecksFailed++
+							}
+						}
+					}
+				} else {
+					// Fallback to session data if GitHub API fails
+					prItem = PRDashboardItem{
+						Number:        session.PRNumber,
+						Title:         session.Task,
+						State:         session.PRStatus,
+						HTMLURL:       session.PRUrl,
+						CheckStatus:   "unknown",
+						Branch:        session.Branch,
+						BaseBranch:    repo.Branch,
+						SessionID:     session.ID,
+						SessionName:   session.Name,
+						WorkspaceID:   repo.ID,
+						WorkspaceName: repo.Name,
+						RepoOwner:     owner,
+						RepoName:      repoName,
+					}
+				}
+			} else {
+				// No GitHub client - use session data
+				prItem = PRDashboardItem{
+					Number:        session.PRNumber,
+					Title:         session.Task,
+					State:         session.PRStatus,
+					HTMLURL:       session.PRUrl,
+					CheckStatus:   "unknown",
+					Branch:        session.Branch,
+					BaseBranch:    repo.Branch,
+					SessionID:     session.ID,
+					SessionName:   session.Name,
+					WorkspaceID:   repo.ID,
+					WorkspaceName: repo.Name,
+					RepoOwner:     owner,
+					RepoName:      repoName,
+				}
+			}
+
+			prItems = append(prItems, prItem)
+		}
+	}
+
+	// Return empty array instead of null
+	if prItems == nil {
+		prItems = []PRDashboardItem{}
+	}
+
+	writeJSON(w, prItems)
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -57,6 +57,9 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	// Rate limiter for comment operations
 	commentRateLimiter := httprate.LimitByIP(60, 1*time.Minute) // 60 comments per minute
 
+	// PR Dashboard endpoint
+	r.Get("/api/prs", h.ListPRs)
+
 	// Repository endpoints
 	r.Route("/api/repos", func(r chi.Router) {
 		r.Get("/", h.ListRepos)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
-import { useSettingsStore } from '@/stores/settingsStore';
+import { useSettingsStore, type ContentView } from '@/stores/settingsStore';
 import { useAuthStore } from '@/stores/authStore';
 import { OnboardingScreen } from '@/components/OnboardingScreen';
 import { initAuth, listenForOAuthCallback, validateStoredToken, OAUTH_TIMEOUT_MS } from '@/lib/auth';
@@ -33,6 +33,8 @@ import { FilePicker } from '@/components/FilePicker';
 // import { UpdateChecker } from '@/components/UpdateChecker';
 import { BackendStatus } from '@/components/BackendStatus';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { FullContentLayout } from '@/components/FullContentLayout';
+import { PRDashboard } from '@/components/PRDashboard';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ToastProvider } from '@/components/ui/toast';
 import { HEALTH_CHECK_MAX_RETRIES, HEALTH_CHECK_INITIAL_DELAY_MS } from '@/lib/constants';
@@ -128,7 +130,11 @@ export default function Home() {
   const leftSidebarRef = useRef<HTMLDivElement>(null);
 
   const confirmCloseActiveTab = useSettingsStore((s) => s.confirmCloseActiveTab);
+  const contentView = useSettingsStore((s) => s.contentView);
   const { showBottomTerminal, setShowBottomTerminal, zenMode, setZenMode } = useSettingsStore();
+
+  // Determine if we're in a Full Content view (not conversation)
+  const isFullContentView = contentView.type !== 'conversation';
 
   const {
     isLoading: authLoading,
@@ -938,10 +944,34 @@ export default function Home() {
           {/* Main Content */}
           <ResizablePanel id="main-content" defaultSize={48} minSize={30}>
             <ResizablePanelGroup direction="vertical">
-              {/* Conversation Area */}
+              {/* Main Content Area */}
               <ResizablePanel id="conversation" defaultSize={showBottomTerminal ? 70 : 100} minSize={20}>
                 {isLoadingData ? (
                   <ConversationSkeleton />
+                ) : isFullContentView ? (
+                  // Full Content Views (PR Dashboard, Workspace Dashboard, etc.)
+                  <ErrorBoundary section="FullContent">
+                    {contentView.type === 'pr-dashboard' && (
+                      <PRDashboard
+                        initialWorkspaceId={contentView.workspaceId}
+                        onOpenSettings={() => setShowSettings(true)}
+                        onOpenShortcuts={() => setShowShortcuts(true)}
+                        showLeftSidebar={showLeftSidebar}
+                      />
+                    )}
+                    {contentView.type === 'workspace-dashboard' && (
+                      <FullContentLayout
+                        title="Dashboard"
+                        onOpenSettings={() => setShowSettings(true)}
+                        onOpenShortcuts={() => setShowShortcuts(true)}
+                        showLeftSidebar={showLeftSidebar}
+                      >
+                        <div className="p-4 text-muted-foreground">
+                          Workspace Dashboard coming soon...
+                        </div>
+                      </FullContentLayout>
+                    )}
+                  </ErrorBoundary>
                 ) : !selectedSessionId ? (
                   <EmptyView
                     onOpenProject={handleOpenProject}
@@ -994,8 +1024,8 @@ export default function Home() {
             </ResizablePanelGroup>
           </ResizablePanel>
 
-          {/* Right Sidebar (hidden in zen mode or when no session selected) */}
-          {showRightSidebar && !zenMode && selectedSessionId && (
+          {/* Right Sidebar (hidden in zen mode, full content view, or when no session selected) */}
+          {showRightSidebar && !zenMode && !isFullContentView && selectedSessionId && (
             <>
               <ResizableHandle direction="horizontal" />
 

--- a/src/components/FullContentLayout.tsx
+++ b/src/components/FullContentLayout.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useUIStore } from '@/stores/uiStore';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  ArrowLeft,
+  Settings,
+  Keyboard,
+  MoreVertical,
+  BookOpen,
+  MessageCircle,
+  ExternalLink,
+} from 'lucide-react';
+
+interface FullContentLayoutProps {
+  title: string;
+  children: ReactNode;
+  headerActions?: ReactNode;
+  onOpenSettings?: () => void;
+  onOpenShortcuts?: () => void;
+  showLeftSidebar?: boolean;
+  onToggleLeftSidebar?: () => void;
+}
+
+export function FullContentLayout({
+  title,
+  children,
+  headerActions,
+  onOpenSettings,
+  onOpenShortcuts,
+  showLeftSidebar = true,
+}: FullContentLayoutProps) {
+  const setContentView = useSettingsStore((s) => s.setContentView);
+  const centerToolbarBg = useUIStore((state) => state.toolbarBackgrounds.center);
+
+  const handleBack = () => {
+    setContentView({ type: 'conversation' });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div
+        data-tauri-drag-region
+        className={cn(
+          'h-10 flex items-center border-b shrink-0 pr-1',
+          centerToolbarBg,
+          !showLeftSidebar && 'pl-20'
+        )}
+      >
+        {/* Back Button */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 ml-2"
+          onClick={handleBack}
+          title="Back to conversation"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+        </Button>
+
+        {/* Title */}
+        <h1 className="text-sm font-medium ml-2">{title}</h1>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* View-specific header actions */}
+        {headerActions && (
+          <div className="flex items-center gap-1 mr-2">{headerActions}</div>
+        )}
+
+        {/* Common actions */}
+        <div className="flex items-center gap-0.5">
+          {/* More Menu with Settings, Shortcuts, etc. */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                title="More options"
+              >
+                <MoreVertical className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onOpenSettings}>
+                <Settings className="size-4" />
+                Settings
+                <span className="ml-auto text-xs text-muted-foreground">⌘,</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onOpenShortcuts}>
+                <Keyboard className="size-4" />
+                Keyboard Shortcuts
+                <span className="ml-auto text-xs text-muted-foreground">⌘/</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => window.open('https://docs.chatml.dev', '_blank')}>
+                <BookOpen className="size-4" />
+                Documentation
+                <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => window.open('https://github.com/chatml/chatml/issues', '_blank')}>
+                <MessageCircle className="size-4" />
+                Send Feedback
+                <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">{children}</div>
+    </div>
+  );
+}

--- a/src/components/PRDashboard.tsx
+++ b/src/components/PRDashboard.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { FullContentLayout } from '@/components/FullContentLayout';
+import { PRCard } from '@/components/pr-dashboard/PRCard';
+import { getPRs, type PRDashboardItem } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { RefreshCw, Loader2, GitPullRequest } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface PRDashboardProps {
+  initialWorkspaceId?: string;
+  onOpenSettings?: () => void;
+  onOpenShortcuts?: () => void;
+  showLeftSidebar?: boolean;
+}
+
+export function PRDashboard({
+  initialWorkspaceId,
+  onOpenSettings,
+  onOpenShortcuts,
+  showLeftSidebar,
+}: PRDashboardProps) {
+  const [prs, setPRs] = useState<PRDashboardItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [workspaceFilter, setWorkspaceFilter] = useState<string>(
+    initialWorkspaceId || 'all'
+  );
+
+  const workspaces = useAppStore((s) => s.workspaces);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const selectSession = useAppStore((s) => s.selectSession);
+  const setContentView = useSettingsStore((s) => s.setContentView);
+
+  // Track if this is the first render to avoid duplicate fetches
+  const isFirstRender = useRef(true);
+
+  const fetchPRs = useCallback(async (isRefresh = false) => {
+    if (isRefresh) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setError(null);
+
+    try {
+      const workspaceId = workspaceFilter === 'all' ? undefined : workspaceFilter;
+      const data = await getPRs(workspaceId);
+      setPRs(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load PRs');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [workspaceFilter]);
+
+  // Initial fetch and auto-refresh
+  useEffect(() => {
+    fetchPRs();
+
+    // Auto-refresh every 60 seconds
+    const interval = setInterval(() => {
+      fetchPRs(true);
+    }, 60000);
+
+    return () => clearInterval(interval);
+  }, [fetchPRs]);
+
+  // Refresh when filter changes (skip initial render since useEffect above handles it)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    fetchPRs();
+  }, [workspaceFilter, fetchPRs]);
+
+  const handleRefresh = () => {
+    fetchPRs(true);
+  };
+
+  const handleJumpToSession = (workspaceId: string, sessionId: string) => {
+    // Navigate to the session's conversation view
+    selectWorkspace(workspaceId);
+    selectSession(sessionId);
+    setContentView({ type: 'conversation' });
+  };
+
+  // Group PRs by status
+  const openPRs = prs.filter((pr) => pr.state === 'open' && !pr.isDraft);
+  const draftPRs = prs.filter((pr) => pr.isDraft);
+
+  return (
+    <FullContentLayout
+      title="Pull Requests"
+      onOpenSettings={onOpenSettings}
+      onOpenShortcuts={onOpenShortcuts}
+      showLeftSidebar={showLeftSidebar}
+      headerActions={
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={handleRefresh}
+          disabled={refreshing}
+          title="Refresh"
+        >
+          <RefreshCw className={cn('h-3.5 w-3.5', refreshing && 'animate-spin')} />
+        </Button>
+      }
+    >
+      <div className="p-4 space-y-4">
+        {/* Filters */}
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Filter:</span>
+            <Select value={workspaceFilter} onValueChange={setWorkspaceFilter}>
+              <SelectTrigger className="w-[180px] h-8">
+                <SelectValue placeholder="All Repos" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Repos</SelectItem>
+                {workspaces.map((w) => (
+                  <SelectItem key={w.id} value={w.id}>
+                    {w.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+            <span>Open ({openPRs.length})</span>
+            <span>Draft ({draftPRs.length})</span>
+          </div>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="text-center py-12 text-destructive">
+            <p>{error}</p>
+            <Button variant="outline" size="sm" className="mt-4" onClick={() => fetchPRs()}>
+              Try Again
+            </Button>
+          </div>
+        ) : prs.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <GitPullRequest className="h-12 w-12 mx-auto mb-4 opacity-50" />
+            <p className="text-lg font-medium">No pull requests</p>
+            <p className="text-sm mt-1">
+              {workspaceFilter === 'all'
+                ? 'No open pull requests found across your workspaces.'
+                : 'No open pull requests found for this workspace.'}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {prs.map((pr) => (
+              <PRCard
+                key={`${pr.workspaceId}-${pr.number}`}
+                pr={pr}
+                onJumpToSession={
+                  pr.sessionId
+                    ? () => handleJumpToSession(pr.workspaceId, pr.sessionId!)
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </FullContentLayout>
+  );
+}

--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -70,6 +70,7 @@ import {
   Bot,
   Search,
   X,
+  LayoutDashboard,
 } from 'lucide-react';
 import { AgentSidebar } from './AgentSidebar';
 import { cn } from '@/lib/utils';
@@ -159,7 +160,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
   };
 
   // Track which workspaces are collapsed (persisted)
-  const { collapsedWorkspaces, toggleWorkspaceCollapsed, expandWorkspace } = useSettingsStore();
+  const { collapsedWorkspaces, toggleWorkspaceCollapsed, expandWorkspace, setContentView } = useSettingsStore();
 
   const isWorkspaceExpanded = (workspaceId: string) => {
     return !collapsedWorkspaces.includes(workspaceId);
@@ -427,6 +428,14 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
                         onArchiveSession={handleArchiveSession}
                         onPinSession={handlePinSession}
                         onRemoveWorkspace={() => setWorkspaceToRemove({ id: workspace.id, name: workspace.name })}
+                        onOpenDashboard={() => {
+                          selectWorkspace(workspace.id);
+                          setContentView({ type: 'workspace-dashboard', workspaceId: workspace.id });
+                        }}
+                        onOpenPRs={() => {
+                          selectWorkspace(workspace.id);
+                          setContentView({ type: 'pr-dashboard', workspaceId: workspace.id });
+                        }}
                         getStatusColor={getStatusColor}
                         formatTimeAgo={formatTimeAgo}
                         getInitial={getInitial}
@@ -583,6 +592,8 @@ interface SortableWorkspaceItemProps {
   onArchiveSession: (sessionId: string) => void;
   onPinSession: (sessionId: string) => void;
   onRemoveWorkspace: () => void;
+  onOpenDashboard: () => void;
+  onOpenPRs: () => void;
   getStatusColor: (status: string) => string;
   formatTimeAgo: (date: string) => string;
   getInitial: (name: string) => string;
@@ -599,6 +610,8 @@ function SortableWorkspaceItem({
   onArchiveSession,
   onPinSession,
   onRemoveWorkspace,
+  onOpenDashboard,
+  onOpenPRs,
   getStatusColor,
   formatTimeAgo,
   getInitial,
@@ -695,9 +708,32 @@ function SortableWorkspaceItem({
           </div>
         </CollapsibleTrigger>
 
-        {/* Sessions */}
+        {/* Workspace Navigation + Sessions */}
         <CollapsibleContent>
           <div className="ml-5 overflow-hidden">
+            {/* Fixed Navigation Items */}
+            <div className="border-b border-border/50 pb-1 mb-1">
+              <div
+                className="group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer hover:bg-surface-1"
+                onClick={onOpenDashboard}
+              >
+                <LayoutDashboard className="w-3.5 h-3.5 text-muted-foreground" />
+                <span className="text-[length:var(--text-sm)] text-muted-foreground group-hover:text-foreground">
+                  Dashboard
+                </span>
+              </div>
+              <div
+                className="group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer hover:bg-surface-1"
+                onClick={onOpenPRs}
+              >
+                <GitPullRequest className="w-3.5 h-3.5 text-muted-foreground" />
+                <span className="text-[length:var(--text-sm)] text-muted-foreground group-hover:text-foreground">
+                  Pull Requests
+                </span>
+              </div>
+            </div>
+
+            {/* Sessions */}
             {sessions.length === 0 ? (
               <div className="py-2 px-2 text-[length:var(--text-micro)] text-muted-foreground/70">
                 No active sessions

--- a/src/components/pr-dashboard/CheckList.tsx
+++ b/src/components/pr-dashboard/CheckList.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { type CheckDetail } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { Check, X, Clock, CircleDot } from 'lucide-react';
+
+interface CheckListProps {
+  checks: CheckDetail[];
+}
+
+export function CheckList({ checks }: CheckListProps) {
+  // Sort: failures first, then pending, then passed
+  const sortedChecks = [...checks].sort((a, b) => {
+    const getOrder = (check: CheckDetail) => {
+      if (check.status !== 'completed') return 1; // pending
+      if (check.conclusion === 'failure' || check.conclusion === 'timed_out') return 0; // failed
+      return 2; // passed
+    };
+    return getOrder(a) - getOrder(b);
+  });
+
+  return (
+    <div className="space-y-1">
+      {sortedChecks.map((check, index) => (
+        <CheckItem key={`${check.name}-${index}`} check={check} />
+      ))}
+    </div>
+  );
+}
+
+interface CheckItemProps {
+  check: CheckDetail;
+}
+
+function CheckItem({ check }: CheckItemProps) {
+  const getStatusInfo = () => {
+    if (check.status !== 'completed') {
+      if (check.status === 'in_progress') {
+        return {
+          icon: CircleDot,
+          color: 'text-yellow-500',
+          label: 'Running',
+        };
+      }
+      return {
+        icon: Clock,
+        color: 'text-muted-foreground',
+        label: 'Queued',
+      };
+    }
+
+    switch (check.conclusion) {
+      case 'success':
+        return {
+          icon: Check,
+          color: 'text-green-500',
+          label: 'Passed',
+        };
+      case 'failure':
+      case 'timed_out':
+      case 'action_required':
+        return {
+          icon: X,
+          color: 'text-red-500',
+          label: 'Failed',
+        };
+      case 'cancelled':
+        return {
+          icon: X,
+          color: 'text-muted-foreground',
+          label: 'Cancelled',
+        };
+      case 'skipped':
+        return {
+          icon: Check,
+          color: 'text-muted-foreground',
+          label: 'Skipped',
+        };
+      case 'neutral':
+        return {
+          icon: Check,
+          color: 'text-muted-foreground',
+          label: 'Neutral',
+        };
+      default:
+        return {
+          icon: Clock,
+          color: 'text-muted-foreground',
+          label: check.conclusion || 'Unknown',
+        };
+    }
+  };
+
+  const statusInfo = getStatusInfo();
+  const StatusIcon = statusInfo.icon;
+
+  return (
+    <div className="flex items-center gap-2 text-xs py-0.5">
+      <StatusIcon className={cn('h-3 w-3 shrink-0', statusInfo.color)} />
+      <span className="truncate flex-1">{check.name}</span>
+      <span className={cn('shrink-0', statusInfo.color)}>{statusInfo.label}</span>
+    </div>
+  );
+}

--- a/src/components/pr-dashboard/PRCard.tsx
+++ b/src/components/pr-dashboard/PRCard.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState } from 'react';
+import { type PRDashboardItem } from '@/lib/api';
+import { CheckList } from './CheckList';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import {
+  GitPullRequest,
+  GitPullRequestDraft,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight,
+  Check,
+  X,
+  Clock,
+  AlertTriangle,
+  ArrowRight,
+} from 'lucide-react';
+
+interface PRCardProps {
+  pr: PRDashboardItem;
+  onJumpToSession?: () => void;
+}
+
+export function PRCard({ pr, onJumpToSession }: PRCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const hasChecks = pr.checksTotal > 0;
+  const hasFailures = pr.checksFailed > 0;
+  // Compute pending from counts rather than relying on checkStatus string
+  const pendingCount = pr.checksTotal - pr.checksPassed - pr.checksFailed;
+  const hasPending = pendingCount > 0;
+  const allPassed = hasChecks && !hasFailures && !hasPending;
+  const hasConflicts = pr.mergeableState === 'dirty' || pr.mergeable === false;
+
+  // Determine status icon and color
+  // Note: Backend currently only returns open PRs
+  const getStatusInfo = () => {
+    if (pr.isDraft) {
+      return {
+        icon: GitPullRequestDraft,
+        color: 'text-muted-foreground',
+        label: 'Draft',
+      };
+    }
+    return {
+      icon: GitPullRequest,
+      color: 'text-green-500',
+      label: 'Open',
+    };
+  };
+
+  const statusInfo = getStatusInfo();
+  const StatusIcon = statusInfo.icon;
+
+  // Check status summary
+  const getCheckSummary = () => {
+    if (!hasChecks) {
+      return { icon: null, text: 'No checks', color: 'text-muted-foreground' };
+    }
+    if (hasFailures) {
+      return {
+        icon: X,
+        text: `${pr.checksPassed}/${pr.checksTotal} checks passed`,
+        color: 'text-red-500',
+      };
+    }
+    if (hasPending) {
+      return {
+        icon: Clock,
+        text: `${pr.checksPassed}/${pr.checksTotal} checks pending`,
+        color: 'text-yellow-500',
+      };
+    }
+    return {
+      icon: Check,
+      text: `${pr.checksTotal}/${pr.checksTotal} checks passed`,
+      color: 'text-green-500',
+    };
+  };
+
+  const checkSummary = getCheckSummary();
+  const CheckIcon = checkSummary.icon;
+
+  return (
+    <div className="border rounded-lg bg-card">
+      <div className="p-3">
+        {/* First row: Status icon, title, PR number, session name */}
+        <div className="flex items-start gap-2">
+          <StatusIcon className={cn('h-4 w-4 mt-0.5 shrink-0', statusInfo.color)} />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-medium text-sm truncate">{pr.title}</span>
+              <span className="text-xs text-muted-foreground shrink-0">#{pr.number}</span>
+              {pr.sessionName && (
+                <span className="text-xs bg-surface-2 px-1.5 py-0.5 rounded shrink-0">
+                  {pr.sessionName}
+                </span>
+              )}
+            </div>
+
+            {/* Second row: Branch info, conflicts indicator */}
+            <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+              <span className="truncate">
+                {pr.branch} <ArrowRight className="h-3 w-3 inline" /> {pr.baseBranch}
+              </span>
+              {hasConflicts && (
+                <span className="flex items-center gap-1 text-yellow-500 shrink-0">
+                  <AlertTriangle className="h-3 w-3" />
+                  Conflicts
+                </span>
+              )}
+              {pr.workspaceName && (
+                <span className="shrink-0">{pr.workspaceName}</span>
+              )}
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-1 shrink-0">
+            {onJumpToSession && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={onJumpToSession}
+              >
+                Go to Session
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => window.open(pr.htmlUrl, '_blank')}
+            >
+              <ExternalLink className="h-3 w-3 mr-1" />
+              GitHub
+            </Button>
+          </div>
+        </div>
+
+        {/* Third row: Check status (expandable) */}
+        {hasChecks && (
+          <div className="mt-2">
+            <button
+              className="flex items-center gap-2 text-xs hover:bg-surface-1 rounded px-1 py-0.5 -ml-1"
+              onClick={() => setExpanded(!expanded)}
+            >
+              {expanded ? (
+                <ChevronDown className="h-3 w-3 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-3 w-3 text-muted-foreground" />
+              )}
+              {CheckIcon && <CheckIcon className={cn('h-3 w-3', checkSummary.color)} />}
+              <span className={checkSummary.color}>{checkSummary.text}</span>
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Expanded check list */}
+      {expanded && hasChecks && (
+        <div className="border-t px-3 py-2">
+          <CheckList checks={pr.checkDetails} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -343,6 +343,51 @@ export async function getPRStatus(workspaceId: string, sessionId: string): Promi
   }
 }
 
+// PR Dashboard types
+export interface CheckDetail {
+  name: string;
+  status: string; // "queued", "in_progress", "completed"
+  conclusion: string; // "success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+}
+
+export interface PRDashboardItem {
+  // PR metadata
+  number: number;
+  title: string;
+  state: string;
+  htmlUrl: string;
+  isDraft: boolean;
+  mergeable: boolean | null;
+  mergeableState: string;
+  checkStatus: string;
+  checkDetails: CheckDetail[];
+
+  // Branch info
+  branch: string;
+  baseBranch: string;
+
+  // Session info (if created from ChatML)
+  sessionId?: string;
+  sessionName?: string;
+
+  // Workspace info
+  workspaceId: string;
+  workspaceName: string;
+  repoOwner: string;
+  repoName: string;
+
+  // Counts for summary
+  checksTotal: number;
+  checksPassed: number;
+  checksFailed: number;
+}
+
+export async function getPRs(workspaceId?: string): Promise<PRDashboardItem[]> {
+  const params = workspaceId ? `?workspaceId=${workspaceId}` : '';
+  const res = await fetchWithAuth(`${API_BASE}/api/prs${params}`);
+  return handleResponse<PRDashboardItem[]>(res);
+}
+
 export async function sendSessionMessage(
   workspaceId: string,
   sessionId: string,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -13,6 +13,12 @@ export const DEFAULT_BOTTOM_TAB_ORDER: AllBottomPanelTab[] = ['todos', 'plans', 
 // Theme options
 export type ThemeOption = 'system' | 'light' | 'dark';
 
+// Content view types for Full Content Area pattern
+export type ContentView =
+  | { type: 'conversation' }
+  | { type: 'workspace-dashboard'; workspaceId: string }
+  | { type: 'pr-dashboard'; workspaceId?: string };
+
 interface SettingsState {
   // Chat settings
   confirmCloseActiveTab: boolean;
@@ -32,6 +38,8 @@ interface SettingsState {
   zenMode: boolean; // Distraction-free mode that hides sidebars
   hiddenBottomTabs: BottomPanelTab[]; // Bottom panel tabs that are hidden (Tasks always visible)
   bottomTabOrder: AllBottomPanelTab[]; // Order of bottom panel tabs
+  // Full Content Area view state (not persisted - always starts in conversation view)
+  contentView: ContentView;
 
   // Actions
   setConfirmCloseActiveTab: (value: boolean) => void;
@@ -49,6 +57,7 @@ interface SettingsState {
   expandWorkspace: (workspaceId: string) => void;
   toggleBottomTab: (tab: BottomPanelTab) => void;
   setBottomTabOrder: (order: AllBottomPanelTab[]) => void;
+  setContentView: (view: ContentView) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -69,6 +78,7 @@ export const useSettingsStore = create<SettingsState>()(
       zenMode: false,
       hiddenBottomTabs: [], // All tabs visible by default
       bottomTabOrder: DEFAULT_BOTTOM_TAB_ORDER, // Default tab order
+      contentView: { type: 'conversation' }, // Always start in conversation view
 
       // Actions
       setConfirmCloseActiveTab: (value) => set({ confirmCloseActiveTab: value }),
@@ -99,9 +109,16 @@ export const useSettingsStore = create<SettingsState>()(
             : [...state.hiddenBottomTabs, tab],
         })),
       setBottomTabOrder: (order) => set({ bottomTabOrder: order }),
+      setContentView: (view) => set({ contentView: view }),
     }),
     {
       name: 'chatml-settings',
+      // Exclude contentView from persistence - always start in conversation view
+      partialize: (state) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { contentView, ...rest } = state;
+        return rest;
+      },
       // Merge persisted state with defaults to handle new tabs added after initial save
       merge: (persistedState, currentState) => {
         const persisted = persistedState as Partial<SettingsState>;


### PR DESCRIPTION
## Summary

- Add PR Dashboard component displaying pull requests across workspaces with CI/CD status
- Implement FullContentLayout as reusable pattern for full-screen views
- Add backend endpoint to list PRs with GitHub details and session metadata
- Include PRCard and CheckList components for PR status visualization

## Test plan

- [ ] PR dashboard displays open PRs with correct status
- [ ] Workspace filter works correctly
- [ ] Auto-refresh updates PR list every 60 seconds
- [ ] Clicking "Go to Session" navigates to the session conversation
- [ ] All linting, TypeScript, and Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)