### PR TITLE
Fix right sidebar responsive overflow and add sortable tabs

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1185,6 +1185,7 @@ export default function Home() {
                   collapsedSize={0}
                   onResize={(size) => setRightSidebarCollapsed(size.asPercentage === 0)}
                   className={cn(
+                    "overflow-hidden",
                     (zenMode || !selectedSessionId) && "hidden"
                   )}
                 >

--- a/src/components/ChangesPanel.tsx
+++ b/src/components/ChangesPanel.tsx
@@ -26,8 +26,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
-import { useSettingsStore, type BottomPanelTab, type AllBottomPanelTab, DEFAULT_BOTTOM_TAB_ORDER } from '@/stores/settingsStore';
+import { useSettingsStore, type BottomPanelTab, type AllBottomPanelTab, DEFAULT_BOTTOM_TAB_ORDER, type TopPanelTab, type AllTopPanelTab, DEFAULT_TOP_TAB_ORDER } from '@/stores/settingsStore';
 import {
   DndContext,
   closestCenter,
@@ -409,7 +410,7 @@ export function ChangesPanel({
   }, [selectedSessionId, currentSession?.worktreePath, debouncedFetchChanges]);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full w-full overflow-hidden">
       {/* Top Bar - changes based on session state */}
       <div
         data-tauri-drag-region
@@ -453,19 +454,19 @@ export function ChangesPanel({
           Review
         </Button>
 
-        {/* PR Status or Conflict indicator - truncates in middle */}
-        <div className="flex items-center gap-1.5 min-w-0 flex-1">
+        {/* PR Status or Conflict indicator - truncates in middle, hidden when very narrow */}
+        <div className="flex items-center gap-1.5 min-w-0 flex-1 overflow-hidden">
           {hasActivePR ? (
             <>
-              <GitPullRequest className="h-3.5 w-3.5 text-text-success shrink-0" />
-              <span className="text-[12px] font-medium text-text-success truncate">
+              <GitPullRequest className="h-3.5 w-3.5 text-text-success shrink-0 hidden @[220px]:block" />
+              <span className="text-[12px] font-medium text-text-success truncate hidden @[180px]:block">
                 PR #{currentSession?.prNumber}
               </span>
               {currentSession?.prUrl && (
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-6 w-6 text-text-success hover:bg-text-success/20 shrink-0"
+                  className="h-6 w-6 text-text-success hover:bg-text-success/20 shrink-0 hidden @[250px]:flex"
                   onClick={() => window.open(currentSession.prUrl, '_blank')}
                 >
                   <ExternalLink className="h-3 w-3" />
@@ -474,8 +475,8 @@ export function ChangesPanel({
             </>
           ) : hasConflictOrFailure && (
             <>
-              <AlertTriangle className="h-3.5 w-3.5 text-text-error shrink-0" />
-              <span className="text-[12px] font-medium text-text-error truncate">
+              <AlertTriangle className="h-3.5 w-3.5 text-text-error shrink-0 hidden @[220px]:block" />
+              <span className="text-[12px] font-medium text-text-error truncate hidden @[180px]:block">
                 {currentSession?.hasMergeConflict ? 'Merge Conflict' : 'Check Failures'}
               </span>
             </>
@@ -501,63 +502,11 @@ export function ChangesPanel({
       </div>
 
       {/* Tabs Row */}
-      <div className="flex items-center gap-0.5 px-1.5 py-1 border-b shrink-0 overflow-hidden min-w-0">
-        <Button
-          variant={selectedTab === 'changes' ? 'secondary' : 'ghost'}
-          size="sm"
-          className={cn("h-6 text-xs px-2 gap-1 shrink-0", selectedTab !== 'changes' && "text-muted-foreground")}
-          onClick={() => setSelectedTab('changes')}
-        >
-          Changes
-          {changes?.length > 0 && (
-            <span className="bg-muted-foreground/20 text-foreground px-1 rounded text-[11px]">
-              {changes.length}
-            </span>
-          )}
-        </Button>
-        <Button
-          variant={selectedTab === 'review' ? 'secondary' : 'ghost'}
-          size="sm"
-          className={cn("h-6 text-xs px-2 shrink-0", selectedTab !== 'review' && "text-muted-foreground")}
-          onClick={() => setSelectedTab('review')}
-        >
-          Review
-        </Button>
-        <Button
-          variant={selectedTab === 'checks' ? 'secondary' : 'ghost'}
-          size="sm"
-          className={cn("h-6 text-xs px-2 shrink-0", selectedTab !== 'checks' && "text-muted-foreground")}
-          onClick={() => setSelectedTab('checks')}
-        >
-          Checks
-        </Button>
-        <Button
-          variant={selectedTab === 'files' ? 'secondary' : 'ghost'}
-          size="sm"
-          className={cn("h-6 text-xs px-2 shrink-0", selectedTab !== 'files' && "text-muted-foreground")}
-          onClick={() => setSelectedTab('files')}
-        >
-          Files
-        </Button>
-        <div className="flex-1 min-w-0" />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0">
-              <MoreVertical className="h-3.5 w-3.5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem>
-              <SplitSquareHorizontal className="size-4" />
-              Split View
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => window.dispatchEvent(new CustomEvent('open-file-picker'))}>
-              <Search className="size-4" />
-              Search Files
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <TopPanelTabs
+        selectedTab={selectedTab}
+        setSelectedTab={setSelectedTab}
+        changesCount={changes?.length || 0}
+      />
 
       {/* Resizable content area */}
       <ResizablePanelGroup
@@ -567,7 +516,7 @@ export function ChangesPanel({
         onLayoutChange={setLayoutChanges}
       >
         {/* File List */}
-        <ResizablePanel id="file-list" defaultSize="65%" minSize="20%">
+        <ResizablePanel id="file-list" defaultSize="65%" minSize="20%" className="overflow-hidden">
           {selectedTab === 'files' ? (
             filesLoading ? (
               <div className="h-full flex items-center justify-center">
@@ -677,8 +626,8 @@ export function ChangesPanel({
         <ResizableHandle direction="vertical" />
 
         {/* Bottom Panel - Todos/MCP/History */}
-        <ResizablePanel id="terminal" defaultSize="35%" minSize="15%">
-          <div className="flex flex-col h-full">
+        <ResizablePanel id="terminal" defaultSize="35%" minSize="15%" className="overflow-hidden">
+          <div className="flex flex-col h-full w-full">
             {/* Tabs Row - matching top panel style */}
             <BottomPanelTabs
               bottomTab={bottomTab}
@@ -700,6 +649,14 @@ export function ChangesPanel({
     </div>
   );
 }
+
+// Top panel tabs configuration
+const TOP_TABS_CONFIG: Record<AllTopPanelTab, { label: string; alwaysVisible?: boolean }> = {
+  changes: { label: 'Changes', alwaysVisible: true },
+  review: { label: 'Review' },
+  checks: { label: 'Checks' },
+  files: { label: 'Files' },
+};
 
 // Bottom panel tabs configuration
 const BOTTOM_TABS_CONFIG: Record<AllBottomPanelTab, { label: string; alwaysVisible?: boolean }> = {
@@ -818,45 +775,47 @@ function BottomPanelTabs({
   }, [bottomTabOrder, setBottomTabOrder]);
 
   return (
-    <div className="flex items-center gap-0.5 px-1.5 py-1 shrink-0">
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={visibleTabIds}
-          strategy={horizontalListSortingStrategy}
+    <div className="flex items-center gap-0.5 px-1.5 py-1 shrink-0 min-w-0 overflow-hidden">
+      {/* Scrollable tabs container */}
+      <div className="flex-1 min-w-0 overflow-x-auto scrollbar-none">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
         >
-          {visibleTabIds.map((tabId) => (
-            <SortableTabButton
-              key={tabId}
-              id={tabId}
-              label={BOTTOM_TABS_CONFIG[tabId].label}
-              isActive={bottomTab === tabId}
-              onClick={() => setBottomTab(tabId)}
-              badge={tabId === 'todos' ? totalPendingTodos : undefined}
-            />
-          ))}
-        </SortableContext>
-      </DndContext>
+          <SortableContext
+            items={visibleTabIds}
+            strategy={horizontalListSortingStrategy}
+          >
+            <div className="flex items-center gap-0.5">
+              {visibleTabIds.map((tabId) => (
+                <SortableTabButton
+                  key={tabId}
+                  id={tabId}
+                  label={BOTTOM_TABS_CONFIG[tabId].label}
+                  isActive={bottomTab === tabId}
+                  onClick={() => setBottomTab(tabId)}
+                  badge={tabId === 'todos' ? totalPendingTodos : undefined}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </div>
 
-      {/* Spacer */}
-      <div className="flex-1" />
-
-      {/* Settings dropdown */}
+      {/* Settings dropdown - always visible */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 w-6 p-0 shrink-0"
+            className="h-6 w-6 p-0 shrink-0 ml-1"
           >
             <MoreVertical className="size-3" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {DEFAULT_BOTTOM_TAB_ORDER.map((tabId) => {
+          {bottomTabOrder.map((tabId) => {
             const config = BOTTOM_TABS_CONFIG[tabId];
             return (
               <DropdownMenuCheckboxItem
@@ -866,6 +825,122 @@ function BottomPanelTabs({
                 onCheckedChange={() => {
                   if (!config.alwaysVisible) {
                     toggleBottomTab(tabId as BottomPanelTab);
+                  }
+                }}
+              >
+                {config.label}
+              </DropdownMenuCheckboxItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+function TopPanelTabs({
+  selectedTab,
+  setSelectedTab,
+  changesCount,
+}: {
+  selectedTab: string;
+  setSelectedTab: (tab: string) => void;
+  changesCount: number;
+}) {
+  const hiddenTopTabs = useSettingsStore((s) => s.hiddenTopTabs);
+  const toggleTopTab = useSettingsStore((s) => s.toggleTopTab);
+  const topTabOrder = useSettingsStore((s) => s.topTabOrder);
+  const setTopTabOrder = useSettingsStore((s) => s.setTopTabOrder);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const visibleTabIds = useMemo(() =>
+    topTabOrder.filter((tabId) => {
+      const config = TOP_TABS_CONFIG[tabId];
+      return config && (config.alwaysVisible || !hiddenTopTabs.includes(tabId as TopPanelTab));
+    }),
+    [topTabOrder, hiddenTopTabs]
+  );
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = topTabOrder.indexOf(active.id as AllTopPanelTab);
+      const newIndex = topTabOrder.indexOf(over.id as AllTopPanelTab);
+      const newOrder = arrayMove(topTabOrder, oldIndex, newIndex);
+      setTopTabOrder(newOrder);
+    }
+  }, [topTabOrder, setTopTabOrder]);
+
+  return (
+    <div className="flex items-center gap-0.5 px-1.5 py-1 border-b shrink-0 min-w-0 overflow-hidden">
+      {/* Scrollable tabs container */}
+      <div className="flex-1 min-w-0 overflow-x-auto scrollbar-none">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={visibleTabIds}
+            strategy={horizontalListSortingStrategy}
+          >
+            <div className="flex items-center gap-0.5">
+              {visibleTabIds.map((tabId) => (
+                <SortableTabButton
+                  key={tabId}
+                  id={tabId}
+                  label={TOP_TABS_CONFIG[tabId].label}
+                  isActive={selectedTab === tabId}
+                  onClick={() => setSelectedTab(tabId)}
+                  badge={tabId === 'changes' && changesCount > 0 ? changesCount : undefined}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </div>
+
+      {/* Settings dropdown - always visible */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 shrink-0 ml-1"
+          >
+            <MoreVertical className="size-3" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem>
+            <SplitSquareHorizontal className="size-4" />
+            Split View
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => window.dispatchEvent(new CustomEvent('open-file-picker'))}>
+            <Search className="size-4" />
+            Search Files
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          {topTabOrder.map((tabId) => {
+            const config = TOP_TABS_CONFIG[tabId];
+            return (
+              <DropdownMenuCheckboxItem
+                key={tabId}
+                checked={config.alwaysVisible || !hiddenTopTabs.includes(tabId as TopPanelTab)}
+                disabled={config.alwaysVisible}
+                onCheckedChange={() => {
+                  if (!config.alwaysVisible) {
+                    toggleTopTab(tabId as TopPanelTab);
                   }
                 }}
               >

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -10,6 +10,15 @@ export type AllBottomPanelTab = 'todos' | BottomPanelTab;
 // Default tab order
 export const DEFAULT_BOTTOM_TAB_ORDER: AllBottomPanelTab[] = ['todos', 'plans', 'history', 'file-history', 'budget', 'mcp'];
 
+// Top panel (right sidebar) tab IDs - Changes is always visible
+export type TopPanelTab = 'review' | 'checks' | 'files';
+
+// All top panel tabs including the always-visible Changes
+export type AllTopPanelTab = 'changes' | TopPanelTab;
+
+// Default top tab order
+export const DEFAULT_TOP_TAB_ORDER: AllTopPanelTab[] = ['changes', 'review', 'checks', 'files'];
+
 // Theme options
 export type ThemeOption = 'system' | 'light' | 'dark';
 
@@ -53,6 +62,8 @@ interface SettingsState {
   zenMode: boolean; // Distraction-free mode that hides sidebars
   hiddenBottomTabs: BottomPanelTab[]; // Bottom panel tabs that are hidden (Tasks always visible)
   bottomTabOrder: AllBottomPanelTab[]; // Order of bottom panel tabs
+  hiddenTopTabs: TopPanelTab[]; // Top panel tabs that are hidden (Changes always visible)
+  topTabOrder: AllTopPanelTab[]; // Order of top panel tabs
   // Full Content Area view state (not persisted - always starts in conversation view)
   contentView: ContentView;
   // Panel layouts (persisted)
@@ -77,6 +88,8 @@ interface SettingsState {
   expandWorkspace: (workspaceId: string) => void;
   toggleBottomTab: (tab: BottomPanelTab) => void;
   setBottomTabOrder: (order: AllBottomPanelTab[]) => void;
+  toggleTopTab: (tab: TopPanelTab) => void;
+  setTopTabOrder: (order: AllTopPanelTab[]) => void;
   setContentView: (view: ContentView) => void;
   setLayoutOuter: (layout: PanelLayout) => void;
   setLayoutInner: (layout: PanelLayout) => void;
@@ -103,6 +116,8 @@ export const useSettingsStore = create<SettingsState>()(
       zenMode: false,
       hiddenBottomTabs: [], // All tabs visible by default
       bottomTabOrder: DEFAULT_BOTTOM_TAB_ORDER, // Default tab order
+      hiddenTopTabs: [], // All top tabs visible by default
+      topTabOrder: DEFAULT_TOP_TAB_ORDER, // Default top tab order
       contentView: { type: 'conversation' }, // Always start in conversation view
       layoutOuter: undefined, // Use defaults until user resizes
       layoutInner: undefined,
@@ -138,6 +153,13 @@ export const useSettingsStore = create<SettingsState>()(
             : [...state.hiddenBottomTabs, tab],
         })),
       setBottomTabOrder: (order) => set({ bottomTabOrder: order }),
+      toggleTopTab: (tab) =>
+        set((state) => ({
+          hiddenTopTabs: state.hiddenTopTabs.includes(tab)
+            ? state.hiddenTopTabs.filter((t) => t !== tab)
+            : [...state.hiddenTopTabs, tab],
+        })),
+      setTopTabOrder: (order) => set({ topTabOrder: order }),
       setContentView: (view) => set({ contentView: view }),
       setLayoutOuter: (layout) => set({ layoutOuter: layout }),
       setLayoutInner: (layout) => set({ layoutInner: layout }),
@@ -172,6 +194,15 @@ export const useSettingsStore = create<SettingsState>()(
           );
           // Append missing tabs to the end of the user's existing order
           merged.bottomTabOrder = [...existingOrder, ...missingTabs];
+        }
+
+        // Ensure topTabOrder includes all tabs from DEFAULT_TOP_TAB_ORDER
+        if (persisted.topTabOrder) {
+          const existingOrder = persisted.topTabOrder;
+          const missingTabs = DEFAULT_TOP_TAB_ORDER.filter(
+            (tab) => !existingOrder.includes(tab)
+          );
+          merged.topTabOrder = [...existingOrder, ...missingTabs];
         }
 
         return merged;


### PR DESCRIPTION
## Summary

- Fixed responsive overflow issues in the right sidebar where content was being cut off at narrow widths
- Added scrollable and sortable tabs to the top panel (Changes, Review, Checks, Files) matching the bottom panel behavior
- Dropdown menu order now syncs with tab order after drag-and-drop reordering

## Implementation Details

- Added `overflow-hidden` to `ResizablePanel` components to constrain content within panel bounds
- Created `TopPanelTabs` component with drag-and-drop using dnd-kit (same pattern as `BottomPanelTabs`)
- Added `topTabOrder` and `hiddenTopTabs` state to settings store with persistence
- Updated both top and bottom panel dropdown menus to use dynamic tab order

## Test Plan

- [ ] Resize sidebar to narrow width - all buttons/menus should remain accessible
- [ ] Drag and drop top tabs to reorder - order should persist
- [ ] Open dropdown menu - items should match tab order
- [ ] Hide/show tabs via dropdown menu - visibility should persist
- [ ] Verify bottom tabs still work correctly