### PR TITLE
feat: display PR labels in pull requests dashboard

### DIFF
--- a/backend/github/pr_status.go
+++ b/backend/github/pr_status.go
@@ -229,15 +229,22 @@ func (c *Client) GetPRDetailsBatch(ctx context.Context, owner, repo string, prNu
 	return results, failedPRs
 }
 
+// PRLabel represents a label on a pull request
+type PRLabel struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
 // PRListItem represents a pull request in a list response
 type PRListItem struct {
-	Number  int    `json:"number"`
-	State   string `json:"state"`
-	Title   string `json:"title"`
-	HTMLURL string `json:"htmlUrl"`
-	IsDraft bool   `json:"isDraft"`
-	Branch  string `json:"branch"`
-	HeadSHA string `json:"headSha"`
+	Number  int       `json:"number"`
+	State   string    `json:"state"`
+	Title   string    `json:"title"`
+	HTMLURL string    `json:"htmlUrl"`
+	IsDraft bool      `json:"isDraft"`
+	Branch  string    `json:"branch"`
+	HeadSHA string    `json:"headSha"`
+	Labels  []PRLabel `json:"labels"`
 }
 
 // githubPRListItem represents a PR in the GitHub API list response
@@ -251,6 +258,10 @@ type githubPRListItem struct {
 		Ref string `json:"ref"`
 		SHA string `json:"sha"`
 	} `json:"head"`
+	Labels []struct {
+		Name  string `json:"name"`
+		Color string `json:"color"`
+	} `json:"labels"`
 }
 
 // ListOpenPRs lists all open pull requests for a repository
@@ -288,6 +299,13 @@ func (c *Client) ListOpenPRs(ctx context.Context, owner, repo string) ([]PRListI
 
 	prs := make([]PRListItem, len(ghPRs))
 	for i, pr := range ghPRs {
+		labels := make([]PRLabel, len(pr.Labels))
+		for j, label := range pr.Labels {
+			labels[j] = PRLabel{
+				Name:  label.Name,
+				Color: label.Color,
+			}
+		}
 		prs[i] = PRListItem{
 			Number:  pr.Number,
 			State:   pr.State,
@@ -296,6 +314,7 @@ func (c *Client) ListOpenPRs(ctx context.Context, owner, repo string) ([]PRListI
 			IsDraft: pr.Draft,
 			Branch:  pr.Head.Ref,
 			HeadSHA: pr.Head.SHA,
+			Labels:  labels,
 		}
 	}
 

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -2781,15 +2781,16 @@ func (h *Handlers) GetSessionPRStatus(w http.ResponseWriter, r *http.Request) {
 // PRDashboardItem represents a PR in the dashboard
 type PRDashboardItem struct {
 	// PR metadata
-	Number         int           `json:"number"`
-	Title          string        `json:"title"`
-	State          string        `json:"state"`
-	HTMLURL        string        `json:"htmlUrl"`
-	IsDraft        bool          `json:"isDraft"`
-	Mergeable      *bool         `json:"mergeable"`
-	MergeableState string        `json:"mergeableState"`
-	CheckStatus    string        `json:"checkStatus"`
-	CheckDetails   []interface{} `json:"checkDetails"`
+	Number         int              `json:"number"`
+	Title          string           `json:"title"`
+	State          string           `json:"state"`
+	HTMLURL        string           `json:"htmlUrl"`
+	IsDraft        bool             `json:"isDraft"`
+	Mergeable      *bool            `json:"mergeable"`
+	MergeableState string           `json:"mergeableState"`
+	CheckStatus    string           `json:"checkStatus"`
+	CheckDetails   []interface{}    `json:"checkDetails"`
+	Labels         []github.PRLabel `json:"labels"`
 
 	// Branch info
 	Branch     string `json:"branch"`
@@ -2910,6 +2911,7 @@ func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
 				RepoOwner:     owner,
 				RepoName:      repoName,
 				CheckStatus:   "unknown",
+				Labels:        ghPR.Labels,
 			}
 
 			// Check if there's a matching session by branch

--- a/src/components/pr-dashboard/PRCard.tsx
+++ b/src/components/pr-dashboard/PRCard.tsx
@@ -196,6 +196,19 @@ export function PRCard({ pr, onJumpToSession, onSendMessage, isSendingMessage }:
                   {pr.sessionName}
                 </span>
               )}
+              {pr.labels?.map((label) => (
+                <span
+                  key={label.name}
+                  className="text-xs px-1.5 py-0.5 rounded shrink-0 font-medium"
+                  style={{
+                    backgroundColor: `#${label.color}20`,
+                    color: `#${label.color}`,
+                    border: `1px solid #${label.color}40`,
+                  }}
+                >
+                  {label.name}
+                </span>
+              ))}
             </div>
 
             {/* Second row: Branch info, conflicts indicator */}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -470,6 +470,11 @@ export interface CheckDetail {
   durationSeconds?: number; // Duration in seconds (only for completed checks)
 }
 
+export interface PRLabel {
+  name: string;
+  color: string;
+}
+
 export interface PRDashboardItem {
   // PR metadata
   number: number;
@@ -481,6 +486,7 @@ export interface PRDashboardItem {
   mergeableState: string;
   checkStatus: string;
   checkDetails: CheckDetail[];
+  labels: PRLabel[];
 
   // Branch info
   branch: string;


### PR DESCRIPTION
## Summary
- Display GitHub labels on PRs in the Pull Requests dashboard
- Labels are shown as colored badges using the label's GitHub color

## Changes

### Backend
- `backend/github/pr_status.go` - Add `PRLabel` struct and parse labels from GitHub API
- `backend/server/handlers.go` - Add labels to `PRDashboardItem`

### Frontend
- `src/lib/api.ts` - Add `PRLabel` interface and update `PRDashboardItem`
- `src/components/pr-dashboard/PRCard.tsx` - Render label badges with colors

## Test plan
- [ ] Open Pull Requests dashboard
- [ ] Verify labels display next to PR titles
- [ ] Verify label colors match GitHub colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)