### PR TITLE
feat: add workspace search with Cmd+Shift+F

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,6 +39,7 @@ import { AddWorkspaceModal } from '@/components/dialogs/AddWorkspaceModal';
 import { CloneFromUrlDialog } from '@/components/dialogs/CloneFromUrlDialog';
 import { QuickStartDialog } from '@/components/dialogs/QuickStartDialog';
 import { FilePicker } from '@/components/dialogs/FilePicker';
+import { WorkspaceSearch } from '@/components/dialogs/WorkspaceSearch';
 // import { UpdateChecker } from '@/components/shared/UpdateChecker';
 import { BackendStatus } from '@/components/shared/BackendStatus';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -1281,6 +1282,9 @@ export default function Home() {
           workspaceId={selectedWorkspaceId}
           sessionId={selectedSessionId}
         />
+
+        {/* Workspace Search (Cmd+Shift+F) */}
+        <WorkspaceSearch />
 
         {/* Keyboard Shortcuts Dialog (Cmd+/) */}
         <KeyboardShortcutsDialog

--- a/src/components/dialogs/WorkspaceSearch.tsx
+++ b/src/components/dialogs/WorkspaceSearch.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { useAppStore } from '@/stores/appStore';
+import { useShortcut } from '@/hooks/useShortcut';
+import { GitBranch, FolderGit2, GitPullRequest } from 'lucide-react';
+
+interface SearchableItem {
+  sessionId: string;
+  workspaceId: string;
+  sessionName: string;
+  branch: string;
+  workspaceName: string;
+  prNumber?: number;
+}
+
+/**
+ * Custom filter for workspace search.
+ * Matches against branch name, workspace/repo name, PR number, and session name.
+ * The `value` is the session ID, and `keywords` contains the searchable fields.
+ */
+function workspaceFilter(_value: string, search: string, keywords?: string[]): number {
+  if (!search) return 1;
+  if (!keywords || keywords.length === 0) return 0;
+
+  const searchLower = search.toLowerCase().replace(/^#+/, '');
+  const terms = searchLower.trim().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return 1;
+
+  let totalScore = 0;
+
+  for (const term of terms) {
+    let bestScore = 0;
+
+    for (const keyword of keywords) {
+      const kwLower = keyword.toLowerCase();
+
+      if (kwLower === term) {
+        bestScore = Math.max(bestScore, 1000);
+      } else if (kwLower.startsWith(term)) {
+        bestScore = Math.max(bestScore, 500);
+      } else if (kwLower.includes(term)) {
+        bestScore = Math.max(bestScore, 200);
+      }
+    }
+
+    if (bestScore === 0) return 0; // Every term must match something
+    totalScore += bestScore;
+  }
+
+  return totalScore;
+}
+
+export function WorkspaceSearch() {
+  const [open, setOpen] = useState(false);
+
+  const workspaces = useAppStore((s) => s.workspaces);
+  const sessions = useAppStore((s) => s.sessions);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const selectSession = useAppStore((s) => s.selectSession);
+
+  useShortcut('workspaceSearch', useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []));
+
+  const items: SearchableItem[] = useMemo(() => {
+    const workspaceMap = new Map(workspaces.map((w) => [w.id, w]));
+
+    return sessions
+      .filter((s) => !s.archived)
+      .map((session) => {
+        const workspace = workspaceMap.get(session.workspaceId);
+        return {
+          sessionId: session.id,
+          workspaceId: session.workspaceId,
+          sessionName: session.name,
+          branch: session.branch,
+          workspaceName: workspace?.name ?? '',
+          prNumber: session.prNumber,
+        };
+      });
+  }, [workspaces, sessions]);
+
+  const handleSelect = useCallback(
+    (sessionId: string) => {
+      const item = items.find((i) => i.sessionId === sessionId);
+      if (!item) return;
+
+      selectWorkspace(item.workspaceId);
+      selectSession(item.sessionId);
+      setOpen(false);
+    },
+    [items, selectWorkspace, selectSession]
+  );
+
+  return (
+    <CommandDialog
+      variant="spotlight"
+      open={open}
+      onOpenChange={setOpen}
+      title="Search Workspaces"
+      description="Search by branch name, repository, or PR number..."
+      showCloseButton={false}
+      filter={workspaceFilter}
+    >
+      <CommandInput placeholder="Search workspaces..." />
+      <CommandList className="max-h-[400px]">
+        <CommandEmpty>No workspaces found.</CommandEmpty>
+        <CommandGroup heading="Workspaces">
+          {items.map((item) => (
+            <CommandItem
+              key={item.sessionId}
+              value={item.sessionId}
+              keywords={[
+                item.branch,
+                item.workspaceName,
+                item.sessionName,
+                ...(item.prNumber ? [String(item.prNumber), `#${item.prNumber}`] : []),
+              ]}
+              onSelect={handleSelect}
+            >
+              <GitBranch className="shrink-0 text-muted-foreground" />
+              <div className="flex flex-col min-w-0 flex-1">
+                <span className="truncate text-sm">{item.sessionName}</span>
+                <span className="truncate text-xs text-muted-foreground">{item.branch}</span>
+              </div>
+              <div className="flex items-center gap-2 shrink-0 ml-auto">
+                {item.prNumber != null && (
+                  <span className="inline-flex items-center gap-0.5 text-xs text-muted-foreground">
+                    <GitPullRequest className="size-3" />
+                    #{item.prNumber}
+                  </span>
+                )}
+                <span className="inline-flex items-center gap-1 text-xs text-muted-foreground max-w-[150px] truncate">
+                  <FolderGit2 className="size-3 shrink-0" />
+                  {item.workspaceName}
+                </span>
+              </div>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -60,6 +60,13 @@ export const SHORTCUTS: Shortcut[] = [
     label: 'Open file picker',
     category: 'Navigation',
   },
+  {
+    id: 'workspaceSearch',
+    key: 'f',
+    modifiers: ['meta', 'shift'],
+    label: 'Search workspaces',
+    category: 'Navigation',
+  },
 
   // Chat
   {


### PR DESCRIPTION
Implements a searchable workspace dialog that allows quick navigation across sessions.

- Matches on branch name, workspace name, session name, and PR number
- Uses intelligent scoring for relevance (exact > prefix > substring)
- Strips leading # symbols for convenient PR number search
- Seamlessly integrates with existing dialog system

Addressed code review feedback on filter logic optimization.