### PR TITLE
feat: add context meter to chat composer

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -803,6 +803,18 @@ function handleMessage(message: SDKMessage): void {
           }
         }
       }
+
+      // Extract per-message usage for context meter
+      const msgUsage = (message.message as { usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } }).usage;
+      if (msgUsage) {
+        emit({
+          type: "context_usage",
+          inputTokens: msgUsage.input_tokens ?? 0,
+          outputTokens: msgUsage.output_tokens ?? 0,
+          cacheReadInputTokens: msgUsage.cache_read_input_tokens ?? 0,
+          cacheCreationInputTokens: msgUsage.cache_creation_input_tokens ?? 0,
+        });
+      }
       break;
     }
 
@@ -954,6 +966,21 @@ function handleMessage(message: SDKMessage): void {
             totalToolDurationMs: runStats.totalToolDurationMs,
           },
         });
+      }
+
+      // Extract context window size from modelUsage for context meter
+      const resultModelUsage = resultMsg.modelUsage as Record<string, { contextWindow?: number }> | undefined;
+      if (resultModelUsage) {
+        for (const modelKey of Object.keys(resultModelUsage)) {
+          const mu = resultModelUsage[modelKey];
+          if (mu?.contextWindow) {
+            emit({
+              type: "context_window_size",
+              contextWindow: mu.contextWindow,
+            });
+            break;
+          }
+        }
       }
       break;
     }

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -74,6 +74,13 @@ type AgentEvent struct {
 	Trigger   string `json:"trigger,omitempty"`
 	PreTokens int    `json:"preTokens,omitempty"`
 
+	// Context usage fields
+	InputTokens              int `json:"inputTokens,omitempty"`
+	OutputTokens             int `json:"outputTokens,omitempty"`
+	CacheReadInputTokens     int `json:"cacheReadInputTokens,omitempty"`
+	CacheCreationInputTokens int `json:"cacheCreationInputTokens,omitempty"`
+	ContextWindow            int `json:"contextWindow,omitempty"`
+
 	// Status fields
 	Status string `json:"status,omitempty"`
 
@@ -206,6 +213,10 @@ const (
 
 	// Warning events
 	EventTypeStreamingWarning = "streaming_warning"
+
+	// Context usage events
+	EventTypeContextUsage      = "context_usage"
+	EventTypeContextWindowSize = "context_window_size"
 
 	// User question events (AskUserQuestion tool)
 	EventTypeUserQuestionRequest = "user_question_request"

--- a/backend/agent/parser_test.go
+++ b/backend/agent/parser_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -196,6 +197,25 @@ func TestParseAgentLine_ValidJSON(t *testing.T) {
 				assert.Equal(t, "Failed to parse input: Unexpected token", event.Message)
 				assert.Equal(t, "{invalid json}", event.RawInput)
 				assert.Equal(t, "Unexpected token", event.ErrorDetails)
+			},
+		},
+		{
+			name:         "context_usage",
+			input:        `{"type":"context_usage","inputTokens":15000,"outputTokens":3000,"cacheReadInputTokens":5000,"cacheCreationInputTokens":2000}`,
+			expectedType: EventTypeContextUsage,
+			checkFields: func(t *testing.T, event *AgentEvent) {
+				assert.Equal(t, 15000, event.InputTokens)
+				assert.Equal(t, 3000, event.OutputTokens)
+				assert.Equal(t, 5000, event.CacheReadInputTokens)
+				assert.Equal(t, 2000, event.CacheCreationInputTokens)
+			},
+		},
+		{
+			name:         "context_window_size",
+			input:        `{"type":"context_window_size","contextWindow":200000}`,
+			expectedType: EventTypeContextWindowSize,
+			checkFields: func(t *testing.T, event *AgentEvent) {
+				assert.Equal(t, 200000, event.ContextWindow)
 			},
 		},
 	}
@@ -553,4 +573,119 @@ func TestParseAgentLine_StreamingWarning_ProcessSource(t *testing.T) {
 	assert.Equal(t, "process", event.Source)
 	assert.Equal(t, "buffer_full", event.Reason)
 	assert.Equal(t, "Some streaming events were dropped due to slow processing", event.Message)
+}
+
+// ============================================================================
+// Context Usage Event Tests
+// ============================================================================
+
+func TestEventTypeContextUsageConstants(t *testing.T) {
+	assert.Equal(t, "context_usage", EventTypeContextUsage)
+	assert.Equal(t, "context_window_size", EventTypeContextWindowSize)
+}
+
+func TestParseAgentLine_ContextUsage(t *testing.T) {
+	line := `{"type":"context_usage","inputTokens":70400,"outputTokens":3000,"cacheReadInputTokens":5000,"cacheCreationInputTokens":1500}`
+
+	event := ParseAgentLine(line)
+	require.NotNil(t, event)
+
+	assert.Equal(t, EventTypeContextUsage, event.Type)
+	assert.Equal(t, 70400, event.InputTokens)
+	assert.Equal(t, 3000, event.OutputTokens)
+	assert.Equal(t, 5000, event.CacheReadInputTokens)
+	assert.Equal(t, 1500, event.CacheCreationInputTokens)
+}
+
+func TestParseAgentLine_ContextUsage_ZeroValues(t *testing.T) {
+	// When only inputTokens is non-zero, other fields should be 0
+	line := `{"type":"context_usage","inputTokens":10000}`
+
+	event := ParseAgentLine(line)
+	require.NotNil(t, event)
+
+	assert.Equal(t, EventTypeContextUsage, event.Type)
+	assert.Equal(t, 10000, event.InputTokens)
+	assert.Equal(t, 0, event.OutputTokens)
+	assert.Equal(t, 0, event.CacheReadInputTokens)
+	assert.Equal(t, 0, event.CacheCreationInputTokens)
+}
+
+func TestParseAgentLine_ContextWindowSize(t *testing.T) {
+	line := `{"type":"context_window_size","contextWindow":1000000}`
+
+	event := ParseAgentLine(line)
+	require.NotNil(t, event)
+
+	assert.Equal(t, EventTypeContextWindowSize, event.Type)
+	assert.Equal(t, 1000000, event.ContextWindow)
+}
+
+func TestParseAgentLine_ContextWindowSize_200k(t *testing.T) {
+	line := `{"type":"context_window_size","contextWindow":200000}`
+
+	event := ParseAgentLine(line)
+	require.NotNil(t, event)
+
+	assert.Equal(t, 200000, event.ContextWindow)
+}
+
+func TestAgentEvent_ContextFieldsRoundTrip(t *testing.T) {
+	// Verify that marshaling and unmarshaling preserves context fields
+	original := &AgentEvent{
+		Type:                     EventTypeContextUsage,
+		InputTokens:              15000,
+		OutputTokens:             3000,
+		CacheReadInputTokens:     5000,
+		CacheCreationInputTokens: 2000,
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var parsed AgentEvent
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Type, parsed.Type)
+	assert.Equal(t, original.InputTokens, parsed.InputTokens)
+	assert.Equal(t, original.OutputTokens, parsed.OutputTokens)
+	assert.Equal(t, original.CacheReadInputTokens, parsed.CacheReadInputTokens)
+	assert.Equal(t, original.CacheCreationInputTokens, parsed.CacheCreationInputTokens)
+}
+
+func TestAgentEvent_ContextWindowRoundTrip(t *testing.T) {
+	original := &AgentEvent{
+		Type:          EventTypeContextWindowSize,
+		ContextWindow: 200000,
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var parsed AgentEvent
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Type, parsed.Type)
+	assert.Equal(t, original.ContextWindow, parsed.ContextWindow)
+}
+
+func TestAgentEvent_ContextUsageOmitsZeroFields(t *testing.T) {
+	// Verify that zero-value fields are omitted in JSON (due to omitempty)
+	event := &AgentEvent{
+		Type:        EventTypeContextUsage,
+		InputTokens: 10000,
+		// All other context fields are zero
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	jsonStr := string(data)
+	assert.Contains(t, jsonStr, `"inputTokens":10000`)
+	assert.NotContains(t, jsonStr, `"outputTokens"`)
+	assert.NotContains(t, jsonStr, `"cacheReadInputTokens"`)
+	assert.NotContains(t, jsonStr, `"cacheCreationInputTokens"`)
+	assert.NotContains(t, jsonStr, `"contextWindow"`)
 }

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -28,6 +28,7 @@ import {
   Upload,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { ContextMeter } from './ContextMeter';
 import { useToast } from '@/components/ui/toast';
 import { listenForFileDrop, listenForDragEnter, listenForDragLeave, openFileDialog } from '@/lib/tauri';
 import type { Attachment } from '@/lib/types';
@@ -1383,6 +1384,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
           {/* Spacer */}
           <div className="flex-1" />
+
+          {/* Context Meter */}
+          <ContextMeter conversationId={selectedConversationId} />
 
           {/* Plus Menu */}
           <DropdownMenu>

--- a/src/components/conversation/ContextMeter.tsx
+++ b/src/components/conversation/ContextMeter.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useAppStore } from '@/stores/appStore';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  return tokens.toString();
+}
+
+interface ContextMeterProps {
+  conversationId: string | null;
+}
+
+export function ContextMeter({ conversationId }: ContextMeterProps) {
+  const contextUsage = useAppStore((s) =>
+    conversationId ? s.contextUsage[conversationId] : null
+  );
+
+  if (!contextUsage || contextUsage.inputTokens === 0) {
+    return null;
+  }
+
+  const maxTokens = contextUsage.contextWindow || 200000;
+  // input_tokens from the API represents total context sent to the model
+  const used = contextUsage.inputTokens;
+  const percentage = Math.min((used / maxTokens) * 100, 100);
+
+  // SVG circle math: circumference = 2 * PI * radius
+  const radius = 7;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDasharray = `${(percentage / 100) * circumference} ${circumference}`;
+
+  const isWarning = percentage >= 80;
+  const isCritical = percentage >= 95;
+
+  const colorClass = isCritical
+    ? 'text-red-500'
+    : isWarning
+    ? 'text-amber-500'
+    : 'text-muted-foreground';
+
+  const barColorClass = isCritical
+    ? 'bg-red-500'
+    : isWarning
+    ? 'bg-amber-500'
+    : 'bg-primary';
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className={cn(
+            'flex items-center gap-1.5 h-7 px-2 rounded-md text-xs',
+            'hover:bg-accent/50 transition-colors cursor-default',
+            colorClass
+          )}
+          aria-label={`Context usage: ${formatTokenCount(used)} of ${formatTokenCount(maxTokens)} tokens`}
+        >
+          <svg className="h-3.5 w-3.5" viewBox="0 0 18 18">
+            <circle
+              cx="9"
+              cy="9"
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              opacity="0.2"
+            />
+            <circle
+              cx="9"
+              cy="9"
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeDasharray={strokeDasharray}
+              strokeLinecap="round"
+              transform="rotate(-90 9 9)"
+            />
+          </svg>
+          <span className="tabular-nums">{formatTokenCount(used)}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" side="top" className="w-64 p-3">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-medium">Context</span>
+          <span className={cn('text-sm tabular-nums', colorClass)}>
+            {formatTokenCount(used)} / {formatTokenCount(maxTokens)}
+          </span>
+        </div>
+
+        <div className="h-1.5 bg-muted rounded-full overflow-hidden mb-3">
+          <div
+            className={cn('h-full rounded-full transition-all duration-300', barColorClass)}
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+
+        <div className="space-y-1.5 text-xs text-muted-foreground">
+          <BreakdownRow
+            label="Input tokens"
+            value={contextUsage.inputTokens}
+            total={maxTokens}
+          />
+          <BreakdownRow
+            label="Output tokens"
+            value={contextUsage.outputTokens}
+          />
+          {contextUsage.cacheReadInputTokens > 0 && (
+            <BreakdownRow
+              label="Cache read"
+              value={contextUsage.cacheReadInputTokens}
+            />
+          )}
+          {contextUsage.cacheCreationInputTokens > 0 && (
+            <BreakdownRow
+              label="Cache creation"
+              value={contextUsage.cacheCreationInputTokens}
+            />
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function BreakdownRow({
+  label,
+  value,
+  total,
+}: {
+  label: string;
+  value: number;
+  total?: number;
+}) {
+  if (value === 0) return null;
+  return (
+    <div className="flex items-center justify-between">
+      <span>{label}</span>
+      <span className="tabular-nums">
+        {formatTokenCount(value)}
+        {total ? ` (${((value / total) * 100).toFixed(1)}%)` : ''}
+      </span>
+    </div>
+  );
+}

--- a/src/components/conversation/__tests__/ContextMeter.test.tsx
+++ b/src/components/conversation/__tests__/ContextMeter.test.tsx
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ContextMeter } from '../ContextMeter';
+import { useAppStore } from '@/stores/appStore';
+import type { ContextUsage } from '@/lib/types';
+
+const CONV_ID = 'conv-1';
+
+function makeContextUsage(overrides: Partial<ContextUsage> = {}): ContextUsage {
+  return {
+    inputTokens: 70400,
+    outputTokens: 3000,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    contextWindow: 200000,
+    lastUpdated: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('ContextMeter', () => {
+  beforeEach(() => {
+    useAppStore.setState({ contextUsage: {} });
+  });
+
+  // ==========================================================================
+  // Null/hidden states
+  // ==========================================================================
+
+  it('returns null when conversationId is null', () => {
+    const { container } = render(<ContextMeter conversationId={null} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns null when no contextUsage data for conversationId', () => {
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns null when inputTokens is 0', () => {
+    useAppStore.setState({
+      contextUsage: { [CONV_ID]: makeContextUsage({ inputTokens: 0 }) },
+    });
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  // ==========================================================================
+  // Rendering
+  // ==========================================================================
+
+  it('renders when contextUsage data exists', () => {
+    useAppStore.setState({
+      contextUsage: { [CONV_ID]: makeContextUsage() },
+    });
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+    expect(container.innerHTML).not.toBe('');
+  });
+
+  it('renders a button with aria-label', () => {
+    useAppStore.setState({
+      contextUsage: { [CONV_ID]: makeContextUsage() },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-label', expect.stringContaining('Context usage'));
+  });
+
+  it('renders SVG circular indicator', () => {
+    useAppStore.setState({
+      contextUsage: { [CONV_ID]: makeContextUsage() },
+    });
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBe(2); // background + progress
+  });
+
+  // ==========================================================================
+  // Token formatting
+  // ==========================================================================
+
+  it('formats large tokens with "k" notation', () => {
+    useAppStore.setState({
+      contextUsage: { [CONV_ID]: makeContextUsage({ inputTokens: 70400 }) },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+    expect(screen.getByText('70.4k')).toBeInTheDocument();
+  });
+
+  it('displays small token counts as raw numbers', () => {
+    useAppStore.setState({
+      contextUsage: { [CONV_ID]: makeContextUsage({ inputTokens: 500 }) },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+    expect(screen.getByText('500')).toBeInTheDocument();
+  });
+
+  it('formats 1000 tokens as "1.0k"', () => {
+    useAppStore.setState({
+      contextUsage: { [CONV_ID]: makeContextUsage({ inputTokens: 1000 }) },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+    expect(screen.getByText('1.0k')).toBeInTheDocument();
+  });
+
+  // ==========================================================================
+  // Color coding
+  // ==========================================================================
+
+  it('uses default color when usage < 80%', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 100000, contextWindow: 200000 }),
+      },
+    });
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+    const button = container.querySelector('button');
+    expect(button?.className).toContain('text-muted-foreground');
+    expect(button?.className).not.toContain('text-amber');
+    expect(button?.className).not.toContain('text-red');
+  });
+
+  it('uses amber color when usage >= 80%', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 160000, contextWindow: 200000 }),
+      },
+    });
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+    const button = container.querySelector('button');
+    expect(button?.className).toContain('text-amber-500');
+  });
+
+  it('uses red color when usage >= 95%', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 195000, contextWindow: 200000 }),
+      },
+    });
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+    const button = container.querySelector('button');
+    expect(button?.className).toContain('text-red-500');
+  });
+
+  // ==========================================================================
+  // Popover
+  // ==========================================================================
+
+  it('shows popover header with token counts on click', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 70400, contextWindow: 200000 }),
+      },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Context')).toBeInTheDocument();
+    // The popover header shows "70.4k / 200.0k"
+    expect(screen.getByText('70.4k / 200.0k')).toBeInTheDocument();
+  });
+
+  it('shows progress bar in popover', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 100000, contextWindow: 200000 }),
+      },
+    });
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // Popover renders in a portal, so query document.body directly
+    const progressBars = document.body.querySelectorAll('[style*="width"]');
+    expect(progressBars.length).toBeGreaterThan(0);
+    // 100000/200000 = 50%
+    const bar = Array.from(progressBars).find(el =>
+      (el as HTMLElement).style.width === '50%'
+    );
+    expect(bar).toBeDefined();
+  });
+
+  it('shows input tokens with percentage in breakdown', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 100000, contextWindow: 200000 }),
+      },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Input tokens')).toBeInTheDocument();
+    // 100000/200000 = 50.0%
+    expect(screen.getByText('100.0k (50.0%)')).toBeInTheDocument();
+  });
+
+  it('shows output tokens in breakdown', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 50000, outputTokens: 3000 }),
+      },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Output tokens')).toBeInTheDocument();
+    expect(screen.getByText('3.0k')).toBeInTheDocument();
+  });
+
+  it('hides cache read row when zero', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 50000, cacheReadInputTokens: 0 }),
+      },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('Cache read')).not.toBeInTheDocument();
+  });
+
+  it('shows cache read row when nonzero', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 50000, cacheReadInputTokens: 5000 }),
+      },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Cache read')).toBeInTheDocument();
+    expect(screen.getByText('5.0k')).toBeInTheDocument();
+  });
+
+  it('hides cache creation row when zero', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 50000, cacheCreationInputTokens: 0 }),
+      },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('Cache creation')).not.toBeInTheDocument();
+  });
+
+  it('shows cache creation row when nonzero', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 50000, cacheCreationInputTokens: 2000 }),
+      },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Cache creation')).toBeInTheDocument();
+    expect(screen.getByText('2.0k')).toBeInTheDocument();
+  });
+
+  // ==========================================================================
+  // Edge cases
+  // ==========================================================================
+
+  it('caps percentage at 100% when inputTokens exceeds contextWindow', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 250000, contextWindow: 200000 }),
+      },
+    });
+    const { container } = render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // Popover renders in a portal, so query document.body directly
+    const progressBars = document.body.querySelectorAll('[style*="width"]');
+    const bar = Array.from(progressBars).find(el =>
+      (el as HTMLElement).style.width === '100%'
+    );
+    expect(bar).toBeDefined();
+  });
+
+  it('uses default contextWindow of 200000 when contextWindow is 0', () => {
+    useAppStore.setState({
+      contextUsage: {
+        [CONV_ID]: makeContextUsage({ inputTokens: 50000, contextWindow: 0 }),
+      },
+    });
+    render(<ContextMeter conversationId={CONV_ID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // Falls back to 200000, so 50000/200000 = 25.0%
+    expect(screen.getByText('50.0k / 200.0k')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useWebSocket.contextUsage.test.ts
+++ b/src/hooks/__tests__/useWebSocket.contextUsage.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAppStore } from '@/stores/appStore';
+
+/**
+ * These tests verify that the context usage event handling logic works correctly
+ * by simulating what the useWebSocket handler does when it receives events.
+ * We test the store mutations directly since the WebSocket handler simply
+ * calls store actions based on event type and fields.
+ */
+
+const CONV_ID = 'conv-1';
+
+describe('useWebSocket — context usage event handling', () => {
+  beforeEach(() => {
+    useAppStore.setState({ contextUsage: {} });
+  });
+
+  // ==========================================================================
+  // context_usage event
+  // ==========================================================================
+
+  describe('context_usage event', () => {
+    it('updates store with token counts', () => {
+      // Simulates: case 'context_usage' in useWebSocket handler
+      const event = {
+        inputTokens: 15000,
+        outputTokens: 3000,
+        cacheReadInputTokens: 5000,
+        cacheCreationInputTokens: 2000,
+      };
+
+      if (event.inputTokens !== undefined) {
+        useAppStore.getState().setContextUsage(CONV_ID, {
+          inputTokens: event.inputTokens,
+          outputTokens: event.outputTokens || 0,
+          cacheReadInputTokens: event.cacheReadInputTokens || 0,
+          cacheCreationInputTokens: event.cacheCreationInputTokens || 0,
+        });
+      }
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(15000);
+      expect(usage.outputTokens).toBe(3000);
+      expect(usage.cacheReadInputTokens).toBe(5000);
+      expect(usage.cacheCreationInputTokens).toBe(2000);
+    });
+
+    it('skips update when inputTokens is undefined', () => {
+      // Simulates: event with no inputTokens field
+      const event: Record<string, unknown> = {
+        type: 'context_usage',
+      };
+
+      if (event.inputTokens !== undefined) {
+        useAppStore.getState().setContextUsage(CONV_ID, {
+          inputTokens: event.inputTokens as number,
+        });
+      }
+
+      expect(useAppStore.getState().contextUsage[CONV_ID]).toBeUndefined();
+    });
+
+    it('handles zero values for optional token fields', () => {
+      const event = {
+        inputTokens: 10000,
+        outputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      };
+
+      if (event.inputTokens !== undefined) {
+        useAppStore.getState().setContextUsage(CONV_ID, {
+          inputTokens: event.inputTokens,
+          outputTokens: event.outputTokens || 0,
+          cacheReadInputTokens: event.cacheReadInputTokens || 0,
+          cacheCreationInputTokens: event.cacheCreationInputTokens || 0,
+        });
+      }
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(10000);
+      expect(usage.outputTokens).toBe(0);
+      expect(usage.cacheReadInputTokens).toBe(0);
+      expect(usage.cacheCreationInputTokens).toBe(0);
+    });
+
+    it('updates existing usage data (simulates successive turns)', () => {
+      // First turn
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 5000,
+        outputTokens: 1000,
+      });
+
+      // Second turn — inputTokens grows as context accumulates
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 12000,
+        outputTokens: 2000,
+      });
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(12000);
+      expect(usage.outputTokens).toBe(2000);
+    });
+  });
+
+  // ==========================================================================
+  // context_window_size event
+  // ==========================================================================
+
+  describe('context_window_size event', () => {
+    it('updates contextWindow in store', () => {
+      // Simulates: case 'context_window_size' in useWebSocket handler
+      const event = { contextWindow: 1000000 };
+
+      if (event.contextWindow) {
+        useAppStore.getState().setContextUsage(CONV_ID, {
+          contextWindow: event.contextWindow,
+        });
+      }
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.contextWindow).toBe(1000000);
+    });
+
+    it('skips update when contextWindow is undefined', () => {
+      const event: Record<string, unknown> = {
+        type: 'context_window_size',
+      };
+
+      if (event.contextWindow) {
+        useAppStore.getState().setContextUsage(CONV_ID, {
+          contextWindow: event.contextWindow as number,
+        });
+      }
+
+      expect(useAppStore.getState().contextUsage[CONV_ID]).toBeUndefined();
+    });
+
+    it('preserves existing token data when updating contextWindow', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 50000,
+        outputTokens: 5000,
+      });
+
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        contextWindow: 1000000,
+      });
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.contextWindow).toBe(1000000);
+      expect(usage.inputTokens).toBe(50000);
+      expect(usage.outputTokens).toBe(5000);
+    });
+  });
+
+  // ==========================================================================
+  // compact_boundary event
+  // ==========================================================================
+
+  describe('compact_boundary event', () => {
+    it('resets all token fields to 0', () => {
+      // First, set some usage data
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 180000,
+        outputTokens: 5000,
+        cacheReadInputTokens: 3000,
+        cacheCreationInputTokens: 1000,
+        contextWindow: 200000,
+      });
+
+      // Simulates: case 'compact_boundary' in useWebSocket handler
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      });
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(0);
+      expect(usage.outputTokens).toBe(0);
+      expect(usage.cacheReadInputTokens).toBe(0);
+      expect(usage.cacheCreationInputTokens).toBe(0);
+      // contextWindow should be preserved
+      expect(usage.contextWindow).toBe(200000);
+    });
+  });
+
+  // ==========================================================================
+  // Full flow simulation
+  // ==========================================================================
+
+  describe('full flow', () => {
+    it('simulates a complete conversation lifecycle', () => {
+      // 1. First assistant message — context_usage
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 5000,
+        outputTokens: 1000,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      });
+
+      // 2. Result message — context_window_size
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        contextWindow: 200000,
+      });
+
+      let usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(5000);
+      expect(usage.contextWindow).toBe(200000);
+
+      // 3. Second turn — context grows
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 15000,
+        outputTokens: 3000,
+        cacheReadInputTokens: 2000,
+      });
+
+      usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(15000);
+      expect(usage.cacheReadInputTokens).toBe(2000);
+
+      // 4. Compact boundary — all token fields reset
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      });
+
+      usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(0);
+      expect(usage.contextWindow).toBe(200000); // preserved
+
+      // 5. Post-compact turn — fresh context data
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 8000,
+        outputTokens: 2000,
+      });
+
+      usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(8000);
+    });
+  });
+});

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -316,6 +316,37 @@ export function useWebSocket(enabled: boolean = true) {
         }
         break;
 
+      case 'context_usage':
+        // Update context usage from per-assistant-message token counts
+        if (event?.inputTokens !== undefined) {
+          store.setContextUsage(conversationId, {
+            inputTokens: event.inputTokens ?? 0,
+            outputTokens: event.outputTokens ?? 0,
+            cacheReadInputTokens: event.cacheReadInputTokens ?? 0,
+            cacheCreationInputTokens: event.cacheCreationInputTokens ?? 0,
+          });
+        }
+        break;
+
+      case 'context_window_size':
+        // Update the max context window from modelUsage in result
+        if (event?.contextWindow) {
+          store.setContextUsage(conversationId, {
+            contextWindow: event.contextWindow,
+          });
+        }
+        break;
+
+      case 'compact_boundary':
+        // After compaction, reset all token fields until next assistant message provides fresh data
+        store.setContextUsage(conversationId, {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+        });
+        break;
+
     }
   // getStore is a stable reference (useAppStore.getState), no deps needed
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -209,6 +209,13 @@ export interface AgentEvent {
   modelUsage?: Record<string, unknown>;
   structuredOutput?: unknown;
 
+  // Context usage fields
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  contextWindow?: number;
+
   // Hook event fields
   toolUseId?: string;
   input?: unknown;
@@ -420,6 +427,16 @@ export interface BudgetStatus {
   maxThinkingTokens?: number;
   currentThinkingTokens: number;
   limitExceeded?: 'budget' | 'turns' | 'thinking_tokens';
+}
+
+// Context window usage tracking
+export interface ContextUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  contextWindow: number;
+  lastUpdated: number;
 }
 
 // User-defined custom todo item

--- a/src/stores/__tests__/appStore.contextUsage.test.ts
+++ b/src/stores/__tests__/appStore.contextUsage.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useAppStore } from '../appStore';
+
+const CONV_ID = 'conv-1';
+const CONV_ID_2 = 'conv-2';
+
+describe('appStore — contextUsage', () => {
+  beforeEach(() => {
+    useAppStore.setState({ contextUsage: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('initial state is empty object', () => {
+    expect(useAppStore.getState().contextUsage).toEqual({});
+  });
+
+  describe('setContextUsage', () => {
+    it('creates entry with defaults when none exists', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 5000,
+      });
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage).toBeDefined();
+      expect(usage.inputTokens).toBe(5000);
+      expect(usage.outputTokens).toBe(0);
+      expect(usage.cacheReadInputTokens).toBe(0);
+      expect(usage.cacheCreationInputTokens).toBe(0);
+      expect(usage.contextWindow).toBe(200000);
+    });
+
+    it('merges partial updates into existing entry', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 5000,
+        outputTokens: 1000,
+      });
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 8000,
+      });
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(8000);
+      expect(usage.outputTokens).toBe(1000);
+    });
+
+    it('sets lastUpdated to current timestamp', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2025-07-01T12:00:00Z'));
+
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 1000,
+      });
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.lastUpdated).toBe(Date.now());
+    });
+
+    it('updates lastUpdated on subsequent calls', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2025-07-01T12:00:00Z'));
+
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 1000 });
+      const firstUpdate = useAppStore.getState().contextUsage[CONV_ID].lastUpdated;
+
+      vi.setSystemTime(new Date('2025-07-01T12:01:00Z'));
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 2000 });
+      const secondUpdate = useAppStore.getState().contextUsage[CONV_ID].lastUpdated;
+
+      expect(secondUpdate).toBeGreaterThan(firstUpdate);
+    });
+
+    it('defaults contextWindow to 200000', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 1000,
+      });
+
+      expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(200000);
+    });
+
+    it('updates contextWindow when provided', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 1000,
+      });
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        contextWindow: 1000000,
+      });
+
+      expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(1000000);
+      expect(useAppStore.getState().contextUsage[CONV_ID].inputTokens).toBe(1000);
+    });
+
+    it('sets all token fields', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 15000,
+        outputTokens: 3000,
+        cacheReadInputTokens: 5000,
+        cacheCreationInputTokens: 2000,
+      });
+
+      const usage = useAppStore.getState().contextUsage[CONV_ID];
+      expect(usage.inputTokens).toBe(15000);
+      expect(usage.outputTokens).toBe(3000);
+      expect(usage.cacheReadInputTokens).toBe(5000);
+      expect(usage.cacheCreationInputTokens).toBe(2000);
+    });
+
+    it('maintains independent state per conversation', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, {
+        inputTokens: 5000,
+        contextWindow: 200000,
+      });
+      useAppStore.getState().setContextUsage(CONV_ID_2, {
+        inputTokens: 80000,
+        contextWindow: 1000000,
+      });
+
+      const state = useAppStore.getState().contextUsage;
+      expect(state[CONV_ID].inputTokens).toBe(5000);
+      expect(state[CONV_ID].contextWindow).toBe(200000);
+      expect(state[CONV_ID_2].inputTokens).toBe(80000);
+      expect(state[CONV_ID_2].contextWindow).toBe(1000000);
+    });
+
+    it('does not affect other conversations when updating one', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 5000 });
+      useAppStore.getState().setContextUsage(CONV_ID_2, { inputTokens: 10000 });
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 7000 });
+
+      expect(useAppStore.getState().contextUsage[CONV_ID_2].inputTokens).toBe(10000);
+    });
+  });
+
+  describe('clearContextUsage', () => {
+    it('removes entry for conversationId', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 5000 });
+      useAppStore.getState().clearContextUsage(CONV_ID);
+
+      expect(useAppStore.getState().contextUsage[CONV_ID]).toBeUndefined();
+    });
+
+    it('is a no-op for nonexistent conversationId', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 5000 });
+      useAppStore.getState().clearContextUsage('nonexistent');
+
+      expect(useAppStore.getState().contextUsage[CONV_ID]).toBeDefined();
+      expect(useAppStore.getState().contextUsage['nonexistent']).toBeUndefined();
+    });
+
+    it('does not affect other conversations', () => {
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 5000 });
+      useAppStore.getState().setContextUsage(CONV_ID_2, { inputTokens: 10000 });
+      useAppStore.getState().clearContextUsage(CONV_ID);
+
+      expect(useAppStore.getState().contextUsage[CONV_ID]).toBeUndefined();
+      expect(useAppStore.getState().contextUsage[CONV_ID_2]).toBeDefined();
+      expect(useAppStore.getState().contextUsage[CONV_ID_2].inputTokens).toBe(10000);
+    });
+  });
+});

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -15,6 +15,7 @@ import type {
   McpServerStatus,
   CheckpointInfo,
   BudgetStatus,
+  ContextUsage,
   ToolUsage,
   RunSummary,
   ReviewComment,
@@ -126,6 +127,9 @@ interface AppState {
   // Checkpoint timeline state
   checkpoints: CheckpointInfo[];
   budgetStatus: BudgetStatus | null;
+
+  // Context window usage (keyed by conversationId)
+  contextUsage: { [conversationId: string]: ContextUsage };
 
   // Review comments state (keyed by sessionId)
   reviewComments: { [sessionId: string]: ReviewComment[] };
@@ -247,6 +251,10 @@ interface AppState {
   clearCheckpoints: () => void;
   setBudgetStatus: (status: BudgetStatus | null) => void;
 
+  // Context usage actions
+  setContextUsage: (conversationId: string, usage: Partial<ContextUsage>) => void;
+  clearContextUsage: (conversationId: string) => void;
+
   // Review comments actions
   setReviewComments: (sessionId: string, comments: ReviewComment[]) => void;
   addReviewComment: (sessionId: string, comment: ReviewComment) => void;
@@ -310,6 +318,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   mcpServers: [],
   checkpoints: [],
   budgetStatus: null,
+  contextUsage: {},
   reviewComments: {},
   branchSyncStatus: {},
   branchSyncLoading: {},
@@ -412,10 +421,12 @@ export const useAppStore = create<AppState>((set, get) => ({
     const cleanedStreamingState = { ...state.streamingState };
     const cleanedActiveTools = { ...state.activeTools };
     const cleanedAgentTodos = { ...state.agentTodos };
+    const cleanedContextUsage = { ...state.contextUsage };
     for (const convId of sessionConvIds) {
       delete cleanedStreamingState[convId];
       delete cleanedActiveTools[convId];
       delete cleanedAgentTodos[convId];
+      delete cleanedContextUsage[convId];
     }
 
     // Clean up custom todos, session outputs, and review comments
@@ -434,6 +445,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       streamingState: cleanedStreamingState,
       activeTools: cleanedActiveTools,
       agentTodos: cleanedAgentTodos,
+      contextUsage: cleanedContextUsage,
       customTodos: remainingCustomTodos,
       sessionOutputs: remainingSessionOutputs,
       reviewComments: remainingReviewComments,
@@ -526,6 +538,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { [id]: _tools, ...remainingActiveTools } = state.activeTools;
     const { [id]: _todos, ...remainingAgentTodos } = state.agentTodos;
     const { [id]: _question, ...remainingPendingQuestions } = state.pendingUserQuestion;
+    const { [id]: _context, ...remainingContextUsage } = state.contextUsage;
 
     const removedConv = state.conversations.find((c) => c.id === id);
     const newConversations = state.conversations.filter((c) => c.id !== id);
@@ -553,6 +566,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       activeTools: remainingActiveTools,
       agentTodos: remainingAgentTodos,
       pendingUserQuestion: remainingPendingQuestions,
+      contextUsage: remainingContextUsage,
     };
   }),
   selectConversation: (id) => set({ selectedConversationId: id }),
@@ -1088,6 +1102,28 @@ updateFileTabContent: (id, content) => set((state) => ({
   })),
   clearCheckpoints: () => set({ checkpoints: [] }),
   setBudgetStatus: (budgetStatus) => set({ budgetStatus }),
+
+  // Context usage actions
+  setContextUsage: (conversationId, usage) => set((state) => {
+    const existing = state.contextUsage[conversationId] || {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      contextWindow: 200000,
+      lastUpdated: Date.now(),
+    };
+    return {
+      contextUsage: {
+        ...state.contextUsage,
+        [conversationId]: { ...existing, ...usage, lastUpdated: Date.now() },
+      },
+    };
+  }),
+  clearContextUsage: (conversationId) => set((state) => {
+    const { [conversationId]: _, ...rest } = state.contextUsage;
+    return { contextUsage: rest };
+  }),
 
   // Review comments actions
   setReviewComments: (sessionId, comments) => set((state) => ({


### PR DESCRIPTION
## Summary
Adds a context window usage meter to the chat composer that tracks token consumption across conversations. The meter displays input, output, and cache token usage with visual indicators (circular progress, color-coded warnings).

## Changes
- **agent-runner**: Extract per-message token usage from SDK messages
- **backend**: Parse new context_usage and context_window_size event types
- **frontend**: ContextMeter component with popover breakdown, store integration, WebSocket event handling
- **cleanup**: Wire up context usage cleanup on conversation/session deletion per code review feedback

## Test Coverage
44 tests across component rendering, popover interactions, store mutations, and event handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)