### PR TITLE
fix: address code review feedback on copy button error handling

### DIFF
--- a/src/components/BranchSyncBanner.tsx
+++ b/src/components/BranchSyncBanner.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState } from 'react';
+import { copyToClipboard } from '@/lib/tauri';
+import { useToast } from '@/components/ui/toast';
 import { Button } from '@/components/ui/button';
 import {
   HoverCard,
@@ -39,6 +41,7 @@ export function BranchSyncBanner({
   onMerge,
   onDismiss,
 }: BranchSyncBannerProps) {
+  const toast = useToast();
   const [copiedSha, setCopiedSha] = useState<string | null>(null);
 
   if (status.behindBy === 0) {
@@ -46,12 +49,12 @@ export function BranchSyncBanner({
   }
 
   const handleCopySha = async (sha: string) => {
-    try {
-      await navigator.clipboard.writeText(sha);
+    const success = await copyToClipboard(sha);
+    if (success) {
       setCopiedSha(sha);
       setTimeout(() => setCopiedSha(null), 2000);
-    } catch (err) {
-      console.error('Failed to copy SHA:', err);
+    } else {
+      toast.error('Failed to copy to clipboard');
     }
   };
 

--- a/src/components/ci/CIFailureAnalysis.tsx
+++ b/src/components/ci/CIFailureAnalysis.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { type WorkflowJobDTO, type CIAnalysisResult, getCIJobLogs } from '@/lib/api';
+import { copyToClipboard } from '@/lib/tauri';
+import { useToast } from '@/components/ui/toast';
 import { Button } from '@/components/ui/button';
 import {
   X,
@@ -33,6 +35,7 @@ export function CIFailureAnalysis({
   onClose,
   onAnalyze,
 }: CIFailureAnalysisProps) {
+  const toast = useToast();
   const [loading, setLoading] = useState(true);
   const [logs, setLogs] = useState<string | null>(null);
   const [analysis, setAnalysis] = useState<CIAnalysisResult | null>(null);
@@ -73,9 +76,13 @@ export function CIFailureAnalysis({
 
   const handleCopyLogs = async () => {
     if (!logs) return;
-    await navigator.clipboard.writeText(logs);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    const success = await copyToClipboard(logs);
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } else {
+      toast.error('Failed to copy logs to clipboard');
+    }
   };
 
   return (

--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -22,6 +22,8 @@ import {
   Wand2,
 } from 'lucide-react';
 import { BranchCleanupDialog } from '@/components/dialogs/branch-cleanup/BranchCleanupDialog';
+import { copyToClipboard } from '@/lib/tauri';
+import { useToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 import { getWorkspaceColor } from '@/lib/workspace-colors';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -210,6 +212,7 @@ const GROUP_SORT_ORDER = ['session', 'main', 'master', 'feature', 'fix', 'releas
 export function BranchesDashboard({
   workspaceId,
 }: BranchesDashboardProps) {
+  const toast = useToast();
   const [branchData, setBranchData] = useState<BranchListResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -386,7 +389,10 @@ export function BranchesDashboard({
       label: 'Copy branch name',
       icon: <Copy className="h-4 w-4" />,
       shortcut: '⌘C',
-      onClick: () => navigator.clipboard.writeText(branch.name),
+      onClick: async () => {
+        const success = await copyToClipboard(branch.name);
+        if (!success) toast.error('Failed to copy to clipboard');
+      },
     });
 
     // View on GitHub (placeholder - would need repo info)
@@ -397,7 +403,7 @@ export function BranchesDashboard({
     // });
 
     return items;
-  }, [handleJumpToSession]);
+  }, [handleJumpToSession, toast]);
 
   // Define columns for the data table
   const columns: Column<BranchDTO>[] = useMemo(() => [

--- a/src/components/dashboards/PRDashboard.tsx
+++ b/src/components/dashboards/PRDashboard.tsx
@@ -13,7 +13,8 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from '@/components/ui/hover-card';
-import { isTauri } from '@/lib/tauri';
+import { isTauri, copyToClipboard } from '@/lib/tauri';
+import { useToast } from '@/components/ui/toast';
 import { getLabelStyles } from '@/lib/label-colors';
 import { useTheme } from 'next-themes';
 import {
@@ -319,6 +320,7 @@ function RepositoryCell({ pr }: { pr: PRWithStatus }) {
 export function PRDashboard({
   initialWorkspaceId,
 }: PRDashboardProps) {
+  const toast = useToast();
   const [prs, setPRs] = useState<PRDashboardItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -452,26 +454,31 @@ export function PRDashboard({
     items.push({ label: '', onClick: () => {}, separator: true });
 
     // Copy actions
+    const handleCopy = async (text: string) => {
+      const success = await copyToClipboard(text);
+      if (!success) toast.error('Failed to copy to clipboard');
+    };
+
     items.push({
       label: 'Copy PR URL',
       icon: <Copy className="h-4 w-4" />,
-      onClick: () => navigator.clipboard.writeText(pr.htmlUrl),
+      onClick: () => handleCopy(pr.htmlUrl),
     });
 
     items.push({
       label: 'Copy PR Number',
       icon: <Copy className="h-4 w-4" />,
-      onClick: () => navigator.clipboard.writeText(`#${pr.number}`),
+      onClick: () => handleCopy(`#${pr.number}`),
     });
 
     items.push({
       label: 'Copy Branch Name',
       icon: <GitBranch className="h-4 w-4" />,
-      onClick: () => navigator.clipboard.writeText(pr.branch),
+      onClick: () => handleCopy(pr.branch),
     });
 
     return items;
-  }, [handleJumpToSession, handleSendMessage]);
+  }, [handleJumpToSession, handleSendMessage, toast]);
 
   // Define columns for the data table
   const columns: Column<PRWithStatus>[] = useMemo(() => [

--- a/src/components/dashboards/RepositoriesDashboard.tsx
+++ b/src/components/dashboards/RepositoriesDashboard.tsx
@@ -20,7 +20,8 @@ import {
 } from 'lucide-react';
 import type { Workspace } from '@/lib/types';
 import { getWorkspaceColor } from '@/lib/workspace-colors';
-import { showInFinder, openInTerminal } from '@/lib/tauri';
+import { showInFinder, openInTerminal, copyToClipboard } from '@/lib/tauri';
+import { useToast } from '@/components/ui/toast';
 
 interface RepositoriesDashboardProps {
   onOpenProject: () => void;
@@ -114,6 +115,7 @@ export function RepositoriesDashboard({
   onOpenWorkspaceSettings,
   showLeftSidebar,
 }: RepositoriesDashboardProps) {
+  const toast = useToast();
   const workspaces = useAppStore((s) => s.workspaces);
   const sessions = useAppStore((s) => s.sessions);
   const removeWorkspace = useAppStore((s) => s.removeWorkspace);
@@ -186,7 +188,10 @@ export function RepositoriesDashboard({
       {
         label: 'Copy Path',
         icon: <Copy className="h-4 w-4" />,
-        onClick: () => navigator.clipboard.writeText(workspace.path),
+        onClick: async () => {
+          const success = await copyToClipboard(workspace.path);
+          if (!success) toast.error('Failed to copy to clipboard');
+        },
       },
       { label: '', onClick: () => {}, separator: true },
       {
@@ -199,7 +204,7 @@ export function RepositoriesDashboard({
         },
       },
     ];
-  }, [onOpenWorkspaceSettings, removeWorkspace]);
+  }, [onOpenWorkspaceSettings, removeWorkspace, toast]);
 
   // Define columns for the data table
   const columns: Column<Workspace & { sessionCount: number }>[] = useMemo(() => [

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -14,6 +14,8 @@ import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useShortcut } from '@/hooks/useShortcut';
 import { navigate } from '@/lib/navigation';
+import { copyToClipboard } from '@/lib/tauri';
+import { useToast } from '@/components/ui/toast';
 import { getShortcutById, formatShortcutKeys } from '@/lib/shortcuts';
 import type { LucideIcon } from 'lucide-react';
 import {
@@ -71,7 +73,7 @@ interface Command {
   available?: () => boolean;
   hasSubmenu?: boolean;
   submenuId?: string;
-  action: () => void;
+  action: () => unknown;
 }
 
 interface SubmenuPage {
@@ -85,7 +87,7 @@ interface SubmenuItem {
   label: string;
   description?: string;
   icon?: LucideIcon;
-  action: () => void;
+  action: () => unknown;
 }
 
 // ============================================================================
@@ -316,11 +318,12 @@ const COMMANDS: Command[] = [
       const sessionId = useAppStore.getState().selectedSessionId;
       return sessionId !== null;
     },
-    action: () => {
+    action: async () => {
       const { selectedSessionId, sessions } = useAppStore.getState();
       const session = sessions.find((s) => s.id === selectedSessionId);
       if (session?.branch) {
-        navigator.clipboard.writeText(session.branch);
+        const success = await copyToClipboard(session.branch);
+        if (!success) throw new Error('Failed to copy branch name to clipboard');
       }
     },
   },
@@ -487,6 +490,7 @@ function ShortcutHint({ shortcutId }: { shortcutId: string }) {
 // ============================================================================
 
 export function CommandPalette() {
+  const toast = useToast();
   const [open, setOpen] = useState(false);
   const [pages, setPages] = useState<string[]>([]);
   const [search, setSearch] = useState('');
@@ -563,6 +567,17 @@ export function CommandPalette() {
     [search, pages.length]
   );
 
+  // Run an action, catching any thrown errors and showing a toast
+  const runAction = useCallback(
+    (action: () => unknown) => {
+      Promise.resolve(action()).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Command failed';
+        toast.error(message);
+      });
+    },
+    [toast]
+  );
+
   // Execute command and track in recents
   const executeCommand = useCallback(
     (cmd: Command) => {
@@ -578,10 +593,10 @@ export function CommandPalette() {
         if (cmd.category === 'Navigation') {
           window.dispatchEvent(new CustomEvent('close-settings'));
         }
-        cmd.action();
+        runAction(cmd.action);
       }
     },
-    [addRecentCommand]
+    [addRecentCommand, runAction]
   );
 
   // Execute submenu item
@@ -591,8 +606,8 @@ export function CommandPalette() {
     setSearch('');
     // Close any overlays (like settings page) when navigating
     window.dispatchEvent(new CustomEvent('close-settings'));
-    item.action();
-  }, []);
+    runAction(item.action);
+  }, [runAction]);
 
   // Go back to previous page
   const goBack = useCallback(() => {

--- a/src/components/files/CodeViewer.tsx
+++ b/src/components/files/CodeViewer.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils';
 import { MonacoEditor, MonacoDiffEditor } from '@/components/files/MonacoEditor';
 import { COPY_FEEDBACK_DURATION_MS } from '@/lib/constants';
 import { copyToClipboard } from '@/lib/tauri';
+import { useToast } from '@/components/ui/toast';
 import { getShikiLanguage } from '@/lib/languageMapping';
 import type { ReviewComment } from '@/lib/types';
 
@@ -61,6 +62,7 @@ export function CodeViewer({
   onCreateComment,
 }: CodeViewerProps) {
   const { resolvedTheme } = useTheme();
+  const toast = useToast();
   const [copied, setCopied] = useState(false);
   const [viewMode, setViewMode] = useState<'code' | 'rendered'>('code');
   const [diffViewMode, setDiffViewMode] = useState<'split' | 'unified'>('unified');
@@ -76,6 +78,8 @@ export function CodeViewer({
     if (success) {
       setCopied(true);
       setTimeout(() => setCopied(false), COPY_FEEDBACK_DURATION_MS);
+    } else {
+      toast.error('Failed to copy to clipboard');
     }
   };
 

--- a/src/components/session-manager/SessionsDataTable.tsx
+++ b/src/components/session-manager/SessionsDataTable.tsx
@@ -17,6 +17,7 @@ import { TaskStatusSelector } from '@/components/shared/TaskStatusSelector';
 import { getPriorityOption, getTaskStatusOption } from '@/lib/session-fields';
 import { useAppStore } from '@/stores/appStore';
 import { updateSession as apiUpdateSession } from '@/lib/api';
+import { copyToClipboard } from '@/lib/tauri';
 import { useToast } from '@/components/ui/toast';
 
 // Row type for the data table
@@ -85,7 +86,8 @@ export function SessionsDataTable({
     );
 
   const storeUpdateSession = useAppStore((s) => s.updateSession);
-  const { error: showError } = useToast();
+  const toast = useToast();
+  const showError = toast.error;
 
   const handlePriorityChange = useCallback((session: WorktreeSession, value: SessionPriority) => {
     const prev = session.priority;
@@ -244,12 +246,15 @@ export function SessionsDataTable({
       items.push({
         label: 'Copy branch name',
         icon: <Copy className="h-4 w-4" />,
-        onClick: () => navigator.clipboard.writeText(row.session.branch),
+        onClick: async () => {
+          const success = await copyToClipboard(row.session.branch);
+          if (!success) toast.error('Failed to copy to clipboard');
+        },
       });
 
       return items;
     },
-    [onSelectSession, onArchiveSession, onUnarchiveSession]
+    [onSelectSession, onArchiveSession, onUnarchiveSession, toast]
   );
 
   // Display options configuration


### PR DESCRIPTION
## Summary

Addresses all three code review comments on the copy button silent failure fix:

1. **CommandPalette**: Made clipboard action async and now shows a toast when copying fails
2. **PRDashboard**: Extracted `handleCopy` helper to reduce code repetition across three similar copy actions
3. **SessionsDataTable**: Aligned toast usage style with the rest of the PR

## Changes

- Updated `Command` and `SubmenuItem` action signatures to support async operations
- Added `runAction` wrapper to catch errors and display toast notifications
- Consolidated duplicate copy handler logic in PRDashboard using a helper function
- Unified toast error API usage across all modified components

🤖 Generated with Claude Code