### PR TITLE
Add real-time WebSocket events for review comments

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.4.2
         version: 4.5.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-virtuoso:
+        specifier: ^4.18.1
+        version: 4.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-zoom-pan-pinch:
         specifier: ^3.7.0
         version: 3.7.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4073,6 +4076,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-virtuoso@4.18.1:
+    resolution: {integrity: sha512-KF474cDwaSb9+SJ380xruBB4P+yGWcVkcu26HtMqYNMTYlYbrNy8vqMkE+GpAApPPufJqgOLMoWMFG/3pJMXUA==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react-zoom-pan-pinch@3.7.0:
     resolution: {integrity: sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==}
@@ -9033,6 +9042,11 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.9
+
+  react-virtuoso@4.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-zoom-pan-pinch@3.7.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import type { WSEvent, AgentEvent, AgentTodoItem, CheckpointInfo, BudgetStatus, UserQuestion } from '@/lib/types';
+import type { WSEvent, AgentEvent, AgentTodoItem, CheckpointInfo, BudgetStatus, UserQuestion, ReviewComment } from '@/lib/types';
 import { WEBSOCKET_RECONNECT_DELAY_MS } from '@/lib/constants';
 import { getAuthToken } from '@/lib/auth-token';
 import { getBackendPort, getBackendPortSync } from '@/lib/backend-port';
@@ -471,6 +471,31 @@ export function useWebSocket(enabled: boolean = true) {
             }
 
             updateSession(data.sessionId, updates);
+          }
+          return;
+        }
+
+        // Handle review comment events
+        if (data.type === 'comment_added' && data.sessionId) {
+          const payload = data.payload as ReviewComment | undefined;
+          if (payload?.id) {
+            useAppStore.getState().addReviewComment(data.sessionId, payload);
+          }
+          return;
+        }
+
+        if ((data.type === 'comment_updated' || data.type === 'comment_resolved') && data.sessionId) {
+          const payload = data.payload as ReviewComment | undefined;
+          if (payload?.id) {
+            useAppStore.getState().updateReviewComment(data.sessionId, payload.id, payload);
+          }
+          return;
+        }
+
+        if (data.type === 'comment_deleted' && data.sessionId) {
+          const payload = data.payload as { id?: string } | undefined;
+          if (payload?.id) {
+            useAppStore.getState().deleteReviewComment(data.sessionId, payload.id);
           }
           return;
         }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1088,12 +1088,16 @@ updateFileTabContent: (id, content) => set((state) => ({
       [sessionId]: comments,
     },
   })),
-  addReviewComment: (sessionId, comment) => set((state) => ({
-    reviewComments: {
-      ...state.reviewComments,
-      [sessionId]: [...(state.reviewComments[sessionId] || []), comment],
-    },
-  })),
+  addReviewComment: (sessionId, comment) => set((state) => {
+    const existing = state.reviewComments[sessionId] || [];
+    if (existing.some((c) => c.id === comment.id)) return state;
+    return {
+      reviewComments: {
+        ...state.reviewComments,
+        [sessionId]: [...existing, comment],
+      },
+    };
+  }),
   updateReviewComment: (sessionId, id, updates) => set((state) => ({
     reviewComments: {
       ...state.reviewComments,


### PR DESCRIPTION
Add handlers for comment_added, comment_updated, comment_resolved, and comment_deleted WebSocket events to enable real-time synchronization of review comments across connected clients. Implement dedup logic in addReviewComment to prevent duplicate entries from reconnection replays or concurrent REST/WebSocket updates.

Fixes CM-81