### PR TITLE
fix: handle race condition in ChangesPanel event listener cleanup

### DIFF
--- a/src/components/ChangesPanel.tsx
+++ b/src/components/ChangesPanel.tsx
@@ -376,13 +376,22 @@ export function ChangesPanel({
       if (isMounted) {
         cleanupRef.current = unlisten;
       } else {
-        unlisten();
+        // Component unmounted before listener was ready - clean up safely
+        try {
+          unlisten();
+        } catch {
+          // Ignore errors if listener wasn't fully registered
+        }
       }
     });
 
     return () => {
       isMounted = false;
-      cleanupRef.current?.();
+      try {
+        cleanupRef.current?.();
+      } catch {
+        // Ignore errors if listener cleanup fails
+      }
       // Stop watching this session's worktree
       unwatchWorkspace(selectedSessionId);
       // Clear any pending debounce timeout


### PR DESCRIPTION
## Summary
- Wraps Tauri event listener cleanup in try-catch to handle race condition
- Prevents TypeError when component unmounts before listener is fully registered
- Adds defensive cleanup for both the Promise callback and the useEffect cleanup function

## Problem
When navigating quickly between sessions or components, the ChangesPanel could unmount before the `listenForFileChanges` promise resolved. This caused a TypeError:
```
undefined is not an object (evaluating 'listeners[eventId].handlerId')
```

## Test plan
- [ ] Navigate quickly between sessions to verify no console errors
- [ ] Verify file change detection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)