### PR TITLE
fix: use user's $SHELL in terminal fallback chain (CM-46)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -246,6 +246,20 @@ pub fn get_image_dimensions(path: String) -> Result<ImageDimensions, String> {
     Err("Unsupported image format".to_string())
 }
 
+/// Get the user's preferred shell from environment variables.
+/// Returns $SHELL on Unix or %COMSPEC% on Windows, if set.
+#[tauri::command]
+pub fn get_user_shell() -> Option<String> {
+    #[cfg(unix)]
+    {
+        std::env::var("SHELL").ok()
+    }
+    #[cfg(windows)]
+    {
+        std::env::var("COMSPEC").ok()
+    }
+}
+
 /// Count lines in a text file
 #[tauri::command]
 pub fn count_file_lines(path: String) -> Result<usize, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -146,7 +146,9 @@ pub fn run() {
             commands::read_file_metadata,
             commands::read_file_as_base64,
             commands::get_image_dimensions,
-            commands::count_file_lines
+            commands::count_file_lines,
+            // Shell detection
+            commands::get_user_shell
         ])
         .setup(move |app| {
             // Create and set the menu

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -5,6 +5,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { SearchAddon } from '@xterm/addon-search';
 import { spawn, type IPty } from 'tauri-pty';
+import { invoke } from '@tauri-apps/api/core';
 
 // Platform detection with modern API fallback
 function detectPlatform(): 'windows' | 'unix' {
@@ -18,16 +19,23 @@ function detectPlatform(): 'windows' | 'unix' {
   return 'unix';
 }
 
-// Get shell fallback chain based on platform
-function getShellFallbackChain(): string[] {
-  if (detectPlatform() === 'windows') {
-    return ['powershell.exe', 'pwsh.exe', 'cmd.exe'];
+// Get shell fallback chain based on platform, preferring the user's $SHELL
+async function getShellFallbackChain(): Promise<string[]> {
+  const defaults =
+    detectPlatform() === 'windows'
+      ? ['powershell.exe', 'pwsh.exe', 'cmd.exe']
+      : ['/bin/zsh', '/bin/bash', '/bin/sh'];
+
+  try {
+    const userShell = await invoke<string | null>('get_user_shell');
+    if (userShell) {
+      return [userShell, ...defaults.filter(s => s !== userShell)];
+    }
+  } catch {
+    // Invoke failed (e.g. running outside Tauri) — use defaults
   }
 
-  // Unix (macOS/Linux): /bin/zsh -> /bin/bash -> /bin/sh
-  // Note: process.env.SHELL isn't available in browser/Tauri context,
-  // so we rely on a fixed fallback chain starting with common defaults.
-  return ['/bin/zsh', '/bin/bash', '/bin/sh'];
+  return defaults;
 }
 
 // Terminal theme matching the app's dark theme
@@ -157,7 +165,7 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
       const initPty = async () => {
         if (cleanupCalled) return;
 
-        const shellChain = getShellFallbackChain();
+        const shellChain = await getShellFallbackChain();
         let lastError: unknown = null;
 
         for (const shell of shellChain) {


### PR DESCRIPTION
## Summary
Add a Tauri command to read the user's preferred shell from environment variables and prepend it to the fallback chain. Fixes CM-46: missing shell fallback in useTerminal causes spawn failures.

## Changes
- Add `get_user_shell()` Tauri command that reads `$SHELL` (Unix) or `%COMSPEC%` (Windows)
- Update `getShellFallbackChain()` to fetch and prioritize the user's preferred shell
- Always respect user preference by promoting it to first position, even if it matches a default

## Test Plan
- Verify terminal spawns with user's `$SHELL` as first option
- Confirm fallback chain works if shell invocation fails
- Test on both Unix and Windows platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)