### PR TITLE
feat: add smart branch cleanup wizard

### DIFF
--- a/backend/git/cleanup.go
+++ b/backend/git/cleanup.go
@@ -1,0 +1,484 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CleanupCategory represents the category of a branch cleanup candidate
+type CleanupCategory string
+
+const (
+	CategoryMerged   CleanupCategory = "merged"
+	CategoryStale    CleanupCategory = "stale"
+	CategoryOrphaned CleanupCategory = "orphaned"
+	CategorySafe     CleanupCategory = "safe"
+)
+
+// protectedBranchNames are branches that should never be deleted
+var protectedBranchNames = map[string]bool{
+	"main":    true,
+	"master":  true,
+	"develop": true,
+}
+
+// CleanupCandidate represents a branch that has been analyzed for cleanup
+type CleanupCandidate struct {
+	Name              string          `json:"name"`
+	IsRemote          bool            `json:"isRemote"`
+	Category          CleanupCategory `json:"category"`
+	Reason            string          `json:"reason"`
+	LastCommitDate    string          `json:"lastCommitDate"`
+	LastAuthor        string          `json:"lastAuthor"`
+	HasLocalAndRemote bool            `json:"hasLocalAndRemote"`
+	SessionID         string          `json:"sessionId,omitempty"`
+	SessionName       string          `json:"sessionName,omitempty"`
+	SessionStatus     string          `json:"sessionStatus,omitempty"`
+	IsProtected       bool            `json:"isProtected"`
+	Deletable         bool            `json:"deletable"`
+}
+
+// CleanupAnalysisRequest contains parameters for branch cleanup analysis
+type CleanupAnalysisRequest struct {
+	StaleDaysThreshold int  `json:"staleDaysThreshold"`
+	IncludeRemote      bool `json:"includeRemote"`
+}
+
+// CleanupAnalysisResponse contains the results of branch cleanup analysis
+type CleanupAnalysisResponse struct {
+	Candidates     []CleanupCandidate `json:"candidates"`
+	Summary        map[string]int     `json:"summary"`
+	ProtectedCount int                `json:"protectedCount"`
+	TotalAnalyzed  int                `json:"totalAnalyzed"`
+}
+
+// CleanupBranchTarget specifies a branch to delete and which copies (local/remote) to remove
+type CleanupBranchTarget struct {
+	Name         string `json:"name"`
+	DeleteLocal  bool   `json:"deleteLocal"`
+	DeleteRemote bool   `json:"deleteRemote"`
+}
+
+// CleanupRequest contains the list of branches to delete
+type CleanupRequest struct {
+	Branches []CleanupBranchTarget `json:"branches"`
+}
+
+// CleanupBranchResult contains the result of deleting a single branch
+type CleanupBranchResult struct {
+	Name          string `json:"name"`
+	DeletedLocal  bool   `json:"deletedLocal"`
+	DeletedRemote bool   `json:"deletedRemote"`
+	Error         string `json:"error,omitempty"`
+}
+
+// CleanupResult contains the overall results of a branch cleanup operation.
+// Note: entries in Failed may have partial deletions (e.g. DeletedLocal=true
+// when the local branch was removed but the remote deletion failed).
+type CleanupResult struct {
+	Succeeded []CleanupBranchResult `json:"succeeded"`
+	Failed    []CleanupBranchResult `json:"failed"`
+}
+
+// SessionInfo contains session metadata for branch analysis
+type SessionInfo struct {
+	ID     string
+	Name   string
+	Status string
+}
+
+// AnalyzeBranchesForCleanup analyzes all branches in a repository and categorizes them for cleanup
+func (rm *RepoManager) AnalyzeBranchesForCleanup(
+	ctx context.Context,
+	repoPath string,
+	staleDays int,
+	includeRemote bool,
+	sessionBranches map[string]*SessionInfo,
+) (*CleanupAnalysisResponse, error) {
+	if staleDays <= 0 {
+		staleDays = 90
+	}
+
+	// Get all branches
+	opts := BranchListOptions{
+		IncludeRemote: includeRemote,
+		Limit:         0, // all
+		SortBy:        "date",
+		SortDesc:      true,
+	}
+	branchResult, err := rm.ListBranches(ctx, repoPath, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list branches: %w", err)
+	}
+
+	// Get current HEAD branch
+	currentBranch, _ := rm.GetCurrentBranch(ctx, repoPath)
+
+	// Get merged branches (local)
+	mergedLocal := rm.getMergedBranches(ctx, repoPath, false)
+	// Get merged branches (remote)
+	var mergedRemote map[string]bool
+	if includeRemote {
+		mergedRemote = rm.getMergedBranches(ctx, repoPath, true)
+	}
+
+	// Get orphaned branches (local only, no upstream tracking)
+	orphanedLocal := rm.getOrphanedBranches(ctx, repoPath)
+
+	// Build a set of local branch names and remote branch names for cross-referencing
+	localBranches := make(map[string]bool)
+	remoteBranches := make(map[string]bool)
+	for _, b := range branchResult.Branches {
+		if b.IsRemote {
+			// Strip "origin/" prefix for matching
+			name := strings.TrimPrefix(b.Name, "origin/")
+			remoteBranches[name] = true
+		} else {
+			localBranches[b.Name] = true
+		}
+	}
+
+	staleThreshold := time.Now().AddDate(0, 0, -staleDays)
+
+	response := &CleanupAnalysisResponse{
+		Candidates: []CleanupCandidate{},
+		Summary:    make(map[string]int),
+	}
+
+	for _, branch := range branchResult.Branches {
+		candidate := CleanupCandidate{
+			Name:           branch.Name,
+			IsRemote:       branch.IsRemote,
+			LastCommitDate: branch.LastCommitDate.Format(time.RFC3339),
+			LastAuthor:     branch.LastAuthor,
+		}
+
+		// Check if branch exists in both local and remote
+		if branch.IsRemote {
+			remoteName := strings.TrimPrefix(branch.Name, "origin/")
+			candidate.HasLocalAndRemote = localBranches[remoteName]
+		} else {
+			candidate.HasLocalAndRemote = remoteBranches[branch.Name]
+		}
+
+		// Attach session info
+		if si, ok := sessionBranches[branch.Name]; ok {
+			candidate.SessionID = si.ID
+			candidate.SessionName = si.Name
+			candidate.SessionStatus = si.Status
+		}
+
+		// Determine category
+		rm.categorizeBranch(
+			&candidate,
+			branch,
+			currentBranch,
+			mergedLocal,
+			mergedRemote,
+			orphanedLocal,
+			staleThreshold,
+			staleDays,
+		)
+
+		response.Candidates = append(response.Candidates, candidate)
+		response.Summary[string(candidate.Category)]++
+		if candidate.IsProtected {
+			response.ProtectedCount++
+		}
+	}
+
+	response.TotalAnalyzed = len(branchResult.Branches)
+
+	return response, nil
+}
+
+// categorizeBranch determines the cleanup category for a single branch
+func (rm *RepoManager) categorizeBranch(
+	candidate *CleanupCandidate,
+	branch BranchInfo,
+	currentBranch string,
+	mergedLocal map[string]bool,
+	mergedRemote map[string]bool,
+	orphanedLocal map[string]bool,
+	staleThreshold time.Time,
+	staleDays int,
+) {
+	// Check if protected
+	isProtected := rm.isBranchProtected(branch, currentBranch, candidate.SessionStatus)
+	candidate.IsProtected = isProtected
+
+	if isProtected {
+		candidate.Category = CategorySafe
+		candidate.Deletable = false
+		candidate.Reason = rm.getProtectedReason(branch, currentBranch, candidate.SessionStatus)
+		return
+	}
+
+	// Check if merged
+	if branch.IsRemote {
+		remoteName := branch.Name
+		if mergedRemote != nil && mergedRemote[remoteName] {
+			candidate.Category = CategoryMerged
+			candidate.Deletable = true
+			candidate.Reason = "Fully merged into main"
+			return
+		}
+	} else {
+		if mergedLocal[branch.Name] {
+			candidate.Category = CategoryMerged
+			candidate.Deletable = true
+			candidate.Reason = "Fully merged into main"
+			return
+		}
+	}
+
+	// Check if stale
+	if !branch.LastCommitDate.IsZero() && branch.LastCommitDate.Before(staleThreshold) {
+		daysSinceCommit := int(time.Since(branch.LastCommitDate).Hours() / 24)
+		candidate.Category = CategoryStale
+		candidate.Deletable = true
+		candidate.Reason = fmt.Sprintf("No commits in %d days", daysSinceCommit)
+		return
+	}
+
+	// Check if orphaned (local only, no remote tracking branch)
+	if !branch.IsRemote && orphanedLocal[branch.Name] {
+		candidate.Category = CategoryOrphaned
+		candidate.Deletable = true
+		candidate.Reason = "No remote tracking branch"
+		return
+	}
+
+	// Otherwise, it's safe/active
+	candidate.Category = CategorySafe
+	candidate.Deletable = false
+	candidate.Reason = "Active branch"
+}
+
+// isBranchProtected checks if a branch should never be deleted
+func (rm *RepoManager) isBranchProtected(branch BranchInfo, currentBranch string, sessionStatus string) bool {
+	name := branch.Name
+	if branch.IsRemote {
+		name = strings.TrimPrefix(name, "origin/")
+	}
+
+	// HEAD branch
+	if branch.IsHead || name == currentBranch {
+		return true
+	}
+
+	// Protected names
+	if protectedBranchNames[name] {
+		return true
+	}
+
+	// Active or idle sessions
+	if sessionStatus == "active" || sessionStatus == "idle" {
+		return true
+	}
+
+	return false
+}
+
+// getProtectedReason returns a human-readable reason why a branch is protected
+func (rm *RepoManager) getProtectedReason(branch BranchInfo, currentBranch string, sessionStatus string) string {
+	name := branch.Name
+	if branch.IsRemote {
+		name = strings.TrimPrefix(name, "origin/")
+	}
+
+	if branch.IsHead || name == currentBranch {
+		return "Current HEAD branch"
+	}
+	if protectedBranchNames[name] {
+		return "Protected branch"
+	}
+	if sessionStatus == "active" || sessionStatus == "idle" {
+		return fmt.Sprintf("Active session (%s)", sessionStatus)
+	}
+	return "Protected"
+}
+
+// getMergedBranches returns a set of branch names that are fully merged into origin/main
+func (rm *RepoManager) getMergedBranches(ctx context.Context, repoPath string, remote bool) map[string]bool {
+	merged := make(map[string]bool)
+
+	// Try origin/main first, then main, then origin/master, master
+	bases := []string{"origin/main", "main", "origin/master", "master"}
+	for _, base := range bases {
+		args := []string{"branch", "--merged", base}
+		if remote {
+			args = append(args, "-r")
+		}
+
+		cmd, cancel := gitCmdWithContext(ctx, repoPath, args...)
+		out, err := cmd.Output()
+		cancel()
+		if err != nil {
+			continue
+		}
+
+		lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+		for _, line := range lines {
+			name := strings.TrimSpace(line)
+			// Remove the "* " prefix for current branch
+			name = strings.TrimPrefix(name, "* ")
+			name = strings.TrimSpace(name)
+			if name != "" {
+				merged[name] = true
+			}
+		}
+		// Return on first successful command (even if empty — an empty result
+		// means no branches are merged into this base, which is valid).
+		// We only fall through to the next base on git command error.
+		return merged
+	}
+
+	return merged
+}
+
+// getOrphanedBranches returns local branches that have no upstream tracking branch
+func (rm *RepoManager) getOrphanedBranches(ctx context.Context, repoPath string) map[string]bool {
+	orphaned := make(map[string]bool)
+
+	// Get all local branches with their upstream
+	cmd, cancel := gitCmdWithContext(ctx, repoPath,
+		"for-each-ref", "--format=%(refname:short) %(upstream)", "refs/heads/")
+	out, err := cmd.Output()
+	cancel()
+	if err != nil {
+		return orphaned
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		branchName := parts[0]
+		upstream := ""
+		if len(parts) > 1 {
+			upstream = strings.TrimSpace(parts[1])
+		}
+		if upstream == "" {
+			orphaned[branchName] = true
+		}
+	}
+
+	return orphaned
+}
+
+// DeleteBranches deletes the specified branches with safety checks
+func (rm *RepoManager) DeleteBranches(
+	ctx context.Context,
+	repoPath string,
+	targets []CleanupBranchTarget,
+	sessionBranches map[string]*SessionInfo,
+) (*CleanupResult, error) {
+	result := &CleanupResult{
+		Succeeded: []CleanupBranchResult{},
+		Failed:    []CleanupBranchResult{},
+	}
+
+	// Get current HEAD for safety
+	currentBranch, _ := rm.GetCurrentBranch(ctx, repoPath)
+
+	// Get merged branches for safe vs force delete decision
+	mergedLocal := rm.getMergedBranches(ctx, repoPath, false)
+
+	for _, target := range targets {
+		branchResult := CleanupBranchResult{Name: target.Name}
+
+		// Validate branch name
+		if err := ValidateGitRef(target.Name); err != nil {
+			branchResult.Error = fmt.Sprintf("invalid branch name: %v", err)
+			result.Failed = append(result.Failed, branchResult)
+			continue
+		}
+
+		// Safety: never delete protected branches
+		if rm.isNameProtected(target.Name, currentBranch, sessionBranches) {
+			branchResult.Error = "branch is protected and cannot be deleted"
+			result.Failed = append(result.Failed, branchResult)
+			continue
+		}
+
+		// Delete local branch
+		if target.DeleteLocal {
+			err := rm.deleteLocalBranch(ctx, repoPath, target.Name, mergedLocal[target.Name])
+			if err != nil {
+				branchResult.Error = fmt.Sprintf("local delete failed: %v", err)
+				result.Failed = append(result.Failed, branchResult)
+				continue
+			}
+			branchResult.DeletedLocal = true
+		}
+
+		// Delete remote branch
+		if target.DeleteRemote {
+			remoteName := strings.TrimPrefix(target.Name, "origin/")
+			err := rm.deleteRemoteBranch(ctx, repoPath, remoteName)
+			if err != nil {
+				// If local succeeded but remote failed, still report as failed
+				branchResult.Error = fmt.Sprintf("remote delete failed: %v", err)
+				result.Failed = append(result.Failed, branchResult)
+				continue
+			}
+			branchResult.DeletedRemote = true
+		}
+
+		result.Succeeded = append(result.Succeeded, branchResult)
+	}
+
+	return result, nil
+}
+
+// isNameProtected checks if a branch name should never be deleted (re-validation before deletion)
+func (rm *RepoManager) isNameProtected(name string, currentBranch string, sessionBranches map[string]*SessionInfo) bool {
+	cleanName := strings.TrimPrefix(name, "origin/")
+
+	if cleanName == currentBranch {
+		return true
+	}
+	if protectedBranchNames[cleanName] {
+		return true
+	}
+	if si, ok := sessionBranches[name]; ok {
+		if si.Status == "active" || si.Status == "idle" {
+			return true
+		}
+	}
+	return false
+}
+
+// deleteLocalBranch deletes a local git branch
+func (rm *RepoManager) deleteLocalBranch(ctx context.Context, repoPath string, name string, isMerged bool) error {
+	// Use -d (safe) for merged branches, -D (force) for unmerged
+	flag := "-d"
+	if !isMerged {
+		flag = "-D"
+	}
+
+	cmd, cancel := gitCmdWithContext(ctx, repoPath, "branch", flag, name)
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// deleteRemoteBranch deletes a remote branch
+func (rm *RepoManager) deleteRemoteBranch(ctx context.Context, repoPath string, name string) error {
+	cmd, cancel := gitCmdWithContext(ctx, repoPath, "push", "origin", "--delete", name)
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -885,6 +885,130 @@ func (h *Handlers) ListBranches(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, response)
 }
 
+// getSessionBranchMap builds a mapping from branch name to session info for a workspace
+func (h *Handlers) getSessionBranchMap(ctx context.Context, workspaceID string) (map[string]*git.SessionInfo, error) {
+	sessions, err := h.store.ListSessions(ctx, workspaceID, false)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionBranches := make(map[string]*git.SessionInfo)
+	for _, sess := range sessions {
+		if sess.Branch != "" {
+			sessionBranches[sess.Branch] = &git.SessionInfo{
+				ID:     sess.ID,
+				Name:   sess.Name,
+				Status: sess.Status,
+			}
+		}
+	}
+	return sessionBranches, nil
+}
+
+// AnalyzeBranchCleanup analyzes branches for cleanup and returns categorized candidates
+// POST /api/repos/{id}/branches/analyze-cleanup
+func (h *Handlers) AnalyzeBranchCleanup(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	workspaceID := chi.URLParam(r, "id")
+
+	// Get the workspace
+	repo, err := h.store.GetRepo(ctx, workspaceID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if repo == nil {
+		writeNotFound(w, "workspace")
+		return
+	}
+
+	// Parse request body
+	var req git.CleanupAnalysisRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+	if req.StaleDaysThreshold <= 0 {
+		req.StaleDaysThreshold = 90
+	}
+
+	// Get sessions for branch -> session mapping
+	sessionBranches, err := h.getSessionBranchMap(ctx, workspaceID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+
+	// Run analysis
+	response, err := h.repoManager.AnalyzeBranchesForCleanup(
+		ctx, repo.Path, req.StaleDaysThreshold, req.IncludeRemote, sessionBranches,
+	)
+	if err != nil {
+		writeInternalError(w, "failed to analyze branches", err)
+		return
+	}
+
+	writeJSON(w, response)
+}
+
+// ExecuteBranchCleanup deletes the specified branches
+// POST /api/repos/{id}/branches/cleanup
+func (h *Handlers) ExecuteBranchCleanup(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	workspaceID := chi.URLParam(r, "id")
+
+	// Get the workspace
+	repo, err := h.store.GetRepo(ctx, workspaceID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if repo == nil {
+		writeNotFound(w, "workspace")
+		return
+	}
+
+	// Parse request body
+	var req git.CleanupRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+	if len(req.Branches) == 0 {
+		writeValidationError(w, "no branches specified")
+		return
+	}
+
+	// Get sessions for safety checks
+	sessionBranches, err := h.getSessionBranchMap(ctx, workspaceID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+
+	// Execute cleanup
+	result, err := h.repoManager.DeleteBranches(ctx, repo.Path, req.Branches, sessionBranches)
+	if err != nil {
+		writeInternalError(w, "failed to delete branches", err)
+		return
+	}
+
+	// Invalidate branch cache and notify clients
+	h.branchCache.InvalidateRepo(repo.Path)
+	if h.hub != nil {
+		h.hub.Broadcast(Event{
+			Type: "branch_dashboard_update",
+			Payload: map[string]interface{}{
+				"reason":    "branch_cleanup",
+				"succeeded": len(result.Succeeded),
+				"failed":    len(result.Failed),
+			},
+		})
+	}
+
+	writeJSON(w, result)
+}
+
 // GetAvatars returns GitHub avatar URLs for a batch of email addresses
 // GET /api/avatars?emails=email1@example.com,email2@example.com
 func (h *Handlers) GetAvatars(w http.ResponseWriter, r *http.Request) {

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -74,6 +74,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Get("/{id}/details", h.GetRepoDetails)
 		r.Delete("/{id}", h.DeleteRepo)
 		r.Get("/{id}/branches", h.ListBranches)
+		r.Post("/{id}/branches/analyze-cleanup", h.AnalyzeBranchCleanup)
+		r.Post("/{id}/branches/cleanup", h.ExecuteBranchCleanup)
 		r.Get("/{id}/files", h.ListRepoFiles)
 		r.Get("/{id}/file", h.GetRepoFileContent)
 		r.Post("/{id}/file/save", h.SaveFile)

--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -19,7 +19,9 @@ import {
   ArrowRight,
   Copy,
   Cloud,
+  Wand2,
 } from 'lucide-react';
+import { BranchCleanupDialog } from '@/components/dialogs/branch-cleanup/BranchCleanupDialog';
 import { cn } from '@/lib/utils';
 import { getWorkspaceColor } from '@/lib/workspace-colors';
 
@@ -212,6 +214,7 @@ export function BranchesDashboard({
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [showRemote, setShowRemote] = useState(false);
+  const [cleanupOpen, setCleanupOpen] = useState(false);
 
   const fetchBranchesRef = useRef<(isRefresh?: boolean) => void>(() => {});
   const hasFetchedRef = useRef(false);
@@ -251,16 +254,27 @@ export function BranchesDashboard({
       ) : undefined,
       titlePosition: 'left' as const,
       actions: (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6"
-          onClick={() => fetchBranchesRef.current(true)}
-          disabled={refreshing}
-          title="Refresh"
-        >
-          <RefreshCw className={cn('h-3.5 w-3.5', refreshing && 'animate-spin')} />
-        </Button>
+        <>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs"
+            onClick={() => setCleanupOpen(true)}
+          >
+            <Wand2 className="h-3.5 w-3.5" />
+            Smart Branch Cleanup
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => fetchBranchesRef.current(true)}
+            disabled={refreshing}
+            title="Refresh"
+          >
+            <RefreshCw className={cn('h-3.5 w-3.5', refreshing && 'animate-spin')} />
+          </Button>
+        </>
       ),
     },
   }), [workspace, workspaceId, branchData, refreshing]);
@@ -551,6 +565,13 @@ export function BranchesDashboard({
           </>
         )}
       </div>
+
+      <BranchCleanupDialog
+        open={cleanupOpen}
+        onOpenChange={setCleanupOpen}
+        workspaceId={workspaceId}
+        onComplete={() => fetchBranchesRef.current(true)}
+      />
     </FullContentLayout>
   );
 }

--- a/src/components/dialogs/branch-cleanup/BranchCleanupDialog.tsx
+++ b/src/components/dialogs/branch-cleanup/BranchCleanupDialog.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { executeBranchCleanup } from '@/lib/api';
+import { useCleanupReducer } from './useCleanupReducer';
+import { CleanupStepAnalysis } from './CleanupStepAnalysis';
+import { CleanupStepReview } from './CleanupStepReview';
+import { CleanupStepConfirmation } from './CleanupStepConfirmation';
+import { CleanupStepExecution } from './CleanupStepExecution';
+import { CleanupStepResults } from './CleanupStepResults';
+
+interface BranchCleanupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+  onComplete: () => void;
+}
+
+export function BranchCleanupDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  onComplete,
+}: BranchCleanupDialogProps) {
+  const [state, dispatch] = useCleanupReducer();
+
+  const handleCancel = useCallback(() => {
+    onOpenChange(false);
+    // Reset state after dialog closes
+    setTimeout(() => dispatch({ type: 'RESET' }), 200);
+  }, [onOpenChange, dispatch]);
+
+  const handleDone = useCallback(() => {
+    onOpenChange(false);
+    onComplete();
+    setTimeout(() => dispatch({ type: 'RESET' }), 200);
+  }, [onOpenChange, onComplete, dispatch]);
+
+  const handleExecute = useCallback(async () => {
+    dispatch({ type: 'SET_STEP', step: 'execution' });
+    dispatch({ type: 'SET_LOADING', loading: true });
+
+    try {
+      const targets = Array.from(state.selectedBranches.values());
+      const result = await executeBranchCleanup(workspaceId, targets);
+      dispatch({ type: 'SET_RESULTS', results: result });
+    } catch (err) {
+      dispatch({
+        type: 'SET_ERROR',
+        error: err instanceof Error ? err.message : 'Cleanup failed',
+      });
+      dispatch({ type: 'SET_STEP', step: 'confirmation' });
+    }
+  }, [workspaceId, state.selectedBranches, dispatch]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    // Prevent closing during execution
+    if (state.step === 'execution') return;
+    if (!nextOpen) {
+      handleCancel();
+    }
+  }, [state.step, handleCancel]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={state.step !== 'execution'} className="sm:max-w-2xl">
+        {state.step === 'analysis' && (
+          <CleanupStepAnalysis
+            workspaceId={workspaceId}
+            staleDaysThreshold={state.staleDaysThreshold}
+            retryCount={state.retryCount}
+            isLoading={state.isLoading}
+            error={state.error}
+            dispatch={dispatch}
+            onCancel={handleCancel}
+          />
+        )}
+
+        {state.step === 'review' && (
+          <CleanupStepReview
+            state={state}
+            dispatch={dispatch}
+            onCancel={handleCancel}
+          />
+        )}
+
+        {state.step === 'confirmation' && (
+          <CleanupStepConfirmation
+            state={state}
+            dispatch={dispatch}
+            onExecute={handleExecute}
+          />
+        )}
+
+        {state.step === 'execution' && (
+          <CleanupStepExecution
+            totalCount={state.selectedBranches.size}
+          />
+        )}
+
+        {state.step === 'results' && state.results && (
+          <CleanupStepResults
+            results={state.results}
+            onDone={handleDone}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dialogs/branch-cleanup/CleanupStepAnalysis.tsx
+++ b/src/components/dialogs/branch-cleanup/CleanupStepAnalysis.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Loader2, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { analyzeBranchCleanup } from '@/lib/api';
+import type { CleanupAction } from './types';
+
+interface CleanupStepAnalysisProps {
+  workspaceId: string;
+  staleDaysThreshold: number;
+  retryCount: number;
+  isLoading: boolean;
+  error: string | null;
+  dispatch: React.Dispatch<CleanupAction>;
+  onCancel: () => void;
+}
+
+export function CleanupStepAnalysis({
+  workspaceId,
+  staleDaysThreshold,
+  retryCount,
+  isLoading,
+  error,
+  dispatch,
+  onCancel,
+}: CleanupStepAnalysisProps) {
+  useEffect(() => {
+    let cancelled = false;
+
+    async function runAnalysis() {
+      dispatch({ type: 'SET_LOADING', loading: true });
+      dispatch({ type: 'SET_ERROR', error: '' });
+
+      try {
+        const result = await analyzeBranchCleanup(workspaceId, {
+          staleDaysThreshold,
+          includeRemote: true,
+        });
+        if (!cancelled) {
+          dispatch({ type: 'SET_ANALYSIS', analysis: result });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          dispatch({ type: 'SET_ERROR', error: err instanceof Error ? err.message : 'Analysis failed' });
+        }
+      }
+    }
+
+    runAnalysis();
+    return () => { cancelled = true; };
+  }, [workspaceId, staleDaysThreshold, retryCount, dispatch]);
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {error ? 'Analysis failed' : 'Analyzing branches...'}
+        </DialogTitle>
+        <DialogDescription>
+          {error
+            ? 'Something went wrong while scanning your branches.'
+            : 'Scanning repository for branches that can be safely cleaned up.'}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex flex-col items-center justify-center py-8 gap-4">
+        {isLoading && !error && (
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        )}
+
+        {error && (
+          <div className="text-center space-y-3">
+            <p className="text-sm text-destructive">{error}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => dispatch({ type: 'RETRY' })}
+            >
+              <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+              Retry
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/components/dialogs/branch-cleanup/CleanupStepConfirmation.tsx
+++ b/src/components/dialogs/branch-cleanup/CleanupStepConfirmation.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useMemo } from 'react';
+import { AlertTriangle, GitBranch, Cloud, Monitor, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { CleanupAction, CleanupState } from './types';
+
+interface CleanupStepConfirmationProps {
+  state: CleanupState;
+  dispatch: React.Dispatch<CleanupAction>;
+  onExecute: () => void;
+}
+
+export function CleanupStepConfirmation({
+  state,
+  dispatch,
+  onExecute,
+}: CleanupStepConfirmationProps) {
+  const { selectedBranches, error } = state;
+
+  const { localCount, remoteCount, branches } = useMemo(() => {
+    let local = 0;
+    let remote = 0;
+    const items: { name: string; deleteLocal: boolean; deleteRemote: boolean }[] = [];
+
+    for (const [, target] of selectedBranches) {
+      if (target.deleteLocal) local++;
+      if (target.deleteRemote) remote++;
+      items.push(target);
+    }
+
+    return { localCount: local, remoteCount: remote, branches: items };
+  }, [selectedBranches]);
+
+  const hasRemote = remoteCount > 0;
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Confirm Branch Cleanup</DialogTitle>
+        <DialogDescription>
+          Please review the branches that will be deleted.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4">
+        {/* Error from failed execution attempt */}
+        {error && (
+          <div className="flex items-start gap-2.5 p-3 rounded-md border border-red-500/30 bg-red-500/5">
+            <XCircle className="h-4 w-4 text-red-400 shrink-0 mt-0.5" />
+            <div className="text-sm text-red-300">{error}</div>
+          </div>
+        )}
+
+        {/* Summary */}
+        <div className="flex gap-4 text-sm">
+          {localCount > 0 && (
+            <div className="flex items-center gap-1.5">
+              <Monitor className="h-3.5 w-3.5 text-muted-foreground" />
+              <span>{localCount} local {localCount === 1 ? 'branch' : 'branches'}</span>
+            </div>
+          )}
+          {remoteCount > 0 && (
+            <div className="flex items-center gap-1.5">
+              <Cloud className="h-3.5 w-3.5 text-blue-400" />
+              <span>{remoteCount} remote {remoteCount === 1 ? 'branch' : 'branches'}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Remote warning */}
+        {hasRemote && (
+          <div className="flex items-start gap-2.5 p-3 rounded-md border border-red-500/30 bg-red-500/5">
+            <AlertTriangle className="h-4 w-4 text-red-400 shrink-0 mt-0.5" />
+            <div className="text-sm text-red-300">
+              <strong>Remote branch deletion is permanent</strong> and may affect other team members
+              who have checked out these branches.
+            </div>
+          </div>
+        )}
+
+        {/* Branch list */}
+        <div className="max-h-[250px] overflow-y-auto rounded-md border border-border bg-surface-1 divide-y divide-border">
+          {branches.map(branch => (
+            <div key={branch.name} className="flex items-center gap-2 px-3 py-1.5 text-sm">
+              <GitBranch className="h-3 w-3 text-muted-foreground shrink-0" />
+              <span className="font-mono truncate">{branch.name}</span>
+              <div className="flex items-center gap-1 ml-auto shrink-0">
+                {branch.deleteLocal && (
+                  <span className="text-[10px] text-muted-foreground px-1 py-0.5 rounded bg-muted">
+                    local
+                  </span>
+                )}
+                {branch.deleteRemote && (
+                  <span className="text-[10px] text-red-400 px-1 py-0.5 rounded bg-red-500/10">
+                    remote
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={() => dispatch({ type: 'SET_STEP', step: 'review' })}>
+          Back
+        </Button>
+        <Button variant="destructive" onClick={onExecute}>
+          Delete {selectedBranches.size} {selectedBranches.size === 1 ? 'branch' : 'branches'}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/components/dialogs/branch-cleanup/CleanupStepExecution.tsx
+++ b/src/components/dialogs/branch-cleanup/CleanupStepExecution.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import {
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface CleanupStepExecutionProps {
+  totalCount: number;
+}
+
+export function CleanupStepExecution({ totalCount }: CleanupStepExecutionProps) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Cleaning up branches...</DialogTitle>
+        <DialogDescription>
+          Deleting {totalCount} {totalCount === 1 ? 'branch' : 'branches'}. Please wait.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex flex-col items-center justify-center py-8 gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          This may take a moment for remote branches...
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/components/dialogs/branch-cleanup/CleanupStepResults.tsx
+++ b/src/components/dialogs/branch-cleanup/CleanupStepResults.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, AlertTriangle, ChevronDown, ChevronRight, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { CleanupResult } from '@/lib/api';
+
+interface CleanupStepResultsProps {
+  results: CleanupResult;
+  onDone: () => void;
+}
+
+export function CleanupStepResults({ results, onDone }: CleanupStepResultsProps) {
+  const [showErrors, setShowErrors] = useState(false);
+  const hasFailures = results.failed.length > 0;
+  const successCount = results.succeeded.length;
+  const failCount = results.failed.length;
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          {hasFailures ? (
+            <AlertTriangle className="h-5 w-5 text-yellow-400" />
+          ) : (
+            <Check className="h-5 w-5 text-green-400" />
+          )}
+          Cleanup Complete
+        </DialogTitle>
+        <DialogDescription>
+          {successCount > 0 && (
+            <>Successfully deleted {successCount} {successCount === 1 ? 'branch' : 'branches'}.</>
+          )}
+          {hasFailures && (
+            <> {failCount} {failCount === 1 ? 'branch' : 'branches'} could not be deleted.</>
+          )}
+          {successCount === 0 && !hasFailures && (
+            <>No branches were deleted.</>
+          )}
+        </DialogDescription>
+      </DialogHeader>
+
+      {hasFailures && (
+        <div className="space-y-2">
+          <button
+            type="button"
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowErrors(!showErrors)}
+          >
+            {showErrors ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+            {failCount} failed {failCount === 1 ? 'deletion' : 'deletions'}
+          </button>
+
+          {showErrors && (
+            <div className="max-h-[200px] overflow-y-auto rounded-md border border-border bg-surface-1 divide-y divide-border">
+              {results.failed.map(result => (
+                <div key={result.name} className="px-3 py-2 space-y-0.5">
+                  <div className="flex items-center gap-1.5 text-sm">
+                    <XCircle className="h-3 w-3 text-red-400 shrink-0" />
+                    <span className="font-mono truncate">{result.name}</span>
+                  </div>
+                  {result.deletedLocal && (
+                    <p className="text-xs text-yellow-400 pl-[18px]">Local branch was deleted</p>
+                  )}
+                  {result.error && (
+                    <p className="text-xs text-muted-foreground pl-[18px]">{result.error}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <DialogFooter>
+        <Button onClick={onDone}>
+          Done
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/components/dialogs/branch-cleanup/CleanupStepReview.tsx
+++ b/src/components/dialogs/branch-cleanup/CleanupStepReview.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  GitBranch,
+  Lock,
+  AlertTriangle,
+  Cloud,
+  Monitor,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { CleanupCandidate, CleanupBranchTarget } from '@/lib/api';
+import type { CleanupAction, CleanupState } from './types';
+
+interface CleanupStepReviewProps {
+  state: CleanupState;
+  dispatch: React.Dispatch<CleanupAction>;
+  onCancel: () => void;
+}
+
+const categoryConfig: Record<string, { label: string; color: string; bgColor: string }> = {
+  merged: { label: 'Merged', color: 'text-green-400', bgColor: 'bg-green-500/10 border-green-500/20' },
+  stale: { label: 'Stale', color: 'text-yellow-400', bgColor: 'bg-yellow-500/10 border-yellow-500/20' },
+  orphaned: { label: 'Orphaned', color: 'text-orange-400', bgColor: 'bg-orange-500/10 border-orange-500/20' },
+  safe: { label: 'Protected', color: 'text-muted-foreground', bgColor: 'bg-muted/50 border-border' },
+};
+
+function CategoryBadge({ category }: { category: string }) {
+  const config = categoryConfig[category] || categoryConfig.safe;
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${config.bgColor} ${config.color}`}>
+      {config.label}
+    </span>
+  );
+}
+
+function BranchRow({
+  candidate,
+  isSelected,
+  onToggle,
+}: {
+  candidate: CleanupCandidate;
+  isSelected: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <label
+      className={`flex items-center gap-2.5 px-3 py-2 rounded-md cursor-pointer transition-colors
+        ${candidate.deletable ? 'hover:bg-surface-2' : 'opacity-60 cursor-default'}`}
+    >
+      <Checkbox
+        checked={isSelected}
+        onCheckedChange={onToggle}
+        disabled={!candidate.deletable}
+        className="shrink-0"
+      />
+      <div className="flex items-center gap-1.5 min-w-0 flex-1">
+        {candidate.isProtected ? (
+          <Lock className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        ) : (
+          <GitBranch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <span className="text-sm font-mono truncate">
+          {candidate.isRemote
+            ? candidate.name.replace(/^origin\//, '')
+            : candidate.name}
+        </span>
+        {candidate.isRemote && (
+          <Cloud className="h-3 w-3 text-blue-400 shrink-0" />
+        )}
+        {candidate.hasLocalAndRemote && !candidate.isRemote && (
+          <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground">
+            <Monitor className="h-2.5 w-2.5" />+<Cloud className="h-2.5 w-2.5" />
+          </span>
+        )}
+        <CategoryBadge category={candidate.category} />
+      </div>
+      <span className="text-xs text-muted-foreground shrink-0 max-w-[200px] truncate">
+        {candidate.reason}
+      </span>
+    </label>
+  );
+}
+
+function CategorySection({
+  category,
+  candidates,
+  selectedBranches,
+  dispatch,
+}: {
+  category: string;
+  candidates: CleanupCandidate[];
+  selectedBranches: Map<string, CleanupBranchTarget>;
+  dispatch: React.Dispatch<CleanupAction>;
+}) {
+  const config = categoryConfig[category] || categoryConfig.safe;
+  const deletable = candidates.filter(c => c.deletable);
+  const selectedCount = candidates.filter(c => selectedBranches.has(c.name)).length;
+  const allSelected = deletable.length > 0 && selectedCount === deletable.length;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between px-3 py-1">
+        <div className="flex items-center gap-2">
+          <span className={`text-xs font-medium ${config.color}`}>
+            {config.label}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            ({candidates.length})
+          </span>
+        </div>
+        {deletable.length > 0 && (
+          <button
+            type="button"
+            className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => {
+              if (allSelected) {
+                dispatch({ type: 'DESELECT_ALL_CATEGORY', category });
+              } else {
+                dispatch({ type: 'SELECT_ALL_CATEGORY', category });
+              }
+            }}
+          >
+            {allSelected ? 'Deselect all' : 'Select all'}
+          </button>
+        )}
+      </div>
+      {candidates.map(candidate => (
+        <BranchRow
+          key={candidate.name}
+          candidate={candidate}
+          isSelected={selectedBranches.has(candidate.name)}
+          onToggle={() =>
+            dispatch({
+              type: 'TOGGLE_BRANCH',
+              name: candidate.name,
+              isRemote: candidate.isRemote,
+              hasLocalAndRemote: candidate.hasLocalAndRemote,
+            })
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+export function CleanupStepReview({
+  state,
+  dispatch,
+  onCancel,
+}: CleanupStepReviewProps) {
+  const { analysis, selectedBranches, deleteRemoteToo } = state;
+
+  const grouped = useMemo(() => {
+    if (!analysis) return {};
+    const groups: Record<string, CleanupCandidate[]> = {};
+    for (const candidate of analysis.candidates) {
+      const cat = candidate.category;
+      if (!groups[cat]) groups[cat] = [];
+      groups[cat].push(candidate);
+    }
+    return groups;
+  }, [analysis]);
+
+  const selectedCount = selectedBranches.size;
+  const hasRemoteCandidates = analysis?.candidates.some(c => c.hasLocalAndRemote && !c.isRemote) ?? false;
+
+  // Count how many deletable candidates exist
+  const deletableCount = analysis?.candidates.filter(c => c.deletable).length ?? 0;
+  const isEmpty = deletableCount === 0;
+
+  if (!analysis) return null;
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Branch Cleanup</DialogTitle>
+        <DialogDescription>
+          {isEmpty ? (
+            'Your repository is clean — no branches need cleanup.'
+          ) : (
+            <>
+              Found {deletableCount} {deletableCount === 1 ? 'branch' : 'branches'} to clean up
+              {analysis.protectedCount > 0 && (
+                <> &middot; {analysis.protectedCount} protected</>
+              )}
+            </>
+          )}
+        </DialogDescription>
+      </DialogHeader>
+
+      {!isEmpty && (
+        <div className="max-h-[400px] overflow-y-auto -mx-6 px-6 space-y-3">
+          {/* Show categories in order: merged, stale, orphaned, safe */}
+          {['merged', 'stale', 'orphaned', 'safe'].map(category => {
+            const candidates = grouped[category];
+            if (!candidates || candidates.length === 0) return null;
+            return (
+              <CategorySection
+                key={category}
+                category={category}
+                candidates={candidates}
+                selectedBranches={selectedBranches}
+                dispatch={dispatch}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {!isEmpty && hasRemoteCandidates && (
+        <label className="flex items-center gap-2 px-3 py-2 rounded-md bg-surface-2 cursor-pointer">
+          <Checkbox
+            checked={deleteRemoteToo}
+            onCheckedChange={() => dispatch({ type: 'TOGGLE_REMOTE_DELETE' })}
+          />
+          <div className="flex items-center gap-1.5">
+            {deleteRemoteToo && (
+              <AlertTriangle className="h-3.5 w-3.5 text-yellow-400 shrink-0" />
+            )}
+            <span className="text-sm">Also delete remote branches</span>
+          </div>
+        </label>
+      )}
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+        {!isEmpty && (
+          <Button
+            variant="destructive"
+            disabled={selectedCount === 0}
+            onClick={() => dispatch({ type: 'SET_STEP', step: 'confirmation' })}
+          >
+            Review deletion ({selectedCount})
+          </Button>
+        )}
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/components/dialogs/branch-cleanup/types.ts
+++ b/src/components/dialogs/branch-cleanup/types.ts
@@ -1,0 +1,29 @@
+import type { CleanupAnalysisResponse, CleanupBranchTarget, CleanupResult } from '@/lib/api';
+
+export type CleanupStep = 'analysis' | 'review' | 'confirmation' | 'execution' | 'results';
+
+export interface CleanupState {
+  step: CleanupStep;
+  analysis: CleanupAnalysisResponse | null;
+  selectedBranches: Map<string, CleanupBranchTarget>;
+  deleteRemoteToo: boolean;
+  staleDaysThreshold: number;
+  retryCount: number;
+  results: CleanupResult | null;
+  error: string | null;
+  isLoading: boolean;
+}
+
+export type CleanupAction =
+  | { type: 'SET_STEP'; step: CleanupStep }
+  | { type: 'SET_ANALYSIS'; analysis: CleanupAnalysisResponse }
+  | { type: 'TOGGLE_BRANCH'; name: string; isRemote: boolean; hasLocalAndRemote: boolean }
+  | { type: 'SELECT_ALL_CATEGORY'; category: string }
+  | { type: 'DESELECT_ALL_CATEGORY'; category: string }
+  | { type: 'TOGGLE_REMOTE_DELETE' }
+  | { type: 'SET_STALE_THRESHOLD'; days: number }
+  | { type: 'RETRY' }
+  | { type: 'SET_RESULTS'; results: CleanupResult }
+  | { type: 'SET_ERROR'; error: string }
+  | { type: 'SET_LOADING'; loading: boolean }
+  | { type: 'RESET' };

--- a/src/components/dialogs/branch-cleanup/useCleanupReducer.ts
+++ b/src/components/dialogs/branch-cleanup/useCleanupReducer.ts
@@ -1,0 +1,132 @@
+import { useReducer } from 'react';
+import type { CleanupBranchTarget } from '@/lib/api';
+import type { CleanupState, CleanupAction } from './types';
+
+const initialState: CleanupState = {
+  step: 'analysis',
+  analysis: null,
+  selectedBranches: new Map(),
+  deleteRemoteToo: false,
+  staleDaysThreshold: 90,
+  retryCount: 0,
+  results: null,
+  error: null,
+  isLoading: false,
+};
+
+function cleanupReducer(state: CleanupState, action: CleanupAction): CleanupState {
+  switch (action.type) {
+    case 'SET_STEP':
+      return { ...state, step: action.step, error: null };
+
+    case 'SET_ANALYSIS': {
+      // Auto-select all deletable branches
+      const selected = new Map<string, CleanupBranchTarget>();
+      for (const candidate of action.analysis.candidates) {
+        if (candidate.deletable) {
+          selected.set(candidate.name, {
+            name: candidate.name,
+            deleteLocal: !candidate.isRemote,
+            deleteRemote: false, // Remote is opt-in
+          });
+        }
+      }
+      return {
+        ...state,
+        analysis: action.analysis,
+        selectedBranches: selected,
+        step: 'review',
+        isLoading: false,
+        error: null,
+      };
+    }
+
+    case 'TOGGLE_BRANCH': {
+      const selected = new Map(state.selectedBranches);
+      if (selected.has(action.name)) {
+        selected.delete(action.name);
+      } else {
+        selected.set(action.name, {
+          name: action.name,
+          deleteLocal: !action.isRemote,
+          deleteRemote: action.isRemote || (action.hasLocalAndRemote && state.deleteRemoteToo),
+        });
+      }
+      return { ...state, selectedBranches: selected };
+    }
+
+    case 'SELECT_ALL_CATEGORY': {
+      if (!state.analysis) return state;
+      const selected = new Map(state.selectedBranches);
+      for (const candidate of state.analysis.candidates) {
+        if (candidate.deletable && candidate.category === action.category) {
+          selected.set(candidate.name, {
+            name: candidate.name,
+            deleteLocal: !candidate.isRemote,
+            deleteRemote: candidate.isRemote || (candidate.hasLocalAndRemote && state.deleteRemoteToo),
+          });
+        }
+      }
+      return { ...state, selectedBranches: selected };
+    }
+
+    case 'DESELECT_ALL_CATEGORY': {
+      if (!state.analysis) return state;
+      const selected = new Map(state.selectedBranches);
+      for (const candidate of state.analysis.candidates) {
+        if (candidate.category === action.category) {
+          selected.delete(candidate.name);
+        }
+      }
+      return { ...state, selectedBranches: selected };
+    }
+
+    case 'TOGGLE_REMOTE_DELETE': {
+      const deleteRemoteToo = !state.deleteRemoteToo;
+      // Build lookup for O(1) candidate access
+      const candidateMap = new Map<string, { isRemote: boolean; hasLocalAndRemote: boolean }>();
+      if (state.analysis) {
+        for (const c of state.analysis.candidates) {
+          candidateMap.set(c.name, { isRemote: c.isRemote, hasLocalAndRemote: c.hasLocalAndRemote });
+        }
+      }
+      // Update all selected branches' remote flag
+      const selected = new Map<string, CleanupBranchTarget>();
+      for (const [name, target] of state.selectedBranches) {
+        const candidate = candidateMap.get(name);
+        selected.set(name, {
+          ...target,
+          deleteRemote: candidate?.isRemote
+            ? true
+            : (candidate?.hasLocalAndRemote && deleteRemoteToo) || false,
+        });
+      }
+      return { ...state, deleteRemoteToo, selectedBranches: selected };
+    }
+
+    case 'SET_STALE_THRESHOLD':
+      return { ...state, staleDaysThreshold: action.days };
+
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1, error: null, isLoading: true };
+
+    case 'SET_RESULTS':
+      return { ...state, results: action.results, step: 'results', isLoading: false };
+
+    case 'SET_ERROR':
+      return { ...state, error: action.error, isLoading: false };
+
+    case 'SET_LOADING':
+      return { ...state, isLoading: action.loading };
+
+    case 'RESET':
+      return { ...initialState, selectedBranches: new Map() };
+
+    default:
+      return state;
+  }
+}
+
+export function useCleanupReducer() {
+  return useReducer(cleanupReducer, initialState);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -319,6 +319,73 @@ export async function listBranches(
   return handleResponse<BranchListResponse>(res);
 }
 
+// Branch cleanup types and API
+export type CleanupCategory = 'merged' | 'stale' | 'orphaned' | 'safe';
+
+export interface CleanupCandidate {
+  name: string;
+  isRemote: boolean;
+  category: CleanupCategory;
+  reason: string;
+  lastCommitDate: string;
+  lastAuthor: string;
+  hasLocalAndRemote: boolean;
+  sessionId?: string;
+  sessionName?: string;
+  sessionStatus?: string;
+  isProtected: boolean;
+  deletable: boolean;
+}
+
+export interface CleanupAnalysisResponse {
+  candidates: CleanupCandidate[];
+  summary: Record<string, number>;
+  protectedCount: number;
+  totalAnalyzed: number;
+}
+
+export interface CleanupBranchTarget {
+  name: string;
+  deleteLocal: boolean;
+  deleteRemote: boolean;
+}
+
+export interface CleanupBranchResult {
+  name: string;
+  deletedLocal: boolean;
+  deletedRemote: boolean;
+  error?: string;
+}
+
+export interface CleanupResult {
+  succeeded: CleanupBranchResult[];
+  failed: CleanupBranchResult[];
+}
+
+export async function analyzeBranchCleanup(
+  workspaceId: string,
+  params: { staleDaysThreshold?: number; includeRemote?: boolean }
+): Promise<CleanupAnalysisResponse> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/branches/analyze-cleanup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+  return handleResponse<CleanupAnalysisResponse>(res);
+}
+
+export async function executeBranchCleanup(
+  workspaceId: string,
+  branches: CleanupBranchTarget[]
+): Promise<CleanupResult> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/branches/cleanup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ branches }),
+  });
+  return handleResponse<CleanupResult>(res);
+}
+
 // Avatar types and API
 export interface AvatarResponse {
   avatars: Record<string, string>;


### PR DESCRIPTION
## Summary

Implements a multi-step interactive wizard for safely cleaning up branches:
- **Analysis**: Scans branches and categorizes by merged, stale, orphaned, or protected status
- **Review**: Category-based filtering with select/deselect all controls  
- **Confirmation**: Final review with remote deletion warnings and partial failure handling
- **Results**: Success/failure summary with error details

## Key Features

- Session-aware protection (active/idle sessions cannot be deleted)
- Safe deletion using git `-d` for merged branches, `-D` for unmerged
- Partial deletion reporting (e.g. local succeeds, remote fails)
- Fixed code review issues: proper retry mechanism, O(1) lookups, error display

## Test Plan

- Click "Smart Branch Cleanup" button in branches dashboard
- Verify analysis identifies merged, stale, orphaned, and protected branches
- Select branches to delete and verify confirmation UI
- Test retry on analysis failure (now properly re-triggers)
- Verify partial deletion shows "Local branch was deleted" indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)