### PR TITLE
feat: add GitHub Issues integration

### DIFF
--- a/backend/github/issues.go
+++ b/backend/github/issues.go
@@ -1,0 +1,317 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// IssueLabel represents a label on a GitHub issue
+type IssueLabel struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// IssueUser represents a GitHub user on an issue
+type IssueUser struct {
+	Login     string `json:"login"`
+	AvatarURL string `json:"avatarUrl"`
+}
+
+// IssueMilestone represents a milestone on an issue
+type IssueMilestone struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+}
+
+// IssueListItem represents an issue in a list response
+type IssueListItem struct {
+	Number    int          `json:"number"`
+	Title     string       `json:"title"`
+	State     string       `json:"state"`
+	HTMLURL   string       `json:"htmlUrl"`
+	Labels    []IssueLabel `json:"labels"`
+	User      IssueUser    `json:"user"`
+	Assignees []IssueUser  `json:"assignees"`
+	Comments  int          `json:"comments"`
+	CreatedAt time.Time    `json:"createdAt"`
+	UpdatedAt time.Time    `json:"updatedAt"`
+}
+
+// IssueDetails extends IssueListItem with body and milestone
+type IssueDetails struct {
+	IssueListItem
+	Body      string          `json:"body"`
+	Milestone *IssueMilestone `json:"milestone,omitempty"`
+}
+
+// ListIssuesResult contains the result of listing issues
+type ListIssuesResult struct {
+	Issues []IssueListItem
+	ETag   string
+}
+
+// SearchIssuesResult contains the result of searching issues
+type SearchIssuesResult struct {
+	TotalCount int             `json:"totalCount"`
+	Issues     []IssueListItem `json:"issues"`
+}
+
+// githubIssueListItem maps the GitHub API response shape for an issue
+type githubIssueListItem struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	State     string    `json:"state"`
+	HTMLURL   string    `json:"html_url"`
+	Body      string    `json:"body"`
+	Comments  int       `json:"comments"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Labels    []struct {
+		Name  string `json:"name"`
+		Color string `json:"color"`
+	} `json:"labels"`
+	User struct {
+		Login     string `json:"login"`
+		AvatarURL string `json:"avatar_url"`
+	} `json:"user"`
+	Assignees []struct {
+		Login     string `json:"login"`
+		AvatarURL string `json:"avatar_url"`
+	} `json:"assignees"`
+	Milestone *struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		State  string `json:"state"`
+	} `json:"milestone"`
+	PullRequest *struct {
+		URL string `json:"url"`
+	} `json:"pull_request"`
+}
+
+// githubSearchIssuesResponse maps the GitHub search API response
+type githubSearchIssuesResponse struct {
+	TotalCount int                   `json:"total_count"`
+	Items      []githubIssueListItem `json:"items"`
+}
+
+// convertToIssueListItem converts a GitHub API issue to our IssueListItem type
+func convertToIssueListItem(gh githubIssueListItem) IssueListItem {
+	labels := make([]IssueLabel, len(gh.Labels))
+	for i, l := range gh.Labels {
+		labels[i] = IssueLabel{Name: l.Name, Color: l.Color}
+	}
+
+	assignees := make([]IssueUser, len(gh.Assignees))
+	for i, a := range gh.Assignees {
+		assignees[i] = IssueUser{Login: a.Login, AvatarURL: a.AvatarURL}
+	}
+
+	return IssueListItem{
+		Number:    gh.Number,
+		Title:     gh.Title,
+		State:     gh.State,
+		HTMLURL:   gh.HTMLURL,
+		Labels:    labels,
+		User:      IssueUser{Login: gh.User.Login, AvatarURL: gh.User.AvatarURL},
+		Assignees: assignees,
+		Comments:  gh.Comments,
+		CreatedAt: gh.CreatedAt,
+		UpdatedAt: gh.UpdatedAt,
+	}
+}
+
+// ListIssuesWithETag lists issues for a repository with ETag support for conditional requests.
+// If etag is non-empty, sends If-None-Match header. Returns ErrNotModified on 304.
+// Filters out pull requests (GitHub's issues endpoint returns both).
+func (c *Client) ListIssuesWithETag(ctx context.Context, owner, repo, state, labels, etag string) (*ListIssuesResult, error) {
+	token := c.GetToken()
+	if token == "" {
+		return nil, fmt.Errorf("not authenticated")
+	}
+
+	if state == "" {
+		state = "open"
+	}
+
+	params := url.Values{}
+	params.Set("state", state)
+	params.Set("sort", "updated")
+	params.Set("direction", "desc")
+	params.Set("per_page", "50")
+	if labels != "" {
+		params.Set("labels", labels)
+	}
+
+	issuesURL := fmt.Sprintf("%s/repos/%s/%s/issues?%s", c.apiURL, owner, repo, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, "GET", issuesURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating issues request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching issues: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, ErrNotModified
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("GitHub returned %d (body unreadable: %v)", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
+	}
+
+	var ghIssues []githubIssueListItem
+	if err := json.NewDecoder(resp.Body).Decode(&ghIssues); err != nil {
+		return nil, fmt.Errorf("decoding issues: %w", err)
+	}
+
+	// Filter out pull requests (GitHub issues endpoint returns both)
+	issues := make([]IssueListItem, 0, len(ghIssues))
+	for _, gh := range ghIssues {
+		if gh.PullRequest != nil {
+			continue
+		}
+		issues = append(issues, convertToIssueListItem(gh))
+	}
+
+	return &ListIssuesResult{
+		Issues: issues,
+		ETag:   resp.Header.Get("ETag"),
+	}, nil
+}
+
+// SearchIssues searches for issues in a repository using the GitHub search API.
+// The query is appended to the repo scope: repo:{owner}/{repo} is:issue {query}
+func (c *Client) SearchIssues(ctx context.Context, owner, repo, query string) (*SearchIssuesResult, error) {
+	token := c.GetToken()
+	if token == "" {
+		return nil, fmt.Errorf("not authenticated")
+	}
+
+	// Build search query: repo:owner/repo is:issue <user query>
+	searchQuery := fmt.Sprintf("repo:%s/%s is:issue %s", owner, repo, query)
+
+	params := url.Values{}
+	params.Set("q", searchQuery)
+	params.Set("per_page", "30")
+
+	searchURL := fmt.Sprintf("%s/search/issues?%s", c.apiURL, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, "GET", searchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating search request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("searching issues: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("GitHub returned %d (body unreadable: %v)", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
+	}
+
+	var ghResult githubSearchIssuesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ghResult); err != nil {
+		return nil, fmt.Errorf("decoding search results: %w", err)
+	}
+
+	// Filter out pull requests (search API also returns PRs)
+	issues := make([]IssueListItem, 0, len(ghResult.Items))
+	for _, gh := range ghResult.Items {
+		if gh.PullRequest != nil {
+			continue
+		}
+		issues = append(issues, convertToIssueListItem(gh))
+	}
+
+	return &SearchIssuesResult{
+		TotalCount: len(issues),
+		Issues:     issues,
+	}, nil
+}
+
+// GetIssue fetches detailed information about a single issue.
+// Returns nil, nil if the issue is not found (404).
+func (c *Client) GetIssue(ctx context.Context, owner, repo string, number int) (*IssueDetails, error) {
+	token := c.GetToken()
+	if token == "" {
+		return nil, fmt.Errorf("not authenticated")
+	}
+
+	issueURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d", c.apiURL, owner, repo, number)
+	req, err := http.NewRequestWithContext(ctx, "GET", issueURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating issue request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching issue: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("GitHub returned %d (body unreadable: %v)", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
+	}
+
+	var gh githubIssueListItem
+	if err := json.NewDecoder(resp.Body).Decode(&gh); err != nil {
+		return nil, fmt.Errorf("decoding issue: %w", err)
+	}
+
+	var milestone *IssueMilestone
+	if gh.Milestone != nil {
+		milestone = &IssueMilestone{
+			Number: gh.Milestone.Number,
+			Title:  gh.Milestone.Title,
+			State:  gh.Milestone.State,
+		}
+	}
+
+	// Trim trailing whitespace/newlines from body
+	body := strings.TrimSpace(gh.Body)
+
+	return &IssueDetails{
+		IssueListItem: convertToIssueListItem(gh),
+		Body:          body,
+		Milestone:     milestone,
+	}, nil
+}

--- a/backend/github/issues_cache.go
+++ b/backend/github/issues_cache.go
@@ -1,0 +1,242 @@
+package github
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chatml/chatml-backend/logger"
+)
+
+// IssueCacheEntry holds cached issue list data
+type IssueCacheEntry struct {
+	Issues     []IssueListItem
+	ETag       string
+	CachedAt   time.Time
+	ExpiresAt  time.Time // "fresh" deadline
+	StaleUntil time.Time // "stale" deadline (serve stale while revalidating)
+}
+
+// IssueCache provides time-based caching for issue lists with stale-while-revalidate
+type IssueCache struct {
+	mu       sync.RWMutex
+	entries  map[string]*IssueCacheEntry
+	freshTTL time.Duration
+	staleTTL time.Duration
+
+	// Background refresh deduplication
+	refreshMu  sync.Mutex
+	refreshing map[string]bool
+
+	// Shutdown signal for cleanup goroutine
+	done chan struct{}
+}
+
+// NewIssueCache creates a new issue cache with the given fresh and stale TTLs.
+// Fresh TTL: serve directly from cache. Stale TTL: serve stale + trigger background refresh.
+func NewIssueCache(freshTTL, staleTTL time.Duration) *IssueCache {
+	cache := &IssueCache{
+		entries:    make(map[string]*IssueCacheEntry),
+		freshTTL:   freshTTL,
+		staleTTL:   staleTTL,
+		refreshing: make(map[string]bool),
+		done:       make(chan struct{}),
+	}
+
+	// Start cleanup goroutine
+	go cache.cleanupLoop()
+
+	return cache
+}
+
+// issueCacheKey generates a cache key for a repo with filters
+func issueCacheKey(owner, repo, state, labels string) string {
+	return owner + "/" + repo + ":" + state + ":" + labels
+}
+
+// GetWithStale retrieves cached issues with freshness status.
+// Returns the entry, its freshness, and whether data was found.
+func (c *IssueCache) GetWithStale(owner, repo, state, labels string) (*IssueCacheEntry, CacheFreshness) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := issueCacheKey(owner, repo, state, labels)
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, CacheMiss
+	}
+
+	now := time.Now()
+
+	if now.Before(entry.ExpiresAt) {
+		return entry, CacheFresh
+	}
+
+	if now.Before(entry.StaleUntil) {
+		return entry, CacheStale
+	}
+
+	return nil, CacheMiss
+}
+
+// SetFull stores issues and ETag in the cache
+func (c *IssueCache) SetFull(owner, repo, state, labels string, issues []IssueListItem, etag string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := issueCacheKey(owner, repo, state, labels)
+	now := time.Now()
+
+	// Store a copy to prevent mutation
+	issuesCopy := make([]IssueListItem, len(issues))
+	for i, issue := range issues {
+		issuesCopy[i] = copyIssueListItem(issue)
+	}
+
+	c.entries[key] = &IssueCacheEntry{
+		Issues:     issuesCopy,
+		ETag:       etag,
+		CachedAt:   now,
+		ExpiresAt:  now.Add(c.freshTTL),
+		StaleUntil: now.Add(c.staleTTL),
+	}
+
+	logger.GitHub.Debugf("Issue cache SET %s: %d issues, etag=%q", key, len(issues), etag)
+}
+
+// copyIssueListItem creates a deep copy of an IssueListItem
+func copyIssueListItem(item IssueListItem) IssueListItem {
+	copied := item
+
+	if item.Labels != nil {
+		copied.Labels = make([]IssueLabel, len(item.Labels))
+		copy(copied.Labels, item.Labels)
+	}
+
+	if item.Assignees != nil {
+		copied.Assignees = make([]IssueUser, len(item.Assignees))
+		copy(copied.Assignees, item.Assignees)
+	}
+
+	return copied
+}
+
+// BumpTTL atomically extends the fresh and stale deadlines for an existing entry.
+// Returns true if the entry was found and bumped.
+func (c *IssueCache) BumpTTL(owner, repo, state, labels string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := issueCacheKey(owner, repo, state, labels)
+	entry, ok := c.entries[key]
+	if !ok {
+		return false
+	}
+
+	now := time.Now()
+	entry.ExpiresAt = now.Add(c.freshTTL)
+	entry.StaleUntil = now.Add(c.staleTTL)
+	entry.CachedAt = now
+	return true
+}
+
+// GetETag returns the stored ETag for a repo's issue list
+func (c *IssueCache) GetETag(owner, repo, state, labels string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := issueCacheKey(owner, repo, state, labels)
+	entry, ok := c.entries[key]
+	if !ok {
+		return ""
+	}
+	return entry.ETag
+}
+
+// TryStartRefresh attempts to claim the refresh lock for a cache key.
+// Returns true if this caller should perform the refresh.
+func (c *IssueCache) TryStartRefresh(owner, repo, state, labels string) bool {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
+	key := issueCacheKey(owner, repo, state, labels)
+	if c.refreshing[key] {
+		return false
+	}
+	c.refreshing[key] = true
+	return true
+}
+
+// EndRefresh releases the refresh lock for a cache key
+func (c *IssueCache) EndRefresh(owner, repo, state, labels string) {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
+	key := issueCacheKey(owner, repo, state, labels)
+	delete(c.refreshing, key)
+}
+
+// Invalidate removes all cache entries for a specific repo (any state/labels combination)
+func (c *IssueCache) Invalidate(owner, repo string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	prefix := owner + "/" + repo + ":"
+	for key := range c.entries {
+		if strings.HasPrefix(key, prefix) {
+			delete(c.entries, key)
+		}
+	}
+	logger.GitHub.Debugf("Issue cache INVALIDATE %s/%s", owner, repo)
+}
+
+// Clear removes all cache entries
+func (c *IssueCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[string]*IssueCacheEntry)
+}
+
+// Done returns a channel that is closed when the cache is shut down.
+// Useful for deriving contexts that should cancel on shutdown.
+func (c *IssueCache) Done() <-chan struct{} {
+	return c.done
+}
+
+// Close stops the cleanup goroutine. Safe to call multiple times.
+func (c *IssueCache) Close() {
+	select {
+	case <-c.done:
+		// Already closed
+	default:
+		close(c.done)
+	}
+}
+
+// cleanupLoop periodically removes expired entries
+func (c *IssueCache) cleanupLoop() {
+	ticker := time.NewTicker(c.staleTTL)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+			c.cleanup()
+		}
+	}
+}
+
+// cleanup removes entries past their stale deadline
+func (c *IssueCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range c.entries {
+		if now.After(entry.StaleUntil) {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/backend/github/issues_cache_test.go
+++ b/backend/github/issues_cache_test.go
@@ -1,0 +1,524 @@
+package github
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Basic Operations
+// ============================================================================
+
+func TestIssueCache_SetAndGet(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	issues := []IssueListItem{
+		{Number: 1, Title: "First Issue", State: "open"},
+		{Number: 2, Title: "Second Issue", State: "open"},
+	}
+
+	cache.SetFull("owner", "repo", "open", "", issues, "etag-1")
+
+	entry, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheFresh, freshness)
+	require.NotNil(t, entry)
+	require.Len(t, entry.Issues, 2)
+	require.Equal(t, 1, entry.Issues[0].Number)
+	require.Equal(t, "First Issue", entry.Issues[0].Title)
+	require.Equal(t, 2, entry.Issues[1].Number)
+	require.Equal(t, "Second Issue", entry.Issues[1].Title)
+	require.Equal(t, "etag-1", entry.ETag)
+}
+
+func TestIssueCache_GetNotFound(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	entry, freshness := cache.GetWithStale("owner", "nonexistent", "open", "")
+	require.Equal(t, CacheMiss, freshness)
+	require.Nil(t, entry)
+}
+
+func TestIssueCache_GetWithStale_Fresh(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	issues := []IssueListItem{
+		{Number: 1, Title: "Test", State: "open", Labels: []IssueLabel{{Name: "bug", Color: "red"}}},
+	}
+	cache.SetFull("owner", "repo", "open", "", issues, "etag-fresh")
+
+	entry, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheFresh, freshness)
+	require.NotNil(t, entry)
+	require.Len(t, entry.Issues, 1)
+	require.Equal(t, "etag-fresh", entry.ETag)
+	require.Len(t, entry.Issues[0].Labels, 1)
+	require.Equal(t, "bug", entry.Issues[0].Labels[0].Name)
+}
+
+func TestIssueCache_ImmutableCopy(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	issues := []IssueListItem{
+		{Number: 1, Title: "Original", Labels: []IssueLabel{{Name: "bug", Color: "red"}}},
+	}
+	cache.SetFull("owner", "repo", "open", "", issues, "")
+
+	// Modify original slice
+	issues[0].Title = "Modified"
+	issues[0].Labels[0].Name = "modified-label"
+
+	// Cache should have original values
+	entry, _ := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, "Original", entry.Issues[0].Title)
+	require.Equal(t, "bug", entry.Issues[0].Labels[0].Name)
+}
+
+// ============================================================================
+// Freshness Transitions
+// ============================================================================
+
+func TestIssueCache_FreshToStaleToExpired(t *testing.T) {
+	cache := NewIssueCache(50*time.Millisecond, 150*time.Millisecond)
+	defer cache.Close()
+
+	issues := []IssueListItem{{Number: 1, Title: "Test"}}
+	cache.SetFull("owner", "repo", "open", "", issues, "etag-1")
+
+	// Should be fresh immediately
+	entry, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheFresh, freshness)
+	require.NotNil(t, entry)
+	require.Len(t, entry.Issues, 1)
+
+	// Wait for fresh TTL to expire
+	time.Sleep(70 * time.Millisecond)
+
+	// Should be stale
+	entry, freshness = cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheStale, freshness)
+	require.NotNil(t, entry)
+
+	// Wait for stale TTL to expire
+	time.Sleep(100 * time.Millisecond)
+
+	// Should be a miss
+	entry, freshness = cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheMiss, freshness)
+	require.Nil(t, entry)
+}
+
+// ============================================================================
+// Filter Isolation
+// ============================================================================
+
+func TestIssueCache_DifferentStatesSeparateEntries(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	openIssues := []IssueListItem{{Number: 1, Title: "Open Issue"}}
+	closedIssues := []IssueListItem{{Number: 2, Title: "Closed Issue"}}
+
+	cache.SetFull("owner", "repo", "open", "", openIssues, "etag-open")
+	cache.SetFull("owner", "repo", "closed", "", closedIssues, "etag-closed")
+
+	// Verify open
+	entry, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheFresh, freshness)
+	require.Len(t, entry.Issues, 1)
+	require.Equal(t, "Open Issue", entry.Issues[0].Title)
+	require.Equal(t, "etag-open", entry.ETag)
+
+	// Verify closed
+	entry, freshness = cache.GetWithStale("owner", "repo", "closed", "")
+	require.Equal(t, CacheFresh, freshness)
+	require.Len(t, entry.Issues, 1)
+	require.Equal(t, "Closed Issue", entry.Issues[0].Title)
+	require.Equal(t, "etag-closed", entry.ETag)
+}
+
+func TestIssueCache_DifferentLabelsSeparateEntries(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	bugIssues := []IssueListItem{{Number: 1, Title: "Bug"}}
+	featureIssues := []IssueListItem{{Number: 2, Title: "Feature"}, {Number: 3, Title: "Feature 2"}}
+
+	cache.SetFull("owner", "repo", "open", "bug", bugIssues, "")
+	cache.SetFull("owner", "repo", "open", "feature", featureIssues, "")
+
+	entry, _ := cache.GetWithStale("owner", "repo", "open", "bug")
+	require.Len(t, entry.Issues, 1)
+	require.Equal(t, "Bug", entry.Issues[0].Title)
+
+	entry, _ = cache.GetWithStale("owner", "repo", "open", "feature")
+	require.Len(t, entry.Issues, 2)
+	require.Equal(t, "Feature", entry.Issues[0].Title)
+}
+
+func TestIssueCache_SameRepoMultipleFilterCombos(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	cache.SetFull("owner", "repo", "open", "", []IssueListItem{{Number: 1}}, "")
+	cache.SetFull("owner", "repo", "closed", "", []IssueListItem{{Number: 2}}, "")
+	cache.SetFull("owner", "repo", "open", "bug", []IssueListItem{{Number: 3}}, "")
+
+	e1, _ := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, 1, e1.Issues[0].Number)
+
+	e2, _ := cache.GetWithStale("owner", "repo", "closed", "")
+	require.Equal(t, 2, e2.Issues[0].Number)
+
+	e3, _ := cache.GetWithStale("owner", "repo", "open", "bug")
+	require.Equal(t, 3, e3.Issues[0].Number)
+}
+
+// ============================================================================
+// Cache Key
+// ============================================================================
+
+func TestIssueCacheKey(t *testing.T) {
+	require.Equal(t, "owner/repo:open:", issueCacheKey("owner", "repo", "open", ""))
+	require.Equal(t, "owner/repo:closed:bug", issueCacheKey("owner", "repo", "closed", "bug"))
+	require.Equal(t, "my-org/my-repo:all:bug,ui", issueCacheKey("my-org", "my-repo", "all", "bug,ui"))
+}
+
+// ============================================================================
+// Invalidate
+// ============================================================================
+
+func TestIssueCache_Invalidate(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	cache.SetFull("owner", "repo", "open", "", []IssueListItem{{Number: 1}}, "")
+	cache.SetFull("owner", "repo", "closed", "", []IssueListItem{{Number: 2}}, "")
+	cache.SetFull("owner", "repo", "open", "bug", []IssueListItem{{Number: 3}}, "")
+
+	// All should be cached
+	_, f1 := cache.GetWithStale("owner", "repo", "open", "")
+	_, f2 := cache.GetWithStale("owner", "repo", "closed", "")
+	_, f3 := cache.GetWithStale("owner", "repo", "open", "bug")
+	require.Equal(t, CacheFresh, f1)
+	require.Equal(t, CacheFresh, f2)
+	require.Equal(t, CacheFresh, f3)
+
+	// Invalidate all entries for this repo
+	cache.Invalidate("owner", "repo")
+
+	// All should be gone
+	_, f1 = cache.GetWithStale("owner", "repo", "open", "")
+	_, f2 = cache.GetWithStale("owner", "repo", "closed", "")
+	_, f3 = cache.GetWithStale("owner", "repo", "open", "bug")
+	require.Equal(t, CacheMiss, f1)
+	require.Equal(t, CacheMiss, f2)
+	require.Equal(t, CacheMiss, f3)
+}
+
+func TestIssueCache_Invalidate_OnlyTargetRepo(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	cache.SetFull("owner", "repo-a", "open", "", []IssueListItem{{Number: 1}}, "")
+	cache.SetFull("owner", "repo-b", "open", "", []IssueListItem{{Number: 2}}, "")
+
+	cache.Invalidate("owner", "repo-a")
+
+	_, f1 := cache.GetWithStale("owner", "repo-a", "open", "")
+	require.Equal(t, CacheMiss, f1)
+
+	entry, f2 := cache.GetWithStale("owner", "repo-b", "open", "")
+	require.Equal(t, CacheFresh, f2)
+	require.Equal(t, 2, entry.Issues[0].Number)
+}
+
+func TestIssueCache_Invalidate_NonExistent(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	// Should not panic
+	cache.Invalidate("nonexistent", "repo")
+}
+
+// ============================================================================
+// BumpTTL
+// ============================================================================
+
+func TestIssueCache_BumpTTL(t *testing.T) {
+	cache := NewIssueCache(50*time.Millisecond, 200*time.Millisecond)
+	defer cache.Close()
+
+	cache.SetFull("owner", "repo", "open", "", []IssueListItem{{Number: 1}}, "etag-1")
+
+	// Wait until stale
+	time.Sleep(70 * time.Millisecond)
+	_, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheStale, freshness)
+
+	// Bump TTL should make it fresh again
+	ok := cache.BumpTTL("owner", "repo", "open", "")
+	require.True(t, ok)
+
+	entry, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheFresh, freshness)
+	require.NotNil(t, entry)
+	require.Len(t, entry.Issues, 1)
+}
+
+func TestIssueCache_BumpTTL_PreservesData(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	issues := []IssueListItem{
+		{Number: 1, Title: "Test", Labels: []IssueLabel{{Name: "bug"}}},
+	}
+	cache.SetFull("owner", "repo", "open", "", issues, "etag-abc")
+
+	cache.BumpTTL("owner", "repo", "open", "")
+
+	entry, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheFresh, freshness)
+	require.Len(t, entry.Issues, 1)
+	require.Equal(t, 1, entry.Issues[0].Number)
+	require.Equal(t, "Test", entry.Issues[0].Title)
+	require.Len(t, entry.Issues[0].Labels, 1)
+	require.Equal(t, "bug", entry.Issues[0].Labels[0].Name)
+	require.Equal(t, "etag-abc", entry.ETag)
+}
+
+func TestIssueCache_BumpTTL_NonExistent(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	ok := cache.BumpTTL("nonexistent", "repo", "open", "")
+	require.False(t, ok)
+}
+
+// ============================================================================
+// ETag
+// ============================================================================
+
+func TestIssueCache_GetETag(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	// Non-existent returns empty
+	etag := cache.GetETag("owner", "repo", "open", "")
+	require.Empty(t, etag)
+
+	// Set with ETag
+	cache.SetFull("owner", "repo", "open", "", []IssueListItem{{Number: 1}}, `W/"abc123"`)
+	etag = cache.GetETag("owner", "repo", "open", "")
+	require.Equal(t, `W/"abc123"`, etag)
+}
+
+func TestIssueCache_GetETag_EmptyETag(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	cache.SetFull("owner", "repo", "open", "", []IssueListItem{{Number: 1}}, "")
+	etag := cache.GetETag("owner", "repo", "open", "")
+	require.Empty(t, etag)
+}
+
+// ============================================================================
+// Refresh Deduplication
+// ============================================================================
+
+func TestIssueCache_TryStartRefresh_Dedup(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	// First call should succeed
+	ok := cache.TryStartRefresh("owner", "repo", "open", "")
+	require.True(t, ok)
+
+	// Second call should fail (already refreshing)
+	ok = cache.TryStartRefresh("owner", "repo", "open", "")
+	require.False(t, ok)
+
+	// After ending, should succeed again
+	cache.EndRefresh("owner", "repo", "open", "")
+	ok = cache.TryStartRefresh("owner", "repo", "open", "")
+	require.True(t, ok)
+	cache.EndRefresh("owner", "repo", "open", "")
+}
+
+func TestIssueCache_TryStartRefresh_DifferentKeys(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	// Different filter combos should be able to refresh concurrently
+	ok1 := cache.TryStartRefresh("owner", "repo", "open", "")
+	ok2 := cache.TryStartRefresh("owner", "repo", "closed", "")
+	require.True(t, ok1)
+	require.True(t, ok2)
+
+	cache.EndRefresh("owner", "repo", "open", "")
+	cache.EndRefresh("owner", "repo", "closed", "")
+}
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+func TestIssueCache_Close(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+
+	// Close should not panic
+	cache.Close()
+}
+
+func TestIssueCache_DoubleClose(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+
+	cache.Close()
+	// Double close should not panic
+	cache.Close()
+}
+
+func TestIssueCache_OperationsAfterClose(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	cache.Close()
+
+	// Operations should still work after close (just no cleanup goroutine)
+	cache.SetFull("owner", "repo", "open", "", []IssueListItem{{Number: 1}}, "")
+	entry, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheFresh, freshness)
+	require.Len(t, entry.Issues, 1)
+}
+
+func TestIssueCache_Done(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+
+	// Done channel should be open before Close
+	select {
+	case <-cache.Done():
+		t.Fatal("Done channel should not be closed yet")
+	default:
+		// Expected
+	}
+
+	cache.Close()
+
+	// Done channel should be closed after Close
+	select {
+	case <-cache.Done():
+		// Expected
+	default:
+		t.Fatal("Done channel should be closed after Close()")
+	}
+}
+
+// ============================================================================
+// Concurrency
+// ============================================================================
+
+func TestIssueCache_ConcurrentAccess(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	var wg sync.WaitGroup
+	const numGoroutines = 100
+
+	// Concurrent writes
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			issues := []IssueListItem{{Number: id, Title: "Issue"}}
+			cache.SetFull("owner", "repo", "open", "", issues, "")
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.GetWithStale("owner", "repo", "open", "")
+		}()
+	}
+
+	// Concurrent invalidates
+	for i := 0; i < numGoroutines/10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.Invalidate("owner", "repo")
+		}()
+	}
+
+	// Concurrent BumpTTL
+	for i := 0; i < numGoroutines/10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.BumpTTL("owner", "repo", "open", "")
+		}()
+	}
+
+	// Concurrent TryStartRefresh/EndRefresh
+	for i := 0; i < numGoroutines/10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if cache.TryStartRefresh("owner", "repo", "open", "") {
+				cache.EndRefresh("owner", "repo", "open", "")
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// ============================================================================
+// Cleanup
+// ============================================================================
+
+func TestIssueCache_CleanupRemovesExpired(t *testing.T) {
+	cache := NewIssueCache(10*time.Millisecond, 20*time.Millisecond)
+	defer cache.Close()
+
+	cache.SetFull("owner", "repo", "open", "", []IssueListItem{{Number: 1}}, "")
+
+	// Should be cached
+	_, freshness := cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheFresh, freshness)
+
+	// Wait for both TTLs to expire
+	time.Sleep(50 * time.Millisecond)
+
+	// Manually trigger cleanup
+	cache.cleanup()
+
+	// Should be removed
+	_, freshness = cache.GetWithStale("owner", "repo", "open", "")
+	require.Equal(t, CacheMiss, freshness)
+}
+
+// ============================================================================
+// Clear
+// ============================================================================
+
+func TestIssueCache_Clear(t *testing.T) {
+	cache := NewIssueCache(5*time.Minute, 10*time.Minute)
+	defer cache.Close()
+
+	cache.SetFull("owner1", "repo1", "open", "", []IssueListItem{{Number: 1}}, "")
+	cache.SetFull("owner2", "repo2", "open", "", []IssueListItem{{Number: 2}}, "")
+
+	cache.Clear()
+
+	_, f1 := cache.GetWithStale("owner1", "repo1", "open", "")
+	_, f2 := cache.GetWithStale("owner2", "repo2", "open", "")
+	require.Equal(t, CacheMiss, f1)
+	require.Equal(t, CacheMiss, f2)
+}

--- a/backend/github/issues_test.go
+++ b/backend/github/issues_test.go
@@ -1,0 +1,800 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// ListIssuesWithETag Tests
+// ============================================================================
+
+func TestClient_ListIssuesWithETag_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/testowner/testrepo/issues", r.URL.Path)
+		require.Equal(t, "Bearer test_token", r.Header.Get("Authorization"))
+		require.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+		require.Equal(t, "open", r.URL.Query().Get("state"))
+		require.Equal(t, "updated", r.URL.Query().Get("sort"))
+		require.Equal(t, "desc", r.URL.Query().Get("direction"))
+		require.Equal(t, "50", r.URL.Query().Get("per_page"))
+
+		w.Header().Set("ETag", `W/"etag-123"`)
+		issues := []map[string]interface{}{
+			{
+				"number":   1,
+				"title":    "Bug report",
+				"state":    "open",
+				"html_url": "https://github.com/testowner/testrepo/issues/1",
+				"body":     "Bug description",
+				"comments": 3,
+				"created_at": "2024-01-01T00:00:00Z",
+				"updated_at": "2024-01-02T00:00:00Z",
+				"labels": []map[string]string{
+					{"name": "bug", "color": "d73a4a"},
+				},
+				"user": map[string]string{
+					"login":      "alice",
+					"avatar_url": "https://github.com/alice.png",
+				},
+				"assignees": []map[string]string{
+					{"login": "bob", "avatar_url": "https://github.com/bob.png"},
+				},
+			},
+			{
+				"number":     2,
+				"title":      "Feature request",
+				"state":      "open",
+				"html_url":   "https://github.com/testowner/testrepo/issues/2",
+				"body":       "Feature description",
+				"comments":   0,
+				"created_at": "2024-01-03T00:00:00Z",
+				"updated_at": "2024-01-04T00:00:00Z",
+				"labels":     []map[string]string{},
+				"user": map[string]string{
+					"login":      "charlie",
+					"avatar_url": "https://github.com/charlie.png",
+				},
+				"assignees": []map[string]string{},
+			},
+		}
+		json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Issues, 2)
+	require.Equal(t, `W/"etag-123"`, result.ETag)
+
+	// Verify first issue fields
+	issue := result.Issues[0]
+	require.Equal(t, 1, issue.Number)
+	require.Equal(t, "Bug report", issue.Title)
+	require.Equal(t, "open", issue.State)
+	require.Equal(t, "https://github.com/testowner/testrepo/issues/1", issue.HTMLURL)
+	require.Equal(t, 3, issue.Comments)
+	require.Equal(t, "alice", issue.User.Login)
+	require.Equal(t, "https://github.com/alice.png", issue.User.AvatarURL)
+	require.Len(t, issue.Labels, 1)
+	require.Equal(t, "bug", issue.Labels[0].Name)
+	require.Equal(t, "d73a4a", issue.Labels[0].Color)
+	require.Len(t, issue.Assignees, 1)
+	require.Equal(t, "bob", issue.Assignees[0].Login)
+
+	// Verify second issue
+	require.Equal(t, 2, result.Issues[1].Number)
+	require.Equal(t, "Feature request", result.Issues[1].Title)
+}
+
+func TestClient_ListIssuesWithETag_WithLabelsFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "bug,ui", r.URL.Query().Get("labels"))
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "bug,ui", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Empty(t, result.Issues)
+}
+
+func TestClient_ListIssuesWithETag_ClosedState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "closed", r.URL.Query().Get("state"))
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "closed", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestClient_ListIssuesWithETag_DefaultState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "open", r.URL.Query().Get("state"))
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	// Empty state should default to "open"
+	result, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestClient_ListIssuesWithETag_EmptyList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Issues)
+	require.Empty(t, result.Issues)
+}
+
+func TestClient_ListIssuesWithETag_NotModified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, `W/"etag-123"`, r.Header.Get("If-None-Match"))
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "", `W/"etag-123"`)
+	require.ErrorIs(t, err, ErrNotModified)
+	require.Nil(t, result)
+}
+
+func TestClient_ListIssuesWithETag_SendsETagHeader(t *testing.T) {
+	var receivedETag string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedETag = r.Header.Get("If-None-Match")
+		w.Header().Set("ETag", `W/"new-etag"`)
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "", `W/"old-etag"`)
+	require.NoError(t, err)
+	require.Equal(t, `W/"old-etag"`, receivedETag)
+	require.Equal(t, `W/"new-etag"`, result.ETag)
+}
+
+func TestClient_ListIssuesWithETag_NoETagSendsNoHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("If-None-Match"))
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	_, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "", "")
+	require.NoError(t, err)
+}
+
+func TestClient_ListIssuesWithETag_FiltersPullRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		items := []map[string]interface{}{
+			{
+				"number": 1, "title": "Issue 1", "state": "open",
+				"html_url": "https://github.com/o/r/issues/1",
+				"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+				"user": map[string]string{"login": "a", "avatar_url": ""},
+			},
+			{
+				"number": 2, "title": "PR 1", "state": "open",
+				"html_url": "https://github.com/o/r/pull/2",
+				"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+				"user":         map[string]string{"login": "b", "avatar_url": ""},
+				"pull_request": map[string]string{"url": "https://api.github.com/repos/o/r/pulls/2"},
+			},
+			{
+				"number": 3, "title": "Issue 2", "state": "open",
+				"html_url": "https://github.com/o/r/issues/3",
+				"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+				"user": map[string]string{"login": "c", "avatar_url": ""},
+			},
+			{
+				"number": 4, "title": "PR 2", "state": "open",
+				"html_url": "https://github.com/o/r/pull/4",
+				"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+				"user":         map[string]string{"login": "d", "avatar_url": ""},
+				"pull_request": map[string]string{"url": "https://api.github.com/repos/o/r/pulls/4"},
+			},
+			{
+				"number": 5, "title": "Issue 3", "state": "open",
+				"html_url": "https://github.com/o/r/issues/5",
+				"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+				"user": map[string]string{"login": "e", "avatar_url": ""},
+			},
+		}
+		json.NewEncoder(w).Encode(items)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListIssuesWithETag(context.Background(), "o", "r", "open", "", "")
+	require.NoError(t, err)
+	require.Len(t, result.Issues, 3)
+	require.Equal(t, 1, result.Issues[0].Number)
+	require.Equal(t, 3, result.Issues[1].Number)
+	require.Equal(t, 5, result.Issues[2].Number)
+}
+
+func TestClient_ListIssuesWithETag_NotAuthenticated(t *testing.T) {
+	client := NewClient("", "")
+	// No token set
+
+	_, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authenticated")
+}
+
+func TestClient_ListIssuesWithETag_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message": "API rate limit exceeded"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	_, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+}
+
+func TestClient_ListIssuesWithETag_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not valid json"))
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	_, err := client.ListIssuesWithETag(context.Background(), "testowner", "testrepo", "open", "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decoding")
+}
+
+func TestClient_ListIssuesWithETag_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.ListIssuesWithETag(ctx, "testowner", "testrepo", "open", "", "")
+	require.Error(t, err)
+}
+
+func TestClient_ListIssuesWithETag_MultipleLabelsAndAssignees(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		issues := []map[string]interface{}{
+			{
+				"number": 1, "title": "Complex issue", "state": "open",
+				"html_url": "https://github.com/o/r/issues/1",
+				"comments": 5,
+				"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-02T00:00:00Z",
+				"labels": []map[string]string{
+					{"name": "bug", "color": "d73a4a"},
+					{"name": "priority:high", "color": "e4e669"},
+					{"name": "ui", "color": "0075ca"},
+				},
+				"user": map[string]string{"login": "alice", "avatar_url": "https://github.com/alice.png"},
+				"assignees": []map[string]string{
+					{"login": "bob", "avatar_url": "https://github.com/bob.png"},
+					{"login": "charlie", "avatar_url": "https://github.com/charlie.png"},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.ListIssuesWithETag(context.Background(), "o", "r", "open", "", "")
+	require.NoError(t, err)
+	require.Len(t, result.Issues, 1)
+
+	issue := result.Issues[0]
+	require.Len(t, issue.Labels, 3)
+	require.Equal(t, "bug", issue.Labels[0].Name)
+	require.Equal(t, "priority:high", issue.Labels[1].Name)
+	require.Equal(t, "ui", issue.Labels[2].Name)
+	require.Equal(t, "0075ca", issue.Labels[2].Color)
+
+	require.Len(t, issue.Assignees, 2)
+	require.Equal(t, "bob", issue.Assignees[0].Login)
+	require.Equal(t, "charlie", issue.Assignees[1].Login)
+	require.Equal(t, "https://github.com/charlie.png", issue.Assignees[1].AvatarURL)
+}
+
+// ============================================================================
+// SearchIssues Tests
+// ============================================================================
+
+func TestClient_SearchIssues_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/search/issues", r.URL.Path)
+		require.Equal(t, "Bearer test_token", r.Header.Get("Authorization"))
+
+		q := r.URL.Query().Get("q")
+		require.Contains(t, q, "repo:testowner/testrepo")
+		require.Contains(t, q, "is:issue")
+		require.Contains(t, q, "memory leak")
+		require.Equal(t, "30", r.URL.Query().Get("per_page"))
+
+		resp := map[string]interface{}{
+			"total_count": 2,
+			"items": []map[string]interface{}{
+				{
+					"number": 10, "title": "Memory leak in parser", "state": "open",
+					"html_url": "https://github.com/testowner/testrepo/issues/10",
+					"comments": 1,
+					"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-02T00:00:00Z",
+					"user": map[string]string{"login": "alice", "avatar_url": ""},
+				},
+				{
+					"number": 20, "title": "Memory leak in cache", "state": "open",
+					"html_url": "https://github.com/testowner/testrepo/issues/20",
+					"comments": 0,
+					"created_at": "2024-01-03T00:00:00Z", "updated_at": "2024-01-04T00:00:00Z",
+					"user": map[string]string{"login": "bob", "avatar_url": ""},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.SearchIssues(context.Background(), "testowner", "testrepo", "memory leak")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 2, result.TotalCount)
+	require.Len(t, result.Issues, 2)
+	require.Equal(t, 10, result.Issues[0].Number)
+	require.Equal(t, "Memory leak in parser", result.Issues[0].Title)
+	require.Equal(t, 20, result.Issues[1].Number)
+}
+
+func TestClient_SearchIssues_FiltersPullRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"total_count": 3,
+			"items": []map[string]interface{}{
+				{
+					"number": 1, "title": "Issue", "state": "open",
+					"html_url": "https://github.com/o/r/issues/1",
+					"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+					"user": map[string]string{"login": "a", "avatar_url": ""},
+				},
+				{
+					"number": 2, "title": "PR", "state": "open",
+					"html_url": "https://github.com/o/r/pull/2",
+					"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+					"user":         map[string]string{"login": "b", "avatar_url": ""},
+					"pull_request": map[string]string{"url": "https://api.github.com/repos/o/r/pulls/2"},
+				},
+				{
+					"number": 3, "title": "Another issue", "state": "open",
+					"html_url": "https://github.com/o/r/issues/3",
+					"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+					"user": map[string]string{"login": "c", "avatar_url": ""},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.SearchIssues(context.Background(), "o", "r", "test")
+	require.NoError(t, err)
+	require.Len(t, result.Issues, 2)
+	require.Equal(t, 1, result.Issues[0].Number)
+	require.Equal(t, 3, result.Issues[1].Number)
+}
+
+func TestClient_SearchIssues_EmptyResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"total_count": 0,
+			"items":       []map[string]interface{}{},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	result, err := client.SearchIssues(context.Background(), "o", "r", "nonexistent")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 0, result.TotalCount)
+	require.NotNil(t, result.Issues)
+	require.Empty(t, result.Issues)
+}
+
+func TestClient_SearchIssues_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"message": "Validation Failed"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	_, err := client.SearchIssues(context.Background(), "o", "r", "bad query")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "422")
+}
+
+func TestClient_SearchIssues_NotAuthenticated(t *testing.T) {
+	client := NewClient("", "")
+
+	_, err := client.SearchIssues(context.Background(), "o", "r", "test")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authenticated")
+}
+
+func TestClient_SearchIssues_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		json.NewEncoder(w).Encode(map[string]interface{}{"total_count": 0, "items": []interface{}{}})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.SearchIssues(ctx, "o", "r", "test")
+	require.Error(t, err)
+}
+
+// ============================================================================
+// GetIssue Tests
+// ============================================================================
+
+func TestClient_GetIssue_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/testowner/testrepo/issues/42", r.URL.Path)
+		require.Equal(t, "Bearer test_token", r.Header.Get("Authorization"))
+		require.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+
+		issue := map[string]interface{}{
+			"number":   42,
+			"title":    "Critical bug in auth",
+			"state":    "open",
+			"html_url": "https://github.com/testowner/testrepo/issues/42",
+			"body":     "The auth module crashes when...",
+			"comments": 7,
+			"created_at": "2024-01-01T00:00:00Z",
+			"updated_at": "2024-01-05T00:00:00Z",
+			"labels": []map[string]string{
+				{"name": "bug", "color": "d73a4a"},
+				{"name": "critical", "color": "b60205"},
+			},
+			"user": map[string]string{
+				"login":      "reporter",
+				"avatar_url": "https://github.com/reporter.png",
+			},
+			"assignees": []map[string]string{
+				{"login": "dev1", "avatar_url": "https://github.com/dev1.png"},
+				{"login": "dev2", "avatar_url": "https://github.com/dev2.png"},
+			},
+			"milestone": map[string]interface{}{
+				"number": 5,
+				"title":  "v2.0",
+				"state":  "open",
+			},
+		}
+		json.NewEncoder(w).Encode(issue)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	details, err := client.GetIssue(context.Background(), "testowner", "testrepo", 42)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+
+	require.Equal(t, 42, details.Number)
+	require.Equal(t, "Critical bug in auth", details.Title)
+	require.Equal(t, "open", details.State)
+	require.Equal(t, "https://github.com/testowner/testrepo/issues/42", details.HTMLURL)
+	require.Equal(t, "The auth module crashes when...", details.Body)
+	require.Equal(t, 7, details.Comments)
+	require.Equal(t, "reporter", details.User.Login)
+
+	require.Len(t, details.Labels, 2)
+	require.Equal(t, "bug", details.Labels[0].Name)
+	require.Equal(t, "critical", details.Labels[1].Name)
+
+	require.Len(t, details.Assignees, 2)
+	require.Equal(t, "dev1", details.Assignees[0].Login)
+
+	require.NotNil(t, details.Milestone)
+	require.Equal(t, 5, details.Milestone.Number)
+	require.Equal(t, "v2.0", details.Milestone.Title)
+	require.Equal(t, "open", details.Milestone.State)
+}
+
+func TestClient_GetIssue_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	details, err := client.GetIssue(context.Background(), "testowner", "testrepo", 999)
+	require.NoError(t, err)
+	require.Nil(t, details)
+}
+
+func TestClient_GetIssue_NoMilestone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		issue := map[string]interface{}{
+			"number": 1, "title": "Simple issue", "state": "open",
+			"html_url": "https://github.com/o/r/issues/1",
+			"body": "No milestone",
+			"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+			"user": map[string]string{"login": "a", "avatar_url": ""},
+		}
+		json.NewEncoder(w).Encode(issue)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	details, err := client.GetIssue(context.Background(), "o", "r", 1)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+	require.Nil(t, details.Milestone)
+}
+
+func TestClient_GetIssue_NotAuthenticated(t *testing.T) {
+	client := NewClient("", "")
+
+	_, err := client.GetIssue(context.Background(), "o", "r", 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authenticated")
+}
+
+func TestClient_GetIssue_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"message": "Internal Server Error"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	_, err := client.GetIssue(context.Background(), "o", "r", 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "500")
+}
+
+func TestClient_GetIssue_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not valid json"))
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	_, err := client.GetIssue(context.Background(), "o", "r", 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decoding")
+}
+
+func TestClient_GetIssue_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		json.NewEncoder(w).Encode(map[string]interface{}{"number": 1})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.GetIssue(ctx, "o", "r", 1)
+	require.Error(t, err)
+}
+
+func TestClient_GetIssue_TrimsBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		issue := map[string]interface{}{
+			"number": 1, "title": "Issue", "state": "open",
+			"html_url": "https://github.com/o/r/issues/1",
+			"body":       "  Body with whitespace  \n\n",
+			"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z",
+			"user": map[string]string{"login": "a", "avatar_url": ""},
+		}
+		json.NewEncoder(w).Encode(issue)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	details, err := client.GetIssue(context.Background(), "o", "r", 1)
+	require.NoError(t, err)
+	require.Equal(t, "Body with whitespace", details.Body)
+}
+
+// ============================================================================
+// JSON Serialization Tests
+// ============================================================================
+
+func TestIssueListItem_JSONSerialization(t *testing.T) {
+	item := IssueListItem{
+		Number:    42,
+		Title:     "Test Issue",
+		State:     "open",
+		HTMLURL:   "https://github.com/o/r/issues/42",
+		Labels:    []IssueLabel{{Name: "bug", Color: "d73a4a"}},
+		User:      IssueUser{Login: "alice", AvatarURL: "https://github.com/alice.png"},
+		Assignees: []IssueUser{{Login: "bob", AvatarURL: "https://github.com/bob.png"}},
+		Comments:  5,
+		CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+
+	data, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	// Verify camelCase field names
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.Contains(t, raw, "htmlUrl")
+	require.Contains(t, raw, "createdAt")
+	require.Contains(t, raw, "updatedAt")
+	userMap := raw["user"].(map[string]interface{})
+	require.Contains(t, userMap, "avatarUrl")
+
+	// Round-trip
+	var decoded IssueListItem
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, item.Number, decoded.Number)
+	require.Equal(t, item.Title, decoded.Title)
+	require.Equal(t, item.HTMLURL, decoded.HTMLURL)
+	require.Equal(t, item.User.Login, decoded.User.Login)
+}
+
+func TestIssueDetails_JSONSerialization(t *testing.T) {
+	details := IssueDetails{
+		IssueListItem: IssueListItem{
+			Number:  42,
+			Title:   "Test",
+			State:   "open",
+			HTMLURL: "https://github.com/o/r/issues/42",
+			User:    IssueUser{Login: "alice"},
+		},
+		Body:      "Description here",
+		Milestone: &IssueMilestone{Number: 1, Title: "v1.0", State: "open"},
+	}
+
+	data, err := json.Marshal(details)
+	require.NoError(t, err)
+
+	var decoded IssueDetails
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, 42, decoded.Number)
+	require.Equal(t, "Description here", decoded.Body)
+	require.NotNil(t, decoded.Milestone)
+	require.Equal(t, "v1.0", decoded.Milestone.Title)
+}
+
+func TestSearchIssuesResult_JSONSerialization(t *testing.T) {
+	result := SearchIssuesResult{
+		TotalCount: 1,
+		Issues: []IssueListItem{
+			{Number: 1, Title: "Test", State: "open", User: IssueUser{Login: "a"}},
+		},
+	}
+
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.Contains(t, raw, "totalCount")
+	require.Contains(t, raw, "issues")
+
+	var decoded SearchIssuesResult
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, 1, decoded.TotalCount)
+	require.Len(t, decoded.Issues, 1)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -353,10 +353,14 @@ func main() {
 		}
 	}
 
+	// Issue cache for GitHub Issues API
+	issueCache := github.NewIssueCache(2*time.Minute, 10*time.Minute)
+	defer issueCache.Close()
+
 	// AI client for PR description generation
 	aiClient := ai.NewClient(os.Getenv("ANTHROPIC_API_KEY"))
 
-	router := server.NewRouter(s, hub, agentMgr, ghClient, nil, branchWatcher, prWatcher, prCache, statsCache, aiClient)
+	router := server.NewRouter(s, hub, agentMgr, ghClient, nil, branchWatcher, prWatcher, prCache, issueCache, statsCache, aiClient)
 
 	// Create HTTP server with graceful shutdown support
 	srv := &http.Server{

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -320,6 +320,7 @@ type Handlers struct {
 	hub              *Hub // For broadcasting WebSocket events
 	ghClient         *github.Client
 	prCache          *github.PRCache
+	issueCache       *github.IssueCache
 	avatarCache      *github.AvatarCache
 	statsCache       *SessionStatsCache
 	aiClient         *ai.Client
@@ -347,7 +348,7 @@ func (h *Handlers) getWorkspacesBaseDir(ctx context.Context) (string, error) {
 	return git.WorkspacesBaseDirWithOverride(configured)
 }
 
-func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, statsCache *SessionStatsCache, aiClient *ai.Client) *Handlers {
+func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, aiClient *ai.Client) *Handlers {
 	// Initialize session name cache with workspaces directory
 	// Cache initializes lazily on first use
 	workspacesDir, err := git.WorkspacesBaseDir()
@@ -369,6 +370,7 @@ func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirList
 		hub:              hub,
 		ghClient:         ghClient,
 		prCache:          prCache,
+		issueCache:       issueCache,
 		avatarCache:      github.NewAvatarCache(24 * time.Hour), // Cache avatars for 24 hours
 		statsCache:       statsCache,
 		aiClient:         aiClient,

--- a/backend/server/issue_handlers.go
+++ b/backend/server/issue_handlers.go
@@ -1,0 +1,197 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/chatml/chatml-backend/github"
+	"github.com/chatml/chatml-backend/logger"
+	"github.com/go-chi/chi/v5"
+)
+
+// ListIssues returns GitHub issues for a workspace's repository.
+// Supports query params: state (open|closed|all, default: open), labels (comma-separated).
+// Uses stale-while-revalidate caching to minimize GitHub API calls.
+func (h *Handlers) ListIssues(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if h.ghClient == nil || !h.ghClient.IsAuthenticated() {
+		writeJSON(w, []github.IssueListItem{})
+		return
+	}
+
+	// Resolve repo and GitHub remote
+	id := chi.URLParam(r, "id")
+	repo, err := h.store.GetRepo(ctx, id)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if repo == nil {
+		writeNotFound(w, "repo")
+		return
+	}
+
+	owner, repoName, err := h.repoManager.GetGitHubRemote(ctx, repo.Path)
+	if err != nil {
+		writeJSON(w, []github.IssueListItem{})
+		return
+	}
+
+	// Query params
+	state := r.URL.Query().Get("state")
+	labels := r.URL.Query().Get("labels")
+	if state == "" {
+		state = "open"
+	}
+
+	// Check cache with stale-while-revalidate
+	entry, freshness := h.issueCache.GetWithStale(owner, repoName, state, labels)
+
+	switch freshness {
+	case github.CacheFresh:
+		writeJSON(w, entry.Issues)
+		return
+
+	case github.CacheStale:
+		// Serve stale immediately, trigger background refresh
+		writeJSON(w, entry.Issues)
+		if h.issueCache.TryStartRefresh(owner, repoName, state, labels) {
+			go h.refreshIssueCache(owner, repoName, state, labels)
+		}
+		return
+
+	default: // CacheMiss
+		result, err := h.ghClient.ListIssuesWithETag(ctx, owner, repoName, state, labels, "")
+		if err != nil {
+			writeInternalError(w, "failed to fetch issues", err)
+			return
+		}
+		h.issueCache.SetFull(owner, repoName, state, labels, result.Issues, result.ETag)
+		writeJSON(w, result.Issues)
+	}
+}
+
+// SearchIssues searches for GitHub issues in a workspace's repository.
+// Requires query param: q (search query).
+// Does not use caching (search queries are too variable for effective caching).
+func (h *Handlers) SearchIssues(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if h.ghClient == nil || !h.ghClient.IsAuthenticated() {
+		writeJSON(w, github.SearchIssuesResult{Issues: []github.IssueListItem{}})
+		return
+	}
+
+	// Resolve repo and GitHub remote
+	id := chi.URLParam(r, "id")
+	repo, err := h.store.GetRepo(ctx, id)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if repo == nil {
+		writeNotFound(w, "repo")
+		return
+	}
+
+	owner, repoName, err := h.repoManager.GetGitHubRemote(ctx, repo.Path)
+	if err != nil {
+		writeJSON(w, github.SearchIssuesResult{Issues: []github.IssueListItem{}})
+		return
+	}
+
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		writeValidationError(w, "query parameter 'q' is required")
+		return
+	}
+
+	result, err := h.ghClient.SearchIssues(ctx, owner, repoName, query)
+	if err != nil {
+		writeInternalError(w, "failed to search issues", err)
+		return
+	}
+
+	writeJSON(w, result)
+}
+
+// GetIssueDetails returns detailed information about a single GitHub issue.
+func (h *Handlers) GetIssueDetails(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if h.ghClient == nil || !h.ghClient.IsAuthenticated() {
+		writeNotFound(w, "issue")
+		return
+	}
+
+	// Resolve repo and GitHub remote
+	id := chi.URLParam(r, "id")
+	repo, err := h.store.GetRepo(ctx, id)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if repo == nil {
+		writeNotFound(w, "repo")
+		return
+	}
+
+	owner, repoName, err := h.repoManager.GetGitHubRemote(ctx, repo.Path)
+	if err != nil {
+		writeNotFound(w, "issue")
+		return
+	}
+
+	numberStr := chi.URLParam(r, "number")
+	number, err := strconv.Atoi(numberStr)
+	if err != nil {
+		writeValidationError(w, "invalid issue number")
+		return
+	}
+
+	issue, err := h.ghClient.GetIssue(ctx, owner, repoName, number)
+	if err != nil {
+		writeInternalError(w, "failed to fetch issue", err)
+		return
+	}
+	if issue == nil {
+		writeNotFound(w, "issue")
+		return
+	}
+
+	writeJSON(w, issue)
+}
+
+// refreshIssueCache performs a background refresh of the issue cache for a repo+filter combination.
+// Uses ETag conditional requests to avoid re-fetching unchanged data.
+func (h *Handlers) refreshIssueCache(owner, repoName, state, labels string) {
+	defer h.issueCache.EndRefresh(owner, repoName, state, labels)
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Handlers.Errorf("Panic in background issue refresh for %s/%s: %v", owner, repoName, r)
+		}
+	}()
+
+	// Use a bounded timeout for the background refresh. During server shutdown,
+	// the HTTP client will fail fast and the 30s timeout provides a hard upper bound.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	etag := h.issueCache.GetETag(owner, repoName, state, labels)
+	result, err := h.ghClient.ListIssuesWithETag(ctx, owner, repoName, state, labels, etag)
+
+	if errors.Is(err, github.ErrNotModified) {
+		h.issueCache.BumpTTL(owner, repoName, state, labels)
+		return
+	}
+	if err != nil {
+		logger.Handlers.Errorf("Background issue refresh failed for %s/%s: %v", owner, repoName, err)
+		return
+	}
+
+	h.issueCache.SetFull(owner, repoName, state, labels, result.Issues, result.ETag)
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -18,10 +18,10 @@ import (
 	"github.com/rs/cors"
 )
 
-func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, orch *orchestrator.Orchestrator, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, statsCache *SessionStatsCache, aiClient *ai.Client) http.Handler {
+func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, orch *orchestrator.Orchestrator, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, aiClient *ai.Client) http.Handler {
 	r := chi.NewRouter()
 	dirCacheConfig := LoadDirListingCacheConfig()
-	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, statsCache, aiClient)
+	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, issueCache, statsCache, aiClient)
 	auth := NewAuthHandlers(ghClient)
 
 	r.Use(middleware.Logger)
@@ -57,6 +57,9 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 
 	// Rate limiter for comment operations
 	commentRateLimiter := httprate.LimitByIP(60, 1*time.Minute) // 60 comments per minute
+
+	// Rate limiter for GitHub search operations (GitHub search API has 30 req/min limit)
+	searchRateLimiter := httprate.LimitByIP(20, 1*time.Minute) // 20 searches per minute
 
 	// PR Dashboard endpoint
 	r.Get("/api/prs", h.ListPRs)
@@ -128,6 +131,10 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Get("/{id}/tabs", h.ListFileTabs)
 		r.Post("/{id}/tabs", h.SaveFileTabs)
 		r.Delete("/{id}/tabs/{tabId}", h.DeleteFileTab)
+		// GitHub Issues endpoints
+		r.Get("/{id}/issues", h.ListIssues)
+		r.With(searchRateLimiter).Get("/{id}/issues/search", h.SearchIssues)
+		r.Get("/{id}/issues/{number}", h.GetIssueDetails)
 	})
 
 	// Conversation endpoints (top-level for direct access)

--- a/backend/server/router_test.go
+++ b/backend/server/router_test.go
@@ -36,7 +36,7 @@ func setupTestRouter(t *testing.T) (http.Handler, *store.SQLiteStore) {
 	t.Cleanup(func() { prCache.Close() })
 
 	// Create router without orchestrator, branch watcher, pr watcher, or stats cache
-	router := NewRouter(s, hub, agentMgr, ghClient, nil, nil, nil, prCache, nil, nil)
+	router := NewRouter(s, hub, agentMgr, ghClient, nil, nil, nil, prCache, nil, nil, nil)
 
 	return router, s
 }

--- a/backend/server/testhelpers_test.go
+++ b/backend/server/testhelpers_test.go
@@ -33,7 +33,7 @@ func setupTestHandlers(t *testing.T) (*Handlers, *store.SQLiteStore) {
 		prCache.Close()
 	})
 
-	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil)
+	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil)
 
 	return handlers, sqliteStore
 }
@@ -55,7 +55,7 @@ func setupTestHandlersWithAgentManager(t *testing.T) (*Handlers, *store.SQLiteSt
 		prCache.Close()
 	})
 
-	handlers := NewHandlers(sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil)
+	handlers := NewHandlers(sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil)
 
 	return handlers, sqliteStore, agentManager
 }


### PR DESCRIPTION
## Summary

Adds GitHub Issues support with list, search, and get-details endpoints. Implements stale-while-revalidate caching with ETag support to minimize API calls, PR filtering, and rate limiting on search.

## Implementation

- `backend/github/issues.go` – API client methods for listing, searching, and fetching issues
- `backend/github/issues_cache.go` – Time-based cache with stale-while-revalidate pattern
- `backend/server/issue_handlers.go` – HTTP handlers for three new endpoints
- Comprehensive test coverage (~1300 lines) for all code paths and concurrency scenarios

## Review Fixes

Fixed code review feedback: TotalCount now reflects actual issue count after PR filtering, aligned error handling for unauthenticated/no-remote cases, and removed potential goroutine leak in background refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)