### PR TITLE
Rename conductor MCP server to chatml

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -23,7 +23,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import * as readline from "readline";
 import { WorkspaceContext } from "./mcp/context.js";
-import { createConductorMcpServer } from "./mcp/server.js";
+import { createChatMLMcpServer } from "./mcp/server.js";
 
 function resolveToolPreset(preset: string): { allowedTools?: string[]; disallowedTools?: string[] } {
   switch (preset) {
@@ -676,8 +676,8 @@ async function main(): Promise<void> {
       linearIssue,
     });
 
-    // Create conductor MCP server
-    const conductorMcp = createConductorMcpServer({ context: workspaceContext });
+    // Create ChatML MCP server
+    const chatmlMcp = createChatMLMcpServer({ context: workspaceContext });
 
     // Resolve tool preset to allowedTools/disallowedTools
     const presetConfig = resolveToolPreset(toolPreset);
@@ -689,7 +689,7 @@ async function main(): Promise<void> {
         permissionMode: "bypassPermissions",
         allowDangerouslySkipPermissions: true,
         canUseTool,
-        mcpServers: { conductor: conductorMcp },
+        mcpServers: { chatml: chatmlMcp },
         includePartialMessages: true,
         tools: { type: "preset", preset: "claude_code" },
         systemPrompt: { type: "preset", preset: "claude_code" },

--- a/agent-runner/src/mcp/server.ts
+++ b/agent-runner/src/mcp/server.ts
@@ -9,11 +9,11 @@ export interface McpServerOptions {
   context: WorkspaceContext;
 }
 
-export function createConductorMcpServer(options: McpServerOptions) {
+export function createChatMLMcpServer(options: McpServerOptions) {
   const { context } = options;
 
   return createSdkMcpServer({
-    name: "conductor",
+    name: "chatml",
     version: "1.0.0",
     tools: [
       // Session status tool

--- a/docs/claude-sdk-events.md
+++ b/docs/claude-sdk-events.md
@@ -71,7 +71,7 @@ const result = await query(
     systemPrompts: { preset: "claude_code" },
     resume: resumeSessionId,
     forkSession: forkSession && !!resumeSessionId,
-    mcpServers: { conductor: conductorMcp },
+    mcpServers: { chatml: chatmlMcp },
     maxBudgetUsd: maxBudgetUsd,
     maxTurns: maxTurns,
     maxThinkingTokens: maxThinkingTokens,
@@ -214,7 +214,7 @@ interface OutputEvent {
   model: "claude-sonnet-4-20250514",
   tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", ...],
   mcpServers: [
-    { name: "conductor", status: "connected", tools: [...] }
+    { name: "chatml", status: "connected", tools: [...] }
   ],
   slashCommands: ["/commit", "/review-pr", ...],
   skills: ["test-driven-development", "systematic-debugging", ...],

--- a/docs/plans/2026-01-19-phase4-mcp-custom-tools-design.md
+++ b/docs/plans/2026-01-19-phase4-mcp-custom-tools-design.md
@@ -27,7 +27,7 @@ agent-runner/src/mcp/
 ```
 agent-runner process
 ├── query() with mcpServers config
-│   └── "conductor": createSdkMcpServer()
+│   └── "chatml": createSdkMcpServer()
 │       ├── Tools registered via tool()
 │       └── Shared WorkspaceContext
 └── MCP status events emitted to frontend
@@ -166,7 +166,7 @@ New **MCP Servers** tab in the right sidebar bottom section (alongside Setup/Run
 ┌─────────────────────────────┐
 │ [Setup] [Run] [MCP Servers] │
 ├─────────────────────────────┤
-│ 🟢 conductor     connected  │
+│ 🟢 chatml        connected  │
 │ 🟢 linear        connected  │
 │ 🟡 github        needs-auth │
 │ 🔴 postgres      failed     │
@@ -221,7 +221,7 @@ New **MCP Servers** tab in the right sidebar bottom section (alongside Setup/Run
 
 ## Verification
 
-- Start agent and verify `conductor` MCP server connects
+- Start agent and verify `chatml` MCP server connects
 - Test workspace tools return correct session/git state
 - Test Linear tools create branches and update issues
 - Verify MCP status displays in right sidebar

--- a/docs/plans/2026-01-19-phase4-mcp-implementation.md
+++ b/docs/plans/2026-01-19-phase4-mcp-implementation.md
@@ -205,11 +205,11 @@ export interface McpServerOptions {
   context: WorkspaceContext;
 }
 
-export function createConductorMcpServer(options: McpServerOptions) {
+export function createChatMLMcpServer(options: McpServerOptions) {
   const { context } = options;
 
   return createSdkMcpServer({
-    name: "conductor",
+    name: "chatml",
     version: "1.0.0",
     tools: [
       // Session status tool
@@ -329,7 +329,7 @@ Find line with existing imports and add:
 
 ```typescript
 import { WorkspaceContext } from "./mcp/context.js";
-import { createConductorMcpServer } from "./mcp/server.js";
+import { createChatMLMcpServer } from "./mcp/server.js";
 ```
 
 **Step 2: Parse new CLI arguments (after line ~37)**
@@ -365,8 +365,8 @@ const workspaceContext = new WorkspaceContext({
   linearIssue,
 });
 
-// Create conductor MCP server
-const conductorMcp = createConductorMcpServer({ context: workspaceContext });
+// Create ChatML MCP server
+const chatmlMcp = createChatMLMcpServer({ context: workspaceContext });
 ```
 
 **Step 4: Add mcpServers to query options**
@@ -380,7 +380,7 @@ options: {
 
 Add inside options object:
 ```typescript
-mcpServers: [conductorMcp],
+mcpServers: [chatmlMcp],
 ```
 
 **Step 5: Build and verify**
@@ -392,7 +392,7 @@ Expected: Compilation succeeds
 
 ```bash
 git add agent-runner/src/index.ts
-git commit -m "feat(mcp): wire conductor MCP server into agent runner"
+git commit -m "feat(mcp): wire chatml MCP server into agent runner"
 ```
 
 ---
@@ -870,7 +870,7 @@ npm run build
 **Step 2: Run the app and verify**
 
 1. Start the app
-2. Start a conversation - verify "conductor" MCP server appears in status
+2. Start a conversation - verify "chatml" MCP server appears in status
 3. Ask agent to use `get_session_status` tool
 4. Check MCP Servers tab shows server status
 
@@ -885,7 +885,7 @@ git commit -m "feat: complete Phase 4 MCP & Custom Tools implementation"
 
 ## Verification Checklist
 
-- [ ] `conductor` MCP server connects when agent starts
+- [ ] `chatml` MCP server connects when agent starts
 - [ ] `get_session_status` returns correct git state
 - [ ] `get_workspace_diff` returns diff summary
 - [ ] `get_recent_activity` returns commit history

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -353,13 +353,13 @@ func (h *Handlers) RewindConversation(w http.ResponseWriter, r *http.Request) {
 
 ## MCP Integration
 
-### Conductor MCP Server
+### ChatML MCP Server
 
 **File: `agent-runner/src/mcp/server.ts:12-114`**
 
 ```mermaid
 flowchart TB
-    subgraph MCPServer["Conductor MCP Server"]
+    subgraph MCPServer["ChatML MCP Server"]
         GSS[get_session_status]
         GWD[get_workspace_diff]
         GRA[get_recent_activity]

--- a/src/components/dialogs/QuickStartDialog.tsx
+++ b/src/components/dialogs/QuickStartDialog.tsx
@@ -25,7 +25,7 @@ type Template = 'empty' | 'nextjs';
 // Generate a unique default project name with timestamp
 function generateDefaultName(): string {
   const timestamp = Date.now().toString(36).slice(-4);
-  return `conductor-playground-${timestamp}`;
+  return `chatml-playground-${timestamp}`;
 }
 
 export function QuickStartDialog({ isOpen, onClose }: QuickStartDialogProps) {
@@ -93,7 +93,7 @@ export function QuickStartDialog({ isOpen, onClose }: QuickStartDialogProps) {
         <DialogHeader>
           <DialogTitle>Quick start</DialogTitle>
           <DialogDescription>
-            Conductor will create a new folder and GitHub repo for you.
+            ChatML will create a new folder and GitHub repo for you.
           </DialogDescription>
         </DialogHeader>
 
@@ -105,7 +105,7 @@ export function QuickStartDialog({ isOpen, onClose }: QuickStartDialogProps) {
                 id="project-name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="conductor-playground"
+                placeholder="chatml-playground"
                 className="text-sm"
                 autoFocus
               />


### PR DESCRIPTION
## Summary

Rename the internal MCP server from "conductor" to "chatml" across the codebase. This includes source code function names, variable references, user-facing UI strings, and documentation.

## Changes

- MCP server creation function: `createConductorMcpServer` → `createChatMLMcpServer`
- Variable naming: `conductorMcp` → `chatmlMcp`
- MCP server identifier: `conductor` → `chatml`
- QuickStartDialog strings updated to reflect ChatML branding

## Testing

Changes are purely refactoring with no behavioral modifications. All references are consistent across source and documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)