### PR TITLE
Surface auto-save failures with error details to users

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -407,7 +407,12 @@ export default function Home() {
   useTabPersistence();
 
   // Auto-save dirty file tabs
-  const { saveCurrentTab, saveTab } = useAutoSave();
+  const handleSaveError = useCallback((filePath: string, error: unknown) => {
+    const fileName = filePath.split('/').pop() ?? filePath;
+    const reason = error instanceof Error ? error.message : 'Unknown error';
+    showError(`Failed to save ${fileName}: ${reason}`, 'Auto-save Error');
+  }, [showError]);
+  const { saveCurrentTab, saveTab } = useAutoSave({ onError: handleSaveError });
 
   // Watch for external file changes
   useFileWatcher();

--- a/src/components/tabs/TabItem.tsx
+++ b/src/components/tabs/TabItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { memo, useState } from 'react';
-import { X, Pin, PinOff, Pencil } from 'lucide-react';
+import { X, Pin, PinOff, Pencil, AlertCircle } from 'lucide-react';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -109,8 +109,18 @@ export const TabItem = memo(function TabItem({
             <Pin className="w-2.5 h-2.5 text-muted-foreground shrink-0" />
           )}
 
+          {/* Save error indicator */}
+          {tab.fileTab?.saveError && (
+            <span title={`Save failed: ${tab.fileTab.saveError}`}>
+              <AlertCircle
+                className="w-3 h-3 text-destructive shrink-0"
+                aria-label="Save failed"
+              />
+            </span>
+          )}
+
           {/* Status indicator (for conversation tabs) or icon (for file tabs) */}
-          {statusIndicator || tab.icon}
+          {!tab.fileTab?.saveError && (statusIndicator || tab.icon)}
 
           {/* Tab label */}
           <span className="truncate flex-1">{tab.label}</span>

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -9,13 +9,18 @@ import type { FileTab } from '@/lib/types';
 // Auto-save delay in milliseconds (30 seconds after last change)
 const AUTO_SAVE_DELAY_MS = 30000;
 
+interface UseAutoSaveOptions {
+  onError?: (filePath: string, error: unknown) => void;
+}
+
 /**
  * Hook that handles auto-saving dirty file tabs
  * - Auto-saves after 30 seconds of inactivity
  * - Provides manual save function for Cmd+S
  * - Updates tab state after save (clears dirty flag)
+ * - Notifies caller of save failures via onError callback
  */
-export function useAutoSave() {
+export function useAutoSave(options?: UseAutoSaveOptions) {
   const { fileTabs, selectedFileTabId, updateFileTab } = useAppStore(
     useShallow((s) => ({
       fileTabs: s.fileTabs,
@@ -25,6 +30,12 @@ export function useAutoSave() {
   );
   const saveTimeoutRef = useRef<Record<string, NodeJS.Timeout>>({});
   const mountedRef = useRef(true);
+  const onErrorRef = useRef(options?.onError);
+
+  // Keep onError ref up to date without causing re-renders
+  useEffect(() => {
+    onErrorRef.current = options?.onError;
+  }, [options?.onError]);
 
   // Track mounted state to prevent state updates after unmount
   useEffect(() => {
@@ -52,12 +63,20 @@ export function useAutoSave() {
           updateFileTab(tab.id, {
             originalContent: tab.content,
             isDirty: false,
+            saveError: undefined,
           });
         }
 
         return true;
       } catch (err) {
         console.error('Failed to save file:', err);
+
+        if (mountedRef.current) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          updateFileTab(tab.id, { saveError: message });
+        }
+
+        onErrorRef.current?.(tab.path, err);
         return false;
       }
     },
@@ -113,9 +132,10 @@ export function useAutoSave() {
   }, [fileTabs, saveTab]);
 
   // Save all dirty tabs immediately (for app unmount/workspace switch)
+  // Uses Promise.allSettled so individual failures don't abort remaining saves
   const saveAllDirty = useCallback(async (): Promise<void> => {
     const dirtyTabs = fileTabs.filter((t) => t.isDirty && t.viewMode !== 'diff');
-    await Promise.all(dirtyTabs.map(saveTab));
+    await Promise.allSettled(dirtyTabs.map(saveTab));
   }, [fileTabs, saveTab]);
 
   return {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -476,6 +476,7 @@ export interface FileTab {
   isTooLarge?: boolean;
   isEmpty?: boolean;          // File has no content (0 bytes)
   loadError?: string;         // Error message if loading failed
+  saveError?: string;         // Error message if saving failed
   isPinned?: boolean;         // Pin support - pinned tabs won't auto-close
   openedAt?: string;          // ISO timestamp for ordering/history
   lastAccessedAt?: string;    // ISO timestamp for LRU tab closing


### PR DESCRIPTION
## Summary
Add visual feedback and error details when auto-save fails. Users now see:
- Toast notification with specific error reason (e.g., "Permission denied")
- AlertCircle icon on the affected tab
- Hover tooltip showing the full error message

## Implementation
- New `onError` callback in `useAutoSave` hook to notify consumers of failures
- `saveError` field on `FileTab` stores error message when save fails
- Error icon in `TabItem` displays error on hover
- Use `Promise.allSettled` in batch saves to prevent cascading failures

## Test Plan
- Manually test save failures (e.g., read-only file) and verify toast appears with error detail
- Verify error icon shows on tab with tooltip on hover
- Confirm icon clears when save succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)