### PR TITLE
feat: add PR action buttons and improve PRCard styling

### DIFF
--- a/src/components/PRDashboard.tsx
+++ b/src/components/PRDashboard.tsx
@@ -5,7 +5,7 @@ import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { FullContentLayout } from '@/components/FullContentLayout';
 import { PRCard } from '@/components/pr-dashboard/PRCard';
-import { getPRs, type PRDashboardItem } from '@/lib/api';
+import { getPRs, sendSessionMessage, type PRDashboardItem } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
   RefreshCw,
@@ -51,6 +51,7 @@ export function PRDashboard({
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sendingMessageFor, setSendingMessageFor] = useState<string | null>(null);
 
   const workspaces = useAppStore((s) => s.workspaces);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
@@ -100,6 +101,24 @@ export function PRDashboard({
     selectWorkspace(workspaceId);
     selectSession(sessionId);
     setContentView({ type: 'conversation' });
+  };
+
+  const handleSendMessage = async (pr: PRDashboardItem, message: string) => {
+    if (!pr.sessionId) return;
+
+    const prKey = `${pr.workspaceId}-${pr.number}`;
+    setSendingMessageFor(prKey);
+
+    try {
+      await sendSessionMessage(pr.workspaceId, pr.sessionId, message);
+      // Navigate to the session after sending
+      handleJumpToSession(pr.workspaceId, pr.sessionId);
+    } catch (err) {
+      console.error('Failed to send message:', err);
+      // Could add toast notification here
+    } finally {
+      setSendingMessageFor(null);
+    }
   };
 
   // Group PRs by status
@@ -222,6 +241,12 @@ export function PRDashboard({
                       ? () => handleJumpToSession(pr.workspaceId, pr.sessionId!)
                       : undefined
                   }
+                  onSendMessage={
+                    pr.sessionId
+                      ? (message) => handleSendMessage(pr, message)
+                      : undefined
+                  }
+                  isSendingMessage={sendingMessageFor === `${pr.workspaceId}-${pr.number}`}
                 />
               </ErrorBoundary>
             ))}

--- a/src/components/pr-dashboard/PRCard.tsx
+++ b/src/components/pr-dashboard/PRCard.tsx
@@ -23,6 +23,9 @@ import {
   Clock,
   AlertTriangle,
   ArrowRight,
+  GitMerge,
+  Wrench,
+  Loader2,
 } from 'lucide-react';
 
 function BranchBadge({ name }: { name: string }) {
@@ -46,9 +49,11 @@ async function openInBrowser(url: string) {
 interface PRCardProps {
   pr: PRDashboardItem;
   onJumpToSession?: () => void;
+  onSendMessage?: (message: string) => void;
+  isSendingMessage?: boolean;
 }
 
-export function PRCard({ pr, onJumpToSession }: PRCardProps) {
+export function PRCard({ pr, onJumpToSession, onSendMessage, isSendingMessage }: PRCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const hasChecks = pr.checksTotal > 0;
@@ -122,6 +127,60 @@ export function PRCard({ pr, onJumpToSession }: PRCardProps) {
   const checkSummary = getCheckSummary();
   const CheckIcon = checkSummary.icon;
 
+  // Determine primary action based on PR state
+  const getPrimaryAction = () => {
+    // Draft PRs - no action for now
+    if (pr.isDraft) {
+      return null;
+    }
+    // Conflicts take priority
+    if (hasConflicts) {
+      return {
+        label: 'Resolve Conflicts',
+        message: 'Please resolve the merge conflicts in this PR.',
+        icon: AlertTriangle,
+        variant: 'warning' as const,
+      };
+    }
+    // Failed checks
+    if (hasFailures) {
+      return {
+        label: 'Fix Failures',
+        message: 'Please fix the failing CI checks in this PR.',
+        icon: Wrench,
+        variant: 'warning' as const,
+      };
+    }
+    // Pending checks - no action, just wait
+    if (hasPending) {
+      return null;
+    }
+    // All passed, no conflicts - ready to merge
+    if (allPassed || !hasChecks) {
+      return {
+        label: 'Merge PR',
+        message: 'Please merge this PR.',
+        icon: GitMerge,
+        variant: 'success' as const,
+      };
+    }
+    return null;
+  };
+
+  const primaryAction = getPrimaryAction();
+
+  const handleActionClick = () => {
+    if (!primaryAction) return;
+
+    if (onSendMessage) {
+      // Has a session - send message to agent
+      onSendMessage(primaryAction.message);
+    } else {
+      // No session - open GitHub
+      openInBrowser(pr.htmlUrl);
+    }
+  };
+
   return (
     <div className="border rounded-lg bg-card hover:bg-surface-1 transition-colors">
       <div className="p-3">
@@ -130,8 +189,8 @@ export function PRCard({ pr, onJumpToSession }: PRCardProps) {
           <StatusIcon className={cn('h-4 w-4 mt-0.5 shrink-0', statusInfo.color)} />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="font-medium text-sm truncate">{pr.title}</span>
-              <span className="text-xs text-muted-foreground shrink-0">#{pr.number}</span>
+              <span className="font-medium text-base truncate">{pr.title}</span>
+              <span className="text-sm text-muted-foreground shrink-0">#{pr.number}</span>
               {pr.sessionName && (
                 <span className="text-xs bg-surface-2 px-1.5 py-0.5 rounded shrink-0">
                   {pr.sessionName}
@@ -163,6 +222,22 @@ export function PRCard({ pr, onJumpToSession }: PRCardProps) {
                 onClick={onJumpToSession}
               >
                 Go to Session
+              </Button>
+            )}
+            {primaryAction && (
+              <Button
+                variant={primaryAction.variant}
+                size="sm"
+                className="h-7 text-xs gap-1"
+                onClick={handleActionClick}
+                disabled={isSendingMessage}
+              >
+                {isSendingMessage ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <primaryAction.icon className="h-3.5 w-3.5" />
+                )}
+                {primaryAction.label}
               </Button>
             )}
             <Tooltip>


### PR DESCRIPTION
## Summary
- Increase font sizes in PRCard (title: text-sm → text-base, PR number: text-xs → text-sm)
- Add contextual action buttons based on PR state:
  - **Fix Failures** (amber) - when CI checks fail
  - **Resolve Conflicts** (yellow) - when merge conflicts exist
  - **Merge PR** (green) - when all checks pass and no conflicts
- Buttons send message to session agent if available, otherwise open GitHub

## Test plan
- [ ] Verify PRCard title and PR number are larger
- [ ] Test "Fix Failures" button appears for PRs with failing checks
- [ ] Test "Resolve Conflicts" button appears for PRs with merge conflicts
- [ ] Test "Merge PR" button appears for PRs ready to merge
- [ ] Verify clicking buttons sends message to agent (for PRs with sessions)
- [ ] Verify clicking buttons opens GitHub (for PRs without sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)