### PR TITLE
Add Session Manager for unified workspace and session view

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ import { BackendStatus } from '@/components/BackendStatus';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { PRDashboard } from '@/components/PRDashboard';
 import { WorkspaceDashboard } from '@/components/workspace-dashboard';
+import { SessionManager } from '@/components/session-manager';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ToastProvider } from '@/components/ui/toast';
 import { HEALTH_CHECK_MAX_RETRIES, HEALTH_CHECK_INITIAL_DELAY_MS } from '@/lib/constants';
@@ -163,10 +164,10 @@ export default function Home() {
 
   const confirmCloseActiveTab = useSettingsStore((s) => s.confirmCloseActiveTab);
   const contentView = useSettingsStore((s) => s.contentView);
-  const { showBottomTerminal, setShowBottomTerminal, zenMode, setZenMode } = useSettingsStore();
+  const { showBottomTerminal, setShowBottomTerminal, zenMode, setZenMode, setContentView } = useSettingsStore();
 
-  // Determine if we're in a Full Content view (not conversation)
-  const isFullContentView = contentView.type !== 'conversation';
+  // Determine if we're in a Full Content view (not conversation or session-manager overlay)
+  const isFullContentView = contentView.type !== 'conversation' && contentView.type !== 'session-manager';
 
   const {
     isLoading: authLoading,
@@ -261,6 +262,11 @@ export default function Home() {
   useEffect(() => {
     zenModeRef.current = zenMode;
   }, [zenMode]);
+
+  const contentViewRef = useRef(contentView);
+  useEffect(() => {
+    contentViewRef.current = contentView;
+  }, [contentView]);
 
   // Track previous zen mode state to detect transitions
   const prevZenModeRef = useRef(zenMode);
@@ -816,16 +822,21 @@ export default function Home() {
           setZenMode(!zenModeRef.current);
         }
       }
-      // Escape to exit zen mode (only when zen mode is active)
-      if (e.key === 'Escape' && zenModeRef.current) {
-        e.preventDefault();
-        setZenMode(false);
+      // Escape to close session manager or exit zen mode
+      if (e.key === 'Escape') {
+        if (contentViewRef.current.type === 'session-manager') {
+          e.preventDefault();
+          setContentView({ type: 'conversation' });
+        } else if (zenModeRef.current) {
+          e.preventDefault();
+          setZenMode(false);
+        }
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [sessions, conversations, workspaces, selectedWorkspaceId, selectedFileTabId, selectSession, selectConversation, handleCloseTab, setShowBottomTerminal, selectNextTab, selectPreviousTab, handleCloseFileTab, saveCurrentTab, setZenMode, toggleLeftSidebar, toggleRightSidebar]);
+  }, [sessions, conversations, workspaces, selectedWorkspaceId, selectedFileTabId, selectSession, selectConversation, handleCloseTab, setShowBottomTerminal, selectNextTab, selectPreviousTab, handleCloseFileTab, saveCurrentTab, setZenMode, setContentView, toggleLeftSidebar, toggleRightSidebar]);
 
   // Handle Tauri menu events
   useEffect(() => {
@@ -938,7 +949,7 @@ export default function Home() {
           direction="horizontal"
           className="flex-1"
         >
-          {/* Left Sidebar - Always rendered, collapsible */}
+          {/* Left Sidebar - Always rendered, collapsible, hidden for global-workspace-manager */}
           <ResizablePanel
             ref={leftSidebarPanelRef}
             id="left-sidebar"
@@ -1097,6 +1108,19 @@ export default function Home() {
               onOpenProject={handleOpenProject}
               onCloneFromUrl={() => setShowCloneFromUrl(true)}
               onQuickStart={() => setShowQuickStart(true)}
+            />
+          </div>
+        )}
+
+        {/* Session Manager Overlay - full screen */}
+        {contentView.type === 'session-manager' && (
+          <div className="absolute inset-0 z-20 bg-background">
+            <SessionManager
+              onOpenSettings={() => setShowSettings(true)}
+              onOpenShortcuts={() => setShowShortcuts(true)}
+              onOpenProject={handleOpenProject}
+              onCloneFromUrl={() => setShowCloneFromUrl(true)}
+              onClose={() => setContentView({ type: 'conversation' })}
             />
           </div>
         )}

--- a/src/components/AppSettingsMenu.tsx
+++ b/src/components/AppSettingsMenu.tsx
@@ -33,6 +33,7 @@ import {
   Moon,
   Monitor,
   Sparkles,
+  Layers,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { logout } from '@/lib/auth';
@@ -53,6 +54,7 @@ export function AppSettingsMenu({
   const { theme, setTheme } = useTheme();
   const zenMode = useSettingsStore((s) => s.zenMode);
   const setZenMode = useSettingsStore((s) => s.setZenMode);
+  const setContentView = useSettingsStore((s) => s.setContentView);
 
   const handleSignOut = async () => {
     try {
@@ -166,6 +168,11 @@ export function AppSettingsMenu({
           <Settings className="size-4" />
           Settings
           <span className="ml-auto text-xs text-muted-foreground">⌘,</span>
+        </DropdownMenuItem>
+
+        <DropdownMenuItem onClick={() => setContentView({ type: 'session-manager' })}>
+          <Layers className="size-4" />
+          Session Manager
         </DropdownMenuItem>
 
         <DropdownMenuSeparator />

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -67,6 +67,7 @@ export function TopBar({
   const centerToolbarBg = useUIStore((state) => state.toolbarBackgrounds.center);
   const zenMode = useSettingsStore((s) => s.zenMode);
   const setZenMode = useSettingsStore((s) => s.setZenMode);
+  const setContentView = useSettingsStore((s) => s.setContentView);
 
   const selectedWorkspace = workspaces.find((w) => w.id === selectedWorkspaceId);
   const selectedSession = sessions.find((s) => s.id === selectedSessionId);
@@ -252,7 +253,11 @@ export function TopBar({
             <DropdownMenuItem onClick={() => setZenMode(!zenMode)}>
               <Sparkles className="size-4" />
               {zenMode ? 'Exit Zen Mode' : 'Enter Zen Mode'}
-              <span className="ml-auto text-xs text-muted-foreground">⌘⇧Z</span>
+              <span className="ml-auto text-xs text-muted-foreground">⌘.</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setContentView({ type: 'session-manager' })}>
+              <Layers className="size-4" />
+              Session Manager
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={() => window.open('https://docs.chatml.dev', '_blank')}>

--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -340,13 +340,21 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
       {/* Tab Switcher */}
       <div className="flex border-b h-[33px]">
         <button
-          onClick={() => setActiveTab('workspaces')}
+          onClick={() => {
+            if (activeTab === 'workspaces') {
+              // If already on workspaces tab, open session manager
+              setContentView({ type: 'session-manager' });
+            } else {
+              setActiveTab('workspaces');
+            }
+          }}
           className={cn(
             'flex-1 flex items-center justify-center gap-1.5 h-full text-[length:var(--text-xs)] font-medium transition-colors',
             activeTab === 'workspaces'
               ? 'text-foreground border-b border-primary/50'
               : 'text-muted-foreground hover:text-foreground'
           )}
+          title={activeTab === 'workspaces' ? 'Open Session Manager' : undefined}
         >
           <Layers className="h-3 w-3" />
           Workspaces

--- a/src/components/session-manager/SessionManager.tsx
+++ b/src/components/session-manager/SessionManager.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useUIStore } from '@/stores/uiStore';
+import { updateSession as updateSessionApi } from '@/lib/api';
+import { SessionManagerSidebar } from './SessionManagerSidebar';
+import { SessionsListView } from './SessionsListView';
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '@/components/ui/resizable';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Settings,
+  Keyboard,
+  MoreVertical,
+  BookOpen,
+  MessageCircle,
+  ExternalLink,
+  X,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface SessionManagerProps {
+  onOpenSettings: () => void;
+  onOpenShortcuts: () => void;
+  onOpenProject: () => void;
+  onCloneFromUrl: () => void;
+  onClose: () => void;
+}
+
+export function SessionManager({
+  onOpenSettings,
+  onOpenShortcuts,
+  onOpenProject,
+  onCloneFromUrl,
+  onClose,
+}: SessionManagerProps) {
+  const [filter, setFilter] = useState('');
+
+  const workspaces = useAppStore((s) => s.workspaces);
+  const sessions = useAppStore((s) => s.sessions);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const selectSession = useAppStore((s) => s.selectSession);
+  const unarchiveSession = useAppStore((s) => s.unarchiveSession);
+  const setContentView = useSettingsStore((s) => s.setContentView);
+  const { expandWorkspace } = useSettingsStore();
+  const leftToolbarBg = useUIStore((state) => state.toolbarBackgrounds.left);
+
+  // Handle session selection - navigate to conversation view
+  const handleSelectSession = useCallback(
+    (workspaceId: string, sessionId: string) => {
+      selectWorkspace(workspaceId);
+      expandWorkspace(workspaceId);
+      selectSession(sessionId);
+      setContentView({ type: 'conversation' });
+    },
+    [selectWorkspace, expandWorkspace, selectSession, setContentView]
+  );
+
+  // Handle unarchive session
+  const handleUnarchiveSession = useCallback(
+    async (sessionId: string) => {
+      const session = sessions.find((s) => s.id === sessionId);
+      if (!session) return;
+
+      try {
+        // Update backend
+        await updateSessionApi(session.workspaceId, sessionId, { archived: false });
+        // Update local store
+        unarchiveSession(sessionId);
+      } catch (error) {
+        console.error('Failed to unarchive session:', error);
+      }
+    },
+    [sessions, unarchiveSession]
+  );
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div
+        data-tauri-drag-region
+        className={cn('h-10 flex items-center border-b shrink-0 pr-1 pl-20', leftToolbarBg)}
+      >
+        <h1 className="text-sm font-medium ml-3">Session Manager</h1>
+
+        <div className="flex-1" />
+
+        {/* Common actions */}
+        <div className="flex items-center gap-0.5">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                title="More options"
+              >
+                <MoreVertical className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onOpenSettings}>
+                <Settings className="size-4" />
+                Settings
+                <span className="ml-auto text-xs text-muted-foreground">
+                  ⌘,
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onOpenShortcuts}>
+                <Keyboard className="size-4" />
+                Keyboard Shortcuts
+                <span className="ml-auto text-xs text-muted-foreground">
+                  ⌘/
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() =>
+                  window.open('https://docs.chatml.dev', '_blank')
+                }
+              >
+                <BookOpen className="size-4" />
+                Documentation
+                <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() =>
+                  window.open(
+                    'https://github.com/chatml/chatml/issues',
+                    '_blank'
+                  )
+                }
+              >
+                <MessageCircle className="size-4" />
+                Send Feedback
+                <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Close button */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={onClose}
+            title="Close (Esc)"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Content: Two-column layout */}
+      <ResizablePanelGroup direction="horizontal" className="flex-1">
+        {/* Left sidebar: Workspace tree */}
+        <ResizablePanel
+          id="session-manager-sidebar"
+          defaultSize={25}
+          minSize="200px"
+          maxSize="350px"
+        >
+          <SessionManagerSidebar
+            workspaces={workspaces}
+            sessions={sessions}
+            selectedSessionId={null}
+            onSelectSession={handleSelectSession}
+            onOpenProject={onOpenProject}
+            onCloneFromUrl={onCloneFromUrl}
+          />
+        </ResizablePanel>
+
+        <ResizableHandle direction="horizontal" />
+
+        {/* Main content: Sessions list */}
+        <ResizablePanel id="sessions-list" defaultSize={75} minSize={40}>
+          <SessionsListView
+            workspaces={workspaces}
+            sessions={sessions}
+            filter={filter}
+            onFilterChange={setFilter}
+            onSelectSession={handleSelectSession}
+            onUnarchiveSession={handleUnarchiveSession}
+          />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+}

--- a/src/components/session-manager/SessionManagerSidebar.tsx
+++ b/src/components/session-manager/SessionManagerSidebar.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import type { WorktreeSession, Workspace } from '@/lib/types';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { WorkspaceTreeItem } from './WorkspaceTreeItem';
+import { Plus, Folder, Globe, SquarePlus, Layers } from 'lucide-react';
+
+interface SessionManagerSidebarProps {
+  workspaces: Workspace[];
+  sessions: WorktreeSession[];
+  selectedSessionId: string | null;
+  onSelectSession: (workspaceId: string, sessionId: string) => void;
+  onOpenProject: () => void;
+  onCloneFromUrl: () => void;
+}
+
+export function SessionManagerSidebar({
+  workspaces,
+  sessions,
+  selectedSessionId,
+  onSelectSession,
+  onOpenProject,
+  onCloneFromUrl,
+}: SessionManagerSidebarProps) {
+  const { collapsedWorkspaces, toggleWorkspaceCollapsed } = useSettingsStore();
+
+  // Get sessions for a workspace (non-archived only)
+  const getWorkspaceSessions = (workspaceId: string) => {
+    return sessions.filter(
+      (s) => s.workspaceId === workspaceId && !s.archived
+    );
+  };
+
+  // Check if workspace is expanded
+  const isWorkspaceExpanded = (workspaceId: string) => {
+    return !collapsedWorkspaces.includes(workspaceId);
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-sidebar border-r">
+      {/* Header */}
+      <div className="h-10 flex items-center px-3 border-b shrink-0">
+        <Layers className="h-4 w-4 text-muted-foreground mr-2" />
+        <span className="text-sm font-semibold">Workspaces</span>
+      </div>
+
+      {/* Workspace tree */}
+      <ScrollArea className="flex-1">
+        <div className="p-2">
+          {workspaces.length === 0 ? (
+            <div className="px-2 py-8 text-center">
+              <p className="text-xs text-muted-foreground">No workspaces</p>
+              <p className="text-xs text-muted-foreground/70 mt-1">
+                Add a repository to get started
+              </p>
+            </div>
+          ) : (
+            workspaces.map((workspace) => (
+              <WorkspaceTreeItem
+                key={workspace.id}
+                workspace={workspace}
+                sessions={getWorkspaceSessions(workspace.id)}
+                isExpanded={isWorkspaceExpanded(workspace.id)}
+                selectedSessionId={selectedSessionId}
+                onToggle={() => toggleWorkspaceCollapsed(workspace.id)}
+                onSelectSession={(sessionId) =>
+                  onSelectSession(workspace.id, sessionId)
+                }
+              />
+            ))
+          )}
+        </div>
+      </ScrollArea>
+
+      {/* Footer with add button */}
+      <div className="p-2 border-t">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-muted-foreground hover:text-foreground"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add repository
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-48">
+            <DropdownMenuItem onClick={onOpenProject}>
+              <Folder className="h-4 w-4" />
+              Open project
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onCloneFromUrl}>
+              <Globe className="h-4 w-4" />
+              Clone from URL
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <SquarePlus className="h-4 w-4" />
+              Quick start
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/src/components/session-manager/SessionRow.tsx
+++ b/src/components/session-manager/SessionRow.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { WorktreeSession, Workspace } from '@/lib/types';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import {
+  Terminal,
+  MessageSquare,
+  GitPullRequest,
+  Archive,
+} from 'lucide-react';
+
+interface SessionRowProps {
+  session: WorktreeSession;
+  workspace: Workspace;
+  onSelect: () => void;
+  onUnarchive?: () => void;
+}
+
+export function SessionRow({ session, workspace, onSelect, onUnarchive }: SessionRowProps) {
+  const isActive = session.status === 'active';
+  const hasPR = session.prStatus && session.prStatus !== 'none';
+  const hasStats = session.stats && (session.stats.additions > 0 || session.stats.deletions > 0);
+
+  // Format date
+  const formatDate = (date: string) => {
+    const d = new Date(date);
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  };
+
+  // Get PR status text
+  const getPRStatusText = () => {
+    if (!hasPR) return null;
+
+    if (session.status === 'active') {
+      return { text: 'Working...', color: 'text-text-warning' };
+    }
+    if (session.hasCheckFailures) {
+      return { text: '1 check pending', color: 'text-text-warning' };
+    }
+    if (session.hasMergeConflict) {
+      return { text: 'Merge conflict', color: 'text-text-error' };
+    }
+    if (session.prStatus === 'open') {
+      return { text: 'Ready to merge', color: 'text-text-success' };
+    }
+    if (session.prStatus === 'merged') {
+      return { text: 'Merged', color: 'text-primary' };
+    }
+    return null;
+  };
+
+  const prStatus = getPRStatusText();
+
+  return (
+    <div
+      className={cn(
+        'group flex items-center gap-3 px-3 py-2 hover:bg-surface-1 cursor-pointer transition-colors',
+        session.archived && 'opacity-60'
+      )}
+      onClick={onSelect}
+    >
+      {/* Type icon */}
+      <div className="shrink-0">
+        {isActive ? (
+          <Terminal className="h-4 w-4 text-text-success" />
+        ) : (
+          <MessageSquare className="h-4 w-4 text-muted-foreground" />
+        )}
+      </div>
+
+      {/* Workspace name */}
+      <span className="text-sm text-muted-foreground shrink-0 w-32 truncate">
+        {workspace.name}
+      </span>
+
+      {/* Branch/session name - clickable area */}
+      <div className="flex-1 min-w-0">
+        <span className="text-sm font-medium truncate">
+          {session.branch || session.name}
+        </span>
+      </div>
+
+      {/* PR info */}
+      {hasPR && session.prNumber && (
+        <span className="text-xs text-muted-foreground shrink-0 flex items-center gap-1">
+          <GitPullRequest className="h-3 w-3" />
+          PR #{session.prNumber}
+        </span>
+      )}
+
+      {/* PR status text */}
+      {prStatus && (
+        <span className={cn('text-xs shrink-0', prStatus.color)}>
+          {prStatus.text}
+        </span>
+      )}
+
+      {/* Diff stats */}
+      {hasStats && (
+        <span className="text-xs px-1.5 py-0.5 rounded border border-text-success/40 font-mono tabular-nums shrink-0">
+          <span className="text-text-success">+{session.stats!.additions}</span>
+          <span className="text-text-error ml-1">-{session.stats!.deletions}</span>
+        </span>
+      )}
+
+      {/* Date */}
+      <span className="text-xs text-muted-foreground shrink-0 w-14 text-right">
+        {formatDate(session.updatedAt)}
+      </span>
+
+      {/* Unarchive button for archived sessions */}
+      {session.archived && onUnarchive && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 text-xs opacity-0 group-hover:opacity-100 transition-opacity"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUnarchive();
+          }}
+        >
+          <Archive className="h-3 w-3 mr-1" />
+          Unarchive
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/session-manager/SessionsListView.tsx
+++ b/src/components/session-manager/SessionsListView.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { WorktreeSession, Workspace } from '@/lib/types';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { SessionRow } from './SessionRow';
+import { Search, Layers } from 'lucide-react';
+
+interface SessionsListViewProps {
+  workspaces: Workspace[];
+  sessions: WorktreeSession[];
+  filter: string;
+  onFilterChange: (value: string) => void;
+  onSelectSession: (workspaceId: string, sessionId: string) => void;
+  onUnarchiveSession: (sessionId: string) => void;
+}
+
+interface GroupedSessions {
+  [dateKey: string]: Array<{
+    session: WorktreeSession;
+    workspace: Workspace;
+  }>;
+}
+
+export function SessionsListView({
+  workspaces,
+  sessions,
+  filter,
+  onFilterChange,
+  onSelectSession,
+  onUnarchiveSession,
+}: SessionsListViewProps) {
+  // Format date group label
+  const formatDateGroup = (date: string) => {
+    const d = new Date(date);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) return 'Today';
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 7) return `${diffDays} days ago`;
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  };
+
+  // Get date key for sorting
+  const getDateKey = (date: string) => {
+    const d = new Date(date);
+    return d.toISOString().split('T')[0]; // YYYY-MM-DD
+  };
+
+  // Filter and group sessions by date
+  const { activeSessions, archivedSessions } = useMemo(() => {
+    const filterLower = filter.toLowerCase();
+
+    // Filter sessions
+    const filtered = sessions.filter((session) => {
+      if (!filter) return true;
+      const workspace = workspaces.find((w) => w.id === session.workspaceId);
+      return (
+        session.name.toLowerCase().includes(filterLower) ||
+        session.branch?.toLowerCase().includes(filterLower) ||
+        session.task?.toLowerCase().includes(filterLower) ||
+        workspace?.name.toLowerCase().includes(filterLower)
+      );
+    });
+
+    // Separate active and archived
+    const active = filtered.filter((s) => !s.archived);
+    const archived = filtered.filter((s) => s.archived);
+
+    // Group active sessions by date
+    const grouped: GroupedSessions = {};
+    active.forEach((session) => {
+      const dateKey = getDateKey(session.updatedAt);
+      const workspace = workspaces.find((w) => w.id === session.workspaceId);
+      if (!workspace) return;
+
+      if (!grouped[dateKey]) {
+        grouped[dateKey] = [];
+      }
+      grouped[dateKey].push({ session, workspace });
+    });
+
+    // Sort sessions within each group by updatedAt (most recent first)
+    Object.keys(grouped).forEach((key) => {
+      grouped[key].sort((a, b) =>
+        new Date(b.session.updatedAt).getTime() - new Date(a.session.updatedAt).getTime()
+      );
+    });
+
+    // Get archived with workspace info
+    const archivedWithWorkspace = archived.map((session) => ({
+      session,
+      workspace: workspaces.find((w) => w.id === session.workspaceId)!,
+    })).filter((item) => item.workspace);
+
+    return { activeSessions: grouped, archivedSessions: archivedWithWorkspace };
+  }, [sessions, workspaces, filter]);
+
+  // Get sorted date keys (most recent first)
+  const sortedDateKeys = useMemo(() => {
+    return Object.keys(activeSessions).sort((a, b) => b.localeCompare(a));
+  }, [activeSessions]);
+
+  // Total counts
+  const totalActive = sortedDateKeys.reduce(
+    (sum, key) => sum + activeSessions[key].length,
+    0
+  );
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Filter input */}
+      <div className="p-3 border-b shrink-0">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          <input
+            type="text"
+            placeholder="Filter workspaces..."
+            value={filter}
+            onChange={(e) => onFilterChange(e.target.value)}
+            className="w-full h-9 pl-9 pr-3 text-sm bg-surface-1 border border-border rounded-md placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50"
+          />
+        </div>
+      </div>
+
+      {/* Sessions list */}
+      <ScrollArea className="flex-1">
+        {totalActive === 0 && archivedSessions.length === 0 ? (
+          <div className="px-3 py-12 text-center">
+            <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mx-auto mb-3">
+              <Layers className="w-6 h-6 text-muted-foreground/50" />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {filter ? 'No matching sessions' : 'No sessions yet'}
+            </p>
+            <p className="text-xs text-muted-foreground/70 mt-1">
+              {filter ? 'Try adjusting your filter' : 'Add a workspace to get started'}
+            </p>
+          </div>
+        ) : (
+          <div className="py-2">
+            {/* Active sessions grouped by date */}
+            {sortedDateKeys.map((dateKey) => {
+              const items = activeSessions[dateKey];
+              const dateLabel = formatDateGroup(items[0].session.updatedAt);
+
+              return (
+                <div key={dateKey}>
+                  {/* Date group header */}
+                  <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground flex items-center gap-2">
+                    <span>{dateLabel}</span>
+                    <span className="text-muted-foreground/50">{items.length}</span>
+                  </div>
+
+                  {/* Sessions in this group */}
+                  {items.map(({ session, workspace }) => (
+                    <SessionRow
+                      key={session.id}
+                      session={session}
+                      workspace={workspace}
+                      onSelect={() => onSelectSession(workspace.id, session.id)}
+                    />
+                  ))}
+                </div>
+              );
+            })}
+
+            {/* Archived sessions section */}
+            {archivedSessions.length > 0 && (
+              <div className="mt-4 pt-4 border-t">
+                <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground flex items-center gap-2">
+                  <span>Archived</span>
+                  <span className="text-muted-foreground/50">{archivedSessions.length}</span>
+                </div>
+
+                {archivedSessions.map(({ session, workspace }) => (
+                  <SessionRow
+                    key={session.id}
+                    session={session}
+                    workspace={workspace}
+                    onSelect={() => onSelectSession(workspace.id, session.id)}
+                    onUnarchive={() => onUnarchiveSession(session.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/components/session-manager/WorkspaceTreeItem.tsx
+++ b/src/components/session-manager/WorkspaceTreeItem.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import type { WorktreeSession, Workspace } from '@/lib/types';
+import { cn } from '@/lib/utils';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+  ChevronDown,
+  Folder,
+  GitBranch,
+  GitPullRequest,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+} from 'lucide-react';
+
+interface WorkspaceTreeItemProps {
+  workspace: Workspace;
+  sessions: WorktreeSession[];
+  isExpanded: boolean;
+  selectedSessionId: string | null;
+  onToggle: () => void;
+  onSelectSession: (sessionId: string) => void;
+}
+
+export function WorkspaceTreeItem({
+  workspace,
+  sessions,
+  isExpanded,
+  selectedSessionId,
+  onToggle,
+  onSelectSession,
+}: WorkspaceTreeItemProps) {
+  // Get PR status display info
+  const getPRStatusInfo = (session: WorktreeSession) => {
+    const hasPR = session.prStatus && session.prStatus !== 'none';
+    if (!hasPR) return null;
+
+    if (session.hasMergeConflict) {
+      return { text: 'Merge conflict', color: 'text-text-warning', icon: AlertTriangle };
+    }
+    if (session.hasCheckFailures) {
+      return { text: 'Checks failing', color: 'text-text-error', icon: XCircle };
+    }
+    if (session.prStatus === 'merged') {
+      return { text: 'Merged', color: 'text-primary', icon: CheckCircle2 };
+    }
+    if (session.prStatus === 'open') {
+      return { text: 'Ready to merge', color: 'text-text-success', icon: CheckCircle2 };
+    }
+    return null;
+  };
+
+  return (
+    <div className="mb-1">
+      <Collapsible open={isExpanded} onOpenChange={onToggle}>
+        {/* Workspace Header */}
+        <CollapsibleTrigger asChild>
+          <div
+            className={cn(
+              'group flex items-center gap-1.5 px-2 py-1.5 rounded-md cursor-pointer',
+              'hover:bg-surface-1 transition-colors'
+            )}
+          >
+            <Folder className="w-4 h-4 text-primary/60 shrink-0" />
+            <span className="text-sm font-medium truncate flex-1">
+              {workspace.name}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {sessions.length}
+            </span>
+            <ChevronDown
+              className={cn(
+                'h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 shrink-0',
+                !isExpanded && '-rotate-90'
+              )}
+            />
+          </div>
+        </CollapsibleTrigger>
+
+        {/* Sessions List */}
+        <CollapsibleContent>
+          <div className="ml-4 border-l border-sidebar-border">
+            {sessions.length === 0 ? (
+              <div className="py-2 px-3 text-xs text-muted-foreground/70">
+                No active sessions
+              </div>
+            ) : (
+              sessions.map((session) => {
+                const isSelected = selectedSessionId === session.id;
+                const hasPR = session.prStatus && session.prStatus !== 'none';
+                const hasStats = session.stats && (session.stats.additions > 0 || session.stats.deletions > 0);
+                const prStatusInfo = getPRStatusInfo(session);
+
+                return (
+                  <div
+                    key={session.id}
+                    className={cn(
+                      'flex items-start gap-2 px-3 py-1.5 cursor-pointer',
+                      isSelected
+                        ? 'bg-surface-2 text-foreground'
+                        : 'hover:bg-surface-1 text-foreground/70'
+                    )}
+                    onClick={() => onSelectSession(session.id)}
+                  >
+                    <div className="flex-1 min-w-0">
+                      {/* Branch name */}
+                      <div className="flex items-center gap-1.5">
+                        {hasPR ? (
+                          <GitPullRequest className="w-3 h-3 text-purple-500 shrink-0" />
+                        ) : (
+                          <GitBranch className="w-3 h-3 text-muted-foreground shrink-0" />
+                        )}
+                        <span className="text-xs font-medium truncate">
+                          {session.branch || session.name}
+                        </span>
+                      </div>
+
+                      {/* PR info and stats */}
+                      <div className="flex items-center gap-2 mt-0.5 text-[10px] text-muted-foreground">
+                        {hasPR && session.prNumber && (
+                          <span>PR #{session.prNumber}</span>
+                        )}
+                        {prStatusInfo && (
+                          <span className={prStatusInfo.color}>
+                            {prStatusInfo.text}
+                          </span>
+                        )}
+                        {hasStats && (
+                          <span className="font-mono">
+                            <span className="text-text-success">+{session.stats!.additions}</span>
+                            <span className="text-text-error ml-1">-{session.stats!.deletions}</span>
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/src/components/session-manager/index.ts
+++ b/src/components/session-manager/index.ts
@@ -1,0 +1,5 @@
+export { SessionManager } from './SessionManager';
+export { SessionManagerSidebar } from './SessionManagerSidebar';
+export { SessionsListView } from './SessionsListView';
+export { SessionRow } from './SessionRow';
+export { WorkspaceTreeItem } from './WorkspaceTreeItem';

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -17,7 +17,8 @@ export type ThemeOption = 'system' | 'light' | 'dark';
 export type ContentView =
   | { type: 'conversation' }
   | { type: 'workspace-dashboard'; workspaceId: string }
-  | { type: 'pr-dashboard'; workspaceId?: string };
+  | { type: 'pr-dashboard'; workspaceId?: string }
+  | { type: 'session-manager' };
 
 interface SettingsState {
   // Chat settings


### PR DESCRIPTION
## Summary
- Add new Session Manager screen with two-column layout for managing all workspaces and sessions
- Left sidebar shows workspace tree with expandable sessions
- Main area shows sessions grouped by date (Today, Yesterday, etc.)
- Filter sessions by name, branch, task, or workspace name
- Support for archived sessions section with unarchive action

## Implementation Details
- Created new `session-manager` component directory with:
  - `SessionManager.tsx` - Main container with full-screen overlay layout
  - `SessionManagerSidebar.tsx` - Left sidebar with workspace tree
  - `SessionsListView.tsx` - Main content with date-grouped sessions
  - `SessionRow.tsx` - Individual session row item
  - `WorkspaceTreeItem.tsx` - Collapsible workspace item
- Added `session-manager` ContentView type to settingsStore
- Navigation entry points:
  - Click "Workspaces" tab when already on that tab
  - TopBar dropdown menu
  - AppSettingsMenu (right sidebar header)
- Close with X button or Escape key

## Test Plan
- [ ] Click "Workspaces" tab in sidebar when already selected → opens Session Manager
- [ ] Click "Session Manager" in TopBar dropdown → opens Session Manager
- [ ] Click "Session Manager" in right sidebar settings menu → opens Session Manager
- [ ] Filter sessions using the search input
- [ ] Click any session → navigates to conversation view
- [ ] Click X or press Escape → closes Session Manager
- [ ] Verify archived sessions appear in separate section
- [ ] Verify sessions are grouped by date correctly

## Notes
- Session Manager renders as a full-screen overlay (similar to Settings)
- Reuses existing collapsedWorkspaces state from settingsStore for workspace expansion