### PR TITLE
Change send button from circle to rounded square

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -1250,7 +1250,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             <Button
               size="icon"
               className={cn(
-                'h-8 w-8 rounded-full',
+                'h-8 w-8 rounded-lg',
                 (!message.trim() || isSending) && 'opacity-50'
               )}
               onClick={handleSubmit}


### PR DESCRIPTION
Updated the send message button in the Compose area to use a rounded square shape instead of a circle, while keeping the upward-pointing arrow icon.