### PR TITLE
fix: prevent race condition in file watcher cleanup

### DIFF
--- a/src/hooks/useFileWatcher.ts
+++ b/src/hooks/useFileWatcher.ts
@@ -119,12 +119,9 @@ export function useFileWatcher() {
         if (isMounted) {
           cleanupRef.current = unlisten;
         } else {
-          // Component unmounted before listener was registered - clean up immediately
-          try {
-            unlisten();
-          } catch {
-            // Ignore errors if listener wasn't fully registered
-          }
+          // Component unmounted before listener was registered
+          // Store for cleanup - the cleanup function will handle it safely
+          cleanupRef.current = unlisten;
         }
       })
       .catch((err) => {
@@ -136,11 +133,15 @@ export function useFileWatcher() {
 
     return () => {
       isMounted = false;
-      try {
-        cleanupRef.current?.();
-      } catch {
-        // Ignore errors if listener cleanup fails
-      }
+      // Delay cleanup slightly to allow Tauri listener to fully register
+      // This prevents "listeners[eventId].handlerId is undefined" errors
+      setTimeout(() => {
+        try {
+          cleanupRef.current?.();
+        } catch {
+          // Ignore errors if listener cleanup fails
+        }
+      }, 10);
     };
   }, [handleFileChange, showError]);
 }


### PR DESCRIPTION
## Summary
Fix runtime TypeError "listeners[eventId].handlerId is undefined" in useFileWatcher hook.

## Problem
When a component using the file watcher unmounted before the Tauri event listener was fully initialized, calling `unlisten()` would fail because Tauri's internal listener state wasn't ready.

## Solution
- Delay cleanup by 10ms to allow Tauri listener to fully register before attempting to unregister
- Store the unlisten function for cleanup even if component unmounts early (instead of trying to call it immediately)

## Test plan
- [ ] Navigate between workspaces quickly - should not see the error
- [ ] File watching should still work correctly after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)