### PR TITLE
fix: add validation and state tracking for plan mode

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -81,6 +81,20 @@ const maxBudgetUsd = maxBudgetIndex !== -1 ? parseFloat(args[maxBudgetIndex + 1]
 const maxTurns = maxTurnsIndex !== -1 ? parseInt(args[maxTurnsIndex + 1], 10) : undefined;
 const maxThinkingTokens = maxThinkingTokensIndex !== -1 ? parseInt(args[maxThinkingTokensIndex + 1], 10) : undefined;
 
+// Permission mode (e.g., "plan" for plan mode at startup)
+const validPermissionModes = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk"] as const;
+type PermissionMode = typeof validPermissionModes[number];
+const permissionModeIndex = args.indexOf("--permission-mode");
+let initialPermissionMode: PermissionMode = "bypassPermissions";
+if (permissionModeIndex !== -1 && permissionModeIndex + 1 < args.length) {
+  const value = args[permissionModeIndex + 1];
+  if ((validPermissionModes as readonly string[]).includes(value)) {
+    initialPermissionMode = value as PermissionMode;
+  } else {
+    console.error(`Invalid --permission-mode value: "${value}". Using default "bypassPermissions".`);
+  }
+}
+
 // Task 6: Settings Sources Configuration
 const settingSourcesIndex = args.indexOf("--setting-sources");
 const settingSourcesArg = settingSourcesIndex !== -1 ? args[settingSourcesIndex + 1] : undefined;
@@ -686,7 +700,7 @@ async function main(): Promise<void> {
       prompt: createMessageStream(),
       options: {
         cwd,
-        permissionMode: "bypassPermissions",
+        permissionMode: initialPermissionMode,
         allowDangerouslySkipPermissions: true,
         canUseTool,
         mcpServers: { chatml: chatmlMcp },

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -83,6 +83,7 @@ func (m *Manager) SetSessionEventHandler(handler SessionEventHandler) {
 type StartConversationOptions struct {
 	MaxThinkingTokens int                 // Enable extended thinking with this token budget
 	Attachments       []models.Attachment // File attachments for the initial message
+	PlanMode          bool                // Start agent in plan mode
 }
 
 // StartConversation creates and starts a new conversation within a session
@@ -149,6 +150,7 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 	// Apply optional parameters
 	if opts != nil {
 		procOpts.MaxThinkingTokens = opts.MaxThinkingTokens
+		procOpts.PlanMode = opts.PlanMode
 	}
 
 	// Create and start process
@@ -438,6 +440,19 @@ func (m *Manager) SetConversationPlanMode(convID string, enabled bool) error {
 	}
 
 	return proc.SetPermissionMode(mode)
+}
+
+// IsConversationInPlanMode returns whether the conversation process is in plan mode
+func (m *Manager) IsConversationInPlanMode(convID string) bool {
+	m.mu.RLock()
+	proc, ok := m.convProcesses[convID]
+	m.mu.RUnlock()
+
+	if !ok || proc.IsStopped() || !proc.IsRunning() {
+		return false
+	}
+
+	return proc.IsPlanModeActive()
 }
 
 // StopConversation stops a running conversation

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -670,3 +670,32 @@ func TestHandleConversationCompletion_CompletesNormally(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.ConversationStatusIdle, conv.Status)
 }
+
+// ============================================================================
+// SetConversationPlanMode Tests
+// ============================================================================
+
+func TestSetConversationPlanMode_NoProcess(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	// Should fail when no process exists for the conversation
+	err := m.SetConversationPlanMode("nonexistent-conv", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conversation process not running")
+}
+
+func TestSetConversationPlanMode_StoppedProcess(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	// Create a process and stop it
+	proc := NewProcess("stopped-proc", "/tmp", "conv-stopped")
+	proc.Stop()
+
+	m.mu.Lock()
+	m.convProcesses["conv-stopped"] = proc
+	m.mu.Unlock()
+
+	err := m.SetConversationPlanMode("conv-stopped", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conversation process not running")
+}

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -45,6 +45,7 @@ type ProcessOptions struct {
 	MaxBudgetUsd        float64
 	MaxTurns            int
 	MaxThinkingTokens   int
+	PlanMode            bool // Start agent in plan mode
 	StructuredOutput    string
 	SettingSources      string // Comma-separated: project,user,local
 	Betas               string // Comma-separated beta features
@@ -61,10 +62,11 @@ type Process struct {
 	cancel         context.CancelFunc
 	output         chan string
 	done           chan struct{}
-	mu             sync.Mutex
-	running        bool
-	stopped        bool // Prevents double-stop race conditions
-	exitErr        error
+	mu              sync.Mutex
+	running         bool
+	stopped         bool // Prevents double-stop race conditions
+	exitErr         error
+	planModeActive  bool // Tracks whether the process is in plan mode
 }
 
 // InputMessage represents a message sent to the agent runner via stdin
@@ -167,6 +169,9 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	if opts.MaxThinkingTokens > 0 {
 		args = append(args, "--max-thinking-tokens", strconv.Itoa(opts.MaxThinkingTokens))
 	}
+	if opts.PlanMode {
+		args = append(args, "--permission-mode", "plan")
+	}
 
 	// Add structured output schema if provided
 	if opts.StructuredOutput != "" {
@@ -200,8 +205,9 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 		// size was increased from 100 to handle high-throughput scenarios
 		// where agents produce rapid bursts of output (e.g., streaming
 		// tool results or large code blocks).
-		output: make(chan string, 1000),
-		done:   make(chan struct{}),
+		output:         make(chan string, 1000),
+		done:           make(chan struct{}),
+		planModeActive: opts.PlanMode,
 	}
 }
 
@@ -355,10 +361,23 @@ func (p *Process) SetModel(model string) error {
 
 // SetPermissionMode sends a message to change the permission mode
 func (p *Process) SetPermissionMode(mode string) error {
-	return p.sendInput(InputMessage{
+	err := p.sendInput(InputMessage{
 		Type:           "set_permission_mode",
 		PermissionMode: mode,
 	})
+	if err == nil {
+		p.mu.Lock()
+		p.planModeActive = (mode == "plan")
+		p.mu.Unlock()
+	}
+	return err
+}
+
+// IsPlanModeActive returns whether the process is currently in plan mode
+func (p *Process) IsPlanModeActive() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.planModeActive
 }
 
 // GetSupportedModels requests the list of supported models

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -35,6 +35,7 @@ func TestNewProcessWithOptions(t *testing.T) {
 		MaxBudgetUsd:        10.0,
 		MaxTurns:            50,
 		MaxThinkingTokens:   1000,
+		PlanMode:            true,
 		StructuredOutput:    `{"type": "object"}`,
 		SettingSources:      "project,user",
 		Betas:               "feature1,feature2",
@@ -390,6 +391,7 @@ func TestProcessOptions_Defaults(t *testing.T) {
 	assert.Zero(t, opts.MaxBudgetUsd)
 	assert.Zero(t, opts.MaxTurns)
 	assert.Zero(t, opts.MaxThinkingTokens)
+	assert.False(t, opts.PlanMode)
 	assert.Empty(t, opts.StructuredOutput)
 	assert.Empty(t, opts.SettingSources)
 	assert.Empty(t, opts.Betas)
@@ -458,4 +460,94 @@ func TestProcess_Stop_ClosesStdin(t *testing.T) {
 	// Writing to the closed pipe should fail
 	_, writeErr := w.Write([]byte("test"))
 	assert.Error(t, writeErr, "stdin should be closed after Stop()")
+}
+
+// ============================================================================
+// Plan Mode CLI Arg Tests
+// ============================================================================
+
+func TestNewProcessWithOptions_PlanModeEnabled(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "plan-test",
+		Workdir:        "/tmp/test",
+		ConversationID: "conv-plan",
+		PlanMode:       true,
+	}
+
+	p := NewProcessWithOptions(opts)
+
+	// Verify --permission-mode plan appears in the command args
+	args := p.cmd.Args
+	found := false
+	for i, arg := range args {
+		if arg == "--permission-mode" && i+1 < len(args) && args[i+1] == "plan" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected --permission-mode plan in args: %v", args)
+}
+
+func TestNewProcessWithOptions_PlanModeDisabled(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "no-plan-test",
+		Workdir:        "/tmp/test",
+		ConversationID: "conv-no-plan",
+		PlanMode:       false,
+	}
+
+	p := NewProcessWithOptions(opts)
+
+	// Verify --permission-mode does NOT appear in args when plan mode is off
+	args := p.cmd.Args
+	for _, arg := range args {
+		assert.NotEqual(t, "--permission-mode", arg, "Should not have --permission-mode when PlanMode is false")
+	}
+}
+
+func TestNewProcessWithOptions_PlanModeWithThinking(t *testing.T) {
+	opts := ProcessOptions{
+		ID:                "combo-test",
+		Workdir:           "/tmp/test",
+		ConversationID:    "conv-combo",
+		PlanMode:          true,
+		MaxThinkingTokens: 5000,
+	}
+
+	p := NewProcessWithOptions(opts)
+	args := p.cmd.Args
+
+	// Both flags should be present
+	foundPlanMode := false
+	foundThinking := false
+	for i, arg := range args {
+		if arg == "--permission-mode" && i+1 < len(args) && args[i+1] == "plan" {
+			foundPlanMode = true
+		}
+		if arg == "--max-thinking-tokens" && i+1 < len(args) && args[i+1] == "5000" {
+			foundThinking = true
+		}
+	}
+	assert.True(t, foundPlanMode, "Expected --permission-mode plan in args: %v", args)
+	assert.True(t, foundThinking, "Expected --max-thinking-tokens 5000 in args: %v", args)
+}
+
+// ============================================================================
+// StartConversationOptions Plan Mode Tests
+// ============================================================================
+
+func TestStartConversationOptions_PlanModeDefaults(t *testing.T) {
+	opts := StartConversationOptions{}
+	assert.False(t, opts.PlanMode)
+	assert.Zero(t, opts.MaxThinkingTokens)
+	assert.Nil(t, opts.Attachments)
+}
+
+func TestStartConversationOptions_PlanModeSet(t *testing.T) {
+	opts := StartConversationOptions{
+		PlanMode:          true,
+		MaxThinkingTokens: 1000,
+	}
+	assert.True(t, opts.PlanMode)
+	assert.Equal(t, 1000, opts.MaxThinkingTokens)
 }

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -2429,6 +2429,7 @@ func (h *Handlers) ListConversations(w http.ResponseWriter, r *http.Request) {
 type CreateConversationRequest struct {
 	Type              string              `json:"type"`              // "task", "review", "chat"
 	Message           string              `json:"message"`           // Initial message (optional)
+	PlanMode          bool                `json:"planMode"`          // Start in plan mode (optional)
 	MaxThinkingTokens int                 `json:"maxThinkingTokens"` // Enable extended thinking (optional)
 	Attachments       []models.Attachment `json:"attachments"`       // File attachments (optional)
 }
@@ -2459,10 +2460,11 @@ func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
 
 	// Build options for starting the conversation
 	var opts *agent.StartConversationOptions
-	if req.MaxThinkingTokens > 0 || len(req.Attachments) > 0 {
+	if req.MaxThinkingTokens > 0 || len(req.Attachments) > 0 || req.PlanMode {
 		opts = &agent.StartConversationOptions{
 			MaxThinkingTokens: req.MaxThinkingTokens,
 			Attachments:       req.Attachments,
+			PlanMode:          req.PlanMode,
 		}
 	}
 
@@ -2685,6 +2687,34 @@ func (h *Handlers) SetConversationPlanMode(w http.ResponseWriter, r *http.Reques
 	}
 
 	writeJSON(w, map[string]bool{"enabled": req.Enabled})
+}
+
+func (h *Handlers) ApprovePlan(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	convID := chi.URLParam(r, "convId")
+	conv, err := h.store.GetConversationMeta(ctx, convID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if conv == nil {
+		writeNotFound(w, "conversation")
+		return
+	}
+
+	// Verify the conversation is actually in plan mode before approving
+	if !h.agentManager.IsConversationInPlanMode(convID) {
+		writeConflict(w, "conversation is not in plan mode")
+		return
+	}
+
+	// Approving a plan means exiting plan mode (switching back to bypassPermissions)
+	if err := h.agentManager.SetConversationPlanMode(convID, false); err != nil {
+		writeInternalError(w, "failed to approve plan", err)
+		return
+	}
+
+	writeJSON(w, map[string]bool{"approved": true})
 }
 
 // Attachment handlers

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -1770,3 +1770,113 @@ func TestSetWorkspacesBaseDir_PathIsFile(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "path is not a directory")
 }
+
+// ============================================================================
+// CreateConversation Plan Mode Tests
+// ============================================================================
+
+func TestCreateConversation_InvalidJSON(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	repoPath := createTestGitRepo(t)
+	createTestRepo(t, s, "ws-1", repoPath)
+	createTestSession(t, s, "sess-1", "ws-1")
+
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/sessions/sess-1/conversations", strings.NewReader(`{bad json`))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"workspaceId": "ws-1", "sessionId": "sess-1"})
+	w := httptest.NewRecorder()
+
+	h.CreateConversation(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateConversation_SessionNotFound(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	body := strings.NewReader(`{"type": "task", "message": "hello"}`)
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/sessions/nonexistent/conversations", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"workspaceId": "ws-1", "sessionId": "nonexistent"})
+	w := httptest.NewRecorder()
+
+	h.CreateConversation(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCreateConversation_RequestParsing_WithPlanMode(t *testing.T) {
+	// Verify that CreateConversationRequest correctly deserializes planMode
+	tests := []struct {
+		name     string
+		body     string
+		expected bool
+	}{
+		{
+			name:     "planMode true",
+			body:     `{"type": "task", "message": "hello", "planMode": true}`,
+			expected: true,
+		},
+		{
+			name:     "planMode false",
+			body:     `{"type": "task", "message": "hello", "planMode": false}`,
+			expected: false,
+		},
+		{
+			name:     "planMode omitted defaults to false",
+			body:     `{"type": "task", "message": "hello"}`,
+			expected: false,
+		},
+		{
+			name:     "planMode with thinking tokens",
+			body:     `{"type": "task", "message": "hello", "planMode": true, "maxThinkingTokens": 5000}`,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req CreateConversationRequest
+			err := json.Unmarshal([]byte(tt.body), &req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, req.PlanMode)
+		})
+	}
+}
+
+// ============================================================================
+// ApprovePlan Handler Tests
+// ============================================================================
+
+func TestApprovePlan_NotFound(t *testing.T) {
+	h, _, _ := setupTestHandlersWithAgentManager(t)
+
+	req := httptest.NewRequest("POST", "/api/conversations/nonexistent/approve-plan", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"convId": "nonexistent"})
+	w := httptest.NewRecorder()
+
+	h.ApprovePlan(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "conversation not found")
+}
+
+func TestApprovePlan_NotInPlanMode(t *testing.T) {
+	h, s, _ := setupTestHandlersWithAgentManager(t)
+
+	createTestRepo(t, s, "ws-1", "/path/to/repo")
+	createTestSession(t, s, "sess-1", "ws-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	req := httptest.NewRequest("POST", "/api/conversations/conv-1/approve-plan", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"convId": "conv-1"})
+	w := httptest.NewRecorder()
+
+	h.ApprovePlan(w, req)
+
+	// Should fail because no process is running (not in plan mode)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "conversation is not in plan mode")
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -121,6 +121,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Post("/{convId}/stop", h.StopConversation)
 		r.Post("/{convId}/rewind", h.RewindConversation)
 		r.Post("/{convId}/plan-mode", h.SetConversationPlanMode)
+		r.Post("/{convId}/approve-plan", h.ApprovePlan)
 		r.Post("/{convId}/answer-question", h.AnswerConversationQuestion)
 		r.Delete("/{convId}", h.DeleteConversation)
 	})

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -900,6 +900,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
           type: convType,
           message: content,
+          // Pass plan mode so agent starts in plan mode if toggled on before first message
+          planMode: planModeEnabled ? true : undefined,
           // Pass thinking tokens when thinking mode is enabled
           maxThinkingTokens: thinkingEnabled ? maxThinkingTokens : undefined,
           // Pass attachments with loaded content

--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../__mocks__/server';
-import { listSessions, updateSession, getWorkspacesBasePath, setWorkspacesBasePath } from '../api';
+import {
+  listSessions,
+  updateSession,
+  getWorkspacesBasePath,
+  setWorkspacesBasePath,
+  createConversation,
+  setConversationPlanMode,
+  approvePlan,
+} from '../api';
 
 const API_BASE = 'http://localhost:9876';
 
@@ -115,6 +123,218 @@ describe('Settings API', () => {
       );
 
       await expect(setWorkspacesBasePath('/nonexistent')).rejects.toThrow();
+    });
+  });
+});
+
+// ============================================================================
+// Conversation API Tests
+// ============================================================================
+
+describe('Conversation API', () => {
+  describe('createConversation', () => {
+    it('creates a conversation without planMode', async () => {
+      const result = await createConversation('workspace-1', 'session-1', {
+        type: 'task',
+        message: 'Hello',
+      });
+
+      expect(result.id).toBe('new-conv-id');
+      expect(result.type).toBe('task');
+      expect(result.status).toBe('active');
+    });
+
+    it('creates a conversation with planMode true', async () => {
+      let receivedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`, async ({ request }) => {
+          receivedBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'plan-conv-id',
+            sessionId: 'session-1',
+            type: receivedBody.type || 'task',
+            name: 'Plan Conversation',
+            status: 'active',
+            messages: [],
+            toolSummary: [],
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        })
+      );
+
+      const result = await createConversation('workspace-1', 'session-1', {
+        type: 'task',
+        message: 'Build a feature',
+        planMode: true,
+      });
+
+      expect(result.id).toBe('plan-conv-id');
+      expect(receivedBody.planMode).toBe(true);
+      expect(receivedBody.message).toBe('Build a feature');
+    });
+
+    it('creates a conversation with planMode false', async () => {
+      let receivedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`, async ({ request }) => {
+          receivedBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'no-plan-conv-id',
+            sessionId: 'session-1',
+            type: 'task',
+            name: 'No Plan Conversation',
+            status: 'active',
+            messages: [],
+            toolSummary: [],
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        })
+      );
+
+      const result = await createConversation('workspace-1', 'session-1', {
+        type: 'task',
+        message: 'Quick fix',
+        planMode: false,
+      });
+
+      expect(result.id).toBe('no-plan-conv-id');
+      expect(receivedBody.planMode).toBe(false);
+    });
+
+    it('creates a conversation with planMode and thinking tokens', async () => {
+      let receivedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`, async ({ request }) => {
+          receivedBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'combo-conv-id',
+            sessionId: 'session-1',
+            type: 'task',
+            name: 'Combo Conversation',
+            status: 'active',
+            messages: [],
+            toolSummary: [],
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        })
+      );
+
+      const result = await createConversation('workspace-1', 'session-1', {
+        type: 'task',
+        message: 'Complex task',
+        planMode: true,
+        maxThinkingTokens: 5000,
+      });
+
+      expect(result.id).toBe('combo-conv-id');
+      expect(receivedBody.planMode).toBe(true);
+      expect(receivedBody.maxThinkingTokens).toBe(5000);
+    });
+
+    it('handles server error on createConversation', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`, () => {
+          return HttpResponse.json({ error: 'session not found' }, { status: 404 });
+        })
+      );
+
+      await expect(
+        createConversation('workspace-1', 'nonexistent', {
+          type: 'task',
+          message: 'Hello',
+        })
+      ).rejects.toThrow();
+    });
+  });
+});
+
+// ============================================================================
+// Plan Mode API Tests
+// ============================================================================
+
+describe('Plan Mode API', () => {
+  describe('setConversationPlanMode', () => {
+    it('enables plan mode', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/plan-mode`, async ({ request }) => {
+          const body = await request.json() as { enabled: boolean };
+          return HttpResponse.json({ enabled: body.enabled });
+        })
+      );
+
+      await expect(setConversationPlanMode('conv-1', true)).resolves.toBeUndefined();
+    });
+
+    it('disables plan mode', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/plan-mode`, async ({ request }) => {
+          const body = await request.json() as { enabled: boolean };
+          return HttpResponse.json({ enabled: body.enabled });
+        })
+      );
+
+      await expect(setConversationPlanMode('conv-1', false)).resolves.toBeUndefined();
+    });
+
+    it('rejects on server error', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/plan-mode`, () => {
+          return HttpResponse.json({ error: 'conversation not found' }, { status: 404 });
+        })
+      );
+
+      await expect(setConversationPlanMode('nonexistent', true)).rejects.toThrow();
+    });
+
+    it('rejects when process not running', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/plan-mode`, () => {
+          return HttpResponse.json(
+            { error: 'failed to set plan mode' },
+            { status: 500 }
+          );
+        })
+      );
+
+      await expect(setConversationPlanMode('conv-1', true)).rejects.toThrow();
+    });
+  });
+
+  describe('approvePlan', () => {
+    it('approves a plan successfully', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/approve-plan`, () => {
+          return HttpResponse.json({ approved: true });
+        })
+      );
+
+      await expect(approvePlan('conv-1')).resolves.toBeUndefined();
+    });
+
+    it('rejects when conversation not found', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/approve-plan`, () => {
+          return HttpResponse.json({ error: 'conversation not found' }, { status: 404 });
+        })
+      );
+
+      await expect(approvePlan('nonexistent')).rejects.toThrow();
+    });
+
+    it('rejects when process not running', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/approve-plan`, () => {
+          return HttpResponse.json(
+            { error: 'failed to approve plan' },
+            { status: 500 }
+          );
+        })
+      );
+
+      await expect(approvePlan('conv-1')).rejects.toThrow();
     });
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -835,6 +835,7 @@ export async function createConversation(
   data: {
     type?: 'task' | 'review' | 'chat';
     message?: string;
+    planMode?: boolean;
     maxThinkingTokens?: number;
     attachments?: AttachmentDTO[];
   }

--- a/src/stores/__tests__/appStore.planMode.test.ts
+++ b/src/stores/__tests__/appStore.planMode.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAppStore } from '../appStore';
+
+// Helper to initialize streaming state for a conversation by setting isStreaming
+function initStreamingState(conversationId: string) {
+  useAppStore.getState().setStreaming(conversationId, false);
+}
+
+describe('appStore - Plan Mode State', () => {
+  const convId = 'test-conv-1';
+
+  beforeEach(() => {
+    // Reset store state
+    useAppStore.setState({ streamingState: {} });
+  });
+
+  describe('setPlanModeActive', () => {
+    it('sets planModeActive to true for a conversation', () => {
+      initStreamingState(convId);
+
+      useAppStore.getState().setPlanModeActive(convId, true);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.planModeActive).toBe(true);
+    });
+
+    it('sets planModeActive to false for a conversation', () => {
+      initStreamingState(convId);
+
+      useAppStore.getState().setPlanModeActive(convId, true);
+      useAppStore.getState().setPlanModeActive(convId, false);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.planModeActive).toBe(false);
+    });
+
+    it('does not affect other conversations', () => {
+      const otherId = 'other-conv';
+      initStreamingState(convId);
+      initStreamingState(otherId);
+
+      useAppStore.getState().setPlanModeActive(convId, true);
+
+      expect(useAppStore.getState().streamingState[convId]?.planModeActive).toBe(true);
+      expect(useAppStore.getState().streamingState[otherId]?.planModeActive).toBe(false);
+    });
+
+    it('initializes streaming state if not present', () => {
+      // No initStreamingState call - setPlanModeActive should still work
+      useAppStore.getState().setPlanModeActive(convId, true);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.planModeActive).toBe(true);
+    });
+  });
+
+  describe('setAwaitingPlanApproval', () => {
+    it('sets awaitingPlanApproval to true', () => {
+      initStreamingState(convId);
+
+      useAppStore.getState().setAwaitingPlanApproval(convId, true);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.awaitingPlanApproval).toBe(true);
+    });
+
+    it('sets awaitingPlanApproval to false', () => {
+      initStreamingState(convId);
+
+      useAppStore.getState().setAwaitingPlanApproval(convId, true);
+      useAppStore.getState().setAwaitingPlanApproval(convId, false);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.awaitingPlanApproval).toBe(false);
+    });
+
+    it('does not affect planModeActive', () => {
+      initStreamingState(convId);
+
+      useAppStore.getState().setPlanModeActive(convId, true);
+      useAppStore.getState().setAwaitingPlanApproval(convId, true);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.planModeActive).toBe(true);
+      expect(state?.awaitingPlanApproval).toBe(true);
+    });
+
+    it('does not affect other conversations', () => {
+      const otherId = 'other-conv';
+      initStreamingState(convId);
+      initStreamingState(otherId);
+
+      useAppStore.getState().setAwaitingPlanApproval(convId, true);
+
+      expect(useAppStore.getState().streamingState[convId]?.awaitingPlanApproval).toBe(true);
+      expect(useAppStore.getState().streamingState[otherId]?.awaitingPlanApproval).toBe(false);
+    });
+  });
+
+  describe('plan mode state defaults', () => {
+    it('defaults planModeActive to false when streaming state initialized', () => {
+      initStreamingState(convId);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.planModeActive).toBe(false);
+    });
+
+    it('defaults awaitingPlanApproval to false when streaming state initialized', () => {
+      initStreamingState(convId);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.awaitingPlanApproval).toBe(false);
+    });
+  });
+
+  describe('plan mode state isolation between conversations', () => {
+    it('maintains independent plan mode state per conversation', () => {
+      const conv1 = 'conv-1';
+      const conv2 = 'conv-2';
+      const conv3 = 'conv-3';
+
+      initStreamingState(conv1);
+      initStreamingState(conv2);
+      initStreamingState(conv3);
+
+      useAppStore.getState().setPlanModeActive(conv1, true);
+      useAppStore.getState().setAwaitingPlanApproval(conv2, true);
+
+      expect(useAppStore.getState().streamingState[conv1]?.planModeActive).toBe(true);
+      expect(useAppStore.getState().streamingState[conv1]?.awaitingPlanApproval).toBe(false);
+
+      expect(useAppStore.getState().streamingState[conv2]?.planModeActive).toBe(false);
+      expect(useAppStore.getState().streamingState[conv2]?.awaitingPlanApproval).toBe(true);
+
+      expect(useAppStore.getState().streamingState[conv3]?.planModeActive).toBe(false);
+      expect(useAppStore.getState().streamingState[conv3]?.awaitingPlanApproval).toBe(false);
+    });
+  });
+
+  describe('finalizeStreamingMessage preserves planModeActive', () => {
+    it('preserves planModeActive after message finalization', () => {
+      initStreamingState(convId);
+      useAppStore.getState().setPlanModeActive(convId, true);
+      useAppStore.getState().appendStreamingText(convId, 'Some response text');
+
+      useAppStore.getState().finalizeStreamingMessage(convId, {});
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.planModeActive).toBe(true);
+    });
+
+    it('clears awaitingPlanApproval after message finalization', () => {
+      initStreamingState(convId);
+      useAppStore.getState().setAwaitingPlanApproval(convId, true);
+      useAppStore.getState().appendStreamingText(convId, 'Some response text');
+
+      useAppStore.getState().finalizeStreamingMessage(convId, {});
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.awaitingPlanApproval).toBe(false);
+    });
+
+    it('preserves planModeActive=false after finalization', () => {
+      initStreamingState(convId);
+      useAppStore.getState().setPlanModeActive(convId, false);
+      useAppStore.getState().appendStreamingText(convId, 'Text');
+
+      useAppStore.getState().finalizeStreamingMessage(convId, {});
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.planModeActive).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add bounds check and validation for --permission-mode CLI arg
- Fix planMode coercion in ChatInput to maintain semantic clarity
- Add planModeActive state tracking to Process struct
- Add IsConversationInPlanMode method to Manager
- Return 409 Conflict if attempting to approve non-plan-mode conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)