### PR TITLE
fix: prevent infinite re-render loop in ChangesPanel

### DIFF
--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -15,6 +15,7 @@
  * if referential stability is needed for downstream dependencies.
  */
 
+import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from './appStore';
 import { useNavigationStore } from './navigationStore';
@@ -296,19 +297,19 @@ export const useReviewComments = (sessionId: string | null) =>
  * Returns a Map of filePath to { total, unresolved } counts.
  * Use in: ChangesPanel for badge display
  *
- * Returns a stable empty Map when there are no comments.
- * Note: Components should use useMemo if they need to avoid re-computation.
+ * Derives stats from useReviewComments via useMemo to ensure referential
+ * stability. The previous implementation created a new Map inside the Zustand
+ * selector on every store update, which caused React's useSyncExternalStore
+ * to detect a new snapshot each time, leading to infinite re-render loops.
  */
-export const useFileCommentStats = (sessionId: string | null) =>
-  useAppStore((s) => {
-    const comments = sessionId ? s.reviewComments[sessionId] : null;
+export const useFileCommentStats = (sessionId: string | null) => {
+  const comments = useReviewComments(sessionId);
 
-    // Return stable empty map when no comments
+  return useMemo(() => {
     if (!comments || comments.length === 0) {
       return EMPTY_FILE_COMMENT_STATS;
     }
 
-    // Only construct Map when we have actual comments
     const stats = new Map<string, { total: number; unresolved: number }>();
     for (const comment of comments) {
       const current = stats.get(comment.filePath) || { total: 0, unresolved: 0 };
@@ -318,7 +319,8 @@ export const useFileCommentStats = (sessionId: string | null) =>
     }
 
     return stats;
-  });
+  }, [comments]);
+};
 
 /**
  * Review comment actions for components that need to modify comments.


### PR DESCRIPTION
## Summary
- `useFileCommentStats` selector created a new `Map` inside the Zustand selector on every store update, causing an infinite re-render loop in `ChangesPanel` (and `ReviewPanel` via ErrorBoundary)
- Fixed by deriving stats from the stable `useReviewComments()` result via `useMemo`, ensuring the Map is only recomputed when the comments array actually changes

## Root Cause
Zustand uses `===` comparison for selector results by default. Creating a new `Map` object inside the selector meant every store update produced a "new" value, triggering a re-render, which caused further updates — hitting React's max update depth guard.

## Test plan
- [ ] Open a session with review comments and verify ChangesPanel renders without errors
- [ ] Open a session without review comments and verify no regressions
- [ ] Verify `npm run build` passes
- [ ] Verify no new lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)