### PR TITLE
Restyle user message bubble

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.4.2
         version: 4.5.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-virtuoso:
+        specifier: ^4.18.1
+        version: 4.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-zoom-pan-pinch:
         specifier: ^3.7.0
         version: 3.7.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4073,6 +4076,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-virtuoso@4.18.1:
+    resolution: {integrity: sha512-KF474cDwaSb9+SJ380xruBB4P+yGWcVkcu26HtMqYNMTYlYbrNy8vqMkE+GpAApPPufJqgOLMoWMFG/3pJMXUA==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react-zoom-pan-pinch@3.7.0:
     resolution: {integrity: sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==}
@@ -9033,6 +9042,11 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.9
+
+  react-virtuoso@4.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-zoom-pan-pinch@3.7.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -82,8 +82,8 @@ export const MessageBlock = memo(function MessageBlock({
   if (message.role === 'user') {
     return (
       <div className={cn('py-2 flex justify-end', !isFirst && 'pt-3')}>
-        <div className="max-w-[85%] border border-purple-400/20 bg-purple-500/10 rounded-2xl rounded-br-md px-4 py-2">
-          <p className="text-sm leading-relaxed whitespace-pre-wrap">
+        <div className="max-w-[85%] bg-[#090909] rounded-2xl px-4 py-2.5">
+          <p className="text-base leading-relaxed whitespace-pre-wrap">
             {highlightedContent || message.content}
           </p>
         </div>


### PR DESCRIPTION
Replace purple-tinted user bubble styling with a solid dark background (#090909), uniform rounded corners, and larger font size (text-base). This gives user messages a cleaner, more prominent appearance in the conversation area.

Changes:
- Remove purple border and background colors
- Use app shell background (#090909) for better contrast
- Uniform rounded corners on all sides
- Increase font size from text-sm to text-base