### PR TITLE
fix: render welcome view as full content instead of overlay

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -175,6 +175,7 @@ export default function Home() {
   const { showBottomTerminal, setShowBottomTerminal, zenMode, setZenMode, setContentView } = useSettingsStore();
 
   // Determine if we're in a Full Content view (not conversation or session-manager overlay)
+  // Also treat as full content view when no session is selected (to show welcome screen)
   const isFullContentView = contentView.type !== 'conversation' && contentView.type !== 'session-manager';
 
   const {
@@ -1003,7 +1004,7 @@ export default function Home() {
           <ResizablePanel id="main-content" defaultSize={78} minSize={30}>
             {isLoadingData ? (
               <ConversationSkeleton />
-            ) : isFullContentView ? (
+            ) : isFullContentView || (!selectedSessionId && contentView.type === 'conversation') ? (
               // Full Content Views take entire main content area
               <ErrorBoundary section="FullContent">
                 {contentView.type === 'pr-dashboard' && (
@@ -1021,6 +1022,16 @@ export default function Home() {
                     onOpenShortcuts={() => setShowShortcuts(true)}
                     showLeftSidebar={!leftSidebarCollapsed}
                     onCreateSession={handleNewSession}
+                  />
+                )}
+                {!selectedSessionId && contentView.type === 'conversation' && (
+                  <EmptyView
+                    onOpenProject={handleOpenProject}
+                    onCloneFromUrl={() => setShowCloneFromUrl(true)}
+                    onQuickStart={() => setShowQuickStart(true)}
+                    onOpenSettings={() => setShowSettings(true)}
+                    onOpenShortcuts={() => setShowShortcuts(true)}
+                    showLeftSidebar={!leftSidebarCollapsed}
                   />
                 )}
               </ErrorBoundary>
@@ -1114,19 +1125,6 @@ export default function Home() {
           </ResizablePanel>
         </ResizablePanelGroup>
 
-        {/* Empty View Overlay - covers main content and right sidebar when no session selected */}
-        {!selectedSessionId && !isFullContentView && !showSettings && (
-          <div
-            className="absolute inset-0 z-10 bg-background"
-            style={{ left: sidebarWidth + 5 }}
-          >
-            <EmptyView
-              onOpenProject={handleOpenProject}
-              onCloneFromUrl={() => setShowCloneFromUrl(true)}
-              onQuickStart={() => setShowQuickStart(true)}
-            />
-          </div>
-        )}
 
         {/* Session Manager Overlay - full screen */}
         {contentView.type === 'session-manager' && (

--- a/src/components/EmptyView.tsx
+++ b/src/components/EmptyView.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { Folder, Globe, SquarePlus, Sparkles } from 'lucide-react';
+import { FullContentLayout } from './FullContentLayout';
 
 interface EmptyViewProps {
   onOpenProject: () => void;
   onCloneFromUrl: () => void;
   onQuickStart: () => void;
+  onOpenSettings?: () => void;
+  onOpenShortcuts?: () => void;
+  showLeftSidebar?: boolean;
 }
 
 const ACTION_CARDS = [
@@ -14,7 +18,14 @@ const ACTION_CARDS = [
   { icon: SquarePlus, label: 'Quick start', key: 'quickstart' },
 ] as const;
 
-export function EmptyView({ onOpenProject, onCloneFromUrl, onQuickStart }: EmptyViewProps) {
+export function EmptyView({
+  onOpenProject,
+  onCloneFromUrl,
+  onQuickStart,
+  onOpenSettings,
+  onOpenShortcuts,
+  showLeftSidebar = true,
+}: EmptyViewProps) {
   const handleCardClick = (key: string) => {
     switch (key) {
       case 'open':
@@ -30,7 +41,13 @@ export function EmptyView({ onOpenProject, onCloneFromUrl, onQuickStart }: Empty
   };
 
   return (
-    <div className="h-full flex flex-col items-center justify-center bg-background">
+    <FullContentLayout
+      title="Welcome"
+      onOpenSettings={onOpenSettings}
+      onOpenShortcuts={onOpenShortcuts}
+      showLeftSidebar={showLeftSidebar}
+    >
+      <div className="h-full flex flex-col items-center justify-center bg-background">
       {/* Logo */}
       <div className="mb-12">
         <div className="relative">
@@ -58,6 +75,7 @@ export function EmptyView({ onOpenProject, onCloneFromUrl, onQuickStart }: Empty
           </button>
         ))}
       </div>
-    </div>
+      </div>
+    </FullContentLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Convert EmptyView from an absolute overlay (z-10) to a proper full content view
- Use `FullContentLayout` wrapper with "Welcome" title, matching Dashboard and PRDashboard
- Renders in the same content area as other full-content views

## Before
The welcome screen was rendered as an absolute overlay positioned over the main content area.

## After  
The welcome screen is rendered as a full content view like Dashboard and Pull Requests, with a proper header bar.

## Test plan
- [ ] Clear app state or get to a state with no session selected
- [ ] Verify welcome screen shows with header bar like Dashboard
- [ ] Verify dragging from header works
- [ ] Verify Settings/Shortcuts menu works from header

🤖 Generated with [Claude Code](https://claude.com/claude-code)