### PR TITLE
fix: add agent-runner CI job, fix TS errors, fix session manager bg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      agent-runner: ${{ steps.filter.outputs.agent-runner }}
       tauri: ${{ steps.filter.outputs.tauri }}
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +37,9 @@ jobs:
               - 'tsconfig.json'
               - 'vitest.config.ts'
               - 'vitest.setup.ts'
+              - '.github/workflows/ci.yml'
+            agent-runner:
+              - 'agent-runner/**'
               - '.github/workflows/ci.yml'
             tauri:
               - 'src-tauri/**'
@@ -67,6 +71,29 @@ jobs:
         run: npm run test:run
 
       - name: Build
+        run: npm run build
+
+  # Agent runner checks (TypeScript build)
+  agent-runner:
+    name: Agent Runner
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.agent-runner == 'true' || github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        working-directory: agent-runner
+        run: npm install
+
+      - name: Build
+        working-directory: agent-runner
         run: npm run build
 
   # Go backend checks (test + build)

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -602,10 +602,10 @@ const askUserQuestionHook: HookCallback = async (input) => {
     // Allow tool execution with answers populated
     return {
       hookSpecificOutput: {
-        hookEventName: input.hook_event_name,
+        hookEventName: "PreToolUse" as const,
         permissionDecision: "allow" as const,
         updatedInput: {
-          ...hookInput.tool_input,
+          ...(hookInput.tool_input as Record<string, unknown>),
           answers,
         },
       },
@@ -614,7 +614,7 @@ const askUserQuestionHook: HookCallback = async (input) => {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       hookSpecificOutput: {
-        hookEventName: input.hook_event_name,
+        hookEventName: "PreToolUse" as const,
         permissionDecision: "deny" as const,
         permissionDecisionReason: errorMessage,
       },

--- a/src/components/session-manager/SessionManager.tsx
+++ b/src/components/session-manager/SessionManager.tsx
@@ -90,7 +90,7 @@ export function SessionManager() {
   );
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full bg-content-background">
       {/* Content: Sessions data table */}
       <div className="flex-1 overflow-hidden">
         <SessionsDataTable


### PR DESCRIPTION
## Summary
- **CI pipeline**: Add `agent-runner` build job to GitHub Actions so TypeScript compilation errors are caught before merge (path filter on `agent-runner/**`)
- **agent-runner TS fix**: Fix `HookCallback` type errors by using `"PreToolUse" as const` literal and `Record<string, unknown>` cast for discriminated union compatibility
- **Session Manager background**: Add `bg-content-background` to SessionManager root div, matching every other full-content view (GlobalDashboard, PRDashboard, etc.)

## Test plan
- [ ] Verify CI runs agent-runner build on PRs touching `agent-runner/**`
- [ ] Verify `agent-runner` builds cleanly with `cd agent-runner && npm run build`
- [ ] Verify Session Manager page uses correct content background color
- [ ] Verify no visual regressions in Session Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)