### PR TITLE
feat: add Session Info panel to right sidebar

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.4.2
         version: 4.5.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-virtuoso:
+        specifier: ^4.18.1
+        version: 4.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-zoom-pan-pinch:
         specifier: ^3.7.0
         version: 3.7.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4073,6 +4076,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-virtuoso@4.18.1:
+    resolution: {integrity: sha512-KF474cDwaSb9+SJ380xruBB4P+yGWcVkcu26HtMqYNMTYlYbrNy8vqMkE+GpAApPPufJqgOLMoWMFG/3pJMXUA==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react-zoom-pan-pinch@3.7.0:
     resolution: {integrity: sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==}
@@ -9033,6 +9042,11 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.9
+
+  react-virtuoso@4.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-zoom-pan-pinch@3.7.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -16,6 +16,7 @@ import { McpServersPanel } from '@/components/panels/McpServersPanel';
 import { PlansPanel } from '@/components/panels/PlansPanel';
 import { ReviewPanel } from '@/components/panels/ReviewPanel';
 import { FileHistoryPanel } from '@/components/panels/FileHistoryPanel';
+import { SessionInfoPanel } from '@/components/panels/SessionInfoPanel';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -501,6 +502,8 @@ export function ChangesPanel() {
             <div className="h-full px-1.5">
               <GitStatusSection onSendMessage={handleGitActionMessage} />
             </div>
+          ) : selectedTab === 'info' ? (
+            <SessionInfoPanel />
           ) : (
             <div className="h-full flex items-center justify-center">
               <div className="text-center text-muted-foreground">
@@ -544,6 +547,7 @@ const TOP_TABS_CONFIG: Record<AllTopPanelTab, { label: string; alwaysVisible?: b
   review: { label: 'Review' },
   checks: { label: 'Checks' },
   files: { label: 'Files' },
+  info: { label: 'Info' },
 };
 
 // Bottom panel tabs configuration

--- a/src/components/panels/SessionInfoPanel.tsx
+++ b/src/components/panels/SessionInfoPanel.tsx
@@ -1,0 +1,362 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useAppStore } from '@/stores/appStore';
+import { useSelectedIds, useSessionConversations } from '@/stores/selectors';
+import { copyToClipboard } from '@/lib/tauri';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { EmptyState } from '@/components/ui/empty-state';
+import { cn } from '@/lib/utils';
+import {
+  Info,
+  GitBranch,
+  FolderOpen,
+  HardDrive,
+  GitPullRequest,
+  AlertTriangle,
+  XCircle,
+  Clock,
+  RefreshCw,
+  MessageSquare,
+  ListChecks,
+  Plus,
+  Minus,
+  GitCompare,
+  Copy,
+  Check,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoDate: string): string {
+  const ms = new Date(isoDate).getTime();
+  if (isNaN(ms)) return '—';
+  const seconds = Math.floor((Date.now() - ms) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ label }: { label: string }) {
+  return (
+    <div className="text-[10px] font-medium text-foreground/60 uppercase tracking-wider pt-1">
+      {label}
+    </div>
+  );
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      copyToClipboard(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    },
+    [text],
+  );
+  return (
+    <button
+      onClick={handleCopy}
+      className="ml-1 opacity-0 group-hover/row:opacity-100 transition-opacity shrink-0"
+      title="Copy to clipboard"
+    >
+      {copied ? (
+        <Check className="w-3 h-3 text-text-success" />
+      ) : (
+        <Copy className="w-3 h-3 text-muted-foreground" />
+      )}
+    </button>
+  );
+}
+
+function InfoRow({
+  icon: Icon,
+  label,
+  value,
+  copyValue,
+  mono,
+  className,
+}: {
+  icon?: LucideIcon;
+  label: string;
+  value: React.ReactNode;
+  copyValue?: string;
+  mono?: boolean;
+  className?: string;
+}) {
+  return (
+    <div className="group/row flex items-center justify-between text-xs gap-2 min-h-[20px]">
+      <div className="flex items-center gap-1.5 text-muted-foreground shrink-0">
+        {Icon && <Icon className="w-3 h-3 shrink-0" />}
+        <span>{label}</span>
+      </div>
+      <div
+        className={cn(
+          'flex items-center text-right truncate min-w-0',
+          mono && 'font-mono text-[11px]',
+          className,
+        )}
+      >
+        <span className="truncate">{value}</span>
+        {copyValue && <CopyButton text={copyValue} />}
+      </div>
+    </div>
+  );
+}
+
+function StatusDot({ status }: { status: string }) {
+  const colorMap: Record<string, string> = {
+    active: 'bg-text-success',
+    idle: 'bg-muted-foreground',
+    done: 'bg-blue-500',
+    error: 'bg-text-error',
+  };
+  return (
+    <span className="flex items-center gap-1.5">
+      <span
+        className={cn(
+          'w-1.5 h-1.5 rounded-full shrink-0',
+          colorMap[status] || 'bg-muted-foreground',
+        )}
+      />
+      <span className="capitalize">{status}</span>
+    </span>
+  );
+}
+
+function PrStatusBadge({
+  status,
+  prNumber,
+  prUrl,
+}: {
+  status: string;
+  prNumber?: number;
+  prUrl?: string;
+}) {
+  const colorMap: Record<string, string> = {
+    open: 'text-text-success',
+    merged: 'text-purple-400',
+    closed: 'text-text-error',
+    none: 'text-muted-foreground',
+  };
+
+  if (status === 'none') {
+    return <span className="text-muted-foreground">None</span>;
+  }
+
+  const label = prNumber ? `#${prNumber}` : status;
+
+  if (prUrl) {
+    return (
+      <a
+        href={prUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn('hover:underline capitalize', colorMap[status])}
+      >
+        {label} &middot; {status}
+      </a>
+    );
+  }
+
+  return (
+    <span className={cn('capitalize', colorMap[status])}>
+      {label} &middot; {status}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function SessionInfoPanel() {
+  const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
+  const session = useAppStore((s) =>
+    selectedSessionId ? s.sessions.find((sess) => sess.id === selectedSessionId) ?? null : null,
+  );
+  const workspace = useAppStore((s) =>
+    selectedWorkspaceId ? s.workspaces.find((w) => w.id === selectedWorkspaceId) ?? null : null,
+  );
+  const branchSync = useAppStore((s) =>
+    selectedSessionId ? s.branchSyncStatus[selectedSessionId] ?? null : null,
+  );
+  const conversations = useSessionConversations(selectedSessionId);
+
+  if (!session) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <EmptyState
+          icon={Info}
+          title="No session selected"
+          description="Select a session to view its details"
+        />
+      </div>
+    );
+  }
+
+  // Conversation counts by type
+  const counts = { task: 0, review: 0, chat: 0 };
+  for (const c of conversations) {
+    if (c.type in counts) counts[c.type as keyof typeof counts]++;
+  }
+  const convParts: string[] = [];
+  if (counts.task > 0) convParts.push(`${counts.task} task`);
+  if (counts.review > 0) convParts.push(`${counts.review} review`);
+  if (counts.chat > 0) convParts.push(`${counts.chat} chat`);
+  const convSummary = convParts.length > 0 ? convParts.join(', ') : 'None';
+
+  // Worktree display — show last 2-3 path segments
+  const worktreeDisplay = session.worktreePath
+    ? session.worktreePath.split('/').slice(-3).join('/')
+    : '—';
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="p-3 space-y-3">
+        {/* Session Identity */}
+        <div className="space-y-1.5">
+          <SectionHeader label="Session" />
+          <InfoRow label="Name" value={session.name} />
+          <InfoRow
+            icon={GitBranch}
+            label="Branch"
+            value={session.branch}
+            copyValue={session.branch}
+            mono
+          />
+          {workspace && (
+            <InfoRow icon={FolderOpen} label="Workspace" value={workspace.name} />
+          )}
+          {session.worktreePath && (
+            <InfoRow
+              icon={HardDrive}
+              label="Worktree"
+              value={worktreeDisplay}
+              copyValue={session.worktreePath}
+              mono
+            />
+          )}
+        </div>
+
+        {/* Status */}
+        <div className="space-y-1.5">
+          <SectionHeader label="Status" />
+          <InfoRow label="Session" value={<StatusDot status={session.status} />} />
+          {session.prStatus && session.prStatus !== 'none' && (
+            <InfoRow
+              icon={GitPullRequest}
+              label="PR"
+              value={
+                <PrStatusBadge
+                  status={session.prStatus}
+                  prNumber={session.prNumber}
+                  prUrl={session.prUrl}
+                />
+              }
+            />
+          )}
+          {session.hasMergeConflict && (
+            <InfoRow
+              icon={AlertTriangle}
+              label="Conflict"
+              value={<span className="text-text-warning">Merge conflict</span>}
+            />
+          )}
+          {session.hasCheckFailures && (
+            <InfoRow
+              icon={XCircle}
+              label="Checks"
+              value={<span className="text-text-error">Failing</span>}
+            />
+          )}
+        </div>
+
+        {/* Git Stats */}
+        {(session.stats || branchSync) && (
+          <div className="space-y-1.5">
+            <SectionHeader label="Git" />
+            {session.stats && (
+              <InfoRow
+                label="Changes"
+                value={
+                  <span className="flex items-center gap-2">
+                    <span className="flex items-center gap-0.5 text-text-success">
+                      <Plus className="w-3 h-3" />
+                      {session.stats.additions}
+                    </span>
+                    <span className="flex items-center gap-0.5 text-text-error">
+                      <Minus className="w-3 h-3" />
+                      {session.stats.deletions}
+                    </span>
+                  </span>
+                }
+              />
+            )}
+            {branchSync && (
+              <InfoRow
+                icon={GitCompare}
+                label="Sync"
+                value={
+                  branchSync.behindBy > 0 ? (
+                    <span className="text-text-warning">
+                      {branchSync.behindBy} behind {branchSync.baseBranch.replace('origin/', '')}
+                    </span>
+                  ) : (
+                    <span className="text-text-success">Up to date</span>
+                  )
+                }
+              />
+            )}
+          </div>
+        )}
+
+        {/* Activity */}
+        <div className="space-y-1.5">
+          <SectionHeader label="Activity" />
+          <InfoRow
+            icon={Clock}
+            label="Created"
+            value={formatRelativeTime(session.createdAt)}
+          />
+          <InfoRow
+            icon={RefreshCw}
+            label="Updated"
+            value={formatRelativeTime(session.updatedAt)}
+          />
+          <InfoRow
+            icon={MessageSquare}
+            label="Conversations"
+            value={convSummary}
+          />
+        </div>
+
+        {/* Task */}
+        {session.task && (
+          <div className="space-y-1.5">
+            <SectionHeader label="Task" />
+            <div className="flex items-start gap-1.5 text-xs">
+              <ListChecks className="w-3 h-3 mt-0.5 text-muted-foreground shrink-0" />
+              <p className="text-foreground/80 leading-relaxed break-words min-w-0">
+                {session.task}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -17,7 +17,7 @@
 
 import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from './appStore';
-import type { Message, AgentTodoItem, CustomTodoItem, TerminalInstance, ReviewComment, ActiveTool } from '@/lib/types';
+import type { Message, Conversation, AgentTodoItem, CustomTodoItem, TerminalInstance, ReviewComment, ActiveTool } from '@/lib/types';
 
 // Stable empty arrays to avoid creating new references
 // Using readonly to prevent accidental mutations
@@ -27,6 +27,7 @@ const EMPTY_AGENT_TODOS: readonly AgentTodoItem[] = [];
 const EMPTY_CUSTOM_TODOS: readonly CustomTodoItem[] = [];
 const EMPTY_TERMINAL_INSTANCES: readonly TerminalInstance[] = [];
 const EMPTY_REVIEW_COMMENTS: readonly ReviewComment[] = [];
+const EMPTY_CONVERSATIONS: readonly Conversation[] = [];
 const EMPTY_FILE_COMMENT_STATS = new Map<string, { total: number; unresolved: number }>();
 
 // ============================================================================
@@ -104,6 +105,19 @@ export const useConversationsWithUserMessages = () =>
       }
       return ids.length > 0 ? ids : EMPTY_CONVERSATION_IDS;
     })
+  );
+
+/**
+ * Conversations for a specific session.
+ * Use in: SessionInfoPanel
+ */
+export const useSessionConversations = (sessionId: string | null) =>
+  useAppStore(
+    useShallow((s) =>
+      sessionId
+        ? s.conversations.filter((c) => c.sessionId === sessionId)
+        : EMPTY_CONVERSATIONS
+    )
   );
 
 // ============================================================================

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -11,13 +11,13 @@ export type AllBottomPanelTab = 'todos' | BottomPanelTab;
 export const DEFAULT_BOTTOM_TAB_ORDER: AllBottomPanelTab[] = ['todos', 'plans', 'history', 'file-history', 'budget', 'mcp'];
 
 // Top panel (right sidebar) tab IDs - Changes is always visible
-export type TopPanelTab = 'review' | 'checks' | 'files';
+export type TopPanelTab = 'review' | 'checks' | 'files' | 'info';
 
 // All top panel tabs including the always-visible Changes
 export type AllTopPanelTab = 'changes' | TopPanelTab;
 
 // Default top tab order
-export const DEFAULT_TOP_TAB_ORDER: AllTopPanelTab[] = ['changes', 'review', 'checks', 'files'];
+export const DEFAULT_TOP_TAB_ORDER: AllTopPanelTab[] = ['changes', 'review', 'checks', 'files', 'info'];
 
 // Theme options
 export type ThemeOption = 'system' | 'light' | 'dark';


### PR DESCRIPTION
## Summary

- Adds a new "Info" tab to the right sidebar displaying session metadata (branch, worktree, status, git stats, PR info, activity, and task)
- Includes peer review improvements: guards `formatRelativeTime` against invalid dates, consolidates conversation counting into a single loop, and moves session/workspace lookups into store selectors

## Test Plan

- Select a session and verify the Info tab displays correct metadata
- Check that relative timestamps render correctly
- Verify conversation counts aggregate properly by type (task, review, chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)