### PR TITLE
Implement retry logic for transient DB errors

### DIFF
--- a/backend/store/retry.go
+++ b/backend/store/retry.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// RetryConfig holds configuration for database operation retries
+type RetryConfig struct {
+	MaxRetries int           // Maximum number of retry attempts (default: 5)
+	BaseDelay  time.Duration // Initial delay between retries (default: 50ms)
+	MaxDelay   time.Duration // Maximum delay between retries (default: 2s)
+	JitterPct  float64       // Jitter percentage (0.0-1.0, default: 0.25)
+}
+
+// DefaultRetryConfig returns the default retry configuration
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries: 5,
+		BaseDelay:  50 * time.Millisecond,
+		MaxDelay:   2 * time.Second,
+		JitterPct:  0.25,
+	}
+}
+
+// IsTransientDBError checks if an error is a transient SQLite error that may succeed on retry.
+// It detects SQLITE_BUSY (database locked) and similar transient conditions.
+func IsTransientDBError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// String-based detection for transient errors
+	// This works reliably with wrapped errors and different SQLite drivers
+	errStr := strings.ToLower(err.Error())
+	transientPatterns := []string{
+		"database is locked",
+		"database table is locked",
+		"sqlite_busy",
+		"sqlite_locked",
+	}
+	for _, pattern := range transientPatterns {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// RetryDBOperation executes a database operation with retry logic for transient errors.
+// The operation function should be idempotent for writes.
+func RetryDBOperation[T any](
+	ctx context.Context,
+	opName string,
+	config RetryConfig,
+	operation func(context.Context) (T, error),
+) (T, error) {
+	var result T
+	var lastErr error
+
+	totalAttempts := config.MaxRetries + 1
+
+	for attempt := 0; attempt < totalAttempts; attempt++ {
+		// Check context before attempting
+		if ctx.Err() != nil {
+			return result, fmt.Errorf("%s: context cancelled: %w", opName, ctx.Err())
+		}
+
+		result, lastErr = operation(ctx)
+		if lastErr == nil {
+			return result, nil
+		}
+
+		if !IsTransientDBError(lastErr) {
+			// Non-transient error, don't retry
+			return result, lastErr
+		}
+
+		if attempt < config.MaxRetries {
+			delay := calculateBackoff(attempt, config)
+			log.Printf("[db-retry] %s: transient error (attempt %d/%d), retrying in %v: %v",
+				opName, attempt+1, totalAttempts, delay, lastErr)
+
+			select {
+			case <-time.After(delay):
+				// Continue to next attempt
+			case <-ctx.Done():
+				return result, fmt.Errorf("%s: context cancelled during retry: %w", opName, ctx.Err())
+			}
+		}
+	}
+
+	return result, fmt.Errorf("%s: max retries exceeded: %w", opName, lastErr)
+}
+
+// RetryDBExec is a convenience wrapper for operations that don't return a value
+func RetryDBExec(
+	ctx context.Context,
+	opName string,
+	config RetryConfig,
+	operation func(context.Context) error,
+) error {
+	_, err := RetryDBOperation(ctx, opName, config, func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, operation(ctx)
+	})
+	return err
+}
+
+// calculateBackoff returns the delay for the given attempt with exponential backoff and jitter
+func calculateBackoff(attempt int, config RetryConfig) time.Duration {
+	// Exponential backoff: baseDelay * 2^attempt
+	delay := float64(config.BaseDelay) * math.Pow(2, float64(attempt))
+
+	// Cap at max delay
+	if delay > float64(config.MaxDelay) {
+		delay = float64(config.MaxDelay)
+	}
+
+	// Add jitter: +/- JitterPct
+	if config.JitterPct > 0 {
+		jitter := delay * config.JitterPct * (2*rand.Float64() - 1) // Range: -JitterPct to +JitterPct
+		delay += jitter
+	}
+
+	// Ensure delay is never negative
+	if delay < 0 {
+		delay = 0
+	}
+
+	return time.Duration(delay)
+}

--- a/backend/store/retry_test.go
+++ b/backend/store/retry_test.go
@@ -1,0 +1,296 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTransientDBError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("some random error"),
+			expected: false,
+		},
+		{
+			name:     "constraint error",
+			err:      errors.New("UNIQUE constraint failed: sessions.id"),
+			expected: false,
+		},
+		{
+			name:     "database locked",
+			err:      errors.New("database is locked"),
+			expected: true,
+		},
+		{
+			name:     "database locked uppercase",
+			err:      errors.New("DATABASE IS LOCKED"),
+			expected: true,
+		},
+		{
+			name:     "database table locked",
+			err:      errors.New("database table is locked"),
+			expected: true,
+		},
+		{
+			name:     "sqlite_busy",
+			err:      errors.New("SQLITE_BUSY"),
+			expected: true,
+		},
+		{
+			name:     "sqlite_locked",
+			err:      errors.New("SQLITE_LOCKED"),
+			expected: true,
+		},
+		{
+			name:     "wrapped database locked",
+			err:      fmt.Errorf("AddSession: %w", errors.New("database is locked")),
+			expected: true,
+		},
+		{
+			name:     "deeply wrapped database locked",
+			err:      fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", errors.New("database is locked"))),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTransientDBError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCalculateBackoff(t *testing.T) {
+	// Test without jitter for predictable results
+	config := RetryConfig{
+		BaseDelay: 100 * time.Millisecond,
+		MaxDelay:  1 * time.Second,
+		JitterPct: 0,
+	}
+
+	tests := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{0, 100 * time.Millisecond},  // 100ms * 2^0 = 100ms
+		{1, 200 * time.Millisecond},  // 100ms * 2^1 = 200ms
+		{2, 400 * time.Millisecond},  // 100ms * 2^2 = 400ms
+		{3, 800 * time.Millisecond},  // 100ms * 2^3 = 800ms
+		{4, 1 * time.Second},         // Capped at MaxDelay
+		{10, 1 * time.Second},        // Still capped
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("attempt_%d", tt.attempt), func(t *testing.T) {
+			result := calculateBackoff(tt.attempt, config)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCalculateBackoff_WithJitter(t *testing.T) {
+	config := RetryConfig{
+		BaseDelay: 100 * time.Millisecond,
+		MaxDelay:  1 * time.Second,
+		JitterPct: 0.25,
+	}
+
+	// Run multiple times to verify jitter is being applied
+	results := make(map[time.Duration]bool)
+	for i := 0; i < 100; i++ {
+		result := calculateBackoff(0, config)
+		results[result] = true
+
+		// Should be within 75ms to 125ms (100ms +/- 25%)
+		assert.GreaterOrEqual(t, result, 75*time.Millisecond)
+		assert.LessOrEqual(t, result, 125*time.Millisecond)
+	}
+
+	// With 100 iterations, we should see some variation
+	assert.Greater(t, len(results), 1, "jitter should produce varying results")
+}
+
+func TestCalculateBackoff_NeverNegative(t *testing.T) {
+	// Test with extreme jitter that could theoretically produce negative values
+	config := RetryConfig{
+		BaseDelay: 1 * time.Millisecond, // Very small base delay
+		MaxDelay:  1 * time.Second,
+		JitterPct: 0.99, // Nearly 100% jitter
+	}
+
+	// Run many times to catch edge cases
+	for i := 0; i < 1000; i++ {
+		result := calculateBackoff(0, config)
+		assert.GreaterOrEqual(t, result, time.Duration(0), "delay should never be negative")
+	}
+}
+
+func TestRetryDBOperation_SucceedsImmediately(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	result, err := RetryDBOperation(ctx, "test", DefaultRetryConfig(), func(ctx context.Context) (string, error) {
+		callCount++
+		return "success", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "success", result)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestRetryDBOperation_RetriesTransientError(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	result, err := RetryDBOperation(ctx, "test", RetryConfig{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Millisecond, // Fast for tests
+		MaxDelay:   10 * time.Millisecond,
+		JitterPct:  0,
+	}, func(ctx context.Context) (string, error) {
+		callCount++
+		if callCount < 3 {
+			return "", errors.New("database is locked")
+		}
+		return "success", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "success", result)
+	assert.Equal(t, 3, callCount)
+}
+
+func TestRetryDBOperation_DoesNotRetryNonTransient(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	_, err := RetryDBOperation(ctx, "test", DefaultRetryConfig(), func(ctx context.Context) (string, error) {
+		callCount++
+		return "", errors.New("UNIQUE constraint failed")
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UNIQUE constraint failed")
+	assert.Equal(t, 1, callCount) // No retries for constraint errors
+}
+
+func TestRetryDBOperation_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	callCount := 0
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := RetryDBOperation(ctx, "test", RetryConfig{
+		MaxRetries: 10,
+		BaseDelay:  100 * time.Millisecond,
+		MaxDelay:   1 * time.Second,
+		JitterPct:  0,
+	}, func(ctx context.Context) (string, error) {
+		callCount++
+		return "", errors.New("database is locked")
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context cancelled")
+	assert.Less(t, callCount, 10) // Should stop before max retries
+}
+
+func TestRetryDBOperation_ExhaustsRetries(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	_, err := RetryDBOperation(ctx, "TestOp", RetryConfig{
+		MaxRetries: 2,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   10 * time.Millisecond,
+		JitterPct:  0,
+	}, func(ctx context.Context) (string, error) {
+		callCount++
+		return "", errors.New("database is locked")
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max retries exceeded")
+	assert.Contains(t, err.Error(), "TestOp")
+	assert.Contains(t, err.Error(), "database is locked")
+	assert.Equal(t, 3, callCount) // Initial + 2 retries
+}
+
+func TestRetryDBExec_SucceedsImmediately(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	err := RetryDBExec(ctx, "test", DefaultRetryConfig(), func(ctx context.Context) error {
+		callCount++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestRetryDBExec_RetriesAndSucceeds(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+
+	err := RetryDBExec(ctx, "test", RetryConfig{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   10 * time.Millisecond,
+		JitterPct:  0,
+	}, func(ctx context.Context) error {
+		callCount++
+		if callCount < 2 {
+			return errors.New("database is locked")
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestRetryDBOperation_ContextAlreadyCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	callCount := 0
+	_, err := RetryDBOperation(ctx, "test", DefaultRetryConfig(), func(ctx context.Context) (string, error) {
+		callCount++
+		return "success", nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context cancelled")
+	assert.Equal(t, 0, callCount) // Should never call operation
+}
+
+func TestDefaultRetryConfig(t *testing.T) {
+	config := DefaultRetryConfig()
+
+	assert.Equal(t, 5, config.MaxRetries)
+	assert.Equal(t, 50*time.Millisecond, config.BaseDelay)
+	assert.Equal(t, 2*time.Second, config.MaxDelay)
+	assert.Equal(t, 0.25, config.JitterPct)
+}

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -481,27 +481,26 @@ func (s *SQLiteStore) DeleteRepo(ctx context.Context, id string) error {
 // ============================================================================
 
 func (s *SQLiteStore) AddSession(ctx context.Context, session *models.Session) error {
-	statsAdditions, statsDeletions := 0, 0
-	if session.Stats != nil {
-		statsAdditions = session.Stats.Additions
-		statsDeletions = session.Stats.Deletions
-	}
+	return RetryDBExec(ctx, "AddSession", DefaultRetryConfig(), func(ctx context.Context) error {
+		statsAdditions, statsDeletions := 0, 0
+		if session.Stats != nil {
+			statsAdditions = session.Stats.Additions
+			statsDeletions = session.Stats.Deletions
+		}
 
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO sessions (id, workspace_id, name, branch, worktree_path, base_commit_sha, task,
-			status, agent_id, pr_status, pr_url, pr_number, has_merge_conflict,
-			has_check_failures, stats_additions, stats_deletions, pinned, archived, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		session.ID, session.WorkspaceID, session.Name, session.Branch,
-		session.WorktreePath, session.BaseCommitSHA, session.Task, session.Status, session.AgentID,
-		session.PRStatus, session.PRUrl, session.PRNumber,
-		boolToInt(session.HasMergeConflict), boolToInt(session.HasCheckFailures),
-		statsAdditions, statsDeletions, boolToInt(session.Pinned), boolToInt(session.Archived),
-		session.CreatedAt, session.UpdatedAt)
-	if err != nil {
-		return fmt.Errorf("AddSession: %w", err)
-	}
-	return nil
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO sessions (id, workspace_id, name, branch, worktree_path, base_commit_sha, task,
+				status, agent_id, pr_status, pr_url, pr_number, has_merge_conflict,
+				has_check_failures, stats_additions, stats_deletions, pinned, archived, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			session.ID, session.WorkspaceID, session.Name, session.Branch,
+			session.WorktreePath, session.BaseCommitSHA, session.Task, session.Status, session.AgentID,
+			session.PRStatus, session.PRUrl, session.PRNumber,
+			boolToInt(session.HasMergeConflict), boolToInt(session.HasCheckFailures),
+			statsAdditions, statsDeletions, boolToInt(session.Pinned), boolToInt(session.Archived),
+			session.CreatedAt, session.UpdatedAt)
+		return err
+	})
 }
 
 func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Session, error) {
@@ -688,7 +687,7 @@ func (s *SQLiteStore) ListAllSessions(ctx context.Context) ([]*models.Session, e
 }
 
 func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, updates func(*models.Session)) error {
-	// Read current state
+	// Read current state outside retry to avoid stale data on retry
 	session, err := s.getSessionNoLock(ctx, id)
 	if err != nil {
 		return err
@@ -701,30 +700,29 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, updates func
 	updates(session)
 	session.UpdatedAt = time.Now()
 
-	// Write back
+	// Write back with retry for transient errors
 	statsAdditions, statsDeletions := 0, 0
 	if session.Stats != nil {
 		statsAdditions = session.Stats.Additions
 		statsDeletions = session.Stats.Deletions
 	}
 
-	_, err = s.db.ExecContext(ctx, `
-		UPDATE sessions SET
-			name = ?, branch = ?, worktree_path = ?, task = ?,
-			status = ?, agent_id = ?, pr_status = ?, pr_url = ?,
-			pr_number = ?, has_merge_conflict = ?, has_check_failures = ?,
-			stats_additions = ?, stats_deletions = ?, pinned = ?, archived = ?, updated_at = ?
-		WHERE id = ?`,
-		session.Name, session.Branch, session.WorktreePath, session.Task,
-		session.Status, session.AgentID, session.PRStatus, session.PRUrl,
-		session.PRNumber, boolToInt(session.HasMergeConflict),
-		boolToInt(session.HasCheckFailures),
-		statsAdditions, statsDeletions, boolToInt(session.Pinned), boolToInt(session.Archived),
-		session.UpdatedAt, id)
-	if err != nil {
-		return fmt.Errorf("UpdateSession: %w", err)
-	}
-	return nil
+	return RetryDBExec(ctx, "UpdateSession", DefaultRetryConfig(), func(ctx context.Context) error {
+		_, err := s.db.ExecContext(ctx, `
+			UPDATE sessions SET
+				name = ?, branch = ?, worktree_path = ?, task = ?,
+				status = ?, agent_id = ?, pr_status = ?, pr_url = ?,
+				pr_number = ?, has_merge_conflict = ?, has_check_failures = ?,
+				stats_additions = ?, stats_deletions = ?, pinned = ?, archived = ?, updated_at = ?
+			WHERE id = ?`,
+			session.Name, session.Branch, session.WorktreePath, session.Task,
+			session.Status, session.AgentID, session.PRStatus, session.PRUrl,
+			session.PRNumber, boolToInt(session.HasMergeConflict),
+			boolToInt(session.HasCheckFailures),
+			statsAdditions, statsDeletions, boolToInt(session.Pinned), boolToInt(session.Archived),
+			session.UpdatedAt, id)
+		return err
+	})
 }
 
 func (s *SQLiteStore) getSessionNoLock(ctx context.Context, id string) (*models.Session, error) {
@@ -851,15 +849,14 @@ func (s *SQLiteStore) DeleteAgent(ctx context.Context, id string) error {
 // ============================================================================
 
 func (s *SQLiteStore) AddConversation(ctx context.Context, conv *models.Conversation) error {
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO conversations (id, session_id, type, name, status, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		conv.ID, conv.SessionID, conv.Type, conv.Name,
-		conv.Status, conv.CreatedAt, conv.UpdatedAt)
-	if err != nil {
-		return fmt.Errorf("AddConversation: %w", err)
-	}
-	return nil
+	return RetryDBExec(ctx, "AddConversation", DefaultRetryConfig(), func(ctx context.Context) error {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO conversations (id, session_id, type, name, status, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			conv.ID, conv.SessionID, conv.Type, conv.Name,
+			conv.Status, conv.CreatedAt, conv.UpdatedAt)
+		return err
+	})
 }
 
 func (s *SQLiteStore) GetConversation(ctx context.Context, id string) (*models.Conversation, error) {
@@ -1262,17 +1259,7 @@ func (s *SQLiteStore) DeleteConversation(ctx context.Context, id string) error {
 }
 
 func (s *SQLiteStore) AddMessageToConversation(ctx context.Context, convID string, msg models.Message) error {
-	// Get next position
-	var maxPos sql.NullInt64
-	if err := s.db.QueryRowContext(ctx, `SELECT MAX(position) FROM messages WHERE conversation_id = ?`, convID).Scan(&maxPos); err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("AddMessageToConversation get position: %w", err)
-	}
-	nextPos := 0
-	if maxPos.Valid {
-		nextPos = int(maxPos.Int64) + 1
-	}
-
-	// Serialize setupInfo if present
+	// Serialize setupInfo if present (outside retry - deterministic)
 	var setupInfoJSON sql.NullString
 	if msg.SetupInfo != nil {
 		data, err := json.Marshal(msg.SetupInfo)
@@ -1282,7 +1269,7 @@ func (s *SQLiteStore) AddMessageToConversation(ctx context.Context, convID strin
 		setupInfoJSON = sql.NullString{String: string(data), Valid: true}
 	}
 
-	// Serialize runSummary if present
+	// Serialize runSummary if present (outside retry - deterministic)
 	var runSummaryJSON sql.NullString
 	if msg.RunSummary != nil {
 		data, err := json.Marshal(msg.RunSummary)
@@ -1292,35 +1279,67 @@ func (s *SQLiteStore) AddMessageToConversation(ctx context.Context, convID strin
 		runSummaryJSON = sql.NullString{String: string(data), Valid: true}
 	}
 
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO messages (id, conversation_id, role, content, setup_info, run_summary, timestamp, position)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		msg.ID, convID, msg.Role, msg.Content, setupInfoJSON, runSummaryJSON, msg.Timestamp, nextPos)
-	if err != nil {
-		return fmt.Errorf("AddMessageToConversation: %w", err)
-	}
-	return nil
+	return RetryDBExec(ctx, "AddMessageToConversation", DefaultRetryConfig(), func(ctx context.Context) error {
+		// Use transaction to make position query + insert atomic
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin: %w", err)
+		}
+
+		// Get next position within transaction
+		var maxPos sql.NullInt64
+		if err := tx.QueryRowContext(ctx, `SELECT MAX(position) FROM messages WHERE conversation_id = ?`, convID).Scan(&maxPos); err != nil && err != sql.ErrNoRows {
+			tx.Rollback()
+			return fmt.Errorf("get position: %w", err)
+		}
+		nextPos := 0
+		if maxPos.Valid {
+			nextPos = int(maxPos.Int64) + 1
+		}
+
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO messages (id, conversation_id, role, content, setup_info, run_summary, timestamp, position)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			msg.ID, convID, msg.Role, msg.Content, setupInfoJSON, runSummaryJSON, msg.Timestamp, nextPos)
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+
+		return tx.Commit()
+	})
 }
 
 func (s *SQLiteStore) AddToolActionToConversation(ctx context.Context, convID string, action models.ToolAction) error {
-	// Get next position
-	var maxPos sql.NullInt64
-	if err := s.db.QueryRowContext(ctx, `SELECT MAX(position) FROM tool_actions WHERE conversation_id = ?`, convID).Scan(&maxPos); err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("AddToolActionToConversation get position: %w", err)
-	}
-	nextPos := 0
-	if maxPos.Valid {
-		nextPos = int(maxPos.Int64) + 1
-	}
+	return RetryDBExec(ctx, "AddToolActionToConversation", DefaultRetryConfig(), func(ctx context.Context) error {
+		// Use transaction to make position query + insert atomic
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin: %w", err)
+		}
 
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO tool_actions (id, conversation_id, tool, target, success, position)
-		VALUES (?, ?, ?, ?, ?, ?)`,
-		action.ID, convID, action.Tool, action.Target, boolToInt(action.Success), nextPos)
-	if err != nil {
-		return fmt.Errorf("AddToolActionToConversation: %w", err)
-	}
-	return nil
+		// Get next position within transaction
+		var maxPos sql.NullInt64
+		if err := tx.QueryRowContext(ctx, `SELECT MAX(position) FROM tool_actions WHERE conversation_id = ?`, convID).Scan(&maxPos); err != nil && err != sql.ErrNoRows {
+			tx.Rollback()
+			return fmt.Errorf("get position: %w", err)
+		}
+		nextPos := 0
+		if maxPos.Valid {
+			nextPos = int(maxPos.Int64) + 1
+		}
+
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO tool_actions (id, conversation_id, tool, target, success, position)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			action.ID, convID, action.Tool, action.Target, boolToInt(action.Success), nextPos)
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+
+		return tx.Commit()
+	})
 }
 
 // ============================================================================
@@ -1455,75 +1474,77 @@ func (s *SQLiteStore) DeleteAllFileTabsForWorkspace(ctx context.Context, workspa
 // SaveFileTabs atomically saves a workspace's file tabs, removing any tabs not in the list.
 // Uses a transaction for atomic updates to prevent partial saves on failure.
 func (s *SQLiteStore) SaveFileTabs(ctx context.Context, workspaceID string, tabs []*models.FileTab) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("SaveFileTabs begin: %w", err)
-	}
-
-	// Collect current tab IDs for deletion of removed tabs
-	currentTabIDs := make([]string, len(tabs))
-	for i, tab := range tabs {
-		currentTabIDs[i] = tab.ID
-	}
-
-	// Delete tabs that are no longer in the list (more efficient than delete-all)
-	if len(currentTabIDs) > 0 {
-		// Build placeholders for IN clause dynamically.
-		// This is safe because we only generate "?" placeholders (not user input),
-		// and actual values are passed via parameterized args.
-		placeholders := "?"
-		for i := 1; i < len(currentTabIDs); i++ {
-			placeholders += ",?"
-		}
-		args := make([]interface{}, len(currentTabIDs)+1)
-		args[0] = workspaceID
-		for i, id := range currentTabIDs {
-			args[i+1] = id
-		}
-		_, err = tx.ExecContext(ctx, `DELETE FROM file_tabs WHERE workspace_id = ? AND id NOT IN (`+placeholders+`)`, args...)
-	} else {
-		// No tabs - delete all for this workspace
-		_, err = tx.ExecContext(ctx, `DELETE FROM file_tabs WHERE workspace_id = ?`, workspaceID)
-	}
-	if err != nil {
-		tx.Rollback()
-		return fmt.Errorf("SaveFileTabs delete: %w", err)
-	}
-
-	// Upsert all tabs (insert or update if exists)
-	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO file_tabs (id, workspace_id, session_id, path, view_mode, is_pinned, position, opened_at, last_accessed_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
-			view_mode = excluded.view_mode,
-			is_pinned = excluded.is_pinned,
-			position = excluded.position,
-			last_accessed_at = excluded.last_accessed_at`)
-	if err != nil {
-		tx.Rollback()
-		return fmt.Errorf("SaveFileTabs prepare: %w", err)
-	}
-	defer stmt.Close()
-
-	for i, tab := range tabs {
-		var sessionID sql.NullString
-		if tab.SessionID != "" {
-			sessionID = sql.NullString{String: tab.SessionID, Valid: true}
+	return RetryDBExec(ctx, "SaveFileTabs", DefaultRetryConfig(), func(ctx context.Context) error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin: %w", err)
 		}
 
-		_, err = stmt.ExecContext(ctx,
-			tab.ID, tab.WorkspaceID, sessionID, tab.Path, tab.ViewMode,
-			boolToInt(tab.IsPinned), i, tab.OpenedAt, tab.LastAccessedAt)
+		// Collect current tab IDs for deletion of removed tabs
+		currentTabIDs := make([]string, len(tabs))
+		for i, tab := range tabs {
+			currentTabIDs[i] = tab.ID
+		}
+
+		// Delete tabs that are no longer in the list (more efficient than delete-all)
+		if len(currentTabIDs) > 0 {
+			// Build placeholders for IN clause dynamically.
+			// This is safe because we only generate "?" placeholders (not user input),
+			// and actual values are passed via parameterized args.
+			placeholders := "?"
+			for i := 1; i < len(currentTabIDs); i++ {
+				placeholders += ",?"
+			}
+			args := make([]interface{}, len(currentTabIDs)+1)
+			args[0] = workspaceID
+			for i, id := range currentTabIDs {
+				args[i+1] = id
+			}
+			_, err = tx.ExecContext(ctx, `DELETE FROM file_tabs WHERE workspace_id = ? AND id NOT IN (`+placeholders+`)`, args...)
+		} else {
+			// No tabs - delete all for this workspace
+			_, err = tx.ExecContext(ctx, `DELETE FROM file_tabs WHERE workspace_id = ?`, workspaceID)
+		}
 		if err != nil {
 			tx.Rollback()
-			return fmt.Errorf("SaveFileTabs upsert: %w", err)
+			return fmt.Errorf("delete: %w", err)
 		}
-	}
 
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("SaveFileTabs commit: %w", err)
-	}
-	return nil
+		// Upsert all tabs (insert or update if exists)
+		stmt, err := tx.PrepareContext(ctx, `
+			INSERT INTO file_tabs (id, workspace_id, session_id, path, view_mode, is_pinned, position, opened_at, last_accessed_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				view_mode = excluded.view_mode,
+				is_pinned = excluded.is_pinned,
+				position = excluded.position,
+				last_accessed_at = excluded.last_accessed_at`)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("prepare: %w", err)
+		}
+		defer stmt.Close()
+
+		for i, tab := range tabs {
+			var sessionID sql.NullString
+			if tab.SessionID != "" {
+				sessionID = sql.NullString{String: tab.SessionID, Valid: true}
+			}
+
+			_, err = stmt.ExecContext(ctx,
+				tab.ID, tab.WorkspaceID, sessionID, tab.Path, tab.ViewMode,
+				boolToInt(tab.IsPinned), i, tab.OpenedAt, tab.LastAccessedAt)
+			if err != nil {
+				tx.Rollback()
+				return fmt.Errorf("upsert: %w", err)
+			}
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit: %w", err)
+		}
+		return nil
+	})
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Implement comprehensive retry logic for transient SQLite errors with exponential backoff and jitter. Wraps key database operations to automatically retry on SQLITE_BUSY and similar transient conditions.

Fixes code review issues including negative delay edge case, read-modify-write races, and position conflicts in concurrent inserts.

## Test Plan
- All existing store tests pass
- New retry logic tests with various scenarios (success, transient errors, context cancellation, max retries exceeded)
- Backoff calculation verified with and without jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)