### PR TITLE
Model-gate thinking mode and make tokens configurable

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -35,15 +35,18 @@ import { AttachmentGrid } from './AttachmentGrid';
 import { processDroppedFiles, validateAttachments, SUPPORTED_EXTENSIONS, loadAllAttachmentContents } from '@/lib/attachments';
 import { UserQuestionPrompt } from './UserQuestionPrompt';
 import { usePendingUserQuestion } from '@/stores/selectors';
+import { useSettingsStore } from '@/stores/settingsStore';
 
 const MODELS = [
-  { id: 'opus-4.5', name: 'Opus 4.5', icon: Snowflake },
-  { id: 'sonnet-4', name: 'Sonnet 4', icon: Snowflake },
-  { id: 'haiku-3.5', name: 'Haiku 3.5', icon: Snowflake },
+  { id: 'opus-4.5', name: 'Opus 4.5', icon: Snowflake, supportsThinking: true },
+  { id: 'sonnet-4', name: 'Sonnet 4', icon: Snowflake, supportsThinking: true },
+  { id: 'haiku-3.5', name: 'Haiku 3.5', icon: Snowflake, supportsThinking: false },
 ];
 
-// Token budget for extended thinking mode
-const DEFAULT_THINKING_TOKENS = 10000;
+// Models that support extended thinking mode (derived from MODELS)
+const THINKING_SUPPORTED_MODELS = new Set(
+  MODELS.filter((m) => m.supportsThinking).map((m) => m.id)
+);
 
 // Common prompt patterns for suggestions
 const COMMON_PATTERNS = [
@@ -580,6 +583,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const [isApproving, setIsApproving] = useState(false);
   const [approvalError, setApprovalError] = useState<string | null>(null);
   const [thinkingEnabled, setThinkingEnabled] = useState(false);
+  const maxThinkingTokens = useSettingsStore((s) => s.maxThinkingTokens);
+  const thinkingSupported = THINKING_SUPPORTED_MODELS.has(selectedModel.id);
   const [planModeEnabled, setPlanModeEnabled] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
   const [suggestion, setSuggestion] = useState<string | null>(null);
@@ -779,6 +784,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     setApprovalError(null);
   }, [selectedConversationId, setAwaitingPlanApproval]);
 
+  // Auto-disable thinking when switching to an unsupported model
+  useEffect(() => {
+    if (thinkingEnabled && !thinkingSupported) {
+      setThinkingEnabled(false);
+    }
+  }, [thinkingSupported, thinkingEnabled]);
+
   // Global keyboard shortcuts
 
   useEffect(() => {
@@ -788,10 +800,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         e.preventDefault();
         textareaRef.current?.focus();
       }
-      // Alt+T to toggle thinking mode
+      // Alt+T to toggle thinking mode (only if model supports it)
       if (e.code === 'KeyT' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
-        setThinkingEnabled(prev => !prev);
+        if (THINKING_SUPPORTED_MODELS.has(selectedModel.id)) {
+          setThinkingEnabled(prev => !prev);
+        }
       }
       // Shift+Tab to toggle plan mode
       if (e.code === 'Tab' && e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
@@ -808,7 +822,11 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
     // Handle menu events from native Tauri menu
     const handleFocusInput = () => textareaRef.current?.focus();
-    const handleToggleThinking = () => setThinkingEnabled(prev => !prev);
+    const handleToggleThinking = () => {
+      if (THINKING_SUPPORTED_MODELS.has(selectedModel.id)) {
+        setThinkingEnabled(prev => !prev);
+      }
+    };
     const handleTogglePlanMode = () => handlePlanModeToggle();
 
     document.addEventListener('keydown', handleGlobalKeyDown);
@@ -821,7 +839,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       window.removeEventListener('toggle-thinking', handleToggleThinking);
       window.removeEventListener('toggle-plan-mode', handleTogglePlanMode);
     };
-  }, [handlePlanModeToggle, handleOpenFilePicker]);
+  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel.id]);
 
   const handleSubmit = async () => {
     if (!message.trim() || !selectedWorkspaceId || !selectedSessionId || isSending || isStreaming) return;
@@ -863,7 +881,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           type: convType,
           message: content,
           // Pass thinking tokens when thinking mode is enabled
-          maxThinkingTokens: thinkingEnabled ? DEFAULT_THINKING_TOKENS : undefined,
+          maxThinkingTokens: thinkingEnabled ? maxThinkingTokens : undefined,
           // Pass attachments with loaded content
           attachments: loadedAttachments.length > 0 ? loadedAttachments : undefined,
         });
@@ -1177,10 +1195,16 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             size={thinkingEnabled ? 'sm' : 'icon'}
             className={cn(
               thinkingEnabled ? 'h-7 gap-1.5 px-2' : 'h-7 w-7',
-              thinkingEnabled && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20'
+              thinkingEnabled && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20',
+              !thinkingSupported && 'opacity-50 cursor-not-allowed'
             )}
             onClick={() => setThinkingEnabled(!thinkingEnabled)}
-            title={`Extended thinking ${thinkingEnabled ? 'on' : 'off'} (⌥T)`}
+            disabled={!thinkingSupported}
+            title={
+              !thinkingSupported
+                ? `Extended thinking not available for ${selectedModel.name}`
+                : `Extended thinking ${thinkingEnabled ? 'on' : 'off'} (⌥T)`
+            }
             aria-label={`Extended thinking ${thinkingEnabled ? 'on' : 'off'}`}
             aria-pressed={thinkingEnabled}
           >

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -569,6 +569,9 @@ AWS_PROFILE=default`);
 }
 
 function ClaudeCodeSettings() {
+  const maxThinkingTokens = useSettingsStore((s) => s.maxThinkingTokens);
+  const setMaxThinkingTokens = useSettingsStore((s) => s.setMaxThinkingTokens);
+
   return (
     <div>
       <h2 className="text-xl font-semibold mb-5">Claude Code</h2>
@@ -582,12 +585,19 @@ function ClaudeCodeSettings() {
         title="Max thinking tokens"
         description="Maximum tokens for extended thinking"
       >
-        <Select defaultValue="16000">
+        <Select
+          value={maxThinkingTokens.toString()}
+          onValueChange={(value) => {
+            const n = parseInt(value, 10);
+            if (!isNaN(n) && n > 0) setMaxThinkingTokens(n);
+          }}
+        >
           <SelectTrigger className="w-32">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="8000">8,000</SelectItem>
+            <SelectItem value="10000">10,000</SelectItem>
             <SelectItem value="16000">16,000</SelectItem>
             <SelectItem value="32000">32,000</SelectItem>
           </SelectContent>

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -48,6 +48,7 @@ interface SettingsState {
   confirmCloseActiveTab: boolean;
   defaultModel: string;
   defaultThinking: boolean;
+  maxThinkingTokens: number;
   desktopNotifications: boolean;
   soundEffects: boolean;
   sendWithEnter: boolean;
@@ -76,6 +77,7 @@ interface SettingsState {
   setConfirmCloseActiveTab: (value: boolean) => void;
   setDefaultModel: (value: string) => void;
   setDefaultThinking: (value: boolean) => void;
+  setMaxThinkingTokens: (value: number) => void;
   setDesktopNotifications: (value: boolean) => void;
   setSoundEffects: (value: boolean) => void;
   setSendWithEnter: (value: boolean) => void;
@@ -105,6 +107,7 @@ export const useSettingsStore = create<SettingsState>()(
       confirmCloseActiveTab: true,
       defaultModel: 'opus-4.5',
       defaultThinking: true,
+      maxThinkingTokens: 10000,
       desktopNotifications: true,
       soundEffects: false,
       sendWithEnter: true,
@@ -128,6 +131,7 @@ export const useSettingsStore = create<SettingsState>()(
       setConfirmCloseActiveTab: (value) => set({ confirmCloseActiveTab: value }),
       setDefaultModel: (value) => set({ defaultModel: value }),
       setDefaultThinking: (value) => set({ defaultThinking: value }),
+      setMaxThinkingTokens: (value) => set({ maxThinkingTokens: value }),
       setDesktopNotifications: (value) => set({ desktopNotifications: value }),
       setSoundEffects: (value) => set({ soundEffects: value }),
       setSendWithEnter: (value) => set({ sendWithEnter: value }),


### PR DESCRIPTION
Add supportsThinking flag to MODELS to create a single source of truth for which models support extended thinking. Auto-disable thinking when switching to an unsupported model and gate all toggle paths (button, keyboard shortcuts, Tauri menu events).

Make max thinking tokens configurable via settings store instead of hardcoded to 10000. Wire up the settings selector in both ChatInput and SettingsPage, and add 10000 as an option.

Apply review fixes: use selectedModel.id in useEffect dependency, remove redundant onClick guard, add NaN guard on parseInt.