### PR TITLE
fix: prevent state updates after unmount in theme registration (CM-44)

### DIFF
--- a/src/components/files/MonacoEditor.tsx
+++ b/src/components/files/MonacoEditor.tsx
@@ -55,10 +55,14 @@ export function MonacoEditor({
   // Register custom theme when editorTheme changes
   // Only show loading spinner on initial load to prevent flash when switching themes
   useEffect(() => {
+    let cancelled = false;
     registerMonacoTheme(editorTheme).then((themeId) => {
-      setActiveTheme(themeId);
-      setIsInitialLoad(false);
+      if (!cancelled) {
+        setActiveTheme(themeId);
+        setIsInitialLoad(false);
+      }
     });
+    return () => { cancelled = true; };
   }, [editorTheme]);
 
   const handleMount: OnMount = useCallback((editor) => {
@@ -230,10 +234,14 @@ export function MonacoDiffEditor({
   // Register custom theme when editorTheme changes
   // Only show loading spinner on initial load to prevent flash when switching themes
   useEffect(() => {
+    let cancelled = false;
     registerMonacoTheme(editorTheme).then((themeId) => {
-      setActiveTheme(themeId);
-      setIsInitialLoad(false);
+      if (!cancelled) {
+        setActiveTheme(themeId);
+        setIsInitialLoad(false);
+      }
     });
+    return () => { cancelled = true; };
   }, [editorTheme]);
 
   // Update sideBySide option when it changes without remounting


### PR DESCRIPTION
## Summary

Add cancellation flag to useEffect cleanup in `MonacoEditor` and `MonacoDiffEditor` to prevent state updates after component unmount or rapid editorTheme prop changes.

## Changes

- Both components now use a `cancelled` flag in the theme registration useEffect
- Cleanup function sets the flag to prevent stale state updates
- Fixes "Can't perform a React state update on an unmounted component" warnings
- Prevents race conditions when rapidly switching themes

## Testing

- Theme switching works correctly without state update warnings
- Components unmount cleanly without dangling promises
- No console warnings about unmounted components

🤖 Generated with [Claude Code](https://claude.com/claude-code)