### PR TITLE
fix: show open folder icon when workspace is expanded

### DIFF
--- a/src/components/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar.tsx
@@ -628,7 +628,11 @@ function SortableWorkspaceItem({
               {...listeners}
               onClick={(e) => e.stopPropagation()}
             >
-              <Folder className="w-4 h-4" />
+              {isExpanded ? (
+                <FolderOpen className="w-4 h-4" />
+              ) : (
+                <Folder className="w-4 h-4" />
+              )}
             </div>
             <span className="text-[length:var(--text-base)] font-semibold truncate">
               {workspace.name}


### PR DESCRIPTION
## Summary
- Show open folder icon when workspace node is expanded in the sidebar
- Show closed folder icon when workspace node is collapsed

## Test plan
- [ ] Expand a workspace in the sidebar - folder icon should change to open folder
- [ ] Collapse the workspace - folder icon should change back to closed folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)