### PR TITLE
refactor: address code review on buffer overflow fix

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -219,74 +219,108 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	ctx := m.ctx
 	var currentAssistantMessage string
+	var lastReportedDrops uint64
 
-	for line := range proc.Output() {
-		event := ParseAgentLine(line)
-		if event == nil {
-			continue
-		}
+	// Periodically check for dropped messages and emit warnings out-of-band.
+	// This bypasses the process output channel, so warnings are delivered even
+	// when the output channel is congested (which is exactly when drops occur).
+	dropCheckTicker := time.NewTicker(2 * time.Second)
+	defer dropCheckTicker.Stop()
 
-		// Handle specific event types
-		switch event.Type {
-		case EventTypeAssistantText:
-			currentAssistantMessage += event.Content
-
-		case EventTypeToolStart:
-			// Record tool start (will be updated on tool_end)
-
-		case EventTypeToolEnd:
-			// Store tool action in summary
-			if err := m.store.AddToolActionToConversation(ctx, convID, models.ToolAction{
-				ID:      event.ID,
-				Tool:    event.Tool,
-				Target:  event.Summary,
-				Success: event.Success,
-			}); err != nil {
-				logger.Manager.Errorf("Failed to store tool action for conv %s: %v", convID, err)
+	outputCh := proc.Output()
+outer:
+	for {
+		select {
+		case line, ok := <-outputCh:
+			if !ok {
+				// Channel closed - process ended
+				break outer
 			}
 
-		case EventTypeNameSuggestion:
-			// Update conversation name
-			var sessionID string
-			if err := m.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
-				c.Name = event.Name
-				c.UpdatedAt = time.Now()
-				sessionID = c.SessionID
-			}); err != nil {
-				logger.Manager.Errorf("Failed to update conversation name for %s: %v", convID, err)
+			event := ParseAgentLine(line)
+			if event == nil {
+				continue
 			}
 
-			// Also update session name if it hasn't been auto-named yet
-			if sessionID != "" && event.Name != "" {
-				m.tryAutoNameSession(ctx, sessionID, event.Name)
-			}
+			// Handle specific event types
+			switch event.Type {
+			case EventTypeAssistantText:
+				currentAssistantMessage += event.Content
 
-		case EventTypeComplete, EventTypeResult:
-			// Store accumulated assistant message
-			if currentAssistantMessage != "" {
-				if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
-					ID:        uuid.New().String()[:8],
-					Role:      "assistant",
-					Content:   currentAssistantMessage,
-					Timestamp: time.Now(),
+			case EventTypeToolStart:
+				// Record tool start (will be updated on tool_end)
+
+			case EventTypeToolEnd:
+				// Store tool action in summary
+				if err := m.store.AddToolActionToConversation(ctx, convID, models.ToolAction{
+					ID:      event.ID,
+					Tool:    event.Tool,
+					Target:  event.Summary,
+					Success: event.Success,
 				}); err != nil {
-					logger.Manager.Errorf("Failed to store assistant message for conv %s: %v", convID, err)
+					logger.Manager.Errorf("Failed to store tool action for conv %s: %v", convID, err)
 				}
-				currentAssistantMessage = ""
+
+			case EventTypeNameSuggestion:
+				// Update conversation name
+				var sessionID string
+				if err := m.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
+					c.Name = event.Name
+					c.UpdatedAt = time.Now()
+					sessionID = c.SessionID
+				}); err != nil {
+					logger.Manager.Errorf("Failed to update conversation name for %s: %v", convID, err)
+				}
+
+				// Also update session name if it hasn't been auto-named yet
+				if sessionID != "" && event.Name != "" {
+					m.tryAutoNameSession(ctx, sessionID, event.Name)
+				}
+
+			case EventTypeComplete, EventTypeResult:
+				// Store accumulated assistant message
+				if currentAssistantMessage != "" {
+					if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
+						ID:        uuid.New().String()[:8],
+						Role:      "assistant",
+						Content:   currentAssistantMessage,
+						Timestamp: time.Now(),
+					}); err != nil {
+						logger.Manager.Errorf("Failed to store assistant message for conv %s: %v", convID, err)
+					}
+					currentAssistantMessage = ""
+				}
 			}
-		}
 
-		// Forward event to handler
-		if m.onConversationEvent != nil {
-			m.onConversationEvent(convID, event)
-		}
+			// Forward event to handler
+			if m.onConversationEvent != nil {
+				m.onConversationEvent(convID, event)
+			}
 
-		// Also support legacy output handler (for backwards compatibility)
-		if m.onOutput != nil {
-			legacy := ParseStreamLine(line)
-			formatted := FormatEvent(legacy)
-			if formatted != "" {
-				m.onOutput(convID, formatted)
+			// Also support legacy output handler (for backwards compatibility)
+			if m.onOutput != nil {
+				legacy := ParseStreamLine(line)
+				formatted := FormatEvent(legacy)
+				if formatted != "" {
+					m.onOutput(convID, formatted)
+				}
+			}
+
+		case <-dropCheckTicker.C:
+			// Check for new drops and emit warning out-of-band
+			currentDrops := proc.DroppedMessages()
+			if currentDrops > lastReportedDrops {
+				newDrops := currentDrops - lastReportedDrops
+				lastReportedDrops = currentDrops
+				logger.Manager.Warnf("Conversation %s: %d new message drops detected (total: %d)", convID, newDrops, currentDrops)
+				if m.onConversationEvent != nil {
+					m.onConversationEvent(convID, &AgentEvent{
+						Type:    "streaming_warning",
+						Source:  "process",
+						Reason:  "buffer_full",
+						Message: fmt.Sprintf("%d streaming events were dropped due to slow processing", newDrops),
+					})
+				}
 			}
 		}
 	}
@@ -300,6 +334,21 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 			Timestamp: time.Now(),
 		}); err != nil {
 			logger.Manager.Errorf("Failed to store final assistant message for conv %s: %v", convID, err)
+		}
+	}
+
+	// Emit final drop stats if any drops occurred
+	finalDrops := proc.DroppedMessages()
+	if finalDrops > 0 {
+		logger.Manager.Warnf("Conversation %s: process ended with %d total dropped messages", convID, finalDrops)
+		if finalDrops > lastReportedDrops && m.onConversationEvent != nil {
+			newDrops := finalDrops - lastReportedDrops
+			m.onConversationEvent(convID, &AgentEvent{
+				Type:    "streaming_warning",
+				Source:  "process",
+				Reason:  "buffer_full",
+				Message: fmt.Sprintf("%d streaming events were dropped due to slow processing", newDrops),
+			})
 		}
 	}
 }
@@ -455,6 +504,22 @@ func (m *Manager) IsConversationInPlanMode(convID string) bool {
 	return proc.IsPlanModeActive()
 }
 
+// GetConversationDropStats returns the number of messages dropped for a conversation's process.
+// Returns nil if no process is running for the given conversation.
+func (m *Manager) GetConversationDropStats(convID string) map[string]uint64 {
+	m.mu.RLock()
+	proc, ok := m.convProcesses[convID]
+	m.mu.RUnlock()
+
+	if !ok {
+		return nil
+	}
+
+	return map[string]uint64{
+		"droppedMessages": proc.DroppedMessages(),
+	}
+}
+
 // StopConversation stops a running conversation
 func (m *Manager) StopConversation(ctx context.Context, convID string) {
 
@@ -502,6 +567,14 @@ func (m *Manager) CompleteConversation(ctx context.Context, convID string) {
 	if m.onConversationStatus != nil {
 		m.onConversationStatus(convID, models.ConversationStatusCompleted)
 	}
+}
+
+// InsertProcessForTest inserts a process into the conversation map for testing purposes.
+// This bypasses the normal spawn flow and should only be used in tests.
+func (m *Manager) InsertProcessForTest(convID string, proc *Process) {
+	m.mu.Lock()
+	m.convProcesses[convID] = proc
+	m.mu.Unlock()
 }
 
 // GetConversationProcess returns the process for a conversation

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -699,3 +699,253 @@ func TestSetConversationPlanMode_StoppedProcess(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "conversation process not running")
 }
+
+// ============================================================================
+// GetConversationDropStats Tests
+// ============================================================================
+
+func TestGetConversationDropStats_NoProcess(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	stats := m.GetConversationDropStats("nonexistent-conv")
+	assert.Nil(t, stats)
+}
+
+func TestGetConversationDropStats_ZeroDrops(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	proc := NewProcess("drop-test", t.TempDir(), "conv-drop")
+	m.InsertProcessForTest("conv-drop", proc)
+
+	stats := m.GetConversationDropStats("conv-drop")
+	require.NotNil(t, stats)
+	assert.Equal(t, uint64(0), stats["droppedMessages"])
+}
+
+func TestGetConversationDropStats_WithDrops(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	proc := NewProcess("drop-test", t.TempDir(), "conv-drop")
+	proc.SimulateDrops(42)
+	m.InsertProcessForTest("conv-drop", proc)
+
+	stats := m.GetConversationDropStats("conv-drop")
+	require.NotNil(t, stats)
+	assert.Equal(t, uint64(42), stats["droppedMessages"])
+}
+
+func TestGetConversationDropStats_ConcurrentAccess(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	proc := NewProcess("drop-test", t.TempDir(), "conv-drop")
+	m.InsertProcessForTest("conv-drop", proc)
+
+	var wg sync.WaitGroup
+
+	// Concurrent writers incrementing drop counter
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proc.SimulateDrops(1)
+		}()
+	}
+
+	// Concurrent readers calling GetConversationDropStats
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stats := m.GetConversationDropStats("conv-drop")
+			assert.NotNil(t, stats)
+		}()
+	}
+
+	wg.Wait()
+	stats := m.GetConversationDropStats("conv-drop")
+	assert.Equal(t, uint64(50), stats["droppedMessages"])
+}
+
+// ============================================================================
+// handleConversationOutput Drop Warning Tests
+// ============================================================================
+
+func TestHandleConversationOutput_EmitsDropWarning(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	proc := NewProcess("drop-warn-test", t.TempDir(), "conv-warn")
+	m.InsertProcessForTest("conv-warn", proc)
+
+	// Capture emitted events
+	var events []*AgentEvent
+	var eventMu sync.Mutex
+	m.SetConversationEventHandler(func(convID string, event *AgentEvent) {
+		eventMu.Lock()
+		events = append(events, event)
+		eventMu.Unlock()
+	})
+
+	// Simulate drops before handleConversationOutput processes them
+	proc.SimulateDrops(5)
+
+	// Send one event then close the channel to end the handler
+	proc.output <- `{"type":"assistant_text","content":"hello"}`
+	close(proc.output)
+
+	// Run handler (blocking, returns when channel closed)
+	done := make(chan struct{})
+	go func() {
+		m.handleConversationOutput("conv-warn", proc)
+		close(done)
+	}()
+
+	// Wait for handler to finish (with timeout)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleConversationOutput did not finish in time")
+	}
+
+	// Should have emitted the assistant_text event + at least one streaming_warning
+	eventMu.Lock()
+	defer eventMu.Unlock()
+
+	var warningEvents []*AgentEvent
+	for _, e := range events {
+		if e.Type == "streaming_warning" {
+			warningEvents = append(warningEvents, e)
+		}
+	}
+	require.NotEmpty(t, warningEvents, "Expected at least one streaming_warning event")
+	assert.Equal(t, "process", warningEvents[0].Source)
+	assert.Equal(t, "buffer_full", warningEvents[0].Reason)
+	assert.Contains(t, warningEvents[0].Message, "5 streaming events were dropped")
+}
+
+func TestHandleConversationOutput_NoWarningWhenNoDrops(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	proc := NewProcess("no-drop-test", t.TempDir(), "conv-no-drop")
+	m.InsertProcessForTest("conv-no-drop", proc)
+
+	var events []*AgentEvent
+	var eventMu sync.Mutex
+	m.SetConversationEventHandler(func(convID string, event *AgentEvent) {
+		eventMu.Lock()
+		events = append(events, event)
+		eventMu.Unlock()
+	})
+
+	// Send one event then close
+	proc.output <- `{"type":"assistant_text","content":"hello"}`
+	close(proc.output)
+
+	done := make(chan struct{})
+	go func() {
+		m.handleConversationOutput("conv-no-drop", proc)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleConversationOutput did not finish in time")
+	}
+
+	// Should have no streaming_warning events
+	eventMu.Lock()
+	defer eventMu.Unlock()
+	for _, e := range events {
+		assert.NotEqual(t, "streaming_warning", e.Type, "Should not emit warning when no drops occurred")
+	}
+}
+
+func TestHandleConversationOutput_ForwardsEvents(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	proc := NewProcess("forward-test", t.TempDir(), "conv-forward")
+	m.InsertProcessForTest("conv-forward", proc)
+
+	var events []*AgentEvent
+	var eventMu sync.Mutex
+	m.SetConversationEventHandler(func(convID string, event *AgentEvent) {
+		eventMu.Lock()
+		events = append(events, event)
+		eventMu.Unlock()
+	})
+
+	// Send multiple events
+	proc.output <- `{"type":"assistant_text","content":"hello"}`
+	proc.output <- `{"type":"tool_start","id":"t1","tool":"Read"}`
+	proc.output <- `{"type":"tool_end","id":"t1","tool":"Read","success":true}`
+	close(proc.output)
+
+	done := make(chan struct{})
+	go func() {
+		m.handleConversationOutput("conv-forward", proc)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleConversationOutput did not finish in time")
+	}
+
+	eventMu.Lock()
+	defer eventMu.Unlock()
+
+	// Should have forwarded all 3 events
+	var types []string
+	for _, e := range events {
+		types = append(types, e.Type)
+	}
+	assert.Contains(t, types, "assistant_text")
+	assert.Contains(t, types, "tool_start")
+	assert.Contains(t, types, "tool_end")
+}
+
+func TestHandleConversationOutput_FinalDropReport(t *testing.T) {
+	m, _ := setupTestManager(t)
+
+	proc := NewProcess("final-drop-test", t.TempDir(), "conv-final")
+	m.InsertProcessForTest("conv-final", proc)
+
+	var events []*AgentEvent
+	var eventMu sync.Mutex
+	m.SetConversationEventHandler(func(convID string, event *AgentEvent) {
+		eventMu.Lock()
+		events = append(events, event)
+		eventMu.Unlock()
+	})
+
+	// Simulate drops that happen right before process ends (within ticker interval)
+	// Close channel immediately - the drops happen but the ticker may not fire
+	proc.SimulateDrops(3)
+	close(proc.output)
+
+	done := make(chan struct{})
+	go func() {
+		m.handleConversationOutput("conv-final", proc)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleConversationOutput did not finish in time")
+	}
+
+	// The final drop report should emit a warning for any unreported drops
+	eventMu.Lock()
+	defer eventMu.Unlock()
+
+	var warningEvents []*AgentEvent
+	for _, e := range events {
+		if e.Type == "streaming_warning" {
+			warningEvents = append(warningEvents, e)
+		}
+	}
+	require.NotEmpty(t, warningEvents, "Expected final drop report warning")
+	assert.Contains(t, warningEvents[len(warningEvents)-1].Message, "3 streaming events were dropped")
+}

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -12,6 +12,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -24,9 +25,6 @@ const (
 	// a message from stdout/stderr. This gives slow consumers time to catch up.
 	processOutputTimeout = 5 * time.Second
 
-	// bufferFullWarningJSON is emitted to the frontend when messages are dropped
-	// due to a full output buffer. This is best-effort (non-blocking).
-	bufferFullWarningJSON = `{"type":"streaming_warning","source":"process","reason":"buffer_full","message":"Some streaming events were dropped due to slow processing"}`
 )
 
 // AgentRunnerPath can be set to override the default agent-runner location
@@ -67,6 +65,7 @@ type Process struct {
 	stopped         bool // Prevents double-stop race conditions
 	exitErr         error
 	planModeActive  bool // Tracks whether the process is in plan mode
+	droppedMessages atomic.Uint64 // Count of messages dropped due to full output buffer
 }
 
 // InputMessage represents a message sent to the agent runner via stdin
@@ -199,13 +198,11 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 		ConversationID: opts.ConversationID,
 		cmd:            cmd,
 		cancel:         cancel,
-		// Buffer size of 1000 provides headroom for bursty agent output.
+		// Buffer size of 4000 provides headroom for bursty agent output.
 		// This allows the process to continue producing output even if
-		// consumers (WebSocket clients) are temporarily slow. The buffer
-		// size was increased from 100 to handle high-throughput scenarios
-		// where agents produce rapid bursts of output (e.g., streaming
-		// tool results or large code blocks).
-		output:         make(chan string, 1000),
+		// consumers (WebSocket clients) are temporarily slow. Large buffer
+		// absorbs transient spikes from tool results and large code blocks.
+		output:         make(chan string, 4000),
 		done:           make(chan struct{}),
 		planModeActive: opts.PlanMode,
 	}
@@ -259,13 +256,8 @@ func (p *Process) Start() error {
 				// Successfully queued
 			case <-time.After(processOutputTimeout):
 				// Buffer full after timeout - downstream reader is persistently slow
-				logger.Process.Warnf("[%s] Output buffer full after %v timeout, dropping stdout message (slow reader)", p.ID, processOutputTimeout)
-				// Emit warning to frontend (best-effort, non-blocking)
-				select {
-				case p.output <- bufferFullWarningJSON:
-				default:
-					// Warning itself couldn't be queued
-				}
+				dropped := p.droppedMessages.Add(1)
+				logger.Process.Warnf("[%s] Output buffer full after %v timeout, dropping stdout message (total dropped: %d)", p.ID, processOutputTimeout, dropped)
 			}
 		}
 	}()
@@ -285,13 +277,8 @@ func (p *Process) Start() error {
 				// Successfully queued
 			case <-time.After(processOutputTimeout):
 				// Buffer full after timeout - downstream reader is persistently slow
-				logger.Process.Warnf("[%s] Output buffer full after %v timeout, dropping stderr message (slow reader)", p.ID, processOutputTimeout)
-				// Emit warning to frontend (best-effort, non-blocking)
-				select {
-				case p.output <- bufferFullWarningJSON:
-				default:
-					// Warning itself couldn't be queued
-				}
+				dropped := p.droppedMessages.Add(1)
+				logger.Process.Warnf("[%s] Output buffer full after %v timeout, dropping stderr message (total dropped: %d)", p.ID, processOutputTimeout, dropped)
 			}
 		}
 	}()
@@ -509,6 +496,16 @@ func (p *Process) TryStop() bool {
 
 func (p *Process) Output() <-chan string {
 	return p.output
+}
+
+// DroppedMessages returns the total number of messages dropped due to a full output buffer.
+func (p *Process) DroppedMessages() uint64 {
+	return p.droppedMessages.Load()
+}
+
+// SimulateDrops adds n to the drop counter. Intended for testing only.
+func (p *Process) SimulateDrops(n uint64) {
+	p.droppedMessages.Add(n)
 }
 
 func (p *Process) Done() <-chan struct{} {

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -415,33 +415,6 @@ func TestNewProcessWithOptions_MinimalOptions(t *testing.T) {
 }
 
 // ============================================================================
-// Streaming Warning Tests
-// ============================================================================
-
-func TestStreamingWarningJSON_ValidFormat(t *testing.T) {
-	// Verify the exported constant is valid and parseable
-	event := ParseAgentLine(bufferFullWarningJSON)
-	require.NotNil(t, event)
-
-	assert.Equal(t, "streaming_warning", event.Type)
-	assert.Equal(t, "process", event.Source)
-	assert.Equal(t, "buffer_full", event.Reason)
-	assert.Equal(t, "Some streaming events were dropped due to slow processing", event.Message)
-}
-
-func TestProcess_OutputBufferFull_EmitsWarning(t *testing.T) {
-	// Verify the warning JSON constant structure is correct
-	var event map[string]interface{}
-	err := json.Unmarshal([]byte(bufferFullWarningJSON), &event)
-	require.NoError(t, err)
-
-	assert.Equal(t, "streaming_warning", event["type"])
-	assert.Equal(t, "process", event["source"])
-	assert.Equal(t, "buffer_full", event["reason"])
-	assert.Equal(t, "Some streaming events were dropped due to slow processing", event["message"])
-}
-
-// ============================================================================
 // Stop with SIGTERM/SIGKILL Escalation Tests
 // ============================================================================
 
@@ -550,4 +523,85 @@ func TestStartConversationOptions_PlanModeSet(t *testing.T) {
 	}
 	assert.True(t, opts.PlanMode)
 	assert.Equal(t, 1000, opts.MaxThinkingTokens)
+}
+
+// ============================================================================
+// Dropped Messages Counter Tests
+// ============================================================================
+
+func TestProcess_DroppedMessages_InitiallyZero(t *testing.T) {
+	p := NewProcess("test-drops", "/tmp", "conv-drops")
+	assert.Equal(t, uint64(0), p.DroppedMessages())
+}
+
+func TestProcess_DroppedMessages_Increment(t *testing.T) {
+	p := NewProcess("test-drops", "/tmp", "conv-drops")
+
+	p.SimulateDrops(1)
+	assert.Equal(t, uint64(1), p.DroppedMessages())
+
+	p.SimulateDrops(1)
+	assert.Equal(t, uint64(2), p.DroppedMessages())
+
+	p.SimulateDrops(5)
+	assert.Equal(t, uint64(7), p.DroppedMessages())
+}
+
+func TestProcess_DroppedMessages_ConcurrentAccess(t *testing.T) {
+	p := NewProcess("test-concurrent-drops", "/tmp", "conv-concurrent")
+
+	var wg sync.WaitGroup
+	numGoroutines := 100
+	incrementsPerGoroutine := 10
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < incrementsPerGoroutine; j++ {
+				p.SimulateDrops(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	expected := uint64(numGoroutines * incrementsPerGoroutine)
+	assert.Equal(t, expected, p.DroppedMessages())
+}
+
+func TestProcess_DroppedMessages_ConcurrentReadWrite(t *testing.T) {
+	p := NewProcess("test-readwrite-drops", "/tmp", "conv-readwrite")
+
+	var wg sync.WaitGroup
+
+	// Writers
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				p.SimulateDrops(1)
+			}
+		}()
+	}
+
+	// Readers - should never panic
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				_ = p.DroppedMessages()
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, uint64(500), p.DroppedMessages())
+}
+
+func TestProcess_OutputBufferSize_Increased(t *testing.T) {
+	p := NewProcess("test-bufsize", "/tmp", "conv-bufsize")
+	// Buffer should be 4000 (increased from 1000)
+	assert.Equal(t, 4000, cap(p.output))
 }

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -2575,6 +2575,17 @@ func (h *Handlers) StopConversation(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *Handlers) GetConversationDropStats(w http.ResponseWriter, r *http.Request) {
+	convID := chi.URLParam(r, "convId")
+	stats := h.agentManager.GetConversationDropStats(convID)
+	if stats == nil {
+		// No active process - return zero drops
+		writeJSON(w, map[string]uint64{"droppedMessages": 0})
+		return
+	}
+	writeJSON(w, stats)
+}
+
 type RewindConversationRequest struct {
 	CheckpointUuid string `json:"checkpointUuid"`
 }

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chatml/chatml-backend/agent"
 	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/models"
 	"github.com/chatml/chatml-backend/store"
@@ -2166,4 +2167,88 @@ func TestGeneratePRDescription_NoAIClient(t *testing.T) {
 
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 	assert.Contains(t, w.Body.String(), "not available")
+}
+
+// ============================================================================
+// Drop Stats Handler Tests
+// ============================================================================
+
+func TestGetConversationDropStats_NoActiveProcess(t *testing.T) {
+	h, _, _ := setupTestHandlersWithAgentManager(t)
+
+	req := httptest.NewRequest("GET", "/api/conversations/conv-nonexistent/drop-stats", nil)
+	req = withChiContext(req, map[string]string{"convId": "conv-nonexistent"})
+	w := httptest.NewRecorder()
+
+	h.GetConversationDropStats(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var stats map[string]uint64
+	err := json.Unmarshal(w.Body.Bytes(), &stats)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), stats["droppedMessages"])
+}
+
+func TestGetConversationDropStats_WithActiveProcess(t *testing.T) {
+	h, _, agentMgr := setupTestHandlersWithAgentManager(t)
+
+	// Manually insert a process with some drops
+	proc := agent.NewProcess("drop-proc", t.TempDir(), "conv-stats")
+	agentMgr.InsertProcessForTest("conv-stats", proc)
+
+	req := httptest.NewRequest("GET", "/api/conversations/conv-stats/drop-stats", nil)
+	req = withChiContext(req, map[string]string{"convId": "conv-stats"})
+	w := httptest.NewRecorder()
+
+	h.GetConversationDropStats(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var stats map[string]uint64
+	err := json.Unmarshal(w.Body.Bytes(), &stats)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), stats["droppedMessages"])
+}
+
+func TestGetConversationDropStats_ReflectsDropCount(t *testing.T) {
+	h, _, agentMgr := setupTestHandlersWithAgentManager(t)
+
+	// Create process and simulate drops
+	proc := agent.NewProcess("drop-proc", t.TempDir(), "conv-stats")
+	proc.SimulateDrops(17)
+	agentMgr.InsertProcessForTest("conv-stats", proc)
+
+	req := httptest.NewRequest("GET", "/api/conversations/conv-stats/drop-stats", nil)
+	req = withChiContext(req, map[string]string{"convId": "conv-stats"})
+	w := httptest.NewRecorder()
+
+	h.GetConversationDropStats(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var stats map[string]uint64
+	err := json.Unmarshal(w.Body.Bytes(), &stats)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(17), stats["droppedMessages"])
+}
+
+func TestGetConversationDropStats_ResponseFormat(t *testing.T) {
+	h, _, _ := setupTestHandlersWithAgentManager(t)
+
+	req := httptest.NewRequest("GET", "/api/conversations/conv-format/drop-stats", nil)
+	req = withChiContext(req, map[string]string{"convId": "conv-format"})
+	w := httptest.NewRecorder()
+
+	h.GetConversationDropStats(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	// Verify response is valid JSON with expected key
+	var result map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+	_, hasDropped := result["droppedMessages"]
+	assert.True(t, hasDropped, "Response should contain droppedMessages key")
 }

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -135,6 +135,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Get("/{convId}", h.GetConversation)
 		r.With(messageRateLimiter).Post("/{convId}/messages", h.SendConversationMessage)
 		r.Post("/{convId}/stop", h.StopConversation)
+		r.Get("/{convId}/drop-stats", h.GetConversationDropStats)
 		r.Post("/{convId}/rewind", h.RewindConversation)
 		r.Post("/{convId}/plan-mode", h.SetConversationPlanMode)
 		r.Post("/{convId}/approve-plan", h.ApprovePlan)

--- a/backend/server/websocket.go
+++ b/backend/server/websocket.go
@@ -127,7 +127,7 @@ type Hub struct {
 func NewHub() *Hub {
 	return &Hub{
 		clients:   make(map[*Client]bool),
-		broadcast: make(chan []byte, 1024),
+		broadcast: make(chan []byte, 4096),
 		register:  make(chan *Client),
 		// Buffered to prevent eviction goroutines from blocking during
 		// high-churn scenarios or if the Hub is slow to process unregisters

--- a/backend/server/websocket_test.go
+++ b/backend/server/websocket_test.go
@@ -80,9 +80,9 @@ func TestHub_Broadcast_Success(t *testing.T) {
 func TestHub_Broadcast_ChannelFull(t *testing.T) {
 	hub := NewHub()
 
-	// Fill the channel to capacity (1024)
+	// Fill the channel to capacity (4096)
 	fillerData, _ := json.Marshal(Event{Type: "filler"})
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 4096; i++ {
 		hub.broadcast <- fillerData
 	}
 
@@ -135,9 +135,9 @@ func TestHub_Broadcast_MultipleEvents(t *testing.T) {
 func TestHub_Broadcast_Backpressure(t *testing.T) {
 	hub := NewHub()
 
-	// Fill channel to >75% capacity (769 messages, which is > 768 = 1024*3/4) to trigger backpressure
+	// Fill channel to >75% capacity (3073 messages, which is > 3072 = 4096*3/4) to trigger backpressure
 	fillerData, _ := json.Marshal(Event{Type: "filler"})
-	for i := 0; i < 769; i++ {
+	for i := 0; i < 3073; i++ {
 		hub.broadcast <- fillerData
 	}
 
@@ -323,7 +323,7 @@ func TestHub_GetStats(t *testing.T) {
 	assert.Equal(t, uint64(1), stats["messagesDropped"])
 	assert.Equal(t, int64(3), stats["currentClients"])
 	assert.Equal(t, int64(3), stats["peakClients"])
-	assert.Equal(t, 1024, stats["broadcastBufferCapacity"])
+	assert.Equal(t, 4096, stats["broadcastBufferCapacity"])
 }
 
 // ============================================================================
@@ -514,9 +514,9 @@ func TestBroadcastResult_SuccessfulDelivery(t *testing.T) {
 func TestHub_Broadcast_TimeoutBehavior(t *testing.T) {
 	hub := NewHub()
 
-	// Fill the channel to capacity (1024)
+	// Fill the channel to capacity (4096)
 	fillerData, _ := json.Marshal(Event{Type: "filler"})
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 4096; i++ {
 		hub.broadcast <- fillerData
 	}
 
@@ -748,7 +748,7 @@ func TestHub_Broadcast_EmitsWarningOnTimeout(t *testing.T) {
 
 	// Fill channel to capacity
 	fillerData, _ := json.Marshal(Event{Type: "filler"})
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 4096; i++ {
 		hub.broadcast <- fillerData
 	}
 
@@ -769,7 +769,7 @@ func TestHub_Broadcast_WarningRateLimited(t *testing.T) {
 
 	// Fill channel
 	fillerData, _ := json.Marshal(Event{Type: "filler"})
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 4096; i++ {
 		hub.broadcast <- fillerData
 	}
 
@@ -789,7 +789,7 @@ func TestHub_Broadcast_WarningAfterRateLimitExpires(t *testing.T) {
 
 	// Fill channel
 	fillerData, _ := json.Marshal(Event{Type: "filler"})
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 4096; i++ {
 		hub.broadcast <- fillerData
 	}
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -11,6 +11,12 @@ import {
 import { getAuthToken } from '@/lib/auth-token';
 import { getBackendPort, getBackendPortSync } from '@/lib/backend-port';
 import { useConnectionStore } from '@/stores/connectionStore';
+import { getConversationDropStats } from '@/lib/api';
+
+// Debounce interval for drop stats REST fetches (ms).
+// The backend ticker fires every 2s, so 3s avoids redundant requests during bursty drops.
+const DROP_STATS_DEBOUNCE_MS = 3000;
+let lastDropStatsFetchTime = 0;
 
 // Type guards for WebSocket payload validation
 function isAgentEvent(payload: unknown): payload is AgentEvent {
@@ -293,16 +299,46 @@ export function useWebSocket(enabled: boolean = true) {
         store.updateConversation(conversationId, { status: 'idle' });
         break;
 
-      case 'streaming_warning':
-        // Emit custom event for StreamingWarningHandler to display toast
-        window.dispatchEvent(new CustomEvent('streaming-warning', {
-          detail: {
-            source: event?.source,
-            reason: event?.reason,
-            message: event?.message || 'Some streaming data may have been lost',
-          }
-        }));
+      case 'streaming_warning': {
+        // Emit custom event for StreamingWarningHandler to display toast.
+        // Debounce the REST call to avoid redundant requests during bursty drops.
+        // The backend ticker fires every 2s, so at most one fetch per 3s is sufficient.
+        const now = Date.now();
+        if (now - lastDropStatsFetchTime >= DROP_STATS_DEBOUNCE_MS) {
+          lastDropStatsFetchTime = now;
+          getConversationDropStats(conversationId).then((stats) => {
+            window.dispatchEvent(new CustomEvent('streaming-warning', {
+              detail: {
+                source: event?.source,
+                reason: event?.reason,
+                message: stats.droppedMessages > 0
+                  ? `${stats.droppedMessages} streaming events were dropped`
+                  : (event?.message || 'Some streaming data may have been lost'),
+                droppedMessages: stats.droppedMessages,
+              }
+            }));
+          }).catch(() => {
+            // Fallback: emit warning with whatever info we have from WebSocket
+            window.dispatchEvent(new CustomEvent('streaming-warning', {
+              detail: {
+                source: event?.source,
+                reason: event?.reason,
+                message: event?.message || 'Some streaming data may have been lost',
+              }
+            }));
+          });
+        } else {
+          // Debounced: emit warning with WebSocket data only (no REST call)
+          window.dispatchEvent(new CustomEvent('streaming-warning', {
+            detail: {
+              source: event?.source,
+              reason: event?.reason,
+              message: event?.message || 'Some streaming data may have been lost',
+            }
+          }));
+        }
         break;
+      }
 
       case 'user_question_request':
         // AskUserQuestion tool - set pending question for the conversation

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -901,6 +901,11 @@ export async function stopConversation(convId: string): Promise<void> {
   await handleVoidResponse(res, 'Failed to stop conversation');
 }
 
+export async function getConversationDropStats(convId: string): Promise<{ droppedMessages: number }> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/drop-stats`);
+  return handleResponse(res);
+}
+
 export async function deleteConversation(convId: string): Promise<void> {
   const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}`, { method: 'DELETE' });
   await handleVoidResponse(res, 'Failed to delete conversation');


### PR DESCRIPTION
## Summary

Applied all 5 code review comments to improve the buffer overflow fix:

- Removed dead `bufferFullWarningJSON` constant and tests that were superseded by out-of-band drop detection
- Replaced `goto` with idiomatic labeled `break` in `handleConversationOutput` 
- Made test helpers consistent: always use `SimulateDrops()` and `InsertProcessForTest()` APIs
- Added debouncing (3s window) to drop stats REST calls to avoid redundant requests during bursty drops

Tests pass. All changes are backwards compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)