### PR TITLE
feat: add desktop notifications for chat events

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,6 +29,7 @@ import { useTabPersistence } from '@/hooks/useTabPersistence';
 import { useAutoSave } from '@/hooks/useAutoSave';
 import { useFileWatcher } from '@/hooks/useFileWatcher';
 import { useExternalLinkGuard } from '@/hooks/useExternalLinkGuard';
+import { useDesktopNotifications } from '@/hooks/useDesktopNotifications';
 import { useReviewTrigger } from '@/hooks/useReviewTrigger';
 import { useShortcut } from '@/hooks/useShortcut';
 import { getDashboardData, listConversations, createSession, createConversation, deleteConversation, addRepo, mapSessionDTO, type RepoDTO, type SessionDTO, type ConversationDTO, type MessageDTO } from '@/lib/api';
@@ -419,6 +420,7 @@ export default function Home() {
   // Watch for external file changes
   useFileWatcher();
   useExternalLinkGuard();
+  useDesktopNotifications();
 
   // Keyboard shortcut: Cmd+/ to show shortcuts dialog
   useShortcut('shortcutsDialog', useCallback(() => {

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -34,7 +34,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { openFolderDialog, setMinimizeToTray } from '@/lib/tauri';
+import { openFolderDialog, setMinimizeToTray, requestNotificationPermission } from '@/lib/tauri';
 import { getWorkspacesBasePath, setWorkspacesBasePath } from '@/lib/api';
 import { EDITOR_THEMES } from '@/lib/monacoThemes';
 
@@ -212,6 +212,16 @@ function SettingsRow({
 function ChatSettings() {
   const confirmCloseActiveTab = useSettingsStore((s) => s.confirmCloseActiveTab);
   const setConfirmCloseActiveTab = useSettingsStore((s) => s.setConfirmCloseActiveTab);
+  const desktopNotifications = useSettingsStore((s) => s.desktopNotifications);
+  const setDesktopNotifications = useSettingsStore((s) => s.setDesktopNotifications);
+
+  const handleNotificationToggle = useCallback(async (enabled: boolean) => {
+    if (enabled) {
+      const perm = await requestNotificationPermission();
+      if (perm !== 'granted') return;
+    }
+    setDesktopNotifications(enabled);
+  }, [setDesktopNotifications]);
 
   return (
     <div>
@@ -276,7 +286,7 @@ function ChatSettings() {
         title="Desktop notifications"
         description="Get notified when AI finishes working in a chat"
       >
-        <Switch defaultChecked />
+        <Switch checked={desktopNotifications} onCheckedChange={handleNotificationToggle} />
       </SettingsRow>
 
       <SettingsRow

--- a/src/hooks/__tests__/useDesktopNotifications.test.ts
+++ b/src/hooks/__tests__/useDesktopNotifications.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+// ---- Mocks ----
+
+vi.mock('@/lib/tauri', () => ({
+  sendNotification: vi.fn().mockResolvedValue(undefined),
+  isTauri: vi.fn().mockReturnValue(true),
+}));
+
+import { sendNotification } from '@/lib/tauri';
+import { notifyDesktop, getConversationLabel, useDesktopNotifications } from '../useDesktopNotifications';
+
+const mockedSendNotification = vi.mocked(sendNotification);
+
+// Incrementing base time to avoid cross-test debounce collisions.
+// The module-level debounceMap persists between tests, so each test
+// needs a time that is >5s from any previous test's timestamp.
+let testTimeOffset = 0;
+
+// Test data factories
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'session-1',
+    workspaceId: 'ws-1',
+    name: 'fix/auth-bug',
+    branch: 'fix/auth-bug',
+    worktreePath: '/tmp/worktrees/fix-auth-bug',
+    status: 'active' as const,
+    priority: 'normal' as const,
+    taskStatus: 'in_progress' as const,
+    ...overrides,
+  };
+}
+
+function makeConversation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'conv-1',
+    sessionId: 'session-1',
+    type: 'task' as const,
+    name: 'Fix authentication flow',
+    status: 'completed' as const,
+    messages: [],
+    toolSummary: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('notifyDesktop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    useSettingsStore.setState({ desktopNotifications: true });
+    // Advance well past any previous test's debounce window
+    testTimeOffset += 10_000;
+    vi.setSystemTime(new Date(1_700_000_000_000 + testTimeOffset));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends a notification when enabled and window is not focused', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+    notifyDesktop('conv-1', 'Task completed', 'Fix auth flow');
+
+    expect(mockedSendNotification).toHaveBeenCalledWith('Task completed', 'Fix auth flow');
+  });
+
+  it('does not send a notification when desktop notifications are disabled', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    useSettingsStore.setState({ desktopNotifications: false });
+
+    notifyDesktop('conv-1', 'Task completed', 'Fix auth flow');
+
+    expect(mockedSendNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not send a notification when the window is focused', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+
+    notifyDesktop('conv-1', 'Task completed', 'Fix auth flow');
+
+    expect(mockedSendNotification).not.toHaveBeenCalled();
+  });
+
+  it('debounces notifications for the same conversation within 5 seconds', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+    notifyDesktop('debounce-conv', 'Task completed', 'First');
+    expect(mockedSendNotification).toHaveBeenCalledTimes(1);
+
+    // Try again immediately — should be debounced
+    notifyDesktop('debounce-conv', 'Task completed', 'Second');
+    expect(mockedSendNotification).toHaveBeenCalledTimes(1);
+
+    // Advance past debounce window
+    vi.advanceTimersByTime(5001);
+
+    notifyDesktop('debounce-conv', 'Task completed', 'Third');
+    expect(mockedSendNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows notifications for different conversations simultaneously', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+    notifyDesktop('multi-conv-a', 'Task completed', 'First conv');
+    notifyDesktop('multi-conv-b', 'Task completed', 'Second conv');
+
+    expect(mockedSendNotification).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getConversationLabel', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      sessions: [makeSession()],
+      conversations: [makeConversation()],
+    });
+  });
+
+  it('returns the conversation name when available', () => {
+    expect(getConversationLabel('conv-1')).toBe('Fix authentication flow');
+  });
+
+  it('falls back to session name when conversation has no name', () => {
+    useAppStore.setState({
+      conversations: [makeConversation({ name: '' })],
+    });
+
+    expect(getConversationLabel('conv-1')).toBe('fix/auth-bug');
+  });
+
+  it('returns empty string for unknown conversation', () => {
+    expect(getConversationLabel('nonexistent')).toBe('');
+  });
+});
+
+describe('useDesktopNotifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // Advance well past any previous test's debounce window
+    testTimeOffset += 10_000;
+    vi.setSystemTime(new Date(1_700_000_000_000 + testTimeOffset));
+
+    useSettingsStore.setState({
+      desktopNotifications: true,
+      collapsedWorkspaces: [],
+      contentView: { type: 'conversation' },
+    });
+
+    useAppStore.setState({
+      sessions: [makeSession()],
+      conversations: [makeConversation()],
+      selectedSessionId: null,
+      selectedConversationId: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('navigates to conversation when window is focused within 3 seconds of notification', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+    const { unmount } = renderHook(() => useDesktopNotifications());
+
+    // Trigger a notification (use unique ID to avoid debounce from other tests)
+    notifyDesktop('conv-1', 'Task completed', 'Fix auth');
+
+    // Simulate window gaining focus within 3 seconds
+    vi.advanceTimersByTime(1000);
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    const state = useAppStore.getState();
+    expect(state.selectedSessionId).toBe('session-1');
+    expect(state.selectedConversationId).toBe('conv-1');
+
+    unmount();
+  });
+
+  it('does not navigate if focus happens after 3 seconds', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+    const { unmount } = renderHook(() => useDesktopNotifications());
+
+    notifyDesktop('conv-1', 'Task completed', 'Fix auth');
+
+    // Focus after the 3-second window
+    vi.advanceTimersByTime(4000);
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    const state = useAppStore.getState();
+    expect(state.selectedConversationId).toBeNull();
+
+    unmount();
+  });
+
+  it('does not navigate when there is no recent notification', () => {
+    const { unmount } = renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    const state = useAppStore.getState();
+    expect(state.selectedConversationId).toBeNull();
+
+    unmount();
+  });
+
+  it('expands a collapsed workspace when navigating', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    useSettingsStore.setState({ collapsedWorkspaces: ['ws-1'] });
+
+    const { unmount } = renderHook(() => useDesktopNotifications());
+
+    notifyDesktop('conv-1', 'Task completed', 'Fix auth');
+
+    vi.advanceTimersByTime(500);
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(useSettingsStore.getState().collapsedWorkspaces).not.toContain('ws-1');
+
+    unmount();
+  });
+
+  it('switches to conversation view if on a different view', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    useSettingsStore.setState({ contentView: { type: 'global-dashboard' } });
+
+    const { unmount } = renderHook(() => useDesktopNotifications());
+
+    notifyDesktop('conv-1', 'Task completed', 'Fix auth');
+
+    vi.advanceTimersByTime(500);
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(useSettingsStore.getState().contentView).toEqual({ type: 'conversation' });
+
+    unmount();
+  });
+
+  it('cleans up the focus event listener on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useDesktopNotifications());
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('focus', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+});

--- a/src/hooks/useDesktopNotifications.ts
+++ b/src/hooks/useDesktopNotifications.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect } from 'react';
+import { sendNotification } from '@/lib/tauri';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useAppStore } from '@/stores/appStore';
+
+const DEBOUNCE_MS = 5000;
+const FOCUS_NAVIGATE_WINDOW_MS = 3000;
+
+// Module-level state so notifyDesktop can be called outside of React hooks
+let lastNotification: { conversationId: string; time: number } | null = null;
+const debounceMap = new Map<string, number>();
+
+/**
+ * Send a desktop notification if the app is not focused and notifications are enabled.
+ * This is a module-level function so it can be called from useWebSocket's getState() pattern.
+ */
+export function notifyDesktop(conversationId: string, title: string, body: string): void {
+  const { desktopNotifications } = useSettingsStore.getState();
+  if (!desktopNotifications) return;
+  if (typeof document !== 'undefined' && document.hasFocus()) return;
+
+  // Debounce per conversation
+  const lastTime = debounceMap.get(conversationId);
+  if (lastTime && Date.now() - lastTime < DEBOUNCE_MS) return;
+
+  // Prune stale entries to prevent unbounded growth in long-running sessions
+  if (debounceMap.size > 200) {
+    const now = Date.now();
+    for (const [k, v] of debounceMap) {
+      if (now - v > DEBOUNCE_MS) debounceMap.delete(k);
+    }
+  }
+
+  debounceMap.set(conversationId, Date.now());
+  lastNotification = { conversationId, time: Date.now() };
+  sendNotification(title, body).catch(() => {});
+}
+
+/**
+ * Get a human-readable label for a conversation (conversation name or session name).
+ */
+export function getConversationLabel(conversationId: string): string {
+  const state = useAppStore.getState();
+  const conversation = state.conversations.find((c) => c.id === conversationId);
+  if (!conversation) return '';
+
+  if (conversation.name) return conversation.name;
+
+  const session = state.sessions.find((s) => s.id === conversation.sessionId);
+  return session?.name || '';
+}
+
+/**
+ * Navigate to a conversation by selecting its session and conversation.
+ * Uses getState() so it always reads the latest store values.
+ */
+function navigateToConversation(conversationId: string): void {
+  const state = useAppStore.getState();
+  const conversation = state.conversations.find((c) => c.id === conversationId);
+  if (!conversation) return;
+
+  const session = state.sessions.find((s) => s.id === conversation.sessionId);
+  if (session) {
+    const { collapsedWorkspaces, expandWorkspace, contentView, setContentView } = useSettingsStore.getState();
+
+    // Expand the workspace if collapsed
+    if (collapsedWorkspaces.includes(session.workspaceId)) {
+      expandWorkspace(session.workspaceId);
+    }
+
+    // Ensure we're in conversation view
+    if (contentView.type !== 'conversation') {
+      setContentView({ type: 'conversation' });
+    }
+
+    state.selectSession(session.id);
+  }
+  state.selectConversation(conversationId);
+}
+
+/**
+ * Hook that listens for window focus events and navigates to the conversation
+ * that triggered the most recent notification. Mount once at the app level.
+ */
+export function useDesktopNotifications(): void {
+  useEffect(() => {
+    const onFocus = () => {
+      if (!lastNotification) return;
+      if (Date.now() - lastNotification.time > FOCUS_NAVIGATE_WINDOW_MS) {
+        lastNotification = null;
+        return;
+      }
+
+      const { conversationId } = lastNotification;
+      lastNotification = null;
+      navigateToConversation(conversationId);
+    };
+
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, []);
+}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -12,6 +12,7 @@ import { getAuthToken } from '@/lib/auth-token';
 import { getBackendPort, getBackendPortSync } from '@/lib/backend-port';
 import { useConnectionStore } from '@/stores/connectionStore';
 import { getConversationDropStats } from '@/lib/api';
+import { notifyDesktop, getConversationLabel } from '@/hooks/useDesktopNotifications';
 
 // Debounce interval for drop stats REST fetches (ms).
 // The backend ticker fires every 2s, so 3s avoids redundant requests during bursty drops.
@@ -269,6 +270,13 @@ export function useWebSocket(enabled: boolean = true) {
         }
         // Update conversation status to completed
         freshStore.updateConversation(conversationId, { status: 'completed' });
+        // Desktop notification for task completion.
+        // success defaults to true when the field is absent (only explicitly false means failure).
+        notifyDesktop(
+          conversationId,
+          event.success !== false ? 'Task completed' : 'Task finished with errors',
+          getConversationLabel(conversationId),
+        );
         break;
 
       case 'complete':
@@ -287,6 +295,9 @@ export function useWebSocket(enabled: boolean = true) {
         if (event?.mode) {
           const isPlanMode = event.mode === 'plan';
           store.setPlanModeActive(conversationId, isPlanMode);
+          if (isPlanMode) {
+            notifyDesktop(conversationId, 'Plan ready for review', 'The AI needs your approval');
+          }
         }
         break;
 
@@ -297,6 +308,8 @@ export function useWebSocket(enabled: boolean = true) {
         store.setStreamingError(conversationId, errorMessage);
         // Update conversation status to idle
         store.updateConversation(conversationId, { status: 'idle' });
+        // Desktop notification for error
+        notifyDesktop(conversationId, 'Task error', (errorMessage || 'Unknown error').slice(0, 100));
         break;
 
       case 'streaming_warning': {
@@ -349,6 +362,7 @@ export function useWebSocket(enabled: boolean = true) {
             currentIndex: 0,
             answers: {},
           });
+          notifyDesktop(conversationId, 'Question from AI', 'The AI needs your input');
         }
         break;
 


### PR DESCRIPTION
## Summary

Notify users when AI tasks complete, encounter errors, enter plan mode, or request user input. Notifications are sent only when the app is not focused and are debounced per conversation to prevent spam.

## Features

- Automatic navigation to the relevant conversation when the window regains focus within 3 seconds of notification
- Debounced notifications per conversation (5-second window) to avoid notification spam
- Configurable toggle in settings with explicit permission request
- Supports task completion, errors, plan mode, and user question prompts

## Code Quality Improvements

- DebounceMap pruning to prevent memory leak in long-running sessions
- Proper async error handling with `.catch()` for sendNotification
- Consolidated store reads to prevent state inconsistencies
- Guarded undefined checks for error message truncation
- Explicit permission requirement for notification toggle
- 268 lines of comprehensive test coverage

🤖 Generated with Claude Code