### PR TITLE
[CM-86] Rich command palette with Linear-style navigation

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -21,6 +21,29 @@
               "value": "^[/~.][-\\w\\s./~]+$"
             }
           ]
+        },
+        {
+          "name": "open-terminal",
+          "cmd": "open",
+          "args": [
+            "-a",
+            "Terminal",
+            {
+              "validator": "regex",
+              "value": "^[/~][-\\w\\s./~]+$"
+            }
+          ]
+        },
+        {
+          "name": "open-finder",
+          "cmd": "open",
+          "args": [
+            "-R",
+            {
+              "validator": "regex",
+              "value": "^[/~][-\\w\\s./~]+$"
+            }
+          ]
         }
       ]
     },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback, useRef } from 'react';
+import { useTheme } from 'next-themes';
 import { Loader2 } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
 import {
@@ -15,7 +16,7 @@ import { navigate } from '@/lib/navigation';
 import { useAuthStore } from '@/stores/authStore';
 import { OnboardingScreen } from '@/components/shared/OnboardingScreen';
 import { initAuth, listenForOAuthCallback, validateStoredToken, OAUTH_TIMEOUT_MS } from '@/lib/auth';
-import { isTauri, safeListen, closeWindow, openFolderDialog } from '@/lib/tauri';
+import { isTauri, safeListen, closeWindow, openFolderDialog, openInVSCode } from '@/lib/tauri';
 import { CloseTabConfirmDialog } from '@/components/dialogs/CloseTabConfirmDialog';
 import { CloseFileConfirmDialog } from '@/components/dialogs/CloseFileConfirmDialog';
 import { KeyboardShortcutsDialog } from '@/components/dialogs/KeyboardShortcutsDialog';
@@ -42,6 +43,7 @@ import { CloneFromUrlDialog } from '@/components/dialogs/CloneFromUrlDialog';
 import { QuickStartDialog } from '@/components/dialogs/QuickStartDialog';
 import { FilePicker } from '@/components/dialogs/FilePicker';
 import { WorkspaceSearch } from '@/components/dialogs/WorkspaceSearch';
+import { CommandPalette } from '@/components/dialogs/CommandPalette';
 // import { UpdateChecker } from '@/components/shared/UpdateChecker';
 import { BackendStatus } from '@/components/shared/BackendStatus';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -152,6 +154,9 @@ export default function Home() {
   const [showCloneFromUrl, setShowCloneFromUrl] = useState(false);
   const [showQuickStart, setShowQuickStart] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
+
+  // Theme from next-themes
+  const { theme, setTheme } = useTheme();
 
   // Panel refs for imperative collapse/expand
   const leftSidebarPanelRef = useRef<PanelImperativeHandle>(null);
@@ -960,6 +965,52 @@ export default function Home() {
     };
   }, []);
 
+  // Handle CommandPalette custom events
+  useEffect(() => {
+    const handleOpenSettings = () => setShowSettings(true);
+    const handleCloseSettings = () => setShowSettings(false);
+    const handleSpawnAgent = () => handleNewSession();
+    const handleNewConv = () => handleNewConversation();
+    const handleAddWorkspace = () => setShowAddWorkspace(true);
+    const handleToggleTheme = () => {
+      // Toggle between light and dark (resolve system to actual theme)
+      const isDark = theme === 'dark' ||
+        (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+      setTheme(isDark ? 'light' : 'dark');
+    };
+    const handleToggleLeftPanel = () => toggleLeftSidebar();
+    const handleToggleRightPanel = () => toggleRightSidebar();
+    const handleOpenInVSCode = () => {
+      const { selectedSessionId, sessions } = useAppStore.getState();
+      const session = sessions.find((s) => s.id === selectedSessionId);
+      if (session?.worktreePath) {
+        openInVSCode(session.worktreePath);
+      }
+    };
+
+    window.addEventListener('open-settings', handleOpenSettings);
+    window.addEventListener('close-settings', handleCloseSettings);
+    window.addEventListener('spawn-agent', handleSpawnAgent);
+    window.addEventListener('new-conversation', handleNewConv);
+    window.addEventListener('add-workspace', handleAddWorkspace);
+    window.addEventListener('toggle-theme', handleToggleTheme);
+    window.addEventListener('toggle-left-panel', handleToggleLeftPanel);
+    window.addEventListener('toggle-right-panel', handleToggleRightPanel);
+    window.addEventListener('open-in-vscode', handleOpenInVSCode);
+
+    return () => {
+      window.removeEventListener('open-settings', handleOpenSettings);
+      window.removeEventListener('close-settings', handleCloseSettings);
+      window.removeEventListener('spawn-agent', handleSpawnAgent);
+      window.removeEventListener('new-conversation', handleNewConv);
+      window.removeEventListener('add-workspace', handleAddWorkspace);
+      window.removeEventListener('toggle-theme', handleToggleTheme);
+      window.removeEventListener('toggle-left-panel', handleToggleLeftPanel);
+      window.removeEventListener('toggle-right-panel', handleToggleRightPanel);
+      window.removeEventListener('open-in-vscode', handleOpenInVSCode);
+    };
+  }, [handleNewSession, handleNewConversation, theme, setTheme, toggleLeftSidebar, toggleRightSidebar]);
+
   // Don't render anything until client-side mounted - prevents hydration flash
   // Body background (set by ThemeScript) shows through
   if (!mounted) {
@@ -1298,6 +1349,9 @@ export default function Home() {
           open={showShortcuts}
           onOpenChange={setShowShortcuts}
         />
+
+        {/* Command Palette (Cmd+K) */}
+        <CommandPalette />
 
         {/* Update Checker - disabled until remote URL is configured
         <UpdateChecker />

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import {
   CommandDialog,
   CommandEmpty,
@@ -10,73 +10,716 @@ import {
   CommandList,
   CommandSeparator,
 } from '@/components/ui/command';
-import { useRepoState } from '@/stores/selectors';
+import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { useShortcut } from '@/hooks/useShortcut';
+import { navigate } from '@/lib/navigation';
+import { getShortcutById, formatShortcutKeys } from '@/lib/shortcuts';
+import type { LucideIcon } from 'lucide-react';
 import {
+  // Navigation
+  LayoutDashboard,
   FolderGit2,
+  GitBranch,
+  MessageSquare,
+  Settings,
+  Layers,
+  GitPullRequest,
+  Archive,
+  // Actions
   Plus,
   Bot,
-  GitBranch,
+  MessageCirclePlus,
+  Brain,
+  Sparkles,
+  Focus,
+  FileSearch,
+  PanelBottom,
+  PanelLeft,
+  PanelRight,
+  // Git
+  GitCommit,
+  Copy,
+  ExternalLink,
+  Terminal,
+  RefreshCw,
+  // Review
+  Search,
+  Shield,
+  FileCode,
+  // Settings
+  Moon,
+  Volume2,
+  ChevronLeft,
+  Clock,
+  ChevronRight,
 } from 'lucide-react';
 
-interface CommandPaletteProps {
-  onAddRepo: () => void;
-  onSpawnAgent?: () => void;
+// ============================================================================
+// Types
+// ============================================================================
+
+type CommandCategory = 'Recent' | 'Navigation' | 'Actions' | 'Git' | 'Review' | 'Settings';
+
+interface Command {
+  id: string;
+  category: CommandCategory;
+  label: string;
+  icon: LucideIcon;
+  shortcutId?: string;
+  keywords?: string[];
+  available?: () => boolean;
+  hasSubmenu?: boolean;
+  submenuId?: string;
+  action: () => void;
 }
 
-export function CommandPalette({ onAddRepo, onSpawnAgent }: CommandPaletteProps) {
+interface SubmenuPage {
+  title: string;
+  icon: LucideIcon;
+  getItems: () => SubmenuItem[];
+}
+
+interface SubmenuItem {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: LucideIcon;
+  action: () => void;
+}
+
+// ============================================================================
+// Command Definitions
+// ============================================================================
+
+const COMMANDS: Command[] = [
+  // Navigation
+  {
+    id: 'go-to-workspace',
+    category: 'Navigation',
+    label: 'Go to Workspace...',
+    icon: FolderGit2,
+    keywords: ['repository', 'repo', 'project'],
+    hasSubmenu: true,
+    submenuId: 'workspaces',
+    available: () => useAppStore.getState().workspaces.length > 0,
+    action: () => {},
+  },
+  {
+    id: 'go-to-session',
+    category: 'Navigation',
+    label: 'Go to Session...',
+    icon: GitBranch,
+    keywords: ['branch', 'worktree'],
+    hasSubmenu: true,
+    submenuId: 'sessions',
+    available: () => useAppStore.getState().sessions.filter((s) => !s.archived).length > 0,
+    action: () => {},
+  },
+  {
+    id: 'go-to-conversation',
+    category: 'Navigation',
+    label: 'Go to Conversation...',
+    icon: MessageSquare,
+    keywords: ['chat', 'message'],
+    hasSubmenu: true,
+    submenuId: 'conversations',
+    available: () => useAppStore.getState().conversations.length > 0,
+    action: () => {},
+  },
+  {
+    id: 'open-settings',
+    category: 'Navigation',
+    label: 'Open Settings',
+    icon: Settings,
+    keywords: ['preferences', 'config', 'configuration'],
+    action: () => window.dispatchEvent(new CustomEvent('open-settings')),
+  },
+  {
+    id: 'open-session-manager',
+    category: 'Navigation',
+    label: 'Open Session Manager',
+    icon: Layers,
+    keywords: ['sessions', 'worktrees', 'branches'],
+    action: () => useSettingsStore.getState().setContentView({ type: 'session-manager' }),
+  },
+  {
+    id: 'open-pr-dashboard',
+    category: 'Navigation',
+    label: 'Open PR Dashboard',
+    icon: GitPullRequest,
+    keywords: ['pull requests', 'prs', 'reviews'],
+    action: () => useSettingsStore.getState().setContentView({ type: 'pr-dashboard' }),
+  },
+  {
+    id: 'open-repositories',
+    category: 'Navigation',
+    label: 'Open Repositories',
+    icon: Archive,
+    keywords: ['repos', 'workspaces', 'projects'],
+    action: () => useSettingsStore.getState().setContentView({ type: 'repositories' }),
+  },
+  {
+    id: 'go-to-dashboard',
+    category: 'Navigation',
+    label: 'Go to Dashboard',
+    icon: LayoutDashboard,
+    keywords: ['home', 'overview'],
+    action: () => useSettingsStore.getState().setContentView({ type: 'global-dashboard' }),
+  },
+
+  // Actions
+  {
+    id: 'new-session',
+    category: 'Actions',
+    label: 'New Session',
+    icon: Bot,
+    keywords: ['spawn', 'agent', 'worktree', 'create'],
+    available: () => useAppStore.getState().selectedWorkspaceId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('spawn-agent')),
+  },
+  {
+    id: 'new-conversation',
+    category: 'Actions',
+    label: 'New Conversation',
+    icon: MessageCirclePlus,
+    keywords: ['chat', 'message', 'create'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('new-conversation')),
+  },
+  {
+    id: 'add-repository',
+    category: 'Actions',
+    label: 'Add Repository',
+    icon: Plus,
+    keywords: ['workspace', 'project', 'clone', 'create'],
+    action: () => window.dispatchEvent(new CustomEvent('add-workspace')),
+  },
+  {
+    id: 'toggle-plan-mode',
+    category: 'Actions',
+    label: 'Toggle Plan Mode',
+    icon: FileCode,
+    shortcutId: 'togglePlanMode',
+    keywords: ['planning', 'architect'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('toggle-plan-mode')),
+  },
+  {
+    id: 'toggle-thinking-mode',
+    category: 'Actions',
+    label: 'Toggle Thinking Mode',
+    icon: Brain,
+    shortcutId: 'toggleThinking',
+    keywords: ['extended', 'reasoning', 'deep'],
+    action: () => {
+      const store = useSettingsStore.getState();
+      store.setDefaultThinking(!store.defaultThinking);
+    },
+  },
+  {
+    id: 'toggle-zen-mode',
+    category: 'Actions',
+    label: 'Toggle Zen Mode',
+    icon: Sparkles,
+    keywords: ['distraction', 'free', 'focus', 'minimal'],
+    action: () => {
+      const store = useSettingsStore.getState();
+      store.setZenMode(!store.zenMode);
+    },
+  },
+  {
+    id: 'focus-chat',
+    category: 'Actions',
+    label: 'Focus Chat Input',
+    icon: Focus,
+    shortcutId: 'focusChat',
+    keywords: ['input', 'message', 'type'],
+    action: () => window.dispatchEvent(new CustomEvent('focus-input')),
+  },
+  {
+    id: 'open-file-picker',
+    category: 'Actions',
+    label: 'Open File Picker',
+    icon: FileSearch,
+    shortcutId: 'filePicker',
+    keywords: ['search', 'find', 'files'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('open-file-picker')),
+  },
+  {
+    id: 'toggle-bottom-panel',
+    category: 'Actions',
+    label: 'Toggle Bottom Panel',
+    icon: PanelBottom,
+    keywords: ['terminal', 'tasks', 'panel'],
+    action: () => {
+      const store = useSettingsStore.getState();
+      store.setShowBottomTerminal(!store.showBottomTerminal);
+    },
+  },
+  {
+    id: 'toggle-left-panel',
+    category: 'Actions',
+    label: 'Toggle Left Panel',
+    icon: PanelLeft,
+    keywords: ['sidebar', 'workspaces', 'sessions'],
+    action: () => window.dispatchEvent(new CustomEvent('toggle-left-panel')),
+  },
+  {
+    id: 'toggle-right-panel',
+    category: 'Actions',
+    label: 'Toggle Right Panel',
+    icon: PanelRight,
+    keywords: ['sidebar', 'changes', 'files'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('toggle-right-panel')),
+  },
+
+  // Git
+  {
+    id: 'git-commit',
+    category: 'Git',
+    label: 'Commit Changes',
+    icon: GitCommit,
+    keywords: ['save', 'stage'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('git-commit')),
+  },
+  {
+    id: 'git-create-pr',
+    category: 'Git',
+    label: 'Create Pull Request',
+    icon: GitPullRequest,
+    keywords: ['pr', 'merge', 'review'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('git-create-pr')),
+  },
+  {
+    id: 'git-sync',
+    category: 'Git',
+    label: 'Sync with Main',
+    icon: RefreshCw,
+    keywords: ['pull', 'rebase', 'update'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('git-sync')),
+  },
+  {
+    id: 'git-copy-branch',
+    category: 'Git',
+    label: 'Copy Branch Name',
+    icon: Copy,
+    keywords: ['clipboard'],
+    available: () => {
+      const sessionId = useAppStore.getState().selectedSessionId;
+      return sessionId !== null;
+    },
+    action: () => {
+      const { selectedSessionId, sessions } = useAppStore.getState();
+      const session = sessions.find((s) => s.id === selectedSessionId);
+      if (session?.branch) {
+        navigator.clipboard.writeText(session.branch);
+      }
+    },
+  },
+  {
+    id: 'open-in-vscode',
+    category: 'Git',
+    label: 'Open in VS Code',
+    icon: ExternalLink,
+    keywords: ['editor', 'ide', 'code'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('open-in-vscode')),
+  },
+  {
+    id: 'open-terminal',
+    category: 'Git',
+    label: 'Open Terminal',
+    icon: Terminal,
+    keywords: ['shell', 'console', 'cli'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => useSettingsStore.getState().setShowBottomTerminal(true),
+  },
+
+  // Review
+  {
+    id: 'start-quick-review',
+    category: 'Review',
+    label: 'Start Quick Review',
+    icon: Search,
+    keywords: ['fast', 'basic', 'code review'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('start-review', { detail: { type: 'quick' } })),
+  },
+  {
+    id: 'start-deep-review',
+    category: 'Review',
+    label: 'Start Deep Review',
+    icon: FileCode,
+    keywords: ['thorough', 'comprehensive', 'code review'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('start-review', { detail: { type: 'deep' } })),
+  },
+  {
+    id: 'start-security-audit',
+    category: 'Review',
+    label: 'Start Security Audit',
+    icon: Shield,
+    keywords: ['vulnerability', 'security', 'audit'],
+    available: () => useAppStore.getState().selectedSessionId !== null,
+    action: () => window.dispatchEvent(new CustomEvent('start-review', { detail: { type: 'security' } })),
+  },
+
+  // Settings
+  {
+    id: 'settings-open',
+    category: 'Settings',
+    label: 'Preferences',
+    icon: Settings,
+    keywords: ['settings', 'config'],
+    action: () => window.dispatchEvent(new CustomEvent('open-settings')),
+  },
+  {
+    id: 'toggle-theme',
+    category: 'Settings',
+    label: 'Toggle Theme',
+    icon: Moon,
+    keywords: ['dark', 'light', 'mode', 'appearance'],
+    action: () => window.dispatchEvent(new CustomEvent('toggle-theme')),
+  },
+  {
+    id: 'toggle-sound',
+    category: 'Settings',
+    label: 'Toggle Sound Effects',
+    icon: Volume2,
+    keywords: ['audio', 'mute', 'notifications'],
+    action: () => {
+      const store = useSettingsStore.getState();
+      store.setSoundEffects(!store.soundEffects);
+    },
+  },
+];
+
+// ============================================================================
+// Submenu Definitions
+// ============================================================================
+
+const SUBMENU_PAGES: Record<string, SubmenuPage> = {
+  workspaces: {
+    title: 'Go to Workspace',
+    icon: FolderGit2,
+    getItems: () => {
+      const { workspaces } = useAppStore.getState();
+      return workspaces.map((w) => ({
+        id: w.id,
+        label: w.name,
+        description: w.path,
+        icon: FolderGit2,
+        action: () =>
+          navigate({
+            workspaceId: w.id,
+            contentView: { type: 'workspace-dashboard', workspaceId: w.id },
+          }),
+      }));
+    },
+  },
+  sessions: {
+    title: 'Go to Session',
+    icon: GitBranch,
+    getItems: () => {
+      const { sessions, workspaces } = useAppStore.getState();
+      return sessions
+        .filter((s) => !s.archived)
+        .map((s) => ({
+          id: s.id,
+          label: s.name || s.branch,
+          description: workspaces.find((w) => w.id === s.workspaceId)?.name,
+          icon: GitBranch,
+          action: () =>
+            navigate({
+              workspaceId: s.workspaceId,
+              sessionId: s.id,
+              contentView: { type: 'conversation' },
+            }),
+        }));
+    },
+  },
+  conversations: {
+    title: 'Go to Conversation',
+    icon: MessageSquare,
+    getItems: () => {
+      const { conversations, sessions } = useAppStore.getState();
+      return conversations.slice(0, 20).map((c) => ({
+        id: c.id,
+        label: c.name,
+        description: sessions.find((s) => s.id === c.sessionId)?.name,
+        icon: MessageSquare,
+        action: () => navigate({ conversationId: c.id }),
+      }));
+    },
+  },
+};
+
+// ============================================================================
+// Helper Components
+// ============================================================================
+
+function ShortcutHint({ shortcutId }: { shortcutId: string }) {
+  const shortcut = getShortcutById(shortcutId);
+  if (!shortcut) return null;
+
+  const keys = formatShortcutKeys(shortcut);
+  return (
+    <span className="ml-auto flex gap-0.5 text-xs text-muted-foreground">
+      {keys.map((k, i) => (
+        <kbd key={i} className="min-w-[20px] px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-center">
+          {k}
+        </kbd>
+      ))}
+    </span>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function CommandPalette() {
   const [open, setOpen] = useState(false);
-  const { repos, selectedRepoId, selectRepo } = useRepoState();
+  const [pages, setPages] = useState<string[]>([]);
+  const [search, setSearch] = useState('');
+
+  // Get recent commands from settings store
+  const recentCommands = useSettingsStore((state) => state.recentCommands);
+  const addRecentCommand = useSettingsStore((state) => state.addRecentCommand);
+
+  // Current submenu page (root if empty)
+  const currentPage = pages[pages.length - 1];
+
+  // Subscribe to store state for command availability
+  const workspaces = useAppStore((state) => state.workspaces);
+  const sessions = useAppStore((state) => state.sessions);
+  const conversations = useAppStore((state) => state.conversations);
+  const selectedWorkspaceId = useAppStore((state) => state.selectedWorkspaceId);
+  const selectedSessionId = useAppStore((state) => state.selectedSessionId);
 
   // Register Cmd+K shortcut
-  useShortcut('commandPalette', useCallback(() => {
-    setOpen((prev) => !prev);
-  }, []));
+  useShortcut(
+    'commandPalette',
+    useCallback(() => {
+      setOpen((prev) => {
+        if (!prev) {
+          // Close file picker when opening command palette
+          window.dispatchEvent(new CustomEvent('close-file-picker'));
+        }
+        return !prev;
+      });
+    }, [])
+  );
 
-  const runCommand = useCallback((command: () => void) => {
-    setOpen(false);
-    command();
+  // Listen for close event (from file picker opening)
+  useEffect(() => {
+    const handleClose = () => setOpen(false);
+    window.addEventListener('close-command-palette', handleClose);
+    return () => window.removeEventListener('close-command-palette', handleClose);
   }, []);
 
-  return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Type a command or search..." />
-      <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
+  // Filter commands by availability (re-evaluate when store state changes)
+  const availableCommands = useMemo(
+    () => COMMANDS.filter((c) => c.available?.() ?? true),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [workspaces.length, sessions.length, conversations.length, selectedWorkspaceId, selectedSessionId]
+  );
 
-        <CommandGroup heading="Actions">
-          <CommandItem onSelect={() => runCommand(onAddRepo)}>
-            <Plus className="size-4" />
-            Add Repository
+  // Get recent commands that are still available
+  const recentItems = useMemo(() => {
+    return recentCommands
+      .map((id) => availableCommands.find((c) => c.id === id))
+      .filter((c): c is Command => c !== undefined)
+      .slice(0, 5);
+  }, [recentCommands, availableCommands]);
+
+  // Group commands by category
+  const commandsByCategory = useMemo(() => {
+    const grouped: Record<CommandCategory, Command[]> = {
+      Recent: [],
+      Navigation: [],
+      Actions: [],
+      Git: [],
+      Review: [],
+      Settings: [],
+    };
+
+    for (const cmd of availableCommands) {
+      grouped[cmd.category].push(cmd);
+    }
+
+    return grouped;
+  }, [availableCommands]);
+
+  // Handle keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Backspace' && !search && pages.length > 0) {
+        e.preventDefault();
+        setPages((p) => p.slice(0, -1));
+      }
+    },
+    [search, pages.length]
+  );
+
+  // Execute command and track in recents
+  const executeCommand = useCallback(
+    (cmd: Command) => {
+      if (cmd.hasSubmenu && cmd.submenuId) {
+        setPages((p) => [...p, cmd.submenuId!]);
+        setSearch('');
+      } else {
+        setOpen(false);
+        setPages([]);
+        setSearch('');
+        addRecentCommand(cmd.id);
+        // Close any overlays (like settings page) when executing navigation commands
+        if (cmd.category === 'Navigation') {
+          window.dispatchEvent(new CustomEvent('close-settings'));
+        }
+        cmd.action();
+      }
+    },
+    [addRecentCommand]
+  );
+
+  // Execute submenu item
+  const executeSubmenuItem = useCallback((item: SubmenuItem) => {
+    setOpen(false);
+    setPages([]);
+    setSearch('');
+    // Close any overlays (like settings page) when navigating
+    window.dispatchEvent(new CustomEvent('close-settings'));
+    item.action();
+  }, []);
+
+  // Go back to previous page
+  const goBack = useCallback(() => {
+    setPages((p) => p.slice(0, -1));
+    setSearch('');
+  }, []);
+
+  // Reset state when dialog closes
+  const handleOpenChange = useCallback((isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      setPages([]);
+      setSearch('');
+    }
+  }, []);
+
+  // Render submenu content
+  const renderSubmenuContent = () => {
+    const page = SUBMENU_PAGES[currentPage];
+    if (!page) return null;
+
+    const items = page.getItems();
+    const PageIcon = page.icon;
+
+    return (
+      <>
+        <CommandGroup>
+          <CommandItem onSelect={goBack} value="__back__">
+            <ChevronLeft className="size-4" />
+            <span>Back</span>
           </CommandItem>
-          {selectedRepoId && onSpawnAgent && (
-            <CommandItem onSelect={() => runCommand(onSpawnAgent)}>
-              <Bot className="size-4" />
-              Spawn New Agent
-            </CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading={page.title}>
+          {items.length === 0 ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">No items found</div>
+          ) : (
+            items.map((item) => {
+              const ItemIcon = item.icon || PageIcon;
+              // Include label and description in value for search filtering
+              const searchValue = `${item.label} ${item.description || ''}`.trim();
+              return (
+                <CommandItem key={item.id} value={searchValue} onSelect={() => executeSubmenuItem(item)}>
+                  <ItemIcon className="size-4" />
+                  <div className="flex flex-col gap-0.5 min-w-0">
+                    <span className="truncate">{item.label}</span>
+                    {item.description && (
+                      <span className="text-xs text-muted-foreground truncate">{item.description}</span>
+                    )}
+                  </div>
+                </CommandItem>
+              );
+            })
           )}
         </CommandGroup>
+      </>
+    );
+  };
 
-        {repos.length > 0 && (
+  // Render root content
+  const renderRootContent = () => {
+    const categories: CommandCategory[] = ['Navigation', 'Actions', 'Git', 'Review', 'Settings'];
+
+    return (
+      <>
+        {/* Recent commands */}
+        {recentItems.length > 0 && !search && (
           <>
-            <CommandSeparator />
-            <CommandGroup heading="Repositories">
-              {repos.map((repo) => (
-                <CommandItem
-                  key={repo.id}
-                  onSelect={() => runCommand(() => selectRepo(repo.id))}
-                >
-                  <FolderGit2 className="size-4" />
-                  <span className="flex-1">{repo.name}</span>
-                  <span className="text-xs text-muted-foreground flex items-center gap-1">
-                    <GitBranch className="h-3 w-3" />
-                    {repo.branch}
-                  </span>
-                </CommandItem>
-              ))}
+            <CommandGroup heading="Recent">
+              {recentItems.map((cmd) => {
+                const Icon = cmd.icon;
+                return (
+                  <CommandItem key={`recent-${cmd.id}`} value={`recent-${cmd.id}`} onSelect={() => executeCommand(cmd)}>
+                    <Clock className="size-4 text-muted-foreground" />
+                    <Icon className="size-4" />
+                    <span className="flex-1">{cmd.label}</span>
+                    {cmd.hasSubmenu && <ChevronRight className="size-4 text-muted-foreground" />}
+                    {cmd.shortcutId && <ShortcutHint shortcutId={cmd.shortcutId} />}
+                  </CommandItem>
+                );
+              })}
             </CommandGroup>
+            <CommandSeparator />
           </>
         )}
+
+        {/* Commands by category */}
+        {categories.map((category) => {
+          const commands = commandsByCategory[category];
+          if (commands.length === 0) return null;
+
+          return (
+            <CommandGroup key={category} heading={category}>
+              {commands.map((cmd) => {
+                const Icon = cmd.icon;
+                return (
+                  <CommandItem key={cmd.id} value={cmd.id} onSelect={() => executeCommand(cmd)}>
+                    <Icon className="size-4" />
+                    <span className="flex-1">{cmd.label}</span>
+                    {cmd.hasSubmenu && <ChevronRight className="size-4 text-muted-foreground" />}
+                    {cmd.shortcutId && <ShortcutHint shortcutId={cmd.shortcutId} />}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          );
+        })}
+      </>
+    );
+  };
+
+  return (
+    <CommandDialog open={open} onOpenChange={handleOpenChange} variant="spotlight">
+      <CommandInput
+        placeholder={currentPage ? SUBMENU_PAGES[currentPage]?.title || 'Search...' : 'Type a command or search...'}
+        value={search}
+        onValueChange={setSearch}
+        onKeyDown={handleKeyDown}
+      />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        {currentPage ? renderSubmenuContent() : renderRootContent()}
       </CommandList>
     </CommandDialog>
   );

--- a/src/components/dialogs/FilePicker.tsx
+++ b/src/components/dialogs/FilePicker.tsx
@@ -220,7 +220,13 @@ export function FilePicker({ workspaceId, sessionId }: FilePickerProps) {
 
   // Register Cmd+P shortcut
   useShortcut('filePicker', useCallback(() => {
-    setOpen((prev) => !prev);
+    setOpen((prev) => {
+      if (!prev) {
+        // Close command palette when opening file picker
+        window.dispatchEvent(new CustomEvent('close-command-palette'));
+      }
+      return !prev;
+    });
   }, []));
 
   // Reset search value when dialog closes
@@ -238,11 +244,20 @@ export function FilePicker({ workspaceId, sessionId }: FilePickerProps) {
     }
   }, [searchValue]);
 
-  // Listen for custom event (from menu or other triggers)
+  // Listen for custom events (from menu or other triggers)
   useEffect(() => {
-    const handleOpenEvent = () => setOpen(true);
+    const handleOpenEvent = () => {
+      // Close command palette when opening file picker
+      window.dispatchEvent(new CustomEvent('close-command-palette'));
+      setOpen(true);
+    };
+    const handleCloseEvent = () => setOpen(false);
     window.addEventListener('open-file-picker', handleOpenEvent);
-    return () => window.removeEventListener('open-file-picker', handleOpenEvent);
+    window.addEventListener('close-file-picker', handleCloseEvent);
+    return () => {
+      window.removeEventListener('open-file-picker', handleOpenEvent);
+      window.removeEventListener('close-file-picker', handleCloseEvent);
+    };
   }, []);
 
   // Fetch files when dialog opens (with caching per session)

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -454,7 +454,7 @@ export async function openInTerminal(path: string): Promise<void> {
   if (!isTauri()) return;
   try {
     const { Command } = await import('@tauri-apps/plugin-shell');
-    Command.create('open', ['-a', 'Terminal', path]).spawn().catch(console.error);
+    Command.create('open-terminal', [path]).spawn().catch(console.error);
   } catch (e) {
     console.error('Failed to open in Terminal', e);
   }
@@ -467,7 +467,7 @@ export async function showInFinder(path: string): Promise<void> {
   if (!isTauri()) return;
   try {
     const { Command } = await import('@tauri-apps/plugin-shell');
-    Command.create('open', ['-R', path]).spawn().catch(console.error);
+    Command.create('open-finder', [path]).spawn().catch(console.error);
   } catch (e) {
     console.error('Failed to show in Finder', e);
   }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -73,6 +73,9 @@ interface SettingsState {
   layoutVertical: PanelLayout | undefined;
   layoutChanges: PanelLayout | undefined;
 
+  // Command palette recent commands (last 5 used)
+  recentCommands: string[];
+
   // Actions
   setConfirmCloseActiveTab: (value: boolean) => void;
   setDefaultModel: (value: string) => void;
@@ -98,6 +101,7 @@ interface SettingsState {
   setLayoutVertical: (layout: PanelLayout) => void;
   setLayoutChanges: (layout: PanelLayout) => void;
   resetLayouts: () => void;
+  addRecentCommand: (commandId: string) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -126,6 +130,7 @@ export const useSettingsStore = create<SettingsState>()(
       layoutInner: undefined,
       layoutVertical: undefined,
       layoutChanges: undefined,
+      recentCommands: [], // Last 5 used command IDs
 
       // Actions
       setConfirmCloseActiveTab: (value) => set({ confirmCloseActiveTab: value }),
@@ -175,6 +180,11 @@ export const useSettingsStore = create<SettingsState>()(
         layoutVertical: undefined,
         layoutChanges: undefined,
       }),
+      addRecentCommand: (commandId) =>
+        set((state) => {
+          const filtered = state.recentCommands.filter((id) => id !== commandId);
+          return { recentCommands: [commandId, ...filtered].slice(0, 5) };
+        }),
     }),
     {
       name: 'chatml-settings',


### PR DESCRIPTION
## Summary

- Rewrote `CommandPalette.tsx` from 83 lines to ~700 lines with 30+ commands
- Added nested submenu navigation for "Go to Workspace/Session/Conversation"
- Implemented recent commands tracking (persisted in settingsStore, last 5 used)
- Added keyboard shortcut hints from the shortcuts registry
- Commands conditionally available based on app state (e.g., Git commands only when session selected)
- Mutual closing between CommandPalette (Cmd+K) and FilePicker (Cmd+P)

## Implementation Details

**Commands by category:**
- **Navigation (8):** Go to Workspace/Session/Conversation, Open Settings, Session Manager, PR Dashboard, Repositories, Dashboard
- **Actions (10):** New Session/Conversation, Add Repository, Toggle Plan/Thinking/Zen Mode, Focus Chat, Open File Picker, Toggle Panels
- **Git (5):** Commit, Create PR, Sync with Main, Copy Branch Name, Open in VS Code
- **Review (3):** Quick Review, Deep Review, Security Audit
- **Settings (3):** Preferences, Toggle Theme, Toggle Sound

**Key features:**
- Submenu pages with Backspace to go back
- Search filtering works in submenus (by name and description)
- Theme toggle resolves system preference and switches to opposite
- Navigation commands close the settings overlay

## Test Plan

- [ ] `Cmd+K` opens command palette
- [ ] Typing filters commands with fuzzy matching
- [ ] Arrow keys navigate, Enter executes, Escape closes
- [ ] Commands with shortcuts show hint (e.g., `⇧⇥` for plan mode)
- [ ] "Go to Session..." opens submenu with session list
- [ ] Backspace on empty input returns to root from submenu
- [ ] Recent commands appear at top after use
- [ ] Git/Review commands hidden when no session selected
- [ ] `Cmd+K` closes FilePicker if open, and vice versa
- [ ] Toggle Theme switches between light/dark correctly

Fixes CM-86