### PR TITLE
fix: prevent white flash on window resize in dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -268,6 +268,10 @@
   }
   html {
     font-size: 100%;  /* Was 106.25% - now standard 16px base */
+    background-color: #141414; /* Dark fallback - matches Tauri window, prevents white flash on resize */
+  }
+  html:not(.dark) {
+    background-color: #ffffff; /* Light mode override */
   }
   html, body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
## Problem
Window resize in dark mode briefly shows a white flash before content renders, caused by WKWebView's default background leaking through during resize operations.

## Solution
Add explicit `background-color` declarations to the `html` element that don't depend on CSS variable resolution timing. Dark mode defaults to `#141414` (matching Tauri window), and light mode explicitly overrides with white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)