### PR TITLE
fix: preserve line breaks in user message bubbles

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -1046,7 +1046,7 @@ const MessageBlock = memo(function MessageBlock({
     return (
       <div className={cn('py-2 flex justify-end', !isFirst && 'pt-3')}>
         <div className="max-w-[85%] border border-purple-400/20 bg-purple-500/10 rounded-2xl rounded-br-md px-4 py-2">
-          <p className="text-sm leading-relaxed">
+          <p className="text-sm leading-relaxed whitespace-pre-wrap">
             {highlightedContent || message.content}
           </p>
         </div>


### PR DESCRIPTION
## Summary

- Fixes user messages losing their line breaks and paragraph formatting when rendered
- Adds `whitespace-pre-wrap` to the message bubble paragraph element
- Storage was already correct (SQLite TEXT preserves newlines)

## Test plan

- [x] Submit a multi-line message with blank lines between paragraphs
- [x] Verify the rendered bubble preserves the line breaks as typed
- [x] Verify long lines still wrap at the container edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)