### PR TITLE
fix: enable window dragging from right sidebar toolbar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,18 @@ mcp__linear__get_issue id="CHA-123"
 | Medium (3) | Normal priority |
 | Low (4) | Nice to have |
 
+## Git Workflow
+
+**NEVER make changes directly on `main`.** Always create a feature branch first:
+
+```bash
+git checkout -b fix/description-of-change
+# or
+git checkout -b feature/description-of-change
+```
+
+Then make changes, commit, push, and create a PR.
+
 ## Verification Checklist
 
 Run before completing any task:

--- a/src/components/ChangesPanel.tsx
+++ b/src/components/ChangesPanel.tsx
@@ -403,6 +403,7 @@ export function ChangesPanel({
     <div className="flex flex-col h-full">
       {/* Top Bar - changes based on session state */}
       <div
+        data-tauri-drag-region
         className={cn(
           'h-10 flex items-center gap-2 px-3 border-b shrink-0',
           hasActivePR && 'bg-text-success/15 border-text-success/30',


### PR DESCRIPTION
## Summary
- Add `data-tauri-drag-region` attribute to the right sidebar toolbar in `ChangesPanel.tsx`
- Previously dragging worked from left and center toolbars but not the right one
- Also adds git workflow documentation to CLAUDE.md

## Test plan
- [ ] Run app with `make dev`
- [ ] Try dragging window from right sidebar toolbar background
- [ ] Verify dragging works same as left and center toolbars

🤖 Generated with [Claude Code](https://claude.com/claude-code)