### PR TITLE
style: update text size design tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,9 +46,8 @@
   --text-display-sm: 22px;   /* Was 26px */
   --text-xl: 18px;           /* Was 22px */
   --text-lg: 16px;           /* Was 19px */
-  --text-base: 14px;         /* Was 17px */
-  --text-sm: 13px;           /* Was 15px */
-  --text-caption: 12px;      /* Captions, labels, secondary info */
+  --text-base: 13px;         /* Body text, standard UI */
+  --text-sm: 12px;           /* Small text, secondary info */
   --text-xs: 11px;           /* Was 13px */
   --text-micro: 10px;        /* Was 12px */
 

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -927,7 +927,7 @@ function SortableWorkspaceItem({
                             </div>
                           </div>
                           {/* Second line: session name · PR info · status */}
-                          <div className="flex items-center gap-1 mt-0.5 text-[length:var(--text-caption)] text-muted-foreground">
+                          <div className="flex items-center gap-1 mt-0.5 text-[length:var(--text-sm)] text-muted-foreground">
                             <span className="truncate">{session.name}</span>
                             {hasPR && session.prNumber && (
                               <>


### PR DESCRIPTION
Update text size design tokens to create a more compact scale. Changes base font from 14px to 13px and small text from 13px to 12px. Removes the deprecated text-caption token.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>