### PR TITLE
fix: prevent slow WebSocket clients from immediate eviction

### DIFF
--- a/backend/server/websocket.go
+++ b/backend/server/websocket.go
@@ -15,8 +15,13 @@ import (
 )
 
 const (
-	// Per-client send buffer size
-	clientSendBufferSize = 256
+	// Per-client send buffer size. Set high because this is a local desktop app
+	// where memory is cheap and the browser may briefly lag during fast streaming.
+	clientSendBufferSize = 2048
+
+	// clientSendTimeout is how long to wait for space in a client's send buffer
+	// before evicting. Gives the browser time to catch up during fast streaming.
+	clientSendTimeout = 100 * time.Millisecond
 
 	// Time allowed to write a message to the client
 	writeWait = 10 * time.Second
@@ -26,6 +31,10 @@ const (
 
 	// Send pings to client with this period (must be less than pongWait)
 	pingPeriod = (pongWait * 9) / 10
+
+	// evictionWarningDeadline is the write deadline for the best-effort
+	// warning message sent to a client just before eviction.
+	evictionWarningDeadline = 500 * time.Millisecond
 
 	// broadcastTimeout is how long to wait for buffer space before dropping
 	// a broadcast message. This gives Hub.Run() time to catch up.
@@ -51,9 +60,10 @@ type Event struct {
 type Client struct {
 	hub       *Hub
 	conn      *websocket.Conn
-	send      chan []byte // Buffered channel for outgoing messages
+	send      chan []byte  // Buffered channel for outgoing messages
 	closeOnce sync.Once   // Ensures send channel is closed only once
 	evicting  atomic.Bool // Prevents multiple eviction goroutines
+	writeMu   sync.Mutex  // Protects concurrent writes to conn
 }
 
 // HubMetrics tracks WebSocket hub statistics
@@ -171,22 +181,35 @@ func (h *Hub) runLoop() {
 			for client := range h.clients {
 				select {
 				case client.send <- message:
-					// Message queued successfully
+					// Message queued successfully (fast path)
 				default:
-					// Client buffer full - they can't keep up, schedule for removal
-					// Use CompareAndSwap to ensure only one eviction goroutine is spawned
+					// Buffer full - spawn goroutine for timed retry instead of instant eviction.
+					// CAS ensures only one retry goroutine runs per client at a time.
 					if client.evicting.CompareAndSwap(false, true) {
-						h.metrics.recordClientDropped()
-						logger.WebSocket.Warnf("Client send buffer full, evicting slow client")
-						go func(c *Client) {
+						go func(c *Client, msg []byte) {
 							defer func() {
 								if r := recover(); r != nil {
 									logger.WebSocket.Errorf("Hub PANIC in eviction goroutine: %v", r)
 								}
 							}()
-							h.unregister <- c
-						}(client)
-					}
+
+							select {
+							case c.send <- msg:
+								// Client caught up - reset flag, continue normally
+								c.evicting.Store(false)
+							case <-time.After(clientSendTimeout):
+								// Still full after timeout - evict
+								h.metrics.recordClientDropped()
+								logger.WebSocket.Warnf("Client send buffer full after %v, evicting", clientSendTimeout)
+								c.sendEvictionWarning()
+								h.unregister <- c
+							}
+						}(client, message)
+					} else {
+					// Another retry goroutine is already handling this client.
+					// Drop this message and record the metric.
+					h.metrics.recordDropped()
+				}
 				}
 			}
 			h.mu.RUnlock()
@@ -325,29 +348,52 @@ func (c *Client) writePump() {
 	for {
 		select {
 		case message, ok := <-c.send:
-			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if !ok {
-				// Hub closed the channel - client was unregistered
-				if err := c.conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
-					logger.WebSocket.Errorf("Error sending close message: %v", err)
-				}
+			if !c.handleSendMessage(message, ok) {
 				return
 			}
-
-			if err := c.conn.WriteMessage(websocket.TextMessage, message); err != nil {
-				logger.WebSocket.Errorf("Error writing message to client: %v", err)
-				return
-			}
-			c.hub.metrics.recordDelivered()
-
 		case <-ticker.C:
-			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				logger.WebSocket.Errorf("Error sending ping to client: %v", err)
+			if !c.handlePing() {
 				return
 			}
 		}
 	}
+}
+
+// handleSendMessage writes a queued message to the WebSocket connection.
+// Returns false if the pump should exit (channel closed or write error).
+func (c *Client) handleSendMessage(message []byte, ok bool) bool {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+	if !ok {
+		// Hub closed the channel - client was unregistered
+		if err := c.conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
+			logger.WebSocket.Errorf("Error sending close message: %v", err)
+		}
+		return false
+	}
+
+	if err := c.conn.WriteMessage(websocket.TextMessage, message); err != nil {
+		logger.WebSocket.Errorf("Error writing message to client: %v", err)
+		return false
+	}
+	c.hub.metrics.recordDelivered()
+	return true
+}
+
+// handlePing sends a WebSocket ping to the client.
+// Returns false if the pump should exit (write error).
+func (c *Client) handlePing() bool {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+	if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+		logger.WebSocket.Errorf("Error sending ping to client: %v", err)
+		return false
+	}
+	return true
 }
 
 // readPump pumps messages from the websocket connection to the hub.
@@ -378,6 +424,31 @@ func (c *Client) readPump() {
 			break
 		}
 	}
+}
+
+// sendEvictionWarning attempts to send a warning event to the client before
+// eviction. Writes directly to the connection (bypassing the full send channel)
+// with a short deadline. Best-effort; errors are ignored.
+func (c *Client) sendEvictionWarning() {
+	if c.conn == nil {
+		return
+	}
+	warningEvent := Event{
+		Type: "streaming_warning",
+		Payload: map[string]interface{}{
+			"source":  "hub",
+			"reason":  "client_eviction",
+			"message": "Connection closed due to slow message processing. Reconnecting...",
+		},
+	}
+	data, err := json.Marshal(warningEvent)
+	if err != nil {
+		return
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	c.conn.SetWriteDeadline(time.Now().Add(evictionWarningDeadline))
+	c.conn.WriteMessage(websocket.TextMessage, data)
 }
 
 // GetStats returns current hub statistics

--- a/backend/server/websocket_test.go
+++ b/backend/server/websocket_test.go
@@ -389,8 +389,8 @@ func TestHub_SlowClientEviction(t *testing.T) {
 	hub.Broadcast(Event{Type: "overflow1"})
 	hub.Broadcast(Event{Type: "overflow2"})
 
-	// Give time for eviction to happen
-	time.Sleep(50 * time.Millisecond)
+	// Give time for timed retry (100ms) + eviction processing
+	time.Sleep(200 * time.Millisecond)
 
 	// Client should be evicted
 	hub.mu.RLock()
@@ -434,8 +434,8 @@ func TestHub_PerClientBuffer_IsolatesSlowClients(t *testing.T) {
 		hub.Broadcast(Event{Type: "test"})
 	}
 
-	// Wait for processing
-	time.Sleep(50 * time.Millisecond)
+	// Wait for timed retry (100ms) + eviction processing
+	time.Sleep(200 * time.Millisecond)
 
 	// Fast client should still be connected
 	hub.mu.RLock()
@@ -448,6 +448,45 @@ func TestHub_PerClientBuffer_IsolatesSlowClients(t *testing.T) {
 
 	// Fast client should have received messages
 	assert.Greater(t, len(fastClient.send), 0, "Fast client should have messages in buffer")
+}
+
+func TestHub_SlowClientRecovery(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	time.Sleep(10 * time.Millisecond)
+
+	// Create a client with a small buffer (2 slots)
+	client := &Client{
+		hub:  hub,
+		send: make(chan []byte, 2),
+	}
+
+	hub.register <- client
+	time.Sleep(10 * time.Millisecond)
+
+	// Fill the buffer completely
+	client.send <- []byte(`{"type":"msg1"}`)
+	client.send <- []byte(`{"type":"msg2"}`)
+
+	// Broadcast a message - this will trigger the timed retry goroutine
+	hub.Broadcast(Event{Type: "overflow"})
+
+	// Quickly drain the buffer (simulating browser catching up)
+	time.Sleep(10 * time.Millisecond)
+	<-client.send
+	<-client.send
+
+	// Wait for the retry goroutine to deliver and reset evicting flag
+	time.Sleep(50 * time.Millisecond)
+
+	// Client should still be registered (not evicted)
+	hub.mu.RLock()
+	exists := hub.clients[client]
+	hub.mu.RUnlock()
+	assert.True(t, exists, "Client that recovered should not be evicted")
+
+	// No clients should have been dropped
+	assert.Equal(t, uint64(0), hub.metrics.clientsDropped.Load(), "No client drops should be recorded")
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes an issue where slow WebSocket clients (the browser UI) were immediately evicted when their send buffer filled during fast AI streaming. Now the system tries a timed retry (100ms) before eviction, giving the browser time to catch up.

## Changes

- Increased client send buffer from 256 to 2048 bytes (suitable for local desktop app)
- Added timed retry goroutine before eviction
- Refactored `writePump` mutex handling with defer for safety
- Records dropped message metrics for observability
- Sends eviction warning event to client before disconnect

## Test Coverage

All 18 existing hub tests pass, including new `TestHub_SlowClientRecovery` test validating the recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)