### PR TITLE
fix: prevent white flash on app startup in dark mode

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -116,8 +116,14 @@ function ConversationSkeleton() {
 }
 
 export default function Home() {
+  const [mounted, setMounted] = useState(false);
   const [backendConnected, setBackendConnected] = useState(false);
   const [isLoadingData, setIsLoadingData] = useState(true);
+
+  // Prevent hydration mismatch - render nothing until client-side mounted
+  useEffect(() => {
+    setMounted(true);
+  }, []);
   const [showAddWorkspace, setShowAddWorkspace] = useState(false);
   const [showWorkspaceSettings, setShowWorkspaceSettings] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
@@ -904,10 +910,16 @@ export default function Home() {
     };
   }, []);
 
-  // Show loading while checking auth
+  // Don't render anything until client-side mounted - prevents hydration flash
+  // Body background (set by ThemeScript) shows through
+  if (!mounted) {
+    return null;
+  }
+
+  // Show loading while checking auth - transparent to let body bg show through
   if (authLoading) {
     return (
-      <div className="flex h-screen items-center justify-center bg-background">
+      <div className="flex h-screen items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
@@ -932,7 +944,7 @@ export default function Home() {
   return (
     <ToastProvider>
       <TooltipProvider>
-        <div className="h-screen overflow-hidden flex relative bg-background">
+        <div className="h-screen overflow-hidden flex relative">
         {/* OUTER GROUP: Left Sidebar | Main Content */}
         <ResizablePanelGroup
           direction="horizontal"

--- a/src/components/BackendStatus.tsx
+++ b/src/components/BackendStatus.tsx
@@ -114,7 +114,7 @@ export function BackendStatus({
   }
 
   return (
-    <div className="h-screen flex items-center justify-center bg-background">
+    <div className="h-screen flex items-center justify-center">
       <div className="text-center max-w-md px-6">
         {state === 'connecting' && (
           <>

--- a/src/components/ThemeScript.tsx
+++ b/src/components/ThemeScript.tsx
@@ -2,16 +2,20 @@
  * ThemeScript - Prevents flash of wrong theme on app startup
  *
  * This component renders an inline script that runs synchronously in the <head>
- * before CSS is parsed. It reads the theme preference from localStorage and
- * immediately applies the correct class and background color to prevent any
- * visible flash.
+ * before the body is parsed. It reads the theme preference and immediately
+ * applies the correct class and background color.
  */
 export function ThemeScript() {
+  // Critical CSS: default to dark background (matches Tauri window)
+  // NO light mode fallback here - we handle that in the script
+  // This ensures dark bg is shown until JS determines actual theme
+  const criticalCSS = `
+    html, body { background-color: #141414 !important; }
+  `;
+
   const script = `
 (function() {
-  // Must match next-themes storageKey (default: 'theme')
   var STORAGE_KEY = 'theme';
-  // Must match globals.css: .dark --background and light theme --background
   var DARK_BG = '#141414';
   var LIGHT_BG = '#ffffff';
 
@@ -26,20 +30,27 @@ export function ThemeScript() {
 
   var theme = getTheme();
   var html = document.documentElement;
+  var bg = theme === 'dark' ? DARK_BG : LIGHT_BG;
 
+  // Set class and inline style on html
   if (theme === 'dark') {
     html.classList.add('dark');
-    html.style.backgroundColor = DARK_BG;
   } else {
     html.classList.remove('dark');
-    html.style.backgroundColor = LIGHT_BG;
   }
+  html.style.backgroundColor = bg;
+
+  // Also inject a style tag for body since body doesn't exist yet
+  var style = document.createElement('style');
+  style.textContent = 'body { background-color: ' + bg + ' !important; }';
+  document.head.appendChild(style);
 })();
 `;
 
   return (
-    <script
-      dangerouslySetInnerHTML={{ __html: script }}
-    />
+    <>
+      <style dangerouslySetInnerHTML={{ __html: criticalCSS }} />
+      <script dangerouslySetInnerHTML={{ __html: script }} />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Add `mounted` state check to prevent React hydration flash
- Update ThemeScript to default to dark background (#141414) and dynamically inject body style
- Remove explicit `bg-background` from loading screens to let body background show through

## Root Cause

The white flash was caused by React hydration rendering content before the theme was properly applied. During SSR/static generation, the page renders with default light theme CSS, then React hydrates and briefly shows this before JavaScript sets the dark theme.

## Solution

Return `null` from the page component until `mounted` is true (set in useEffect). This lets the ThemeScript-set body background show through during the hydration phase.

## Test plan

- [ ] Start app in dark mode - no white flash
- [ ] Start app in light mode - works normally
- [ ] Toggle themes - works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)