### PR TITLE
refactor: address code review feedback on PR cache

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -53,6 +53,7 @@ type PRWatcher struct {
 	ghClient    *github.Client
 	repoManager PRWatcherRepoManager
 	store       PRWatcherStore
+	prCache     *github.PRCache // Shared cache with ListPRs handler
 	onChange    func(PRChangeEvent)
 	ctx         context.Context
 	cancel      context.CancelFunc
@@ -63,6 +64,7 @@ func NewPRWatcher(
 	ghClient *github.Client,
 	repoManager PRWatcherRepoManager,
 	store PRWatcherStore,
+	prCache *github.PRCache,
 	onChange func(PRChangeEvent),
 ) *PRWatcher {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -71,6 +73,7 @@ func NewPRWatcher(
 		ghClient:    ghClient,
 		repoManager: repoManager,
 		store:       store,
+		prCache:     prCache,
 		onChange:    onChange,
 		ctx:         ctx,
 		cancel:      cancel,
@@ -220,7 +223,8 @@ func (w *PRWatcher) groupSessionsByRepo(filter func(*PRWatchEntry) bool) map[rep
 	return result
 }
 
-// checkRepoSessions checks PR status for sessions grouped by repo
+// checkRepoSessions checks PR status for sessions grouped by repo.
+// Uses the shared PR cache to avoid redundant GitHub API calls.
 func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry) {
 	for key, entries := range repoSessions {
 		// Check context cancellation
@@ -228,11 +232,29 @@ func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry) 
 			return
 		}
 
-		// Get open PRs for this repo (one API call per repo)
-		openPRs, err := w.ghClient.ListOpenPRs(w.ctx, key.owner, key.repo)
-		if err != nil {
-			logger.PRWatcher.Errorf("Failed to list PRs for %s/%s: %v", key.owner, key.repo, err)
-			continue
+		// Try the shared cache first
+		var openPRs []github.PRListItem
+		if w.prCache != nil {
+			cached, ok := w.prCache.Get(key.owner, key.repo)
+			if ok {
+				openPRs = cached
+			}
+		}
+
+		// Cache miss -- fetch from GitHub and populate shared cache.
+		// NOTE: This stores PRs without details or ETag. If the HTTP handler
+		// hits this entry while fresh, it will serve PRs with unknown check status
+		// until the next background refresh cycle populates details.
+		if openPRs == nil {
+			var err error
+			openPRs, err = w.ghClient.ListOpenPRs(w.ctx, key.owner, key.repo)
+			if err != nil {
+				logger.PRWatcher.Errorf("Failed to list PRs for %s/%s: %v", key.owner, key.repo, err)
+				continue
+			}
+			if w.prCache != nil {
+				w.prCache.Set(key.owner, key.repo, openPRs)
+			}
 		}
 
 		// Build branch -> PR map for quick lookup
@@ -265,9 +287,19 @@ func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, bran
 		prNumber = pr.Number
 		prUrl = pr.HTMLURL
 
-		// Get detailed PR info for CI status and mergeable state
-		details, err := w.ghClient.GetPRDetails(w.ctx, owner, repo, pr.Number)
-		if err == nil && details != nil {
+		// Try cached details first, then fetch from GitHub
+		var details *github.PRDetails
+		if w.prCache != nil {
+			details, _ = w.prCache.GetDetails(owner, repo, pr.Number)
+		}
+		if details == nil {
+			var err error
+			details, err = w.ghClient.GetPRDetails(w.ctx, owner, repo, pr.Number)
+			if err == nil && details != nil && w.prCache != nil {
+				w.prCache.SetDetails(owner, repo, map[int]*github.PRDetails{pr.Number: details})
+			}
+		}
+		if details != nil {
 			checkStatus = string(details.CheckStatus)
 			mergeable = details.Mergeable
 		}

--- a/backend/github/pr_cache.go
+++ b/backend/github/pr_cache.go
@@ -3,27 +3,56 @@ package github
 import (
 	"sync"
 	"time"
+
+	"github.com/chatml/chatml-backend/logger"
 )
 
-// PRCacheEntry holds cached PR list data
+// CacheFreshness indicates how fresh a cache entry is
+type CacheFreshness int
+
+const (
+	// CacheMiss means no entry exists in cache
+	CacheMiss CacheFreshness = iota
+	// CacheFresh means the entry is within the fresh TTL (serve directly)
+	CacheFresh
+	// CacheStale means the entry is past fresh but within stale TTL (serve + revalidate)
+	CacheStale
+)
+
+// PRCacheEntry holds cached PR list data with details
 type PRCacheEntry struct {
-	PRs       []PRListItem
-	CachedAt  time.Time
-	ExpiresAt time.Time
+	PRs        []PRListItem
+	Details    map[int]*PRDetails // keyed by PR number
+	ETag       string             // GitHub ETag for conditional requests on the list
+	CachedAt   time.Time
+	ExpiresAt  time.Time // "fresh" deadline
+	StaleUntil time.Time // "stale" deadline (serve stale while revalidating)
 }
 
-// PRCache provides time-based caching for PR lists
+// PRCache provides time-based caching for PR lists and details with stale-while-revalidate
 type PRCache struct {
-	mu      sync.RWMutex
-	entries map[string]*PRCacheEntry
-	ttl     time.Duration
+	mu       sync.RWMutex
+	entries  map[string]*PRCacheEntry
+	freshTTL time.Duration
+	staleTTL time.Duration
+
+	// Background refresh deduplication
+	refreshMu  sync.Mutex
+	refreshing map[string]bool
+
+	// Shutdown signal for cleanup goroutine
+	done chan struct{}
 }
 
-// NewPRCache creates a new PR cache with the given TTL
-func NewPRCache(ttl time.Duration) *PRCache {
+// NewPRCache creates a new PR cache with the given fresh and stale TTLs.
+// Fresh TTL: serve directly from cache. Stale TTL: serve stale + trigger background refresh.
+func NewPRCache(freshTTL, staleTTL time.Duration) *PRCache {
 	cache := &PRCache{
-		entries: make(map[string]*PRCacheEntry),
-		ttl:     ttl,
+		entries:    make(map[string]*PRCacheEntry),
+		freshTTL:   freshTTL,
+		staleTTL:   staleTTL,
+		refreshing: make(map[string]bool),
+		done:       make(chan struct{}),
 	}
 
 	// Start cleanup goroutine
@@ -37,19 +66,35 @@ func cacheKey(owner, repo string) string {
 	return owner + "/" + repo
 }
 
-// Get retrieves cached PRs for a repo
-func (c *PRCache) Get(owner, repo string) ([]PRListItem, bool) {
+// GetWithStale retrieves cached PRs with freshness status.
+// Returns the entry, its freshness, and whether data was found.
+func (c *PRCache) GetWithStale(owner, repo string) (*PRCacheEntry, CacheFreshness) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	key := cacheKey(owner, repo)
 	entry, ok := c.entries[key]
 	if !ok {
-		return nil, false
+		return nil, CacheMiss
 	}
 
-	// Check if expired
-	if time.Now().After(entry.ExpiresAt) {
+	now := time.Now()
+
+	if now.Before(entry.ExpiresAt) {
+		return entry, CacheFresh
+	}
+
+	if now.Before(entry.StaleUntil) {
+		return entry, CacheStale
+	}
+
+	return nil, CacheMiss
+}
+
+// Get retrieves cached PRs for a repo (backwards-compatible, serves both fresh and stale entries)
+func (c *PRCache) Get(owner, repo string) ([]PRListItem, bool) {
+	entry, freshness := c.GetWithStale(owner, repo)
+	if freshness == CacheMiss || entry == nil {
 		return nil, false
 	}
 
@@ -59,23 +104,144 @@ func (c *PRCache) Get(owner, repo string) ([]PRListItem, bool) {
 	return result, true
 }
 
-// Set stores PRs in the cache
-func (c *PRCache) Set(owner, repo string, prs []PRListItem) {
+// GetDetails retrieves cached details for a single PR
+func (c *PRCache) GetDetails(owner, repo string, prNumber int) (*PRDetails, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := cacheKey(owner, repo)
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+
+	// Serve details from both fresh and stale entries
+	now := time.Now()
+	if now.After(entry.StaleUntil) {
+		return nil, false
+	}
+
+	details, ok := entry.Details[prNumber]
+	return details, ok
+}
+
+// SetFull stores PRs, details, and ETag in the cache
+func (c *PRCache) SetFull(owner, repo string, prs []PRListItem, details map[int]*PRDetails, etag string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	key := cacheKey(owner, repo)
 	now := time.Now()
 
-	// Store a copy to prevent mutation
+	// Store copies to prevent mutation
 	prsCopy := make([]PRListItem, len(prs))
 	copy(prsCopy, prs)
 
-	c.entries[key] = &PRCacheEntry{
-		PRs:       prsCopy,
-		CachedAt:  now,
-		ExpiresAt: now.Add(c.ttl),
+	detailsCopy := make(map[int]*PRDetails, len(details))
+	for k, v := range details {
+		copied := *v
+		if v.CheckDetails != nil {
+			copied.CheckDetails = make([]CheckDetail, len(v.CheckDetails))
+			copy(copied.CheckDetails, v.CheckDetails)
+		}
+		detailsCopy[k] = &copied
 	}
+
+	c.entries[key] = &PRCacheEntry{
+		PRs:        prsCopy,
+		Details:    detailsCopy,
+		ETag:       etag,
+		CachedAt:   now,
+		ExpiresAt:  now.Add(c.freshTTL),
+		StaleUntil: now.Add(c.staleTTL),
+	}
+
+	logger.GitHub.Debugf("PR cache SET %s: %d PRs, %d details, etag=%q", key, len(prs), len(details), etag)
+}
+
+// Set stores PRs in the cache (backwards-compatible, no details)
+func (c *PRCache) Set(owner, repo string, prs []PRListItem) {
+	c.SetFull(owner, repo, prs, nil, "")
+}
+
+// SetDetails updates the details for specific PRs within an existing cache entry
+func (c *PRCache) SetDetails(owner, repo string, details map[int]*PRDetails) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := cacheKey(owner, repo)
+	entry, ok := c.entries[key]
+	if !ok {
+		return
+	}
+
+	if entry.Details == nil {
+		entry.Details = make(map[int]*PRDetails)
+	}
+
+	for k, v := range details {
+		copied := *v
+		if v.CheckDetails != nil {
+			copied.CheckDetails = make([]CheckDetail, len(v.CheckDetails))
+			copy(copied.CheckDetails, v.CheckDetails)
+		}
+		entry.Details[k] = &copied
+	}
+}
+
+// BumpTTL atomically extends the fresh and stale deadlines for an existing entry.
+// Returns true if the entry was found and bumped.
+func (c *PRCache) BumpTTL(owner, repo string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := cacheKey(owner, repo)
+	entry, ok := c.entries[key]
+	if !ok {
+		return false
+	}
+
+	now := time.Now()
+	entry.ExpiresAt = now.Add(c.freshTTL)
+	entry.StaleUntil = now.Add(c.staleTTL)
+	entry.CachedAt = now
+	return true
+}
+
+// GetETag returns the stored ETag for a repo's PR list
+func (c *PRCache) GetETag(owner, repo string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := cacheKey(owner, repo)
+	entry, ok := c.entries[key]
+	if !ok {
+		return ""
+	}
+	return entry.ETag
+}
+
+// TryStartRefresh attempts to claim the refresh lock for a cache key.
+// Returns true if this caller should perform the refresh.
+func (c *PRCache) TryStartRefresh(owner, repo string) bool {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
+	key := cacheKey(owner, repo)
+	if c.refreshing[key] {
+		return false
+	}
+	c.refreshing[key] = true
+	return true
+}
+
+// EndRefresh releases the refresh lock for a cache key
+func (c *PRCache) EndRefresh(owner, repo string) {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
+	key := cacheKey(owner, repo)
+	delete(c.refreshing, key)
 }
 
 // Invalidate removes a specific repo from cache
@@ -85,6 +251,7 @@ func (c *PRCache) Invalidate(owner, repo string) {
 
 	key := cacheKey(owner, repo)
 	delete(c.entries, key)
+	logger.GitHub.Debugf("PR cache INVALIDATE %s", key)
 }
 
 // Clear removes all cache entries
@@ -94,40 +261,65 @@ func (c *PRCache) Clear() {
 	c.entries = make(map[string]*PRCacheEntry)
 }
 
-// cleanupLoop periodically removes expired entries
-func (c *PRCache) cleanupLoop() {
-	ticker := time.NewTicker(c.ttl)
-	defer ticker.Stop()
+// Done returns a channel that is closed when the cache is shut down.
+// Useful for deriving contexts that should cancel on shutdown.
+func (c *PRCache) Done() <-chan struct{} {
+	return c.done
+}
 
-	for range ticker.C {
-		c.cleanup()
+// Close stops the cleanup goroutine. Safe to call multiple times.
+func (c *PRCache) Close() {
+	select {
+	case <-c.done:
+		// Already closed
+	default:
+		close(c.done)
 	}
 }
 
-// cleanup removes expired entries
+// cleanupLoop periodically removes expired entries
+func (c *PRCache) cleanupLoop() {
+	ticker := time.NewTicker(c.staleTTL)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+			c.cleanup()
+		}
+	}
+}
+
+// cleanup removes entries past their stale deadline
 func (c *PRCache) cleanup() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	now := time.Now()
 	for key, entry := range c.entries {
-		if now.After(entry.ExpiresAt) {
+		if now.After(entry.StaleUntil) {
 			delete(c.entries, key)
 		}
 	}
 }
 
 // Stats returns cache statistics
-func (c *PRCache) Stats() (total int, expired int) {
+func (c *PRCache) Stats() (total int, fresh int, stale int, expired int) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	now := time.Now()
 	total = len(c.entries)
 	for _, entry := range c.entries {
-		if now.After(entry.ExpiresAt) {
+		if now.Before(entry.ExpiresAt) {
+			fresh++
+		} else if now.Before(entry.StaleUntil) {
+			stale++
+		} else {
 			expired++
 		}
 	}
-	return total, expired
+	return total, fresh, stale, expired
 }

--- a/backend/github/pr_cache_test.go
+++ b/backend/github/pr_cache_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPRCache_SetAndGet(t *testing.T) {
-	cache := NewPRCache(5 * time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
 
 	prs := []PRListItem{
 		{Number: 1, Title: "First PR", Branch: "feature-1"},
@@ -27,7 +27,7 @@ func TestPRCache_SetAndGet(t *testing.T) {
 }
 
 func TestPRCache_GetNotFound(t *testing.T) {
-	cache := NewPRCache(5 * time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
 
 	result, ok := cache.Get("owner", "nonexistent")
 	require.False(t, ok)
@@ -35,17 +35,25 @@ func TestPRCache_GetNotFound(t *testing.T) {
 }
 
 func TestPRCache_Expiration(t *testing.T) {
-	cache := NewPRCache(50 * time.Millisecond)
+	cache := NewPRCache(50*time.Millisecond, 150*time.Millisecond)
 
 	prs := []PRListItem{{Number: 1, Title: "Test PR"}}
 	cache.Set("owner", "repo", prs)
 
-	// Should be available immediately
+	// Should be available immediately (fresh)
 	result, ok := cache.Get("owner", "repo")
 	require.True(t, ok)
 	require.Len(t, result, 1)
 
-	// Wait for expiration
+	// Wait for fresh TTL to expire but still within stale TTL
+	time.Sleep(80 * time.Millisecond)
+
+	// Get still works (returns fresh + stale entries)
+	result, ok = cache.Get("owner", "repo")
+	require.True(t, ok)
+	require.Len(t, result, 1)
+
+	// Wait for stale TTL to expire
 	time.Sleep(100 * time.Millisecond)
 
 	// Should be expired now
@@ -55,7 +63,7 @@ func TestPRCache_Expiration(t *testing.T) {
 }
 
 func TestPRCache_Invalidate(t *testing.T) {
-	cache := NewPRCache(5 * time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
 
 	prs := []PRListItem{{Number: 1, Title: "Test PR"}}
 	cache.Set("owner", "repo", prs)
@@ -73,22 +81,22 @@ func TestPRCache_Invalidate(t *testing.T) {
 }
 
 func TestPRCache_Clear(t *testing.T) {
-	cache := NewPRCache(5 * time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
 
 	cache.Set("owner1", "repo1", []PRListItem{{Number: 1}})
 	cache.Set("owner2", "repo2", []PRListItem{{Number: 2}})
 
-	total, _ := cache.Stats()
+	total, _, _, _ := cache.Stats()
 	require.Equal(t, 2, total)
 
 	cache.Clear()
 
-	total, _ = cache.Stats()
+	total, _, _, _ = cache.Stats()
 	require.Equal(t, 0, total)
 }
 
 func TestPRCache_ImmutableCopy(t *testing.T) {
-	cache := NewPRCache(5 * time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
 
 	prs := []PRListItem{{Number: 1, Title: "Original"}}
 	cache.Set("owner", "repo", prs)
@@ -111,7 +119,7 @@ func TestPRCache_ImmutableCopy(t *testing.T) {
 }
 
 func TestPRCache_ConcurrentAccess(t *testing.T) {
-	cache := NewPRCache(5 * time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
 
 	var wg sync.WaitGroup
 	const numGoroutines = 100
@@ -148,15 +156,249 @@ func TestPRCache_ConcurrentAccess(t *testing.T) {
 }
 
 func TestPRCache_Stats(t *testing.T) {
-	// Use a longer TTL to avoid cleanup goroutine removing entries
-	cache := NewPRCache(5 * time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
 
 	cache.Set("owner1", "repo1", []PRListItem{{Number: 1}})
 	cache.Set("owner2", "repo2", []PRListItem{{Number: 2}})
 
-	total, expired := cache.Stats()
+	total, fresh, stale, expired := cache.Stats()
 	require.Equal(t, 2, total)
+	require.Equal(t, 2, fresh)
+	require.Equal(t, 0, stale)
 	require.Equal(t, 0, expired)
+}
+
+func TestPRCache_StaleWhileRevalidate(t *testing.T) {
+	cache := NewPRCache(50*time.Millisecond, 200*time.Millisecond)
+
+	prs := []PRListItem{{Number: 1, Title: "Test PR"}}
+	details := map[int]*PRDetails{
+		1: {Number: 1, Title: "Test PR", CheckStatus: CheckStatusSuccess},
+	}
+	cache.SetFull("owner", "repo", prs, details, "etag-123")
+
+	// Should be fresh
+	entry, freshness := cache.GetWithStale("owner", "repo")
+	require.Equal(t, CacheFresh, freshness)
+	require.NotNil(t, entry)
+	require.Len(t, entry.PRs, 1)
+	require.Len(t, entry.Details, 1)
+	require.Equal(t, "etag-123", entry.ETag)
+
+	// Wait for fresh TTL to expire
+	time.Sleep(70 * time.Millisecond)
+
+	// Should be stale
+	entry, freshness = cache.GetWithStale("owner", "repo")
+	require.Equal(t, CacheStale, freshness)
+	require.NotNil(t, entry)
+
+	// Wait for stale TTL to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Should be a miss
+	entry, freshness = cache.GetWithStale("owner", "repo")
+	require.Equal(t, CacheMiss, freshness)
+	require.Nil(t, entry)
+}
+
+func TestPRCache_RefreshDeduplication(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+
+	// First call should succeed
+	ok := cache.TryStartRefresh("owner", "repo")
+	require.True(t, ok)
+
+	// Second call should fail (already refreshing)
+	ok = cache.TryStartRefresh("owner", "repo")
+	require.False(t, ok)
+
+	// After ending, should succeed again
+	cache.EndRefresh("owner", "repo")
+	ok = cache.TryStartRefresh("owner", "repo")
+	require.True(t, ok)
+	cache.EndRefresh("owner", "repo")
+}
+
+func TestPRCache_GetDetails(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+
+	details := map[int]*PRDetails{
+		1: {Number: 1, Title: "PR 1", CheckStatus: CheckStatusSuccess},
+		2: {Number: 2, Title: "PR 2", CheckStatus: CheckStatusFailure},
+	}
+	cache.SetFull("owner", "repo", []PRListItem{{Number: 1}, {Number: 2}}, details, "")
+
+	// Should find details
+	d, ok := cache.GetDetails("owner", "repo", 1)
+	require.True(t, ok)
+	require.Equal(t, "PR 1", d.Title)
+
+	// Should not find non-existent PR
+	_, ok = cache.GetDetails("owner", "repo", 999)
+	require.False(t, ok)
+
+	// Should not find in non-existent repo
+	_, ok = cache.GetDetails("owner", "nonexistent", 1)
+	require.False(t, ok)
+}
+
+func TestPRCache_SetDetails(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+
+	// Set initial data
+	cache.SetFull("owner", "repo", []PRListItem{{Number: 1}}, nil, "")
+
+	// Update details
+	cache.SetDetails("owner", "repo", map[int]*PRDetails{
+		1: {Number: 1, Title: "Updated", CheckStatus: CheckStatusSuccess},
+	})
+
+	d, ok := cache.GetDetails("owner", "repo", 1)
+	require.True(t, ok)
+	require.Equal(t, "Updated", d.Title)
+}
+
+func TestPRCache_BumpTTL(t *testing.T) {
+	cache := NewPRCache(50*time.Millisecond, 200*time.Millisecond)
+	defer cache.Close()
+
+	prs := []PRListItem{{Number: 1, Title: "Test PR"}}
+	cache.SetFull("owner", "repo", prs, nil, "etag-1")
+
+	// Wait until entry is stale
+	time.Sleep(70 * time.Millisecond)
+	_, freshness := cache.GetWithStale("owner", "repo")
+	require.Equal(t, CacheStale, freshness)
+
+	// BumpTTL should make it fresh again
+	ok := cache.BumpTTL("owner", "repo")
+	require.True(t, ok)
+
+	entry, freshness := cache.GetWithStale("owner", "repo")
+	require.Equal(t, CacheFresh, freshness)
+	require.NotNil(t, entry)
+	require.Len(t, entry.PRs, 1)
+
+	// BumpTTL on non-existent entry returns false
+	ok = cache.BumpTTL("nonexistent", "repo")
+	require.False(t, ok)
+}
+
+func TestPRCache_BumpTTL_PreservesData(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	details := map[int]*PRDetails{
+		1: {Number: 1, Title: "PR 1", CheckStatus: CheckStatusSuccess},
+	}
+	cache.SetFull("owner", "repo", []PRListItem{{Number: 1}}, details, "etag-abc")
+
+	cache.BumpTTL("owner", "repo")
+
+	// Verify data is preserved after bump
+	entry, freshness := cache.GetWithStale("owner", "repo")
+	require.Equal(t, CacheFresh, freshness)
+	require.Len(t, entry.PRs, 1)
+	require.Equal(t, 1, entry.PRs[0].Number)
+	require.Len(t, entry.Details, 1)
+	require.Equal(t, "PR 1", entry.Details[1].Title)
+	require.Equal(t, "etag-abc", entry.ETag)
+}
+
+func TestPRCache_Close(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+
+	// Close should not panic
+	cache.Close()
+
+	// Double close should not panic
+	cache.Close()
+
+	// Operations after close should still work (cache is still usable, just no cleanup)
+	cache.Set("owner", "repo", []PRListItem{{Number: 1}})
+	result, ok := cache.Get("owner", "repo")
+	require.True(t, ok)
+	require.Len(t, result, 1)
+}
+
+func TestPRCache_GetETag(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	// No entry returns empty string
+	etag := cache.GetETag("owner", "repo")
+	require.Empty(t, etag)
+
+	// Set with ETag
+	cache.SetFull("owner", "repo", []PRListItem{{Number: 1}}, nil, "W/\"abc123\"")
+
+	etag = cache.GetETag("owner", "repo")
+	require.Equal(t, "W/\"abc123\"", etag)
+
+	// Set without ETag
+	cache.SetFull("owner", "repo2", []PRListItem{{Number: 2}}, nil, "")
+	etag = cache.GetETag("owner", "repo2")
+	require.Empty(t, etag)
+}
+
+func TestPRCache_SetFull_WithETagAndDetails(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	prs := []PRListItem{
+		{Number: 1, Title: "PR 1", Branch: "feature-1"},
+		{Number: 2, Title: "PR 2", Branch: "feature-2"},
+	}
+	details := map[int]*PRDetails{
+		1: {Number: 1, Title: "PR 1", CheckStatus: CheckStatusSuccess},
+		2: {Number: 2, Title: "PR 2", CheckStatus: CheckStatusPending},
+	}
+
+	cache.SetFull("owner", "repo", prs, details, "etag-full")
+
+	entry, freshness := cache.GetWithStale("owner", "repo")
+	require.Equal(t, CacheFresh, freshness)
+	require.Len(t, entry.PRs, 2)
+	require.Len(t, entry.Details, 2)
+	require.Equal(t, "etag-full", entry.ETag)
+
+	// Verify details are accessible
+	d, ok := cache.GetDetails("owner", "repo", 1)
+	require.True(t, ok)
+	require.Equal(t, CheckStatusSuccess, d.CheckStatus)
+
+	d, ok = cache.GetDetails("owner", "repo", 2)
+	require.True(t, ok)
+	require.Equal(t, CheckStatusPending, d.CheckStatus)
+}
+
+func TestPRCache_SetFull_ImmutableDetails(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	details := map[int]*PRDetails{
+		1: {Number: 1, Title: "Original", CheckDetails: []CheckDetail{
+			{Name: "ci", Status: "completed", Conclusion: "success"},
+		}},
+	}
+
+	cache.SetFull("owner", "repo", []PRListItem{{Number: 1}}, details, "")
+
+	// Mutate the original map and pointed-to values
+	details[1].Title = "Mutated"
+	details[1].CheckDetails[0].Name = "mutated-check"
+	details[1].CheckDetails = append(details[1].CheckDetails, CheckDetail{Name: "extra"})
+	details[99] = &PRDetails{Number: 99}
+
+	// Cache should be fully unaffected (deep copy)
+	entry, _ := cache.GetWithStale("owner", "repo")
+	require.Len(t, entry.Details, 1)
+	_, exists := entry.Details[99]
+	require.False(t, exists)
+	require.Equal(t, "Original", entry.Details[1].Title)
+	require.Len(t, entry.Details[1].CheckDetails, 1)
+	require.Equal(t, "ci", entry.Details[1].CheckDetails[0].Name)
 }
 
 func TestCacheKey(t *testing.T) {

--- a/backend/github/pr_status.go
+++ b/backend/github/pr_status.go
@@ -267,8 +267,27 @@ type githubPRListItem struct {
 	} `json:"labels"`
 }
 
+// ErrNotModified is returned when a conditional request receives 304 Not Modified
+var ErrNotModified = fmt.Errorf("not modified")
+
+// ListOpenPRsResult contains the result of listing open PRs
+type ListOpenPRsResult struct {
+	PRs  []PRListItem
+	ETag string // Response ETag for conditional requests
+}
+
 // ListOpenPRs lists all open pull requests for a repository
 func (c *Client) ListOpenPRs(ctx context.Context, owner, repo string) ([]PRListItem, error) {
+	result, err := c.ListOpenPRsWithETag(ctx, owner, repo, "")
+	if err != nil {
+		return nil, err
+	}
+	return result.PRs, nil
+}
+
+// ListOpenPRsWithETag lists open PRs with ETag support for conditional requests.
+// If etag is non-empty, sends If-None-Match header. Returns ErrNotModified on 304.
+func (c *Client) ListOpenPRsWithETag(ctx context.Context, owner, repo, etag string) (*ListOpenPRsResult, error) {
 	token := c.GetToken()
 	if token == "" {
 		return nil, fmt.Errorf("not authenticated")
@@ -283,12 +302,19 @@ func (c *Client) ListOpenPRs(ctx context.Context, owner, repo string) ([]PRListI
 
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching PRs: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, ErrNotModified
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, readErr := io.ReadAll(resp.Body)
@@ -324,7 +350,10 @@ func (c *Client) ListOpenPRs(ctx context.Context, owner, repo string) ([]PRListI
 		}
 	}
 
-	return prs, nil
+	return &ListOpenPRsResult{
+		PRs:  prs,
+		ETag: resp.Header.Get("ETag"),
+	}, nil
 }
 
 // githubSearchResult represents the GitHub API response for PR search

--- a/backend/github/pr_status_test.go
+++ b/backend/github/pr_status_test.go
@@ -334,6 +334,85 @@ func TestClient_GetPRDetails_NotAuthenticated(t *testing.T) {
 	require.Contains(t, err.Error(), "not authenticated")
 }
 
+func TestClient_ListOpenPRsWithETag_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/testowner/testrepo/pulls", r.URL.Path)
+
+		// Should not send If-None-Match when no etag provided
+		require.Empty(t, r.Header.Get("If-None-Match"))
+
+		w.Header().Set("ETag", "W/\"abc123\"")
+		prs := []map[string]interface{}{
+			{
+				"number":   1,
+				"state":    "open",
+				"title":    "Test PR",
+				"html_url": "https://github.com/testowner/testrepo/pull/1",
+				"draft":    false,
+				"head":     map[string]string{"ref": "feature-1", "sha": "sha1"},
+			},
+		}
+		json.NewEncoder(w).Encode(prs)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListOpenPRsWithETag(context.Background(), "testowner", "testrepo", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.PRs, 1)
+	require.Equal(t, "W/\"abc123\"", result.ETag)
+	require.Equal(t, 1, result.PRs[0].Number)
+}
+
+func TestClient_ListOpenPRsWithETag_NotModified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Should send If-None-Match with the provided etag
+		require.Equal(t, "W/\"abc123\"", r.Header.Get("If-None-Match"))
+
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListOpenPRsWithETag(context.Background(), "testowner", "testrepo", "W/\"abc123\"")
+	require.ErrorIs(t, err, ErrNotModified)
+	require.Nil(t, result)
+}
+
+func TestClient_ListOpenPRsWithETag_SendsETagHeader(t *testing.T) {
+	var receivedETag string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedETag = r.Header.Get("If-None-Match")
+		w.Header().Set("ETag", "W/\"new-etag\"")
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListOpenPRsWithETag(context.Background(), "testowner", "testrepo", "W/\"old-etag\"")
+	require.NoError(t, err)
+	require.Equal(t, "W/\"old-etag\"", receivedETag)
+	require.Equal(t, "W/\"new-etag\"", result.ETag)
+}
+
+func TestClient_ListOpenPRsWithETag_NotAuthenticated(t *testing.T) {
+	client := NewClient("", "")
+
+	_, err := client.ListOpenPRsWithETag(context.Background(), "testowner", "testrepo", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authenticated")
+}
+
 func TestClient_FindPRForBranch_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/repos/testowner/testrepo/pulls", r.URL.Path)

--- a/backend/main.go
+++ b/backend/main.go
@@ -171,6 +171,15 @@ func main() {
 					"branch": event.NewBranch,
 				},
 			})
+
+			// Emit dashboard-level invalidation signal for branches dashboard
+			hub.Broadcast(server.Event{
+				Type: "branch_dashboard_update",
+				Payload: map[string]interface{}{
+					"sessionId": event.SessionID,
+					"updatedAt": time.Now().Unix(),
+				},
+			})
 		}()
 	})
 	if err != nil {
@@ -276,9 +285,13 @@ func main() {
 
 	go hub.Run()
 
+	// Shared PR cache used by both PRWatcher and HTTP handlers
+	prCache := github.NewPRCache(2*time.Minute, 10*time.Minute)
+	defer prCache.Close()
+
 	// PR watcher for background GitHub PR status monitoring
 	// Creates a watcher that polls GitHub for PR changes and broadcasts updates via WebSocket
-	prWatcher := branch.NewPRWatcher(ghClient, repoManager, s, func(event branch.PRChangeEvent) {
+	prWatcher := branch.NewPRWatcher(ghClient, repoManager, s, prCache, func(event branch.PRChangeEvent) {
 		// Handle updates asynchronously to avoid blocking the watcher
 		go func() {
 			defer func() {
@@ -295,7 +308,7 @@ func main() {
 			logger.PRWatcher.Infof("Broadcasting PR update for session %s: status=%s, pr=%d",
 				event.SessionID, event.PRStatus, event.PRNumber)
 
-			// Emit WebSocket event for frontend
+			// Emit per-session WebSocket event for session views
 			hub.Broadcast(server.Event{
 				Type:      "session_pr_update",
 				SessionID: event.SessionID,
@@ -305,6 +318,15 @@ func main() {
 					"prUrl":       event.PRUrl,
 					"checkStatus": event.CheckStatus,
 					"mergeable":   event.Mergeable,
+				},
+			})
+
+			// Emit dashboard-level invalidation signal for PR dashboard
+			hub.Broadcast(server.Event{
+				Type: "pr_dashboard_update",
+				Payload: map[string]interface{}{
+					"sessionId": event.SessionID,
+					"updatedAt": time.Now().Unix(),
 				},
 			})
 		}()
@@ -330,7 +352,7 @@ func main() {
 		}
 	}
 
-	router := server.NewRouter(s, hub, agentMgr, ghClient, nil, branchWatcher, prWatcher, statsCache)
+	router := server.NewRouter(s, hub, agentMgr, ghClient, nil, branchWatcher, prWatcher, prCache, statsCache)
 
 	// Create HTTP server with graceful shutdown support
 	srv := &http.Server{

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -83,6 +83,7 @@ type BranchCache struct {
 	mu      sync.RWMutex
 	entries map[string]*branchCacheEntry
 	ttl     time.Duration
+	done    chan struct{}
 }
 
 type branchCacheEntry struct {
@@ -92,10 +93,13 @@ type branchCacheEntry struct {
 
 // NewBranchCache creates a new branch cache with the given TTL
 func NewBranchCache(ttl time.Duration) *BranchCache {
-	return &BranchCache{
+	c := &BranchCache{
 		entries: make(map[string]*branchCacheEntry),
 		ttl:     ttl,
+		done:    make(chan struct{}),
 	}
+	go c.cleanupLoop()
+	return c
 }
 
 // Get retrieves a cached branch list by key
@@ -141,6 +145,37 @@ func (c *BranchCache) InvalidateRepo(repoPath string) {
 	for key := range c.entries {
 		if strings.HasPrefix(key, repoPath+":") {
 			delete(c.entries, key)
+		}
+	}
+}
+
+// Close stops the cleanup goroutine. Safe to call multiple times.
+func (c *BranchCache) Close() {
+	select {
+	case <-c.done:
+	default:
+		close(c.done)
+	}
+}
+
+// cleanupLoop periodically removes expired branch cache entries
+func (c *BranchCache) cleanupLoop() {
+	ticker := time.NewTicker(c.ttl)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+			c.mu.Lock()
+			now := time.Now()
+			for key, entry := range c.entries {
+				if now.After(entry.expiresAt) {
+					delete(c.entries, key)
+				}
+			}
+			c.mu.Unlock()
 		}
 	}
 }
@@ -297,7 +332,7 @@ func writeJSON(w http.ResponseWriter, data interface{}) {
 	}
 }
 
-func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, statsCache *SessionStatsCache) *Handlers {
+func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, statsCache *SessionStatsCache) *Handlers {
 	// Initialize session name cache with workspaces directory
 	// Cache initializes lazily on first use
 	workspacesDir, err := git.WorkspacesBaseDir()
@@ -318,7 +353,7 @@ func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirList
 		prWatcher:        prw,
 		hub:              hub,
 		ghClient:         ghClient,
-		prCache:          github.NewPRCache(30 * time.Second),   // Cache PR data for 30 seconds
+		prCache:          prCache,
 		avatarCache:      github.NewAvatarCache(24 * time.Hour), // Cache avatars for 24 hours
 		statsCache:       statsCache,
 	}
@@ -1141,6 +1176,9 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 		h.prWatcher.WatchSession(sess.ID, workspaceID, branchName, repo.Path, models.PRStatusNone)
 	}
 
+	// Invalidate branch cache after new session/branch creation
+	h.branchCache.InvalidateRepo(repo.Path)
+
 	// All operations succeeded - disable rollback
 	rollback = false
 	writeJSON(w, sess)
@@ -1297,6 +1335,9 @@ func (h *Handlers) DeleteSession(w http.ResponseWriter, r *http.Request) {
 
 			// Remove from session name cache
 			h.sessionNameCache.Remove(sess.Name)
+
+			// Invalidate branch cache after branch/worktree removal
+			h.branchCache.InvalidateRepo(repo.Path)
 		}
 	}
 
@@ -1700,6 +1741,9 @@ func (h *Handlers) MergeAgent(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w, "failed to merge agent changes", err)
 		return
 	}
+
+	// Invalidate branch cache after merge
+	h.branchCache.InvalidateRepo(repo.Path)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -3045,6 +3089,11 @@ func (h *Handlers) SyncSessionBranch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Invalidate branch cache after sync operation
+	if repo, err := h.store.GetRepo(ctx, session.WorkspaceID); err == nil && repo != nil {
+		h.branchCache.InvalidateRepo(repo.Path)
+	}
+
 	// Convert to response format
 	response := models.BranchSyncResult{
 		Success:       result.Success,
@@ -3094,6 +3143,11 @@ func (h *Handlers) AbortSessionSync(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeValidationError(w, "no rebase or merge in progress")
 		return
+	}
+
+	// Invalidate branch cache after abort
+	if repo, err := h.store.GetRepo(ctx, session.WorkspaceID); err == nil && repo != nil {
+		h.branchCache.InvalidateRepo(repo.Path)
 	}
 
 	w.WriteHeader(http.StatusNoContent)
@@ -3180,17 +3234,44 @@ func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		// Check PR cache first
-		ghPRs, cacheHit := h.prCache.Get(owner, repoName)
-		if !cacheHit {
-			// Fetch all open PRs directly from GitHub
-			ghPRs, err = h.ghClient.ListOpenPRs(ctx, owner, repoName)
-			if err != nil {
-				// Log error but continue with other repos
+		// Check unified PR cache (list + details) with stale-while-revalidate
+		cacheEntry, freshness := h.prCache.GetWithStale(owner, repoName)
+
+		var ghPRs []github.PRListItem
+		var prDetailsMap map[int]*github.PRDetails
+
+		switch freshness {
+		case github.CacheFresh:
+			// Serve directly from cache -- zero API calls
+			ghPRs = cacheEntry.PRs
+			prDetailsMap = cacheEntry.Details
+
+		case github.CacheStale:
+			// Serve stale data immediately, trigger background refresh
+			ghPRs = cacheEntry.PRs
+			prDetailsMap = cacheEntry.Details
+
+			if h.prCache.TryStartRefresh(owner, repoName) {
+				go h.refreshPRCache(owner, repoName)
+			}
+
+		default:
+			// Cache miss -- fetch synchronously with ETag capture
+			result, fetchErr := h.ghClient.ListOpenPRsWithETag(ctx, owner, repoName, "")
+			if fetchErr != nil {
 				continue
 			}
-			// Cache the result
-			h.prCache.Set(owner, repoName, ghPRs)
+			ghPRs = result.PRs
+
+			// Batch fetch all PR details
+			prNumbers := make([]int, len(ghPRs))
+			for i, pr := range ghPRs {
+				prNumbers[i] = pr.Number
+			}
+			prDetailsMap, _ = h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 5)
+
+			// Store combined result in cache (including ETag for future conditional requests)
+			h.prCache.SetFull(owner, repoName, ghPRs, prDetailsMap, result.ETag)
 		}
 
 		// List sessions to match PRs with sessions by branch
@@ -3207,15 +3288,6 @@ func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
 				sessionByBranch[session.Branch] = session
 			}
 		}
-
-		// Collect all PR numbers for batch fetching
-		prNumbers := make([]int, len(ghPRs))
-		for i, pr := range ghPRs {
-			prNumbers[i] = pr.Number
-		}
-
-		// Batch fetch all PR details concurrently (max 5 parallel requests)
-		prDetailsMap, _ := h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 5)
 
 		// Process each PR from GitHub
 		for _, ghPR := range ghPRs {
@@ -3241,25 +3313,27 @@ func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
 				prItem.SessionName = session.Name
 			}
 
-			// Use batch-fetched PR details
-			if prDetails, ok := prDetailsMap[ghPR.Number]; ok && prDetails != nil {
-				prItem.Mergeable = prDetails.Mergeable
-				prItem.MergeableState = prDetails.MergeableState
-				prItem.CheckStatus = string(prDetails.CheckStatus)
+			// Use cached or freshly-fetched PR details
+			if prDetailsMap != nil {
+				if prDetails, ok := prDetailsMap[ghPR.Number]; ok && prDetails != nil {
+					prItem.Mergeable = prDetails.Mergeable
+					prItem.MergeableState = prDetails.MergeableState
+					prItem.CheckStatus = string(prDetails.CheckStatus)
 
-				// Convert check details
-				for _, check := range prDetails.CheckDetails {
-					prItem.CheckDetails = append(prItem.CheckDetails, check)
-				}
+					// Convert check details
+					for _, check := range prDetails.CheckDetails {
+						prItem.CheckDetails = append(prItem.CheckDetails, check)
+					}
 
-				// Calculate counts
-				prItem.ChecksTotal = len(prDetails.CheckDetails)
-				for _, check := range prDetails.CheckDetails {
-					if check.Status == "completed" {
-						if check.Conclusion == "success" || check.Conclusion == "neutral" || check.Conclusion == "skipped" {
-							prItem.ChecksPassed++
-						} else {
-							prItem.ChecksFailed++
+					// Calculate counts
+					prItem.ChecksTotal = len(prDetails.CheckDetails)
+					for _, check := range prDetails.CheckDetails {
+						if check.Status == "completed" {
+							if check.Conclusion == "success" || check.Conclusion == "neutral" || check.Conclusion == "skipped" {
+								prItem.ChecksPassed++
+							} else {
+								prItem.ChecksFailed++
+							}
 						}
 					}
 				}
@@ -3275,4 +3349,55 @@ func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, prItems)
+}
+
+// refreshPRCache fetches fresh PR data from GitHub in the background
+// and updates the unified cache. Called when serving stale data.
+// Uses ETag conditional requests to avoid re-fetching unchanged data.
+// Respects the prCache shutdown signal so goroutines don't outlive the server.
+func (h *Handlers) refreshPRCache(owner, repoName string) {
+	defer h.prCache.EndRefresh(owner, repoName)
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Handlers.Errorf("Panic in background PR refresh for %s/%s: %v", owner, repoName, r)
+		}
+	}()
+
+	// Derive a context that cancels on timeout OR server shutdown (whichever comes first)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-h.prCache.Done():
+			cancel()
+		}
+	}()
+
+	// Use cached ETag for conditional request
+	etag := h.prCache.GetETag(owner, repoName)
+	result, err := h.ghClient.ListOpenPRsWithETag(ctx, owner, repoName, etag)
+
+	if errors.Is(err, github.ErrNotModified) {
+		// Data unchanged -- atomically refresh the TTL on the existing entry
+		h.prCache.BumpTTL(owner, repoName)
+		logger.Handlers.Debugf("Background PR refresh for %s/%s: not modified (ETag hit)", owner, repoName)
+		return
+	}
+	if err != nil {
+		logger.Handlers.Errorf("Background PR refresh failed for %s/%s: %v", owner, repoName, err)
+		return
+	}
+
+	// Batch fetch all PR details
+	prNumbers := make([]int, len(result.PRs))
+	for i, pr := range result.PRs {
+		prNumbers[i] = pr.Number
+	}
+	prDetailsMap, _ := h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 5)
+
+	// Update the unified cache with new ETag
+	h.prCache.SetFull(owner, repoName, result.PRs, prDetailsMap, result.ETag)
+
+	logger.Handlers.Debugf("Background PR refresh complete for %s/%s: %d PRs", owner, repoName, len(result.PRs))
 }

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -1483,3 +1483,148 @@ func TestDeleteConversation_ExistingConversation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, conv)
 }
+
+// ============================================================================
+// BranchCache Tests
+// ============================================================================
+
+func TestBranchCache_GetSet(t *testing.T) {
+	cache := NewBranchCache(5 * time.Minute)
+	defer cache.Close()
+
+	data := &git.BranchListResult{
+		Branches: []git.BranchInfo{
+			{Name: "main", IsHead: true},
+			{Name: "feature-1"},
+		},
+	}
+	cache.Set("/repo:local:false:", data)
+
+	result, ok := cache.Get("/repo:local:false:")
+	require.True(t, ok)
+	require.Len(t, result.Branches, 2)
+	require.Equal(t, "main", result.Branches[0].Name)
+}
+
+func TestBranchCache_GetNotFound(t *testing.T) {
+	cache := NewBranchCache(5 * time.Minute)
+	defer cache.Close()
+
+	result, ok := cache.Get("nonexistent")
+	require.False(t, ok)
+	require.Nil(t, result)
+}
+
+func TestBranchCache_Expiration(t *testing.T) {
+	cache := NewBranchCache(50 * time.Millisecond)
+	defer cache.Close()
+
+	data := &git.BranchListResult{
+		Branches: []git.BranchInfo{{Name: "main"}},
+	}
+	cache.Set("key", data)
+
+	// Should be available immediately
+	result, ok := cache.Get("key")
+	require.True(t, ok)
+	require.Len(t, result.Branches, 1)
+
+	// Wait for expiration
+	time.Sleep(70 * time.Millisecond)
+
+	result, ok = cache.Get("key")
+	require.False(t, ok)
+	require.Nil(t, result)
+}
+
+func TestBranchCache_Invalidate(t *testing.T) {
+	cache := NewBranchCache(5 * time.Minute)
+	defer cache.Close()
+
+	data := &git.BranchListResult{
+		Branches: []git.BranchInfo{{Name: "main"}},
+	}
+	cache.Set("key1", data)
+
+	_, ok := cache.Get("key1")
+	require.True(t, ok)
+
+	cache.Invalidate("key1")
+
+	_, ok = cache.Get("key1")
+	require.False(t, ok)
+}
+
+func TestBranchCache_InvalidateRepo(t *testing.T) {
+	cache := NewBranchCache(5 * time.Minute)
+	defer cache.Close()
+
+	data := &git.BranchListResult{
+		Branches: []git.BranchInfo{{Name: "main"}},
+	}
+
+	// Set entries for two different repos
+	cache.Set("/path/to/repo:local:false:", data)
+	cache.Set("/path/to/repo:remote:true:", data)
+	cache.Set("/other/repo:local:false:", data)
+
+	// Invalidate only /path/to/repo
+	cache.InvalidateRepo("/path/to/repo")
+
+	// Repo entries should be gone
+	_, ok := cache.Get("/path/to/repo:local:false:")
+	require.False(t, ok)
+	_, ok = cache.Get("/path/to/repo:remote:true:")
+	require.False(t, ok)
+
+	// Other repo should still exist
+	_, ok = cache.Get("/other/repo:local:false:")
+	require.True(t, ok)
+}
+
+func TestBranchCache_Close(t *testing.T) {
+	cache := NewBranchCache(5 * time.Minute)
+
+	// Close should not panic
+	cache.Close()
+
+	// Double close should not panic
+	cache.Close()
+
+	// Cache is still usable after close (just no background cleanup)
+	data := &git.BranchListResult{
+		Branches: []git.BranchInfo{{Name: "main"}},
+	}
+	cache.Set("key", data)
+	result, ok := cache.Get("key")
+	require.True(t, ok)
+	require.Equal(t, "main", result.Branches[0].Name)
+}
+
+func TestBranchCache_ConcurrentAccess(t *testing.T) {
+	cache := NewBranchCache(5 * time.Minute)
+	defer cache.Close()
+
+	var wg sync.WaitGroup
+	const n = 100
+
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		key := "key-" + string(rune('a'+i%26))
+
+		go func(k string) {
+			defer wg.Done()
+			cache.Set(k, &git.BranchListResult{
+				Branches: []git.BranchInfo{{Name: k}},
+			})
+		}(key)
+
+		go func(k string) {
+			defer wg.Done()
+			cache.Get(k)
+		}(key)
+	}
+
+	wg.Wait()
+	// Should not panic
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -17,10 +17,10 @@ import (
 	"github.com/rs/cors"
 )
 
-func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, orch *orchestrator.Orchestrator, bw *branch.Watcher, prw *branch.PRWatcher, statsCache *SessionStatsCache) http.Handler {
+func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, orch *orchestrator.Orchestrator, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, statsCache *SessionStatsCache) http.Handler {
 	r := chi.NewRouter()
 	dirCacheConfig := LoadDirListingCacheConfig()
-	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, statsCache)
+	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, statsCache)
 	auth := NewAuthHandlers(ghClient)
 
 	r.Use(middleware.Logger)

--- a/backend/server/router_test.go
+++ b/backend/server/router_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/chatml/chatml-backend/agent"
 	gitpkg "github.com/chatml/chatml-backend/git"
@@ -31,9 +32,11 @@ func setupTestRouter(t *testing.T) (http.Handler, *store.SQLiteStore) {
 	wm := gitpkg.NewWorktreeManager()
 	agentMgr := agent.NewManager(context.Background(), s, wm)
 	ghClient := github.NewClient("", "")
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
+	t.Cleanup(func() { prCache.Close() })
 
 	// Create router without orchestrator, branch watcher, pr watcher, or stats cache
-	router := NewRouter(s, hub, agentMgr, ghClient, nil, nil, nil, nil)
+	router := NewRouter(s, hub, agentMgr, ghClient, nil, nil, nil, prCache, nil)
 
 	return router, s
 }

--- a/backend/server/testhelpers_test.go
+++ b/backend/server/testhelpers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/chatml/chatml-backend/agent"
 	"github.com/chatml/chatml-backend/git"
+	"github.com/chatml/chatml-backend/github"
 	"github.com/chatml/chatml-backend/models"
 	"github.com/chatml/chatml-backend/store"
 	"github.com/go-chi/chi/v5"
@@ -25,11 +26,14 @@ func setupTestHandlers(t *testing.T) (*Handlers, *store.SQLiteStore) {
 	sqliteStore, err := store.NewSQLiteStoreInMemory()
 	require.NoError(t, err)
 
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
+
 	t.Cleanup(func() {
 		sqliteStore.Close()
+		prCache.Close()
 	})
 
-	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, nil)
+	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil)
 
 	return handlers, sqliteStore
 }
@@ -44,12 +48,14 @@ func setupTestHandlersWithAgentManager(t *testing.T) (*Handlers, *store.SQLiteSt
 
 	worktreeManager := git.NewWorktreeManager()
 	agentManager := agent.NewManager(context.Background(), sqliteStore, worktreeManager)
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
 
 	t.Cleanup(func() {
 		sqliteStore.Close()
+		prCache.Close()
 	})
 
-	handlers := NewHandlers(sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, nil)
+	handlers := NewHandlers(sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil)
 
 	return handlers, sqliteStore, agentManager
 }

--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -291,18 +291,26 @@ export function BranchesDashboard({
   }, [workspaceId, showRemote, searchTerm]);
   fetchBranchesRef.current = fetchBranches;
 
-  // Initial fetch and auto-refresh
+  // Initial fetch + WebSocket-driven refresh + slow fallback poll
   // After the first fetch, subsequent dependency changes use refresh mode
   // to keep the DataTable mounted and preserve its display options state.
   useEffect(() => {
     fetchBranches(hasFetchedRef.current);
     hasFetchedRef.current = true;
 
+    // Listen for WebSocket invalidation events from BranchWatcher
+    const handleBranchUpdate = () => fetchBranchesRef.current(true);
+    window.addEventListener('branch_dashboard_update', handleBranchUpdate);
+
+    // Slow fallback poll (5 minutes) as a safety net
     const interval = setInterval(() => {
       fetchBranches(true);
-    }, 60000);
+    }, 300000);
 
-    return () => clearInterval(interval);
+    return () => {
+      window.removeEventListener('branch_dashboard_update', handleBranchUpdate);
+      clearInterval(interval);
+    };
   }, [fetchBranches]);
 
 

--- a/src/components/dashboards/PRDashboard.tsx
+++ b/src/components/dashboards/PRDashboard.tsx
@@ -353,16 +353,23 @@ export function PRDashboard({
   }, [initialWorkspaceId]);
   fetchPRsRef.current = fetchPRs;
 
-  // Initial fetch and auto-refresh
+  // Initial fetch + WebSocket-driven refresh + slow fallback poll
   useEffect(() => {
     fetchPRs();
 
-    // Auto-refresh every 60 seconds
+    // Listen for WebSocket invalidation events from PRWatcher
+    const handlePRUpdate = () => fetchPRsRef.current(true);
+    window.addEventListener('pr_dashboard_update', handlePRUpdate);
+
+    // Slow fallback poll (5 minutes) as a safety net
     const interval = setInterval(() => {
       fetchPRs(true);
-    }, 60000);
+    }, 300000);
 
-    return () => clearInterval(interval);
+    return () => {
+      window.removeEventListener('pr_dashboard_update', handlePRUpdate);
+      clearInterval(interval);
+    };
   }, [fetchPRs]);
 
   const handleJumpToSession = useCallback((workspaceId: string, sessionId: string) => {

--- a/src/hooks/usePRStatus.ts
+++ b/src/hooks/usePRStatus.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getPRStatus, type PRDetails } from '@/lib/api';
 
-const PR_STATUS_POLL_INTERVAL_MS = 60000; // 60 seconds
+const PR_STATUS_FALLBACK_POLL_MS = 300000; // 5 minutes (fallback, WebSocket is primary)
 
 interface UsePRStatusResult {
   prDetails: PRDetails | null;
@@ -80,13 +80,13 @@ export function usePRStatus(
     };
   }, [fetchStatus, prStatus]);
 
-  // Periodic polling only when PR is open
+  // Slow fallback poll when PR is open (WebSocket is the primary update mechanism)
   useEffect(() => {
     if (!workspaceId || !sessionId || prStatus !== 'open') return;
 
     const interval = setInterval(() => {
       fetchStatus();
-    }, PR_STATUS_POLL_INTERVAL_MS);
+    }, PR_STATUS_FALLBACK_POLL_MS);
 
     return () => clearInterval(interval);
   }, [workspaceId, sessionId, prStatus, fetchStatus]);

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -437,6 +437,13 @@ export function useWebSocket(enabled: boolean = true) {
           return;
         }
 
+        // Handle dashboard-level invalidation events (PR or branch changes)
+        if (data.type === 'pr_dashboard_update' || data.type === 'branch_dashboard_update') {
+          window.dispatchEvent(new CustomEvent(data.type, { detail: data.payload }));
+          // Don't return -- pr_dashboard_update is also followed by session_pr_update
+          // which we still want to process
+        }
+
         // Handle session PR status update (background GitHub polling)
         if (data.type === 'session_pr_update' && data.sessionId) {
           const payload = data.payload as Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

Address 6 code review comments on PR branch caching:

1. **Deep-copy PRDetails** — SetFull/SetDetails now deep-copy PRDetails values including CheckDetails slices to prevent caller mutation from corrupting cache
2. **Capture ETag on first fetch** — Initial cache-miss path now uses ListOpenPRsWithETag to store ETag, enabling conditional requests on first background refresh
3. **Shutdown-aware refresh** — refreshPRCache respects prCache.Done() channel so background refreshes cancel on server shutdown (30s timeout OR shutdown, whichever first)
4. **Panic recovery** — Added recover() in refreshPRCache to log panics (EndRefresh defer still guarantees cleanup)
5. **Documented watcher limitation** — Added comment explaining that PRWatcher entries lack details/ETag
6. **Enhanced test** — TestPRCache_SetFull_ImmutableDetails now verifies deep copy of CheckDetails slices

All existing tests pass.