### PR TITLE
Add thinking/reasoning visibility toggle

### DIFF
--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -8,7 +8,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
-import { Copy, Check, FileText } from 'lucide-react';
+import { Copy, Check, FileText, Brain, ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Message } from '@/lib/types';
 import { COPY_FEEDBACK_DURATION_MS } from '@/lib/constants';
@@ -23,6 +23,7 @@ import { highlightSearchMatches } from '@/components/conversation/ChatSearchBar'
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
+import { useSettingsStore } from '@/stores/settingsStore';
 
 export interface MessageBlockProps {
   message: Message;
@@ -43,6 +44,8 @@ export const MessageBlock = memo(function MessageBlock({
   // comparator below to skip re-renders for messages without search matches.
 }: MessageBlockProps) {
   const [copied, setCopied] = useState(false);
+  const [isThinkingExpanded, setIsThinkingExpanded] = useState(false);
+  const showThinkingBlocks = useSettingsStore((s) => s.showThinkingBlocks);
 
   const copyContent = useCallback(async () => {
     const success = await copyToClipboard(message.content);
@@ -95,6 +98,29 @@ export const MessageBlock = memo(function MessageBlock({
   return (
     <div className={cn('py-2', !isFirst && 'border-t border-border')}>
       <div className="space-y-1.5">
+        {/* Thinking/Reasoning Content */}
+        {message.role === 'assistant' && showThinkingBlocks && message.thinkingContent && (
+          <div className="flex flex-col gap-1">
+            <button
+              onClick={() => setIsThinkingExpanded(!isThinkingExpanded)}
+              className="flex items-center gap-2 text-xs text-ai-thinking hover:text-ai-thinking/80 transition-colors"
+            >
+              <Brain className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+              <span className="font-medium">Thinking</span>
+              {isThinkingExpanded ? (
+                <ChevronDown className="w-3 h-3" />
+              ) : (
+                <ChevronRight className="w-3 h-3" />
+              )}
+            </button>
+            {isThinkingExpanded && (
+              <div className="ml-5 text-xs px-2 py-1.5 rounded bg-ai-thinking/10 text-muted-foreground font-mono border border-ai-thinking/20 whitespace-pre-wrap max-h-[300px] overflow-y-auto">
+                {message.thinkingContent}
+              </div>
+            )}
+          </div>
+        )}
+
           {/* Tool Usage History */}
           {message.toolUsage && message.toolUsage.length > 0 && (
             <ErrorBoundary

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { useStreamingState, useActiveTools } from '@/stores/selectors';
 import { Loader2, AlertCircle, Brain, Clock, ChevronDown, ChevronRight } from 'lucide-react';
 import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
@@ -87,6 +88,8 @@ export function StreamingMessage({ conversationId }: StreamingMessageProps) {
   const budgetStatus = useAppStore((s) => s.budgetStatus);
   const [elapsedTime, setElapsedTime] = useState(0);
   const startTimeRef = useRef<number | null>(null);
+
+  const showThinkingBlocks = useSettingsStore((s) => s.showThinkingBlocks);
 
   // Check if extended thinking is enabled for this conversation
   const isExtendedThinkingEnabled = budgetStatus?.maxThinkingTokens !== undefined && budgetStatus.maxThinkingTokens > 0;
@@ -209,7 +212,7 @@ export function StreamingMessage({ conversationId }: StreamingMessageProps) {
                 {streaming.isThinking && (
                   <Loader2 className="w-3 h-3 animate-spin text-ai-thinking" aria-hidden="true" />
                 )}
-                {thinkingNeedsTruncation && (
+                {showThinkingBlocks && thinkingNeedsTruncation && (
                   <button
                     onClick={() => setIsThinkingExpanded(!isThinkingExpanded)}
                     className="flex items-center gap-0.5 text-xs text-primary hover:text-primary/80 transition-colors"
@@ -228,7 +231,7 @@ export function StreamingMessage({ conversationId }: StreamingMessageProps) {
                   </button>
                 )}
               </div>
-              {streaming.thinking && (
+              {showThinkingBlocks && streaming.thinking && (
                 <div
                   className={cn(
                     'ml-5 text-xs px-2 py-1.5 rounded bg-ai-thinking/10 text-muted-foreground font-mono',

--- a/src/components/conversation/__tests__/MessageBlock.test.tsx
+++ b/src/components/conversation/__tests__/MessageBlock.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MessageBlock } from '../MessageBlock';
 import { clearMarkdownCache } from '@/lib/markdownCache';
+import { useSettingsStore } from '@/stores/settingsStore';
 import type { Message } from '@/lib/types';
 
 // Mock Tauri utilities
@@ -225,6 +226,205 @@ describe('MessageBlock', () => {
       const marks = container.querySelectorAll('mark');
       expect(marks.length).toBe(1);
       expect(marks[0].textContent).toBe('needle');
+    });
+  });
+
+  describe('thinking blocks', () => {
+    beforeEach(() => {
+      useSettingsStore.setState({ showThinkingBlocks: true });
+    });
+
+    it('renders thinking header when thinkingContent is present and visible', () => {
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'assistant',
+            content: 'The answer is 42.',
+            thinkingContent: 'Let me reason step by step...',
+          })}
+          isFirst={false}
+        />
+      );
+
+      expect(screen.getByText('Thinking')).toBeInTheDocument();
+    });
+
+    it('does not render thinking block when thinkingContent is absent', () => {
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'assistant',
+            content: 'No thinking here.',
+          })}
+          isFirst={false}
+        />
+      );
+
+      expect(screen.queryByText('Thinking')).not.toBeInTheDocument();
+    });
+
+    it('hides thinking block when showThinkingBlocks is false', () => {
+      useSettingsStore.setState({ showThinkingBlocks: false });
+
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'assistant',
+            content: 'Response.',
+            thinkingContent: 'Hidden reasoning...',
+          })}
+          isFirst={false}
+        />
+      );
+
+      expect(screen.queryByText('Thinking')).not.toBeInTheDocument();
+      expect(screen.queryByText('Hidden reasoning...')).not.toBeInTheDocument();
+    });
+
+    it('starts collapsed by default — thinking content not visible initially', () => {
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'assistant',
+            content: 'Response.',
+            thinkingContent: 'My detailed reasoning process...',
+          })}
+          isFirst={false}
+        />
+      );
+
+      // Header visible, content hidden
+      expect(screen.getByText('Thinking')).toBeInTheDocument();
+      expect(screen.queryByText('My detailed reasoning process...')).not.toBeInTheDocument();
+    });
+
+    it('expands thinking content on click', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'assistant',
+            content: 'Response.',
+            thinkingContent: 'My detailed reasoning process...',
+          })}
+          isFirst={false}
+        />
+      );
+
+      // Click to expand
+      const thinkingButton = screen.getByText('Thinking').closest('button');
+      expect(thinkingButton).toBeInTheDocument();
+      await user.click(thinkingButton!);
+
+      // Content should now be visible
+      expect(screen.getByText('My detailed reasoning process...')).toBeInTheDocument();
+    });
+
+    it('collapses thinking content on second click', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'assistant',
+            content: 'Response.',
+            thinkingContent: 'Collapsible content.',
+          })}
+          isFirst={false}
+        />
+      );
+
+      const thinkingButton = screen.getByText('Thinking').closest('button');
+
+      // Expand
+      await user.click(thinkingButton!);
+      expect(screen.getByText('Collapsible content.')).toBeInTheDocument();
+
+      // Collapse
+      await user.click(thinkingButton!);
+      expect(screen.queryByText('Collapsible content.')).not.toBeInTheDocument();
+    });
+
+    it('does not show thinking block for user messages', () => {
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'user',
+            content: 'User message.',
+            thinkingContent: 'Should not appear.',
+          })}
+          isFirst={false}
+        />
+      );
+
+      expect(screen.queryByText('Thinking')).not.toBeInTheDocument();
+    });
+
+    it('does not show thinking block for system messages', () => {
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'system',
+            content: 'System notice.',
+            thinkingContent: 'Should not appear.',
+          })}
+          isFirst={false}
+        />
+      );
+
+      expect(screen.queryByText('Thinking')).not.toBeInTheDocument();
+    });
+
+    it('renders thinking block with correct styling', async () => {
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'assistant',
+            content: 'Styled response.',
+            thinkingContent: 'Styled thinking content.',
+          })}
+          isFirst={false}
+        />
+      );
+
+      // Expand to see content
+      const thinkingButton = screen.getByText('Thinking').closest('button');
+      await user.click(thinkingButton!);
+
+      // Check monospace font class
+      const thinkingContent = container.querySelector('.font-mono');
+      expect(thinkingContent).toBeInTheDocument();
+      expect(thinkingContent?.textContent).toBe('Styled thinking content.');
+    });
+
+    it('renders alongside other message blocks', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MessageBlock
+          message={makeMessage({
+            role: 'assistant',
+            content: 'Main response.',
+            thinkingContent: 'My reasoning.',
+            toolUsage: [
+              { id: 't1', tool: 'Read', success: true, durationMs: 100 },
+            ],
+          })}
+          isFirst={false}
+        />
+      );
+
+      // Both thinking header and tool usage should be present
+      expect(screen.getByText('Thinking')).toBeInTheDocument();
+      expect(screen.getByText('1 passed')).toBeInTheDocument();
+
+      // Expand thinking
+      const thinkingButton = screen.getByText('Thinking').closest('button');
+      await user.click(thinkingButton!);
+      expect(screen.getByText('My reasoning.')).toBeInTheDocument();
     });
   });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -137,6 +137,8 @@ export interface Message {
   runSummary?: RunSummary;
   // File attachments (images, code, text files)
   attachments?: Attachment[];
+  // Extended thinking/reasoning content from the model
+  thinkingContent?: string;
 }
 
 // Run statistics from agent

--- a/src/stores/__tests__/appStore.thinking.test.ts
+++ b/src/stores/__tests__/appStore.thinking.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useAppStore } from '../appStore';
+
+describe('appStore - thinking content preservation', () => {
+  const conversationId = 'conv-test';
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-01T12:00:00Z'));
+
+    // Reset store state
+    useAppStore.setState({
+      messages: [],
+      streamingState: {},
+      activeTools: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('preserves thinking content when finalizing a streaming message', () => {
+    // Set up streaming state with thinking content
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: 'The answer is 42.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: 'Let me reason through this step by step...',
+          isThinking: false,
+          planModeActive: false,
+          awaitingPlanApproval: false,
+        },
+      },
+    });
+
+    // Finalize the message
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 1000,
+    });
+
+    // Check the finalized message has thinking content
+    const messages = useAppStore.getState().messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('The answer is 42.');
+    expect(messages[0].thinkingContent).toBe('Let me reason through this step by step...');
+  });
+
+  it('does not set thinkingContent when there is no thinking', () => {
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: 'Simple response.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          awaitingPlanApproval: false,
+        },
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 500,
+    });
+
+    const messages = useAppStore.getState().messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('Simple response.');
+    expect(messages[0].thinkingContent).toBeUndefined();
+  });
+
+  it('does not set thinkingContent when thinking is empty string', () => {
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: 'Response.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: '',
+          isThinking: false,
+          planModeActive: false,
+          awaitingPlanApproval: false,
+        },
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 500,
+    });
+
+    const messages = useAppStore.getState().messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].thinkingContent).toBeUndefined();
+  });
+
+  it('clears streaming thinking state after finalization', () => {
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: 'Done.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: 'Some deep thoughts here...',
+          isThinking: true,
+          planModeActive: false,
+          awaitingPlanApproval: false,
+        },
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 2000,
+    });
+
+    // Streaming state should be cleared
+    const streaming = useAppStore.getState().streamingState[conversationId];
+    expect(streaming?.thinking).toBeNull();
+    expect(streaming?.isThinking).toBe(false);
+  });
+
+  it('preserves long thinking content', () => {
+    const longThinking = 'Step 1: '.padEnd(500, 'analyze ') +
+      'Step 2: '.padEnd(500, 'synthesize ') +
+      'Step 3: conclusion.';
+
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: 'Final answer.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: longThinking,
+          isThinking: false,
+          planModeActive: false,
+          awaitingPlanApproval: false,
+        },
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 3000,
+    });
+
+    const messages = useAppStore.getState().messages;
+    expect(messages[0].thinkingContent).toBe(longThinking);
+  });
+
+  it('does not create a message when there is no streaming text', () => {
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: '',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: 'Thinking without output',
+          isThinking: false,
+          planModeActive: false,
+          awaitingPlanApproval: false,
+        },
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 500,
+    });
+
+    // No message should be created since there's no text
+    const messages = useAppStore.getState().messages;
+    expect(messages).toHaveLength(0);
+  });
+
+  it('preserves thinking content alongside other metadata', () => {
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: 'Analysis complete.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: 'Reasoning about the problem...',
+          isThinking: false,
+          planModeActive: false,
+          awaitingPlanApproval: false,
+        },
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 5000,
+      toolUsage: [
+        { id: 't1', tool: 'Read', success: true, durationMs: 100 },
+      ],
+      runSummary: { success: true, durationMs: 5000, turns: 2 },
+    });
+
+    const msg = useAppStore.getState().messages[0];
+    expect(msg.thinkingContent).toBe('Reasoning about the problem...');
+    expect(msg.durationMs).toBe(5000);
+    expect(msg.toolUsage).toHaveLength(1);
+    expect(msg.runSummary?.success).toBe(true);
+  });
+});
+
+describe('appStore - appendThinkingText', () => {
+  const conversationId = 'conv-test';
+
+  beforeEach(() => {
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: '',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          awaitingPlanApproval: false,
+        },
+      },
+    });
+  });
+
+  it('appends thinking text to empty thinking state', () => {
+    useAppStore.getState().appendThinkingText(conversationId, 'First thought.');
+
+    const streaming = useAppStore.getState().streamingState[conversationId];
+    expect(streaming?.thinking).toBe('First thought.');
+    expect(streaming?.isThinking).toBe(true);
+  });
+
+  it('appends thinking text incrementally', () => {
+    useAppStore.getState().appendThinkingText(conversationId, 'First. ');
+    useAppStore.getState().appendThinkingText(conversationId, 'Second.');
+
+    const streaming = useAppStore.getState().streamingState[conversationId];
+    expect(streaming?.thinking).toBe('First. Second.');
+  });
+});

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSettingsStore } from '../settingsStore';
+
+describe('settingsStore - showThinkingBlocks', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ showThinkingBlocks: true });
+  });
+
+  it('defaults to true', () => {
+    expect(useSettingsStore.getState().showThinkingBlocks).toBe(true);
+  });
+
+  it('setShowThinkingBlocks sets to false', () => {
+    useSettingsStore.getState().setShowThinkingBlocks(false);
+    expect(useSettingsStore.getState().showThinkingBlocks).toBe(false);
+  });
+
+  it('setShowThinkingBlocks sets to true', () => {
+    useSettingsStore.setState({ showThinkingBlocks: false });
+    useSettingsStore.getState().setShowThinkingBlocks(true);
+    expect(useSettingsStore.getState().showThinkingBlocks).toBe(true);
+  });
+
+  it('toggleShowThinkingBlocks flips from true to false', () => {
+    useSettingsStore.getState().toggleShowThinkingBlocks();
+    expect(useSettingsStore.getState().showThinkingBlocks).toBe(false);
+  });
+
+  it('toggleShowThinkingBlocks flips from false to true', () => {
+    useSettingsStore.setState({ showThinkingBlocks: false });
+    useSettingsStore.getState().toggleShowThinkingBlocks();
+    expect(useSettingsStore.getState().showThinkingBlocks).toBe(true);
+  });
+
+  it('toggleShowThinkingBlocks round-trips correctly', () => {
+    expect(useSettingsStore.getState().showThinkingBlocks).toBe(true);
+    useSettingsStore.getState().toggleShowThinkingBlocks();
+    expect(useSettingsStore.getState().showThinkingBlocks).toBe(false);
+    useSettingsStore.getState().toggleShowThinkingBlocks();
+    expect(useSettingsStore.getState().showThinkingBlocks).toBe(true);
+  });
+
+  it('does not affect other settings when toggling', () => {
+    const before = useSettingsStore.getState();
+    const originalModel = before.defaultModel;
+    const originalThinking = before.defaultThinking;
+
+    useSettingsStore.getState().toggleShowThinkingBlocks();
+
+    const after = useSettingsStore.getState();
+    expect(after.defaultModel).toBe(originalModel);
+    expect(after.defaultThinking).toBe(originalThinking);
+    expect(after.showThinkingBlocks).toBe(false);
+  });
+});

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -937,6 +937,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       durationMs: metadata.durationMs,
       toolUsage: metadata.toolUsage,
       runSummary: metadata.runSummary,
+      ...(streaming.thinking ? { thinkingContent: streaming.thinking } : {}),
     };
 
     // Atomically: add message AND clear streaming state

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -50,6 +50,7 @@ interface SettingsState {
   defaultModel: string;
   defaultThinking: boolean;
   maxThinkingTokens: number;
+  showThinkingBlocks: boolean; // Whether to show thinking/reasoning content in messages
   desktopNotifications: boolean;
   soundEffects: boolean;
   sendWithEnter: boolean;
@@ -86,6 +87,8 @@ interface SettingsState {
   setDefaultModel: (value: string) => void;
   setDefaultThinking: (value: boolean) => void;
   setMaxThinkingTokens: (value: number) => void;
+  setShowThinkingBlocks: (value: boolean) => void;
+  toggleShowThinkingBlocks: () => void;
   setDesktopNotifications: (value: boolean) => void;
   setSoundEffects: (value: boolean) => void;
   setSendWithEnter: (value: boolean) => void;
@@ -120,6 +123,7 @@ export const useSettingsStore = create<SettingsState>()(
       defaultModel: 'opus-4.5',
       defaultThinking: true,
       maxThinkingTokens: 10000,
+      showThinkingBlocks: true,
       desktopNotifications: true,
       soundEffects: false,
       sendWithEnter: true,
@@ -147,6 +151,8 @@ export const useSettingsStore = create<SettingsState>()(
       setDefaultModel: (value) => set({ defaultModel: value }),
       setDefaultThinking: (value) => set({ defaultThinking: value }),
       setMaxThinkingTokens: (value) => set({ maxThinkingTokens: value }),
+      setShowThinkingBlocks: (value) => set({ showThinkingBlocks: value }),
+      toggleShowThinkingBlocks: () => set((state) => ({ showThinkingBlocks: !state.showThinkingBlocks })),
       setDesktopNotifications: (value) => set({ desktopNotifications: value }),
       setSoundEffects: (value) => set({ soundEffects: value }),
       setSendWithEnter: (value) => set({ sendWithEnter: value }),


### PR DESCRIPTION
## Summary

Implements user-controlled visibility of extended thinking content in messages. Users can now toggle whether thinking/reasoning blocks appear in the UI. Thinking content is preserved when finalizing streamed messages and rendered in a collapsible block with expand/collapse controls.

- Adds `showThinkingBlocks` setting (defaults to true) in settingsStore
- Preserves thinking content from streaming state via `thinkingContent` field on messages
- Renders collapsible thinking block in MessageBlock with Brain icon and chevron controls
- Gated behind showThinkingBlocks setting in both streaming and finalized message views

## Test Plan

- All 39 tests pass (23 MessageBlock tests + 9 appStore tests + 7 settingsStore tests)
- Thinking blocks render and expand/collapse correctly
- Thinking content preserved during message finalization
- Role-based rendering (assistant only, not user/system)
- Works alongside other message blocks (tool usage, attachments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)