### PR TITLE
feat: add error boundaries for key components

### DIFF
--- a/src/components/conversation/VirtualizedMessageList.tsx
+++ b/src/components/conversation/VirtualizedMessageList.tsx
@@ -3,6 +3,8 @@
 import { forwardRef, useCallback, useMemo, useRef, useImperativeHandle } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { MessageBlock } from '@/components/conversation/MessageBlock';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { CardErrorFallback } from '@/components/shared/ErrorFallbacks';
 import type { Message } from '@/lib/types';
 
 export interface VirtualizedMessageListHandle {
@@ -57,14 +59,19 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
     const itemContent = useCallback(
       (index: number, message: Message) => (
         <div className="pl-5 pr-12">
-          <MessageBlock
-            message={message}
-            isFirst={index === 0}
-            searchQuery={searchQuery}
-            currentMatchIndex={currentMatchIndex}
-            matchOffset={searchMatches.messageOffsets[index] ?? 0}
-            hasMatches={messageHasMatches[index] ?? false}
-          />
+          <ErrorBoundary
+            section="Message"
+            fallback={<CardErrorFallback message="Error rendering message" />}
+          >
+            <MessageBlock
+              message={message}
+              isFirst={index === 0}
+              searchQuery={searchQuery}
+              currentMatchIndex={currentMatchIndex}
+              matchOffset={searchMatches.messageOffsets[index] ?? 0}
+              hasMatches={messageHasMatches[index] ?? false}
+            />
+          </ErrorBoundary>
         </div>
       ),
       [searchQuery, currentMatchIndex, searchMatches.messageOffsets, messageHasMatches]

--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -24,6 +24,8 @@ import {
 import { BranchCleanupDialog } from '@/components/dialogs/branch-cleanup/BranchCleanupDialog';
 import { cn } from '@/lib/utils';
 import { getWorkspaceColor } from '@/lib/workspace-colors';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 
 interface BranchesDashboardProps {
   workspaceId: string;
@@ -404,10 +406,12 @@ export function BranchesDashboard({
       header: 'Branch',
       accessorKey: 'name',
       cell: (branch) => (
-        <div className="flex items-center gap-1.5">
-          <BranchIconCell branch={branch} currentBranch={branchData?.currentBranch ?? ''} />
-          <BranchNameCell branch={branch} currentBranch={branchData?.currentBranch ?? ''} />
-        </div>
+        <ErrorBoundary section="BranchNameCell" fallback={<InlineErrorFallback message="Error" />}>
+          <div className="flex items-center gap-1.5">
+            <BranchIconCell branch={branch} currentBranch={branchData?.currentBranch ?? ''} />
+            <BranchNameCell branch={branch} currentBranch={branchData?.currentBranch ?? ''} />
+          </div>
+        </ErrorBoundary>
       ),
       sortable: true,
       // No width = flexible, will truncate
@@ -416,7 +420,11 @@ export function BranchesDashboard({
       id: 'commit',
       header: 'Last Commit',
       accessorKey: 'lastCommitSubject',
-      cell: (branch) => <CommitCell branch={branch} />,
+      cell: (branch) => (
+        <ErrorBoundary section="BranchCommitCell" fallback={<InlineErrorFallback message="Error" />}>
+          <CommitCell branch={branch} />
+        </ErrorBoundary>
+      ),
       // No width = flexible, will truncate
     },
     {

--- a/src/components/dashboards/GlobalDashboard.tsx
+++ b/src/components/dashboards/GlobalDashboard.tsx
@@ -7,6 +7,8 @@ import { useMainToolbarContent } from '@/hooks/useMainToolbarContent';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, Layers, GitBranch, GitPullRequest, FolderGit2, Activity, LayoutDashboard } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { CardErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 
 export function GlobalDashboard() {
@@ -194,39 +196,44 @@ export function GlobalDashboard() {
               {recentSessions.map((session) => {
                 const workspace = workspaces.find((w) => w.id === session.workspaceId);
                 return (
-                  <div
+                  <ErrorBoundary
                     key={session.id}
-                    className="bg-surface-1 rounded-lg p-3 border border-border/50 hover:bg-surface-2 cursor-pointer transition-colors"
-                    onClick={() => handleJumpToSession(session.id, session.workspaceId)}
+                    section="SessionCard"
+                    fallback={<CardErrorFallback message="Error loading session" />}
                   >
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3 min-w-0">
-                        {session.prStatus && session.prStatus !== 'none' ? (
-                          <GitPullRequest className="h-4 w-4 text-purple-400 shrink-0" />
-                        ) : (
-                          <GitBranch className="h-4 w-4 text-muted-foreground shrink-0" />
-                        )}
-                        <div className="min-w-0">
-                          <div className="font-medium truncate">{session.branch || session.name}</div>
-                          <div className="text-xs text-muted-foreground truncate">
-                            {workspace?.name || 'Unknown'} {session.prNumber && `· PR #${session.prNumber}`}
+                    <div
+                      className="bg-surface-1 rounded-lg p-3 border border-border/50 hover:bg-surface-2 cursor-pointer transition-colors"
+                      onClick={() => handleJumpToSession(session.id, session.workspaceId)}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3 min-w-0">
+                          {session.prStatus && session.prStatus !== 'none' ? (
+                            <GitPullRequest className="h-4 w-4 text-purple-400 shrink-0" />
+                          ) : (
+                            <GitBranch className="h-4 w-4 text-muted-foreground shrink-0" />
+                          )}
+                          <div className="min-w-0">
+                            <div className="font-medium truncate">{session.branch || session.name}</div>
+                            <div className="text-xs text-muted-foreground truncate">
+                              {workspace?.name || 'Unknown'} {session.prNumber && `· PR #${session.prNumber}`}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                      <div className="flex items-center gap-3 shrink-0">
-                        {session.stats && (session.stats.additions > 0 || session.stats.deletions > 0) && (
-                          <span className="text-xs font-mono">
-                            <span className="text-green-400">+{session.stats.additions}</span>
-                            {' '}
-                            <span className="text-red-400">-{session.stats.deletions}</span>
+                        <div className="flex items-center gap-3 shrink-0">
+                          {session.stats && (session.stats.additions > 0 || session.stats.deletions > 0) && (
+                            <span className="text-xs font-mono">
+                              <span className="text-green-400">+{session.stats.additions}</span>
+                              {' '}
+                              <span className="text-red-400">-{session.stats.deletions}</span>
+                            </span>
+                          )}
+                          <span className="text-xs text-muted-foreground">
+                            {formatTimeAgo(session.updatedAt || session.createdAt)}
                           </span>
-                        )}
-                        <span className="text-xs text-muted-foreground">
-                          {formatTimeAgo(session.updatedAt || session.createdAt)}
-                        </span>
+                        </div>
                       </div>
                     </div>
-                  </div>
+                  </ErrorBoundary>
                 );
               })}
             </div>

--- a/src/components/dashboards/PRDashboard.tsx
+++ b/src/components/dashboards/PRDashboard.tsx
@@ -36,6 +36,8 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getWorkspaceColor } from '@/lib/workspace-colors';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 
 interface PRDashboardProps {
   initialWorkspaceId?: string;
@@ -478,10 +480,12 @@ export function PRDashboard({
       header: '#',
       accessorKey: 'number',
       cell: (pr) => (
-        <div className="flex items-center gap-1.5">
-          <StatusIconCell pr={pr} />
-          <PRNumberCell pr={pr} />
-        </div>
+        <ErrorBoundary section="PRCell" fallback={<InlineErrorFallback message="Error" />}>
+          <div className="flex items-center gap-1.5">
+            <StatusIconCell pr={pr} />
+            <PRNumberCell pr={pr} />
+          </div>
+        </ErrorBoundary>
       ),
       sortable: true,
       width: '80px',
@@ -490,20 +494,32 @@ export function PRDashboard({
       id: 'title',
       header: 'Title',
       accessorKey: 'title',
-      cell: (pr) => <TitleCell pr={pr} />,
+      cell: (pr) => (
+        <ErrorBoundary section="PRTitleCell" fallback={<InlineErrorFallback message="Error" />}>
+          <TitleCell pr={pr} />
+        </ErrorBoundary>
+      ),
       sortable: true,
     },
     {
       id: 'branch',
       header: 'Branch',
       accessorKey: 'branch',
-      cell: (pr) => <BranchCell pr={pr} />,
+      cell: (pr) => (
+        <ErrorBoundary section="PRBranchCell" fallback={<InlineErrorFallback message="Error" />}>
+          <BranchCell pr={pr} />
+        </ErrorBoundary>
+      ),
     },
     {
       id: 'checks',
       header: 'Checks',
       accessorKey: (pr) => `${pr.checksPassed}/${pr.checksTotal}`,
-      cell: (pr) => <ChecksCell pr={pr} />,
+      cell: (pr) => (
+        <ErrorBoundary section="PRChecksCell" fallback={<InlineErrorFallback message="Error" />}>
+          <ChecksCell pr={pr} />
+        </ErrorBoundary>
+      ),
       width: '80px',
     },
     {

--- a/src/components/layout/BottomTerminal.tsx
+++ b/src/components/layout/BottomTerminal.tsx
@@ -6,6 +6,8 @@ import { X, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTerminalState } from '@/stores/selectors';
 import { cn } from '@/lib/utils';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { BlockErrorFallback } from '@/components/shared/ErrorFallbacks';
 
 const Terminal = dynamic(
   () => import('@/components/shared/Terminal').then((mod) => mod.Terminal),
@@ -139,11 +141,16 @@ export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTermi
                 activeId === terminal.id ? 'block' : 'hidden'
               )}
             >
-              <Terminal
-                sessionId={terminal.id}
-                workspacePath={workspacePath}
-                onExit={() => handleTerminalExit(terminal.id)}
-              />
+              <ErrorBoundary
+                section="TerminalTab"
+                fallback={<BlockErrorFallback title="Terminal error" description="This terminal encountered an error" />}
+              >
+                <Terminal
+                  sessionId={terminal.id}
+                  workspacePath={workspacePath}
+                  onExit={() => handleTerminalExit(terminal.id)}
+                />
+              </ErrorBoundary>
             </div>
           ))
         )}

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -98,6 +98,8 @@ import {
 import type { Workspace, WorktreeSession, SetupInfo } from '@/lib/types';
 import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog';
 import { useArchiveSession } from '@/hooks/useArchiveSession';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { CardErrorFallback } from '@/components/shared/ErrorFallbacks';
 
 interface WorkspaceSidebarProps {
   onOpenProject: () => void;
@@ -910,165 +912,199 @@ function SortableWorkspaceItem({
                 No active sessions
               </div>
             ) : (
-              sessions.map((session) => {
-                const isSessionSelected = contentView.type === 'conversation' && selectedSessionId === session.id;
-                const hasPR = session.prStatus && session.prStatus !== 'none';
-                const hasStats = session.stats && (session.stats.additions > 0 || session.stats.deletions > 0);
-
-                // Determine PR status display
-                const getPRStatusInfo = () => {
-                  if (!hasPR) return null;
-                  if (session.hasMergeConflict) {
-                    return { text: 'Merge conflict', color: 'text-text-warning', icon: AlertTriangle };
-                  }
-                  if (session.hasCheckFailures) {
-                    return { text: 'Checks failing', color: 'text-text-error', icon: XCircle };
-                  }
-                  if (session.prStatus === 'merged') {
-                    return { text: 'Merged', color: 'text-primary', icon: CheckCircle2 };
-                  }
-                  if (session.prStatus === 'open') {
-                    return { text: 'Ready to merge', color: 'text-text-success', icon: CheckCircle2 };
-                  }
-                  return null;
-                };
-
-                const prStatusInfo = getPRStatusInfo();
-
-                return (
-                  <ContextMenu key={session.id}>
-                    <ContextMenuTrigger asChild>
-                      <div
-                        className={cn(
-                          'group flex items-start gap-1 pl-0 pr-2 py-2 rounded-md cursor-pointer my-0.5',
-                          isSessionSelected
-                            ? 'bg-surface-2 hover:bg-surface-3'
-                            : 'hover:bg-surface-1'
-                        )}
-                        onClick={(e) => onSelectSession(session.id, e)}
-                      >
-                        {/* Status indicator column */}
-                        <div className="w-3.5 shrink-0 flex items-center justify-center pt-0.5">
-                          {session.status === 'active' && (
-                            <div className="session-active-indicator">
-                              <div className="bar" />
-                              <div className="bar" />
-                              <div className="bar" />
-                            </div>
-                          )}
-                        </div>
-                        {/* Git icon column */}
-                        <div className="w-4 shrink-0 flex items-start justify-center pt-0.5">
-                          {hasPR ? (
-                            <GitPullRequest className="w-3.5 h-3.5 text-purple-500" />
-                          ) : (
-                            <GitBranch className="w-3.5 h-3.5 text-muted-foreground" />
-                          )}
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          {/* First line: branch name + stats/actions */}
-                          <div className="flex items-center gap-1.5">
-                            {/* Branch name container - grows and truncates */}
-                            <div className="flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
-                              <span className={cn(
-                                "text-base font-normal truncate flex-1 w-0",
-                                isSessionSelected ? "text-foreground" : "text-foreground/60"
-                              )}>
-                                {session.branch || session.name}
-                              </span>
-                              {/* Pinned indicator - fade out on hover */}
-                              {session.pinned && (
-                                <Pin className="h-2.5 w-2.5 text-primary shrink-0 group-hover:opacity-0 transition-opacity" />
-                              )}
-                            </div>
-                            {/* Git line stats badge and actions container */}
-                            <div className="relative shrink-0 flex items-center">
-                              {/* Stats - fade out on hover */}
-                              {hasStats && (
-                                <span className="text-2xs px-1 py-px rounded border border-text-success/40 font-mono tabular-nums group-hover:opacity-0 transition-opacity whitespace-nowrap">
-                                  <span className="text-text-success">+{session.stats!.additions}</span>
-                                  <span className="text-text-error ml-1">-{session.stats!.deletions}</span>
-                                </span>
-                              )}
-                              {/* Actions - positioned absolutely to avoid layout shift */}
-                              <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                <button
-                                  className={cn(
-                                    "p-0.5 rounded hover:bg-surface-1 hover:text-foreground",
-                                    session.pinned ? "text-primary" : "text-muted-foreground"
-                                  )}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onPinSession(session.id);
-                                  }}
-                                >
-                                  <Pin className="h-2.5 w-2.5" />
-                                </button>
-                                <button
-                                  className="p-0.5 rounded hover:bg-surface-1 text-muted-foreground hover:text-foreground"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onArchiveSession(session.id);
-                                  }}
-                                >
-                                  <Archive className="h-2.5 w-2.5" />
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                          {/* Second line: task status · priority · session name · PR info · status */}
-                          <div className="flex items-center gap-1 mt-0.5 text-sm text-muted-foreground">
-                            {session.taskStatus && session.taskStatus !== 'backlog' && (() => {
-                              const opt = getTaskStatusOption(session.taskStatus);
-                              return <opt.icon className={cn('h-3 w-3 shrink-0', opt.color)} />;
-                            })()}
-                            {session.priority > 0 && (() => {
-                              const opt = getPriorityOption(session.priority);
-                              return <opt.icon className={cn('h-3 w-3 shrink-0', opt.color)} />;
-                            })()}
-                            <span className="truncate">{session.name}</span>
-                            {hasPR && session.prNumber && (
-                              <>
-                                <span className="text-muted-foreground/50">·</span>
-                                <span className="shrink-0">PR #{session.prNumber}</span>
-                              </>
-                            )}
-                            {prStatusInfo && (
-                              <>
-                                <span className="text-muted-foreground/50">·</span>
-                                <span className={cn('shrink-0', prStatusInfo.color)}>
-                                  {prStatusInfo.text}
-                                </span>
-                              </>
-                            )}
-                            {!hasPR && (
-                              <>
-                                <span className="text-muted-foreground/50">·</span>
-                                <span className="shrink-0">{formatTimeAgo(session.updatedAt)}</span>
-                              </>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </ContextMenuTrigger>
-                    <ContextMenuContent>
-                      <ContextMenuItem onClick={() => onPinSession(session.id)}>
-                        <Pin className="h-4 w-4" />
-                        {session.pinned ? 'Unpin' : 'Pin'}
-                      </ContextMenuItem>
-                      <ContextMenuSeparator />
-                      <ContextMenuItem onClick={() => onArchiveSession(session.id)} variant="destructive">
-                        <Archive className="h-4 w-4" />
-                        Archive
-                      </ContextMenuItem>
-                    </ContextMenuContent>
-                  </ContextMenu>
-                );
-              })
+              sessions.map((session) => (
+                <ErrorBoundary
+                  key={session.id}
+                  section="SessionRow"
+                  fallback={<CardErrorFallback message="Error loading session" />}
+                >
+                  <SessionRow
+                    session={session}
+                    contentView={contentView}
+                    selectedSessionId={selectedSessionId}
+                    onSelectSession={onSelectSession}
+                    onPinSession={onPinSession}
+                    onArchiveSession={onArchiveSession}
+                    formatTimeAgo={formatTimeAgo}
+                  />
+                </ErrorBoundary>
+              ))
             )}
           </div>
         </CollapsibleContent>
       </Collapsible>
     </div>
+  );
+}
+
+function SessionRow({
+  session,
+  contentView,
+  selectedSessionId,
+  onSelectSession,
+  onPinSession,
+  onArchiveSession,
+  formatTimeAgo,
+}: {
+  session: WorktreeSession;
+  contentView: ContentView;
+  selectedSessionId: string | null;
+  onSelectSession: (sessionId: string, event?: React.MouseEvent) => void;
+  onPinSession: (sessionId: string) => void;
+  onArchiveSession: (sessionId: string) => void;
+  formatTimeAgo: (date: string) => string;
+}) {
+  const isSessionSelected = contentView.type === 'conversation' && selectedSessionId === session.id;
+  const hasPR = session.prStatus && session.prStatus !== 'none';
+  const hasStats = session.stats && (session.stats.additions > 0 || session.stats.deletions > 0);
+
+  // Determine PR status display
+  const getPRStatusInfo = () => {
+    if (!hasPR) return null;
+    if (session.hasMergeConflict) {
+      return { text: 'Merge conflict', color: 'text-text-warning', icon: AlertTriangle };
+    }
+    if (session.hasCheckFailures) {
+      return { text: 'Checks failing', color: 'text-text-error', icon: XCircle };
+    }
+    if (session.prStatus === 'merged') {
+      return { text: 'Merged', color: 'text-primary', icon: CheckCircle2 };
+    }
+    if (session.prStatus === 'open') {
+      return { text: 'Ready to merge', color: 'text-text-success', icon: CheckCircle2 };
+    }
+    return null;
+  };
+
+  const prStatusInfo = getPRStatusInfo();
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          className={cn(
+            'group flex items-start gap-1 pl-0 pr-2 py-2 rounded-md cursor-pointer my-0.5',
+            isSessionSelected
+              ? 'bg-surface-2 hover:bg-surface-3'
+              : 'hover:bg-surface-1'
+          )}
+          onClick={(e) => onSelectSession(session.id, e)}
+        >
+          {/* Status indicator column */}
+          <div className="w-3.5 shrink-0 flex items-center justify-center pt-0.5">
+            {session.status === 'active' && (
+              <div className="session-active-indicator">
+                <div className="bar" />
+                <div className="bar" />
+                <div className="bar" />
+              </div>
+            )}
+          </div>
+          {/* Git icon column */}
+          <div className="w-4 shrink-0 flex items-start justify-center pt-0.5">
+            {hasPR ? (
+              <GitPullRequest className="w-3.5 h-3.5 text-purple-500" />
+            ) : (
+              <GitBranch className="w-3.5 h-3.5 text-muted-foreground" />
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            {/* First line: branch name + stats/actions */}
+            <div className="flex items-center gap-1.5">
+              {/* Branch name container - grows and truncates */}
+              <div className="flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
+                <span className={cn(
+                  "text-base font-normal truncate flex-1 w-0",
+                  isSessionSelected ? "text-foreground" : "text-foreground/60"
+                )}>
+                  {session.branch || session.name}
+                </span>
+                {/* Pinned indicator - fade out on hover */}
+                {session.pinned && (
+                  <Pin className="h-2.5 w-2.5 text-primary shrink-0 group-hover:opacity-0 transition-opacity" />
+                )}
+              </div>
+              {/* Git line stats badge and actions container */}
+              <div className="relative shrink-0 flex items-center">
+                {/* Stats - fade out on hover */}
+                {hasStats && (
+                  <span className="text-2xs px-1 py-px rounded border border-text-success/40 font-mono tabular-nums group-hover:opacity-0 transition-opacity whitespace-nowrap">
+                    <span className="text-text-success">+{session.stats!.additions}</span>
+                    <span className="text-text-error ml-1">-{session.stats!.deletions}</span>
+                  </span>
+                )}
+                {/* Actions - positioned absolutely to avoid layout shift */}
+                <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <button
+                    className={cn(
+                      "p-0.5 rounded hover:bg-surface-1 hover:text-foreground",
+                      session.pinned ? "text-primary" : "text-muted-foreground"
+                    )}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onPinSession(session.id);
+                    }}
+                  >
+                    <Pin className="h-2.5 w-2.5" />
+                  </button>
+                  <button
+                    className="p-0.5 rounded hover:bg-surface-1 text-muted-foreground hover:text-foreground"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onArchiveSession(session.id);
+                    }}
+                  >
+                    <Archive className="h-2.5 w-2.5" />
+                  </button>
+                </div>
+              </div>
+            </div>
+            {/* Second line: task status · priority · session name · PR info · status */}
+            <div className="flex items-center gap-1 mt-0.5 text-sm text-muted-foreground">
+              {session.taskStatus && session.taskStatus !== 'backlog' && (() => {
+                const opt = getTaskStatusOption(session.taskStatus);
+                return <opt.icon className={cn('h-3 w-3 shrink-0', opt.color)} />;
+              })()}
+              {session.priority > 0 && (() => {
+                const opt = getPriorityOption(session.priority);
+                return <opt.icon className={cn('h-3 w-3 shrink-0', opt.color)} />;
+              })()}
+              <span className="truncate">{session.name}</span>
+              {hasPR && session.prNumber && (
+                <>
+                  <span className="text-muted-foreground/50">·</span>
+                  <span className="shrink-0">PR #{session.prNumber}</span>
+                </>
+              )}
+              {prStatusInfo && (
+                <>
+                  <span className="text-muted-foreground/50">·</span>
+                  <span className={cn('shrink-0', prStatusInfo.color)}>
+                    {prStatusInfo.text}
+                  </span>
+                </>
+              )}
+              {!hasPR && (
+                <>
+                  <span className="text-muted-foreground/50">·</span>
+                  <span className="shrink-0">{formatTimeAgo(session.updatedAt)}</span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => onPinSession(session.id)}>
+          <Pin className="h-4 w-4" />
+          {session.pinned ? 'Unpin' : 'Pin'}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => onArchiveSession(session.id)} variant="destructive">
+          <Archive className="h-4 w-4" />
+          Archive
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -60,6 +60,8 @@ import {
   GitCommitHorizontal,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import type { FileTab } from '@/lib/types';
 
 // Common binary file extensions
@@ -436,12 +438,14 @@ export function ChangesPanel() {
               </div>
             ) : (
               <div className="h-full min-h-0 p-1 overflow-hidden">
-                <FileTree
-                  files={files}
-                  onFileSelect={handleFileSelect}
-                  workspacePath={currentSession?.worktreePath}
-                  workspaceName={currentWorkspace?.name}
-                />
+                <ErrorBoundary section="FileTree" fallback={<InlineErrorFallback message="Unable to display file tree" />}>
+                  <FileTree
+                    files={files}
+                    onFileSelect={handleFileSelect}
+                    workspacePath={currentSession?.worktreePath}
+                    workspaceName={currentWorkspace?.name}
+                  />
+                </ErrorBoundary>
               </div>
             )
           ) : selectedTab === 'changes' ? (
@@ -545,13 +549,19 @@ export function ChangesPanel() {
               </ScrollArea>
             )
           ) : selectedTab === 'review' ? (
-            <ReviewPanel workspaceId={selectedWorkspaceId} sessionId={selectedSessionId} onFileSelect={handleFileSelect} />
+            <ErrorBoundary section="ReviewPanel" fallback={<InlineErrorFallback message="Unable to display review" />}>
+              <ReviewPanel workspaceId={selectedWorkspaceId} sessionId={selectedSessionId} onFileSelect={handleFileSelect} />
+            </ErrorBoundary>
           ) : selectedTab === 'checks' ? (
-            <div className="h-full px-1.5">
-              <GitStatusSection onSendMessage={handleGitActionMessage} />
-            </div>
+            <ErrorBoundary section="GitStatus" fallback={<InlineErrorFallback message="Unable to display git status" />}>
+              <div className="h-full px-1.5">
+                <GitStatusSection onSendMessage={handleGitActionMessage} />
+              </div>
+            </ErrorBoundary>
           ) : selectedTab === 'info' ? (
-            <SessionInfoPanel />
+            <ErrorBoundary section="SessionInfo" fallback={<InlineErrorFallback message="Unable to display session info" />}>
+              <SessionInfoPanel />
+            </ErrorBoundary>
           ) : (
             <div className="h-full flex items-center justify-center">
               <div className="text-center text-muted-foreground">
@@ -575,12 +585,36 @@ export function ChangesPanel() {
             />
             {/* Tab content */}
             <div className="flex-1 min-h-0">
-              {bottomTab === 'todos' && <TodoPanel />}
-              {bottomTab === 'plans' && <PlansPanel />}
-              {bottomTab === 'budget' && <BudgetStatusPanel />}
-              {bottomTab === 'mcp' && <McpServersPanel />}
-              {bottomTab === 'history' && <CheckpointTimeline />}
-              {bottomTab === 'file-history' && <FileHistoryPanel />}
+              {bottomTab === 'todos' && (
+                <ErrorBoundary section="TodoPanel" fallback={<InlineErrorFallback message="Unable to display tasks" />}>
+                  <TodoPanel />
+                </ErrorBoundary>
+              )}
+              {bottomTab === 'plans' && (
+                <ErrorBoundary section="PlansPanel" fallback={<InlineErrorFallback message="Unable to display plans" />}>
+                  <PlansPanel />
+                </ErrorBoundary>
+              )}
+              {bottomTab === 'budget' && (
+                <ErrorBoundary section="BudgetPanel" fallback={<InlineErrorFallback message="Unable to display budget" />}>
+                  <BudgetStatusPanel />
+                </ErrorBoundary>
+              )}
+              {bottomTab === 'mcp' && (
+                <ErrorBoundary section="McpPanel" fallback={<InlineErrorFallback message="Unable to display MCP servers" />}>
+                  <McpServersPanel />
+                </ErrorBoundary>
+              )}
+              {bottomTab === 'history' && (
+                <ErrorBoundary section="CheckpointTimeline" fallback={<InlineErrorFallback message="Unable to display checkpoints" />}>
+                  <CheckpointTimeline />
+                </ErrorBoundary>
+              )}
+              {bottomTab === 'file-history' && (
+                <ErrorBoundary section="FileHistory" fallback={<InlineErrorFallback message="Unable to display file history" />}>
+                  <FileHistoryPanel />
+                </ErrorBoundary>
+              )}
             </div>
           </div>
         </ResizablePanel>

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -4,9 +4,14 @@ import { Component, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
+export interface ErrorBoundaryFallbackProps {
+  error: Error;
+  retry: () => void;
+}
+
 interface Props {
   children: ReactNode;
-  fallback?: ReactNode;
+  fallback?: ReactNode | ((props: ErrorBoundaryFallbackProps) => ReactNode);
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
   /** Name of the section for error reporting */
   section?: string;
@@ -39,6 +44,12 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       if (this.props.fallback) {
+        if (typeof this.props.fallback === 'function') {
+          return this.props.fallback({
+            error: this.state.error!,
+            retry: this.handleRetry,
+          });
+        }
         return this.props.fallback;
       }
 


### PR DESCRIPTION
## Summary

- Add ErrorBoundary wrappers around critical UI components across dashboards, sidebar, panels, and terminal
- Improve ErrorBoundary API to support render prop fallbacks with retry capability
- Fix SessionRow indentation and remove unnecessary key prefix

## Details

The ErrorBoundary component now supports passing either a static ReactNode fallback or a render function that receives `{ error, retry }`, enabling custom fallback UI to offer recovery options. All existing static fallback usages remain compatible.

Wrapped components include VirtualizedMessageList, session cards, PR/branch dashboards, file tree, and various panel tabs.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>