### PR TITLE
fix: prevent useAutoSave from saving closed tabs (CM-58)

### DIFF
--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -55,6 +55,12 @@ export function useAutoSave(options?: UseAutoSaveOptions) {
         return false;
       }
 
+      // Verify tab still exists before saving (it may have been closed)
+      const currentTabs = useAppStore.getState().fileTabs;
+      if (!currentTabs.find((t) => t.id === tab.id)) {
+        return false;
+      }
+
       try {
         await saveFile(tab.workspaceId, tab.path, tab.content, tab.sessionId);
 


### PR DESCRIPTION
## Summary
Fixes a race condition in useAutoSave where a setTimeout callback could fire with a stale tab reference after the tab was closed, attempting to save a file against a deleted session.

## Changes
Added an existence check in `saveTab()` to verify the tab still exists in the store before calling `saveFile()`. Uses `useAppStore.getState().fileTabs` to read the latest state rather than relying on the stale closure value.

## Testing
- Lint: passes
- TypeScript: no new errors
- Manual: open a file, edit it (dirty), close it, wait 30s — no save attempt occurs