### PR TITLE
feat: add author avatars to branches dashboard

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -637,15 +637,16 @@ func (rm *RepoManager) getStashCount(ctx context.Context, repoPath string) (int,
 
 // branchInfo is an internal struct for branch data during processing
 type branchInfo struct {
-	Name           string
-	IsRemote       bool
-	IsHead         bool
-	LastCommitSHA  string
-	LastCommitDate time.Time
-	LastAuthor     string
-	AheadMain      int
-	BehindMain     int
-	Prefix         string
+	Name            string
+	IsRemote        bool
+	IsHead          bool
+	LastCommitSHA   string
+	LastCommitDate  time.Time
+	LastAuthor      string
+	LastAuthorEmail string
+	AheadMain       int
+	BehindMain      int
+	Prefix          string
 }
 
 // BranchListOptions controls branch listing behavior
@@ -676,8 +677,8 @@ func (rm *RepoManager) ListBranches(ctx context.Context, repoPath string, opts B
 	}
 
 	// Get all branches with metadata
-	// Format: refname|objectname|committerdate|authorname|HEAD
-	args := []string{"branch", "--format=%(refname:short)|%(objectname:short)|%(committerdate:iso-strict)|%(authorname)|%(HEAD)"}
+	// Format: refname|objectname|committerdate|authorname|authoremail|HEAD
+	args := []string{"branch", "--format=%(refname:short)|%(objectname:short)|%(committerdate:iso-strict)|%(authorname)|%(authoremail)|%(HEAD)"}
 	if opts.IncludeRemote {
 		args = append(args, "-a")
 	}
@@ -698,7 +699,7 @@ func (rm *RepoManager) ListBranches(ctx context.Context, repoPath string, opts B
 		}
 
 		parts := strings.Split(line, "|")
-		if len(parts) < 5 {
+		if len(parts) < 6 {
 			continue
 		}
 
@@ -706,7 +707,8 @@ func (rm *RepoManager) ListBranches(ctx context.Context, repoPath string, opts B
 		commitSHA := parts[1]
 		dateStr := parts[2]
 		author := parts[3]
-		isHead := strings.TrimSpace(parts[4]) == "*"
+		authorEmail := strings.Trim(parts[4], "<>") // Remove angle brackets from email
+		isHead := strings.TrimSpace(parts[5]) == "*"
 
 		// Filter by search term if provided
 		if opts.Search != "" && !strings.Contains(strings.ToLower(name), strings.ToLower(opts.Search)) {
@@ -743,13 +745,14 @@ func (rm *RepoManager) ListBranches(ctx context.Context, repoPath string, opts B
 		}
 
 		allBranches = append(allBranches, branchInfo{
-			Name:           name,
-			IsRemote:       isRemote,
-			IsHead:         isHead,
-			LastCommitSHA:  commitSHA,
-			LastCommitDate: commitDate,
-			LastAuthor:     author,
-			Prefix:         prefix,
+			Name:            name,
+			IsRemote:        isRemote,
+			IsHead:          isHead,
+			LastCommitSHA:   commitSHA,
+			LastCommitDate:  commitDate,
+			LastAuthor:      author,
+			LastAuthorEmail: authorEmail,
+			Prefix:          prefix,
 		})
 	}
 

--- a/backend/github/avatar_cache.go
+++ b/backend/github/avatar_cache.go
@@ -1,0 +1,166 @@
+package github
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// AvatarEntry holds cached avatar data for an email
+type AvatarEntry struct {
+	AvatarURL string
+	NotFound  bool // true if we looked up and found no matching user
+	CachedAt  time.Time
+	ExpiresAt time.Time
+}
+
+// AvatarCache provides time-based caching for GitHub avatar URLs by email
+type AvatarCache struct {
+	mu      sync.RWMutex
+	entries map[string]*AvatarEntry
+	ttl     time.Duration
+}
+
+// NewAvatarCache creates a new avatar cache with the given TTL
+func NewAvatarCache(ttl time.Duration) *AvatarCache {
+	cache := &AvatarCache{
+		entries: make(map[string]*AvatarEntry),
+		ttl:     ttl,
+	}
+
+	// Start cleanup goroutine
+	go cache.cleanupLoop()
+
+	return cache
+}
+
+// normalizeEmail lowercases and trims email for consistent cache keys
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// Get retrieves cached avatar URL for an email
+// Returns (avatarURL, notFound, found)
+// - found=false means not in cache
+// - found=true, notFound=true means we know there's no GitHub user for this email
+// - found=true, notFound=false means we have a valid avatar URL
+func (c *AvatarCache) Get(email string) (avatarURL string, notFound bool, found bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := normalizeEmail(email)
+	entry, ok := c.entries[key]
+	if !ok {
+		return "", false, false
+	}
+
+	// Check if expired
+	if time.Now().After(entry.ExpiresAt) {
+		return "", false, false
+	}
+
+	return entry.AvatarURL, entry.NotFound, true
+}
+
+// Set stores an avatar URL in the cache
+func (c *AvatarCache) Set(email string, avatarURL string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := normalizeEmail(email)
+	now := time.Now()
+
+	c.entries[key] = &AvatarEntry{
+		AvatarURL: avatarURL,
+		NotFound:  false,
+		CachedAt:  now,
+		ExpiresAt: now.Add(c.ttl),
+	}
+}
+
+// SetNotFound marks an email as having no GitHub user
+func (c *AvatarCache) SetNotFound(email string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := normalizeEmail(email)
+	now := time.Now()
+
+	c.entries[key] = &AvatarEntry{
+		AvatarURL: "",
+		NotFound:  true,
+		CachedAt:  now,
+		ExpiresAt: now.Add(c.ttl),
+	}
+}
+
+// GetMultiple retrieves cached avatars for multiple emails
+// Returns a map of email -> avatarURL for found entries (including not-found markers)
+// and a slice of emails that need to be looked up
+func (c *AvatarCache) GetMultiple(emails []string) (cached map[string]string, needLookup []string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cached = make(map[string]string)
+	now := time.Now()
+
+	for _, email := range emails {
+		key := normalizeEmail(email)
+		entry, ok := c.entries[key]
+		if !ok || now.After(entry.ExpiresAt) {
+			needLookup = append(needLookup, email)
+			continue
+		}
+		// Include both found avatars and "not found" markers (empty string)
+		cached[email] = entry.AvatarURL
+	}
+
+	return cached, needLookup
+}
+
+// Clear removes all cache entries
+func (c *AvatarCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[string]*AvatarEntry)
+}
+
+// cleanupLoop periodically removes expired entries
+func (c *AvatarCache) cleanupLoop() {
+	ticker := time.NewTicker(c.ttl)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.cleanup()
+	}
+}
+
+// cleanup removes expired entries
+func (c *AvatarCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range c.entries {
+		if now.After(entry.ExpiresAt) {
+			delete(c.entries, key)
+		}
+	}
+}
+
+// Stats returns cache statistics
+func (c *AvatarCache) Stats() (total int, notFound int, expired int) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	now := time.Now()
+	total = len(c.entries)
+	for _, entry := range c.entries {
+		if now.After(entry.ExpiresAt) {
+			expired++
+		} else if entry.NotFound {
+			notFound++
+		}
+	}
+	return total, notFound, expired
+}

--- a/backend/github/client.go
+++ b/backend/github/client.go
@@ -216,3 +216,70 @@ func (c *Client) SetBaseURL(url string) {
 func (c *Client) SetAPIURL(url string) {
 	c.apiURL = url
 }
+
+// SearchUserResult represents a user from the GitHub search API
+type SearchUserResult struct {
+	Login     string `json:"login"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+// SearchUsersResponse represents the response from GitHub's user search API
+type SearchUsersResponse struct {
+	TotalCount int                `json:"total_count"`
+	Items      []SearchUserResult `json:"items"`
+}
+
+// GetAvatarByEmail searches for a GitHub user by email and returns their avatar URL.
+// Returns empty string if no user is found.
+// Uses authenticated requests if a token is available (higher rate limits).
+func (c *Client) GetAvatarByEmail(ctx context.Context, email string) (string, error) {
+	if email == "" {
+		return "", nil
+	}
+
+	// Build search query: email must be in the user's public email
+	query := url.QueryEscape(email + " in:email")
+	searchURL := fmt.Sprintf("%s/search/users?q=%s&per_page=1", c.apiURL, query)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", searchURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	// Use token if available for higher rate limits
+	token := c.GetToken()
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("searching users: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Handle rate limiting
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+		return "", fmt.Errorf("rate limited by GitHub API")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
+	}
+
+	var result SearchUsersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding response: %w", err)
+	}
+
+	// No users found
+	if result.TotalCount == 0 || len(result.Items) == 0 {
+		return "", nil
+	}
+
+	return result.Items[0].AvatarURL, nil
+}

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -240,15 +240,16 @@ type CommentStats struct {
 
 // BranchInfo represents metadata about a git branch
 type BranchInfo struct {
-	Name           string    `json:"name"`
-	IsRemote       bool      `json:"isRemote"`
-	IsHead         bool      `json:"isHead"`
-	LastCommitSHA  string    `json:"lastCommitSha"`
-	LastCommitDate time.Time `json:"lastCommitDate"`
-	LastAuthor     string    `json:"lastAuthor"`
-	AheadMain      int       `json:"aheadMain"`
-	BehindMain     int       `json:"behindMain"`
-	Prefix         string    `json:"prefix"` // e.g., "feature", "fix", "session"
+	Name            string    `json:"name"`
+	IsRemote        bool      `json:"isRemote"`
+	IsHead          bool      `json:"isHead"`
+	LastCommitSHA   string    `json:"lastCommitSha"`
+	LastCommitDate  time.Time `json:"lastCommitDate"`
+	LastAuthor      string    `json:"lastAuthor"`
+	LastAuthorEmail string    `json:"lastAuthorEmail,omitempty"`
+	AheadMain       int       `json:"aheadMain"`
+	BehindMain      int       `json:"behindMain"`
+	Prefix          string    `json:"prefix"` // e.g., "feature", "fix", "session"
 }
 
 // BranchWithSession combines branch info with optional session linkage

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -215,6 +215,7 @@ type Handlers struct {
 	hub              *Hub // For broadcasting WebSocket events
 	ghClient         *github.Client
 	prCache          *github.PRCache
+	avatarCache      *github.AvatarCache
 	statsCache       *SessionStatsCache
 }
 
@@ -247,7 +248,8 @@ func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirList
 		prWatcher:        prw,
 		hub:              hub,
 		ghClient:         ghClient,
-		prCache:          github.NewPRCache(30 * time.Second), // Cache PR data for 30 seconds
+		prCache:          github.NewPRCache(30 * time.Second),   // Cache PR data for 30 seconds
+		avatarCache:      github.NewAvatarCache(24 * time.Hour), // Cache avatars for 24 hours
 		statsCache:       statsCache,
 	}
 }
@@ -693,15 +695,16 @@ func (h *Handlers) ListBranches(w http.ResponseWriter, r *http.Request) {
 	for _, branch := range branchResult.Branches {
 		bws := models.BranchWithSession{
 			BranchInfo: models.BranchInfo{
-				Name:           branch.Name,
-				IsRemote:       branch.IsRemote,
-				IsHead:         branch.IsHead,
-				LastCommitSHA:  branch.LastCommitSHA,
-				LastCommitDate: branch.LastCommitDate,
-				LastAuthor:     branch.LastAuthor,
-				AheadMain:      branch.AheadMain,
-				BehindMain:     branch.BehindMain,
-				Prefix:         branch.Prefix,
+				Name:            branch.Name,
+				IsRemote:        branch.IsRemote,
+				IsHead:          branch.IsHead,
+				LastCommitSHA:   branch.LastCommitSHA,
+				LastCommitDate:  branch.LastCommitDate,
+				LastAuthor:      branch.LastAuthor,
+				LastAuthorEmail: branch.LastAuthorEmail,
+				AheadMain:       branch.AheadMain,
+				BehindMain:      branch.BehindMain,
+				Prefix:          branch.Prefix,
 			},
 		}
 
@@ -733,6 +736,68 @@ func (h *Handlers) ListBranches(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, response)
+}
+
+// GetAvatars returns GitHub avatar URLs for a batch of email addresses
+// GET /api/avatars?emails=email1@example.com,email2@example.com
+func (h *Handlers) GetAvatars(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Parse emails from query parameter
+	emailsParam := r.URL.Query().Get("emails")
+	if emailsParam == "" {
+		writeJSON(w, map[string]interface{}{"avatars": map[string]string{}})
+		return
+	}
+
+	emails := strings.Split(emailsParam, ",")
+	if len(emails) == 0 {
+		writeJSON(w, map[string]interface{}{"avatars": map[string]string{}})
+		return
+	}
+
+	// Limit batch size to prevent abuse
+	if len(emails) > 50 {
+		emails = emails[:50]
+	}
+
+	// Check cache for existing entries
+	cached, needLookup := h.avatarCache.GetMultiple(emails)
+
+	// If we have all entries cached, return immediately
+	if len(needLookup) == 0 {
+		writeJSON(w, map[string]interface{}{"avatars": cached})
+		return
+	}
+
+	// Look up missing emails from GitHub API
+	for _, email := range needLookup {
+		email = strings.TrimSpace(email)
+		if email == "" {
+			continue
+		}
+
+		avatarURL, err := h.ghClient.GetAvatarByEmail(ctx, email)
+		if err != nil {
+			// Log error but continue - don't fail the whole batch
+			logger.Handlers.Debugf("Failed to get avatar for %s: %v", email, err)
+			// Cache as not found to avoid repeated failed lookups
+			h.avatarCache.SetNotFound(email)
+			cached[email] = ""
+			continue
+		}
+
+		if avatarURL == "" {
+			// No user found - cache as not found
+			h.avatarCache.SetNotFound(email)
+			cached[email] = ""
+		} else {
+			h.avatarCache.Set(email, avatarURL)
+			cached[email] = avatarURL
+		}
+	}
+
+	writeJSON(w, map[string]interface{}{"avatars": cached})
 }
 
 type CreateSessionRequest struct {

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -60,6 +60,9 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	// PR Dashboard endpoint
 	r.Get("/api/prs", h.ListPRs)
 
+	// Avatar lookup endpoint
+	r.Get("/api/avatars", h.GetAvatars)
+
 	// Dashboard data endpoint - fetches all workspaces, sessions, and conversations in one request
 	r.Get("/api/dashboard/data", h.GetDashboardData)
 

--- a/src/components/BranchesDashboard.tsx
+++ b/src/components/BranchesDashboard.tsx
@@ -6,6 +6,7 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { FullContentLayout } from '@/components/FullContentLayout';
 import { BranchCard } from '@/components/branches/BranchCard';
 import { listBranches, type BranchDTO, type BranchListResponse } from '@/lib/api';
+import { useAvatars } from '@/hooks/useAvatars';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -181,6 +182,21 @@ export function BranchesDashboard({
     return sortGroupKeys(Array.from(groupedOtherBranches.keys()));
   }, [groupedOtherBranches]);
 
+  // Collect all unique author emails from branches
+  const authorEmails = useMemo(() => {
+    if (!branchData) return [];
+    const emails = new Set<string>();
+    for (const branch of [...branchData.sessionBranches, ...branchData.otherBranches]) {
+      if (branch.lastAuthorEmail) {
+        emails.add(branch.lastAuthorEmail);
+      }
+    }
+    return Array.from(emails);
+  }, [branchData]);
+
+  // Fetch avatars for all author emails
+  const avatars = useAvatars(authorEmails);
+
   // Calculate total pages
   const totalPages = branchData ? Math.ceil(branchData.total / PAGE_SIZE) : 0;
 
@@ -301,6 +317,7 @@ export function BranchesDashboard({
                       <BranchCard
                         branch={branch}
                         currentBranch={branchData.currentBranch}
+                        avatarUrl={branch.lastAuthorEmail ? avatars[branch.lastAuthorEmail.toLowerCase()] : undefined}
                         onJumpToSession={
                           branch.sessionId
                             ? () => handleJumpToSession(branch.sessionId!)
@@ -353,6 +370,7 @@ export function BranchesDashboard({
                                 <BranchCard
                                   branch={branch}
                                   currentBranch={branchData.currentBranch}
+                                  avatarUrl={branch.lastAuthorEmail ? avatars[branch.lastAuthorEmail.toLowerCase()] : undefined}
                                 />
                               </ErrorBoundary>
                             ))}

--- a/src/components/branches/BranchCard.tsx
+++ b/src/components/branches/BranchCard.tsx
@@ -2,12 +2,14 @@
 
 import { GitBranch, Check, ArrowRight, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { AuthorAvatar } from '@/components/ui/author-avatar';
 import { cn } from '@/lib/utils';
 import type { BranchDTO } from '@/lib/api';
 
 interface BranchCardProps {
   branch: BranchDTO;
   currentBranch: string;
+  avatarUrl?: string;
   onJumpToSession?: () => void;
   onViewOnGitHub?: () => void;
 }
@@ -31,6 +33,7 @@ function formatTimeAgo(dateStr: string): string {
 export function BranchCard({
   branch,
   currentBranch,
+  avatarUrl,
   onJumpToSession,
   onViewOnGitHub,
 }: BranchCardProps) {
@@ -140,7 +143,10 @@ export function BranchCard({
       {/* Row 2: Metadata - author, date, ahead/behind */}
       <div className="flex items-center gap-2 mt-1.5 ml-6 text-xs text-muted-foreground">
         {branch.lastAuthor && (
-          <span className="truncate max-w-[120px]">{branch.lastAuthor}</span>
+          <span className="flex items-center gap-1.5 truncate max-w-[150px]">
+            <AuthorAvatar name={branch.lastAuthor} avatarUrl={avatarUrl} size="sm" />
+            <span className="truncate">{branch.lastAuthor}</span>
+          </span>
         )}
 
         {branch.lastCommitDate && (

--- a/src/components/ui/author-avatar.tsx
+++ b/src/components/ui/author-avatar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface AuthorAvatarProps {
+  name: string;
+  avatarUrl?: string;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+export function AuthorAvatar({ name, avatarUrl, size = 'sm', className }: AuthorAvatarProps) {
+  const sizeClasses = {
+    sm: 'h-5 w-5 text-[9px]',
+    md: 'h-6 w-6 text-[10px]',
+  };
+
+  const initial = (name || '?')[0].toUpperCase();
+
+  if (avatarUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={avatarUrl}
+        alt={name}
+        className={cn('rounded-full shrink-0', sizeClasses[size], className)}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-full bg-muted flex items-center justify-center shrink-0',
+        sizeClasses[size],
+        className
+      )}
+    >
+      <span className="font-medium">{initial}</span>
+    </div>
+  );
+}

--- a/src/hooks/useAvatars.ts
+++ b/src/hooks/useAvatars.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { getAvatars } from '@/lib/api';
+
+// Client-side avatar cache (persists across component remounts within the session)
+const avatarCache = new Map<string, string>();
+
+/**
+ * Hook to fetch and cache avatar URLs for email addresses.
+ * Uses both client-side caching and batches requests to reduce API calls.
+ */
+export function useAvatars(emails: string[]): Record<string, string> {
+  const [fetchedAvatars, setFetchedAvatars] = useState<Record<string, string>>({});
+  const fetchedRef = useRef(new Set<string>());
+
+  // Normalize and deduplicate emails
+  const normalizedEmails = useMemo(() => {
+    return [...new Set(emails)]
+      .filter(email => email && email.trim())
+      .map(email => email.toLowerCase());
+  }, [emails]);
+
+  // Build initial result from cache (computed synchronously, not in effect)
+  const cachedAvatars = useMemo(() => {
+    const result: Record<string, string> = {};
+    for (const email of normalizedEmails) {
+      if (avatarCache.has(email)) {
+        result[email] = avatarCache.get(email)!;
+      }
+    }
+    return result;
+  }, [normalizedEmails]);
+
+  const fetchAvatars = useCallback(async (emailsToFetch: string[]) => {
+    if (emailsToFetch.length === 0) return;
+
+    try {
+      const result = await getAvatars(emailsToFetch);
+
+      // Update cache and state
+      for (const [email, url] of Object.entries(result)) {
+        avatarCache.set(email.toLowerCase(), url);
+      }
+
+      setFetchedAvatars(prev => ({ ...prev, ...result }));
+    } catch (error) {
+      console.error('Failed to fetch avatars:', error);
+      // Mark as fetched even on error to avoid repeated failed requests
+      for (const email of emailsToFetch) {
+        avatarCache.set(email.toLowerCase(), '');
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (normalizedEmails.length === 0) return;
+
+    // Collect emails that need fetching
+    const needFetch: string[] = [];
+
+    for (const email of normalizedEmails) {
+      if (!avatarCache.has(email) && !fetchedRef.current.has(email)) {
+        needFetch.push(email);
+        fetchedRef.current.add(email);
+      }
+    }
+
+    // Fetch missing avatars with debounce
+    if (needFetch.length > 0) {
+      const timeoutId = setTimeout(() => {
+        fetchAvatars(needFetch);
+      }, 50);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [normalizedEmails, fetchAvatars]);
+
+  // Merge cached and fetched avatars
+  return useMemo(() => {
+    return { ...cachedAvatars, ...fetchedAvatars };
+  }, [cachedAvatars, fetchedAvatars]);
+}
+
+/**
+ * Get a single avatar from the cache synchronously.
+ * Returns undefined if not cached.
+ */
+export function getCachedAvatar(email: string): string | undefined {
+  return avatarCache.get(email.toLowerCase());
+}
+
+/**
+ * Clear the avatar cache (useful for testing or cache invalidation).
+ */
+export function clearAvatarCache(): void {
+  avatarCache.clear();
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -265,6 +265,7 @@ export interface BranchDTO {
   lastCommitSha: string;
   lastCommitDate: string;
   lastAuthor: string;
+  lastAuthorEmail?: string;
   aheadMain: number;
   behindMain: number;
   prefix: string;
@@ -315,6 +316,22 @@ export async function listBranches(
   const url = `${getApiBase()}/api/repos/${workspaceId}/branches${queryString ? `?${queryString}` : ''}`;
   const res = await fetchWithAuth(url);
   return handleResponse<BranchListResponse>(res);
+}
+
+// Avatar types and API
+export interface AvatarResponse {
+  avatars: Record<string, string>;
+}
+
+export async function getAvatars(emails: string[]): Promise<Record<string, string>> {
+  if (emails.length === 0) {
+    return {};
+  }
+  const emailsParam = emails.join(',');
+  const url = `${getApiBase()}/api/avatars?emails=${encodeURIComponent(emailsParam)}`;
+  const res = await fetchWithAuth(url);
+  const response = await handleResponse<AvatarResponse>(res);
+  return response.avatars;
 }
 
 export interface FileChangeDTO {


### PR DESCRIPTION
## Summary
- Display GitHub avatars next to branch author names in the Branches page
- Use GitHub API to search for users by commit email and fetch their avatar URLs
- Cache avatars on both backend (24-hour TTL) and frontend to minimize API calls
- Show initials fallback when avatar is not available

## Architecture
```
Git Commit → Author Email → GitHub API Search → Avatar URL → Cache → Frontend Display
```

## Changes

### Backend
- `backend/git/repo.go` - Add author email to git branch query
- `backend/github/avatar_cache.go` - New in-memory cache for avatar URLs
- `backend/github/client.go` - Add `GetAvatarByEmail` method using GitHub search API
- `backend/models/types.go` - Add `LastAuthorEmail` to BranchInfo
- `backend/server/handlers.go` - Add avatar endpoint and update branch mapping
- `backend/server/router.go` - Register `/api/avatars` endpoint

### Frontend
- `src/components/ui/author-avatar.tsx` - Reusable avatar component with initials fallback
- `src/hooks/useAvatars.ts` - Hook for fetching and caching avatars
- `src/components/branches/BranchCard.tsx` - Display avatar next to author name
- `src/components/BranchesDashboard.tsx` - Fetch avatars for visible branches
- `src/lib/api.ts` - Add `getAvatars` API function and update types

## Test plan
- [x] Backend builds and tests pass
- [x] Frontend builds and lints clean
- [ ] Navigate to Branches page and verify avatars display
- [ ] Verify initials fallback for unknown emails
- [ ] Check Network tab - avatar requests should be batched and cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)