### PR TITLE
feat: add sessions sidebar link and promote from overlay

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -202,9 +202,9 @@ export default function Home() {
     resetLayouts,
   } = useSettingsStore();
 
-  // Determine if we're in a Full Content view (not conversation or session-manager overlay)
+  // Determine if we're in a Full Content view (not conversation)
   // Also treat as full content view when no session is selected (to show welcome screen)
-  const isFullContentView = contentView.type !== 'conversation' && contentView.type !== 'session-manager';
+  const isFullContentView = contentView.type !== 'conversation';
 
   const {
     isLoading: authLoading,
@@ -851,12 +851,9 @@ export default function Home() {
         // Force page reload to apply default layouts
         window.location.reload();
       }
-      // Escape to close session manager or exit zen mode
+      // Escape to exit zen mode
       if (e.key === 'Escape') {
-        if (contentViewRef.current.type === 'session-manager') {
-          e.preventDefault();
-          navigate({ contentView: { type: 'conversation' } });
-        } else if (zenModeRef.current) {
+        if (zenModeRef.current) {
           e.preventDefault();
           setZenMode(false);
         }
@@ -1129,6 +1126,9 @@ export default function Home() {
                     showLeftSidebar={!leftSidebarCollapsed}
                   />
                 )}
+                {contentView.type === 'session-manager' && (
+                  <SessionManager />
+                )}
                 {contentView.type === 'workspace-dashboard' && (
                   <WorkspaceDashboard
                     workspaceId={contentView.workspaceId}
@@ -1248,15 +1248,6 @@ export default function Home() {
           </ResizablePanel>
         </ResizablePanelGroup>
 
-
-        {/* Session Manager Overlay - full screen */}
-        {contentView.type === 'session-manager' && (
-          <div className="absolute inset-0 z-20 bg-content-background">
-            <SessionManager
-              onClose={() => navigate({ contentView: { type: 'conversation' } })}
-            />
-          </div>
-        )}
 
         {/* Settings Overlay - full screen */}
         {showSettings && (

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -74,6 +74,7 @@ import {
   Search,
   X,
   LayoutDashboard,
+  Layers,
   Bot,
   Clock,
 } from 'lucide-react';
@@ -362,6 +363,28 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
               : "text-muted-foreground group-hover:text-foreground"
           )}>
             Dashboard
+          </span>
+        </div>
+        <div
+          className={cn(
+            "group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer",
+            contentView.type === 'session-manager'
+              ? "bg-surface-2 text-foreground"
+              : "hover:bg-surface-1"
+          )}
+          onClick={() => navigate({ contentView: { type: 'session-manager' } })}
+        >
+          <Layers className={cn(
+            "w-4 h-4",
+            contentView.type === 'session-manager' ? "text-orange-400" : "text-orange-400/70"
+          )} />
+          <span className={cn(
+            "text-base font-medium",
+            contentView.type === 'session-manager'
+              ? "text-foreground"
+              : "text-muted-foreground group-hover:text-foreground"
+          )}>
+            Sessions
           </span>
         </div>
       </div>

--- a/src/components/session-manager/SessionManager.tsx
+++ b/src/components/session-manager/SessionManager.tsx
@@ -1,30 +1,54 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { navigate } from '@/lib/navigation';
-import { useUIStore } from '@/stores/uiStore';
 import { updateSession as updateSessionApi } from '@/lib/api';
 import { SessionsDataTable } from './SessionsDataTable';
-import { cn } from '@/lib/utils';
 import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog';
 import { useArchiveSession } from '@/hooks/useArchiveSession';
+import { useMainToolbarContent } from '@/hooks/useMainToolbarContent';
+import { Layers } from 'lucide-react';
 
-interface SessionManagerProps {
-  onClose: () => void;
-}
-
-export function SessionManager({
-  onClose,
-}: SessionManagerProps) {
+export function SessionManager() {
 
   const workspaces = useAppStore((s) => s.workspaces);
   const sessions = useAppStore((s) => s.sessions);
   const unarchiveSession = useAppStore((s) => s.unarchiveSession);
   const { expandWorkspace } = useSettingsStore();
-  const leftToolbarBg = useUIStore((state) => state.toolbarBackgrounds.left);
   const { requestArchive, dialogProps: archiveDialogProps } = useArchiveSession();
+
+  // Set dynamic toolbar content
+  const { activeSessions, archivedSessions } = useMemo(() => {
+    let active = 0;
+    let archived = 0;
+    for (const s of sessions) {
+      if (s.archived) archived++;
+      else active++;
+    }
+    return { activeSessions: active, archivedSessions: archived };
+  }, [sessions]);
+
+  const toolbarConfig = useMemo(() => ({
+    titlePosition: 'center' as const,
+    title: (
+      <span className="flex items-center gap-1.5">
+        <Layers className="h-4 w-4 text-orange-400" />
+        <h1 className="text-base font-semibold">Sessions</h1>
+      </span>
+    ),
+    bottom: {
+      title: (
+        <span className="text-sm text-muted-foreground">
+          {activeSessions} {activeSessions === 1 ? 'session' : 'sessions'}
+          {archivedSessions > 0 && <span className="ml-2">{archivedSessions} archived</span>}
+        </span>
+      ),
+      titlePosition: 'left' as const,
+    },
+  }), [activeSessions, archivedSessions]);
+  useMainToolbarContent(toolbarConfig);
 
   // Handle session selection - navigate to conversation view
   const handleSelectSession = useCallback(
@@ -67,14 +91,6 @@ export function SessionManager({
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header - minimal drag region */}
-      <div
-        data-tauri-drag-region
-        className={cn('h-10 flex items-center justify-center border-b shrink-0', leftToolbarBg)}
-      >
-        <h1 className="text-sm font-medium">Session Manager</h1>
-      </div>
-
       {/* Content: Sessions data table */}
       <div className="flex-1 overflow-hidden">
         <SessionsDataTable
@@ -83,7 +99,6 @@ export function SessionManager({
           onSelectSession={handleSelectSession}
           onArchiveSession={handleArchiveSession}
           onUnarchiveSession={handleUnarchiveSession}
-          onClose={onClose}
         />
       </div>
       {archiveDialogProps && <ArchiveSessionDialog {...archiveDialogProps} />}

--- a/src/components/session-manager/SessionsDataTable.tsx
+++ b/src/components/session-manager/SessionsDataTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useCallback } from 'react';
-import { Layers, Archive, ExternalLink, Copy, FolderOpen, ArrowLeft } from 'lucide-react';
+import { Layers, Archive, ExternalLink, Copy, FolderOpen } from 'lucide-react';
 import type { WorktreeSession, Workspace, SessionPriority, SessionTaskStatus } from '@/lib/types';
 import { DataTable, type Column, type ContextMenuItem, type DisplayOptionsConfig } from '@/components/data-table';
 import {
@@ -37,7 +37,6 @@ interface SessionsDataTableProps {
   onSelectSession: (workspaceId: string, sessionId: string) => void;
   onArchiveSession: (sessionId: string) => void;
   onUnarchiveSession: (sessionId: string) => void;
-  onClose: () => void;
 }
 
 // Helper to get date group label
@@ -62,7 +61,6 @@ export function SessionsDataTable({
   onSelectSession,
   onArchiveSession,
   onUnarchiveSession,
-  onClose,
 }: SessionsDataTableProps) {
   // Transform sessions into table rows
   const tableData = sessions
@@ -283,18 +281,6 @@ export function SessionsDataTable({
     []
   );
 
-  // Back link for toolbar
-  const backButton = (
-    <button
-      type="button"
-      onClick={onClose}
-      className="flex items-center gap-2 text-foreground hover:text-foreground/80 transition-colors"
-    >
-      <ArrowLeft className="h-4 w-4" />
-      <span className="text-sm font-medium">Back</span>
-    </button>
-  );
-
   // Empty state
   const emptyState = (
     <div className="flex flex-col items-center justify-center py-24 text-center">
@@ -326,7 +312,6 @@ export function SessionsDataTable({
         emptyState={emptyState}
         searchPlaceholder="Filter sessions by branch, workspace, or task..."
         displayOptionsConfig={displayOptionsConfig}
-        toolbarLeftContent={backButton}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
Promotes the Session Manager from a full-screen overlay to a first-class sidebar navigation item. Adds a "Sessions" link in the workspace sidebar allowing quick access to view and manage all sessions.

## Changes
- Move SessionManager from z-20 overlay to inline content view
- Add Sessions navigation link with Layers icon (orange accent)
- Simplify isFullContentView logic and remove Escape-to-close handler
- Use useMainToolbarContent for dynamic toolbar displaying active/archived counts
- Consolidate session filtering into single pass for performance

## Test Plan
- [ ] Verify Sessions link appears in workspace sidebar
- [ ] Verify clicking Sessions link navigates to session manager
- [ ] Verify toolbar displays correct active/archived session counts
- [ ] Verify switching between Sessions view and other content views works
- [ ] Verify ESC key only closes zen mode, not session manager view

🤖 Generated with [Claude Code](https://claude.com/claude-code)