### PR TITLE
Standardize dialog background color to bg-surface-1

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -43,7 +43,7 @@ function Command({
       <CommandPrimitive
         data-slot="command"
         className={cn(
-          "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+          "bg-surface-1 text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
           className
         )}
         // Disable cmdk's pointer selection - we handle mouse hover separately
@@ -115,7 +115,7 @@ function CommandDialog({
             className={cn(
               "fixed top-8 inset-x-0 mx-auto z-50",
               "w-full max-w-xl",
-              "bg-popover/95 backdrop-blur-xl",
+              "bg-surface-1/95 backdrop-blur-xl",
               "border rounded-lg shadow-2xl",
               "overflow-hidden p-0",
               "data-[state=open]:animate-in data-[state=closed]:animate-out",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          "bg-surface-1 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

Standardize all dialog backgrounds to use the existing `--surface-1` design token (`#1a1c1d` / `rgb(26, 28, 29)`) instead of mixing `bg-background` and `bg-popover`. This ensures consistent styling across all dialogs, popovers, and dropdown menus.

## Changes

- Changed `DialogContent` base component to use `bg-surface-1` (covers 11+ standard dialogs)
- Updated spotlight `CommandDialog` variant to use `bg-surface-1/95` (covers command palette, file picker, workspace search)
- Updated `Command` base component to use `bg-surface-1` (ensures inner wrapper matches)

All dialogs now share the same background color per the design system.

## Test Plan

- Open standard dialogs (delete session, add workspace, clone repo)
- Open command palette, file picker, keyboard shortcuts
- Verify all dialog backgrounds are the same color