### PR TITLE
Improve chat streaming with interleaved timeline and auto-scroll

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -381,9 +381,11 @@ export function ConversationArea({ children }: ConversationAreaProps) {
 
   // Auto-scroll management
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const isUserScrolledRef = useRef(false);
   const wasAtBottomRef = useRef(true); // Track if we were at bottom before content changes
   const [showScrollButton, setShowScrollButton] = useState(false);
+  const scrollRAFRef = useRef<number | null>(null);
 
   // Check if currently at bottom (utility function)
   const checkIsAtBottom = useCallback(() => {
@@ -404,22 +406,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     // Update button visibility (React bails out if value unchanged)
     setShowScrollButton(!isAtBottom);
   }, [checkIsAtBottom]);
-
-  // Auto-scroll to bottom when new content arrives (only if user hasn't scrolled away)
-  const scrollToBottom = useCallback(() => {
-    // Don't scroll if user has explicitly scrolled away
-    if (isUserScrolledRef.current) return;
-
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    // Use requestAnimationFrame for smoother scrolling
-    requestAnimationFrame(() => {
-      container.scrollTop = container.scrollHeight;
-      // Update wasAtBottomRef after scrolling
-      wasAtBottomRef.current = true;
-    });
-  }, []);
 
   // Force scroll to bottom (for manual button click or message submit)
   const forceScrollToBottom = useCallback(() => {
@@ -448,10 +434,40 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     [selectedConversationId, streamingState]
   );
 
-  // Auto-scroll when content changes - but only if we were at the bottom
+  // ResizeObserver-based auto-scroll - responds to actual DOM changes, not React state
+  // This is more reliable for streaming because it catches all content changes
+  // regardless of React's state batching
   useEffect(() => {
-    // Check if we were at bottom before this render
-    // wasAtBottomRef is updated by handleScroll and tracks our position
+    const content = contentRef.current;
+    const container = scrollContainerRef.current;
+    if (!content || !container) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Only scroll if user hasn't manually scrolled away
+      if (!isUserScrolledRef.current && wasAtBottomRef.current) {
+        // Debounce with RAF to avoid excessive scrolling
+        if (scrollRAFRef.current) {
+          cancelAnimationFrame(scrollRAFRef.current);
+        }
+        scrollRAFRef.current = requestAnimationFrame(() => {
+          container.scrollTop = container.scrollHeight;
+          scrollRAFRef.current = null;
+        });
+      }
+    });
+
+    resizeObserver.observe(content);
+
+    return () => {
+      resizeObserver.disconnect();
+      if (scrollRAFRef.current) {
+        cancelAnimationFrame(scrollRAFRef.current);
+      }
+    };
+  }, [selectedConversationId]); // Re-create observer when conversation changes
+
+  // Fallback: Also scroll on state changes for cases where ResizeObserver might miss
+  useEffect(() => {
     if (wasAtBottomRef.current && !isUserScrolledRef.current) {
       const container = scrollContainerRef.current;
       if (container) {
@@ -955,7 +971,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
               onScroll={handleScroll}
               className="h-full overflow-auto"
             >
-              <div className="pt-3 pl-5 pr-12 pb-10 space-y-1">
+              <div ref={contentRef} className="pt-3 pl-5 pr-12 pb-10 space-y-1">
               {conversationMessages.length === 0 && !selectedConversationId ? (
                 <ConversationEmptyState sessionName={currentSession?.name} />
               ) : (

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import { useAppStore } from '@/stores/appStore';
 import { useStreamingState, useActiveTools } from '@/stores/selectors';
 import { Loader2, AlertCircle, Brain, Clock, ChevronDown, ChevronRight } from 'lucide-react';
-import { ActiveToolsDisplay } from '@/components/conversation/ToolUsageBlock';
+import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
 import { MarkdownPre, MarkdownCode } from '@/components/shared/MarkdownCodeBlock';
 import { cn } from '@/lib/utils';
+
+// Timeline item types for interleaved display
+type TimelineItem =
+  | { type: 'text'; id: string; text: string; timestamp: number }
+  | { type: 'tool'; id: string; tool: string; params?: Record<string, unknown>; startTime: number; endTime?: number; success?: boolean; summary?: string; stdout?: string; stderr?: string };
 
 interface StreamingMessageProps {
   conversationId: string;
@@ -132,8 +137,46 @@ export function StreamingMessage({ conversationId }: StreamingMessageProps) {
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
+  // Build interleaved timeline from segments and tools
+  const timeline = useMemo((): TimelineItem[] => {
+    const items: TimelineItem[] = [];
+
+    // Add text segments
+    const segments = streaming?.segments || [];
+    for (const seg of segments) {
+      if (seg.text) {
+        items.push({ type: 'text', id: seg.id, text: seg.text, timestamp: seg.timestamp });
+      }
+    }
+
+    // Add tools
+    for (const tool of tools) {
+      items.push({
+        type: 'tool',
+        id: tool.id,
+        tool: tool.tool,
+        params: tool.params,
+        startTime: tool.startTime,
+        endTime: tool.endTime,
+        success: tool.success,
+        summary: tool.summary,
+        stdout: tool.stdout,
+        stderr: tool.stderr,
+      });
+    }
+
+    // Sort by timestamp (text segments use timestamp, tools use startTime)
+    items.sort((a, b) => {
+      const aTime = a.type === 'text' ? a.timestamp : a.startTime;
+      const bTime = b.type === 'text' ? b.timestamp : b.startTime;
+      return aTime - bTime;
+    });
+
+    return items;
+  }, [streaming?.segments, tools]);
+
   // Don't render if no streaming content, no active tools, no thinking, and no error
-  if (!streaming?.text && tools.length === 0 && !streaming?.error && !streaming?.thinking && !streaming?.isThinking && !streaming?.isStreaming) {
+  if (timeline.length === 0 && !streaming?.error && !streaming?.thinking && !streaming?.isThinking && !streaming?.isStreaming) {
     return null;
   }
 
@@ -202,21 +245,40 @@ export function StreamingMessage({ conversationId }: StreamingMessageProps) {
             </div>
           )}
 
-          {/* Active Tools */}
-          <ActiveToolsDisplay conversationId={conversationId} />
-
-          {/* Streaming Text */}
-          {streaming?.text && (
-            <div className="prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed prose-p:my-1.5 prose-pre:my-2 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:text-base prose-headings:font-semibold prose-headings:my-2 prose-ul:marker:text-primary prose-ol:marker:text-primary">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeHighlight]}
-                components={{ pre: MarkdownPre, code: MarkdownCode }}
-              >
-                {streaming.text}
-              </ReactMarkdown>
-            </div>
-          )}
+          {/* Interleaved timeline of text and tools */}
+          {timeline.map((item) => {
+            if (item.type === 'text') {
+              return (
+                <div
+                  key={item.id}
+                  className="prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed prose-p:my-1.5 prose-pre:my-2 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:text-base prose-headings:font-semibold prose-headings:my-2 prose-ul:marker:text-primary prose-ol:marker:text-primary"
+                >
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    rehypePlugins={[rehypeHighlight]}
+                    components={{ pre: MarkdownPre, code: MarkdownCode }}
+                  >
+                    {item.text}
+                  </ReactMarkdown>
+                </div>
+              );
+            } else {
+              return (
+                <ToolUsageBlock
+                  key={item.id}
+                  id={item.id}
+                  tool={item.tool}
+                  params={item.params}
+                  isActive={!item.endTime}
+                  success={item.success}
+                  summary={item.summary}
+                  duration={item.endTime ? item.endTime - item.startTime : undefined}
+                  stdout={item.stdout}
+                  stderr={item.stderr}
+                />
+              );
+            }
+          })}
 
           {/* Enhanced error display */}
           {streaming?.error && (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,19 @@ export interface ToolUsage {
   stderr?: string;
 }
 
+// Active tool during streaming (real-time tracking)
+export interface ActiveTool {
+  id: string;
+  tool: string;
+  params?: Record<string, unknown>;
+  startTime: number;
+  endTime?: number;
+  success?: boolean;
+  summary?: string;
+  stdout?: string;
+  stderr?: string;
+}
+
 // Setup info for system messages
 export interface SetupInfo {
   sessionName: string;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -20,6 +20,7 @@ import type {
   ReviewComment,
   BranchSyncStatus,
   PendingUserQuestion,
+  ActiveTool,
 } from '@/lib/types';
 
 // Maximum number of file tabs before LRU eviction kicks in
@@ -29,9 +30,18 @@ interface SessionOutput {
   [sessionId: string]: string[];
 }
 
+// Text segment for interleaved timeline display
+interface TextSegment {
+  id: string;
+  text: string;
+  timestamp: number; // When this segment started
+}
+
 // Streaming state for conversations
 interface StreamingState {
-  text: string;
+  text: string; // Legacy: full accumulated text for compatibility
+  segments: TextSegment[]; // Text segments for interleaved display
+  currentSegmentId: string | null; // Current segment being appended to
   isStreaming: boolean;
   error: string | null;
   thinking: string | null; // Current thinking content being streamed
@@ -41,17 +51,7 @@ interface StreamingState {
   awaitingPlanApproval: boolean; // Whether we're waiting for user to approve ExitPlanMode
 }
 
-interface ActiveTool {
-  id: string;
-  tool: string;
-  params?: Record<string, unknown>;
-  startTime: number;
-  endTime?: number;
-  success?: boolean;
-  summary?: string;
-  stdout?: string;
-  stderr?: string;
-}
+// ActiveTool is imported from @/lib/types
 
 interface AppState {
   // New data model
@@ -738,25 +738,53 @@ updateFileTabContent: (id, content) => set((state) => ({
   })),
 
   // Streaming state actions
-  appendStreamingText: (conversationId, text) => set((state) => ({
-    streamingState: {
-      ...state.streamingState,
-      [conversationId]: {
-        ...state.streamingState[conversationId],
-        text: (state.streamingState[conversationId]?.text || '') + text,
-        isStreaming: true,
-        error: null,
-        thinking: state.streamingState[conversationId]?.thinking || null,
-        isThinking: false, // Stop thinking when text starts
+  appendStreamingText: (conversationId, text) => set((state) => {
+    const current = state.streamingState[conversationId];
+    const existingSegments = current?.segments || [];
+    const currentSegmentId = current?.currentSegmentId;
+
+    let newSegments: TextSegment[];
+    let newCurrentSegmentId: string | null;
+
+    if (currentSegmentId) {
+      // Append to existing segment
+      newSegments = existingSegments.map(seg =>
+        seg.id === currentSegmentId
+          ? { ...seg, text: seg.text + text }
+          : seg
+      );
+      newCurrentSegmentId = currentSegmentId;
+    } else {
+      // Create new segment
+      const segmentId = `seg-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      newSegments = [...existingSegments, { id: segmentId, text, timestamp: Date.now() }];
+      newCurrentSegmentId = segmentId;
+    }
+
+    return {
+      streamingState: {
+        ...state.streamingState,
+        [conversationId]: {
+          ...current,
+          text: (current?.text || '') + text, // Keep legacy text for compatibility
+          segments: newSegments,
+          currentSegmentId: newCurrentSegmentId,
+          isStreaming: true,
+          error: null,
+          thinking: current?.thinking || null,
+          isThinking: false, // Stop thinking when text starts
+        },
       },
-    },
-  })),
+    };
+  }),
   setStreaming: (conversationId, isStreaming) => set((state) => ({
     streamingState: {
       ...state.streamingState,
       [conversationId]: {
         ...state.streamingState[conversationId],
         text: state.streamingState[conversationId]?.text || '',
+        segments: state.streamingState[conversationId]?.segments || [],
+        currentSegmentId: state.streamingState[conversationId]?.currentSegmentId || null,
         isStreaming,
         error: state.streamingState[conversationId]?.error || null,
         thinking: state.streamingState[conversationId]?.thinking || null,
@@ -773,6 +801,8 @@ updateFileTabContent: (id, content) => set((state) => ({
       ...state.streamingState,
       [conversationId]: {
         text: state.streamingState[conversationId]?.text || '',
+        segments: state.streamingState[conversationId]?.segments || [],
+        currentSegmentId: null,
         isStreaming: false,
         error,
         thinking: null,
@@ -787,6 +817,8 @@ updateFileTabContent: (id, content) => set((state) => ({
       ...state.streamingState,
       [conversationId]: {
         text: '',
+        segments: [],
+        currentSegmentId: null,
         isStreaming: false,
         error: null,
         thinking: null,
@@ -802,6 +834,8 @@ updateFileTabContent: (id, content) => set((state) => ({
       [conversationId]: {
         ...state.streamingState[conversationId],
         text: state.streamingState[conversationId]?.text || '',
+        segments: state.streamingState[conversationId]?.segments || [],
+        currentSegmentId: state.streamingState[conversationId]?.currentSegmentId || null,
         isStreaming: true,
         error: null,
         thinking: (state.streamingState[conversationId]?.thinking || '') + text,
@@ -815,6 +849,8 @@ updateFileTabContent: (id, content) => set((state) => ({
       [conversationId]: {
         ...state.streamingState[conversationId],
         text: state.streamingState[conversationId]?.text || '',
+        segments: state.streamingState[conversationId]?.segments || [],
+        currentSegmentId: state.streamingState[conversationId]?.currentSegmentId || null,
         isStreaming: state.streamingState[conversationId]?.isStreaming || false,
         error: state.streamingState[conversationId]?.error || null,
         thinking: state.streamingState[conversationId]?.thinking || null,
@@ -828,6 +864,8 @@ updateFileTabContent: (id, content) => set((state) => ({
       [conversationId]: {
         ...state.streamingState[conversationId],
         text: state.streamingState[conversationId]?.text || '',
+        segments: state.streamingState[conversationId]?.segments || [],
+        currentSegmentId: state.streamingState[conversationId]?.currentSegmentId || null,
         isStreaming: state.streamingState[conversationId]?.isStreaming || false,
         error: state.streamingState[conversationId]?.error || null,
         thinking: null,
@@ -843,6 +881,8 @@ updateFileTabContent: (id, content) => set((state) => ({
       [conversationId]: {
         ...state.streamingState[conversationId],
         text: state.streamingState[conversationId]?.text || '',
+        segments: state.streamingState[conversationId]?.segments || [],
+        currentSegmentId: state.streamingState[conversationId]?.currentSegmentId || null,
         isStreaming: state.streamingState[conversationId]?.isStreaming || false,
         error: state.streamingState[conversationId]?.error || null,
         thinking: state.streamingState[conversationId]?.thinking || null,
@@ -858,6 +898,8 @@ updateFileTabContent: (id, content) => set((state) => ({
       [conversationId]: {
         ...state.streamingState[conversationId],
         text: state.streamingState[conversationId]?.text || '',
+        segments: state.streamingState[conversationId]?.segments || [],
+        currentSegmentId: state.streamingState[conversationId]?.currentSegmentId || null,
         isStreaming: state.streamingState[conversationId]?.isStreaming || false,
         error: state.streamingState[conversationId]?.error || null,
         thinking: state.streamingState[conversationId]?.thinking || null,
@@ -871,6 +913,22 @@ updateFileTabContent: (id, content) => set((state) => ({
     activeTools: {
       ...state.activeTools,
       [conversationId]: [...(state.activeTools[conversationId] || []), tool],
+    },
+    // Seal current text segment so next text creates a new segment after this tool
+    streamingState: {
+      ...state.streamingState,
+      [conversationId]: {
+        ...state.streamingState[conversationId],
+        text: state.streamingState[conversationId]?.text || '',
+        segments: state.streamingState[conversationId]?.segments || [],
+        currentSegmentId: null, // Seal current segment
+        isStreaming: state.streamingState[conversationId]?.isStreaming || false,
+        error: state.streamingState[conversationId]?.error || null,
+        thinking: state.streamingState[conversationId]?.thinking || null,
+        isThinking: state.streamingState[conversationId]?.isThinking || false,
+        planModeActive: state.streamingState[conversationId]?.planModeActive || false,
+        awaitingPlanApproval: state.streamingState[conversationId]?.awaitingPlanApproval || false,
+      },
     },
   })),
   completeActiveTool: (conversationId, toolId, success, summary, stdout, stderr) => set((state) => ({
@@ -898,6 +956,8 @@ updateFileTabContent: (id, content) => set((state) => ({
     // Build cleared streaming state (preserve planModeActive)
     const clearedStreaming = {
       text: '',
+      segments: [],
+      currentSegmentId: null,
       isStreaming: false,
       error: null,
       thinking: null,

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -17,12 +17,12 @@
 
 import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from './appStore';
-import type { Message, AgentTodoItem, CustomTodoItem, TerminalInstance, ReviewComment } from '@/lib/types';
+import type { Message, AgentTodoItem, CustomTodoItem, TerminalInstance, ReviewComment, ActiveTool } from '@/lib/types';
 
 // Stable empty arrays to avoid creating new references
 // Using readonly to prevent accidental mutations
 const EMPTY_MESSAGES: readonly Message[] = [];
-const EMPTY_TOOLS: readonly unknown[] = []; // ActiveTool is internal to appStore
+const EMPTY_TOOLS: readonly ActiveTool[] = [];
 const EMPTY_AGENT_TODOS: readonly AgentTodoItem[] = [];
 const EMPTY_CUSTOM_TODOS: readonly CustomTodoItem[] = [];
 const EMPTY_TERMINAL_INSTANCES: readonly TerminalInstance[] = [];


### PR DESCRIPTION
## Summary

- Add ResizeObserver-based auto-scroll that responds to DOM changes instead of React state batching, ensuring smooth scroll during streaming
- Implement interleaved text and tools timeline display so users see an accurate chronological view of Claude's actions
- Fix jarring UX where tool activity would appear above text and push content down

## Implementation Details

- **Auto-scroll fix**: Added `ResizeObserver` on the content container that triggers scroll when content height changes, bypassing React's state batching which was causing missed scroll updates
- **Interleaved timeline**: 
  - Added `TextSegment` interface with timestamps to track text chunks
  - Modified `addActiveTool` to "seal" the current text segment, so subsequent text creates a new segment
  - `StreamingMessage` now merges segments and tools, sorts by timestamp, and renders in chronological order
- **Type cleanup**: Exported `ActiveTool` type from `types.ts` for shared use

## Test plan

- [ ] Send a message that triggers multiple tool uses
- [ ] Verify text and tools appear interleaved in the order they occurred
- [ ] Verify auto-scroll keeps chat at bottom during streaming
- [ ] Verify manual scroll up disables auto-scroll (respects user intent)
- [ ] Verify "Scroll to bottom" button appears when scrolled away