### PR TITLE
fix: parallelize drag-drop listener setup and add error handling

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -837,25 +837,48 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
   // Listen for drag-drop events from Tauri
   useEffect(() => {
+    let isCancelled = false;
     let unlistenDrop: (() => void) | undefined;
     let unlistenEnter: (() => void) | undefined;
     let unlistenLeave: (() => void) | undefined;
 
     const setupListeners = async () => {
-      unlistenDrop = await listenForFileDrop((paths) => {
-        handleFileDrop(paths);
-      });
-      unlistenEnter = await listenForDragEnter(() => {
-        setIsDragOver(true);
-      });
-      unlistenLeave = await listenForDragLeave(() => {
-        setIsDragOver(false);
-      });
+      try {
+        const [drop, enter, leave] = await Promise.all([
+          listenForFileDrop((paths) => {
+            handleFileDrop(paths);
+          }),
+          listenForDragEnter(() => {
+            setIsDragOver(true);
+          }),
+          listenForDragLeave(() => {
+            setIsDragOver(false);
+          }),
+        ]);
+
+        if (isCancelled) {
+          drop();
+          enter();
+          leave();
+          return;
+        }
+
+        unlistenDrop = drop;
+        unlistenEnter = enter;
+        unlistenLeave = leave;
+      } catch (error) {
+        console.error('Failed to setup drag-drop listeners:', error);
+        // Clean up any listeners that were registered before the failure
+        unlistenDrop?.();
+        unlistenEnter?.();
+        unlistenLeave?.();
+      }
     };
 
     setupListeners();
 
     return () => {
+      isCancelled = true;
       unlistenDrop?.();
       unlistenEnter?.();
       unlistenLeave?.();


### PR DESCRIPTION
Improves the drag-drop listener setup in ChatInput by parallelizing the three independent listener registrations with Promise.all, reducing setup latency. Adds try/catch error handling to gracefully handle listener setup failures and prevent unhandled promise rejections.

- Parallelize listenForFileDrop, listenForDragEnter, listenForDragLeave with Promise.all
- Add try/catch to handle and log listener setup errors
- Maintain isCancelled guard against race conditions with cleanup