### PR TITLE
fix: register archived sessions with file watcher on startup

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -542,10 +542,18 @@ func (h *Handlers) ListRepos(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, repos)
 }
 
+// ArchivedSessionDirJSON is the JSON representation of an archived session's directory info.
+// Used by the frontend to register archived worktrees with the file watcher.
+type ArchivedSessionDirJSON struct {
+	DirName   string `json:"dirName"`
+	SessionID string `json:"sessionId"`
+}
+
 // DashboardData represents the combined data for initial dashboard load
 type DashboardData struct {
-	Workspaces []*models.Repo              `json:"workspaces"`
-	Sessions   []*SessionWithConversations `json:"sessions"`
+	Workspaces          []*models.Repo              `json:"workspaces"`
+	Sessions            []*SessionWithConversations  `json:"sessions"`
+	ArchivedSessionDirs []ArchivedSessionDirJSON     `json:"archivedSessionDirs"`
 }
 
 // SessionWithConversations embeds session data with its conversations
@@ -566,6 +574,22 @@ func (h *Handlers) GetDashboardData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fetch archived session dirs for file watcher registration
+	archivedDirs, err := h.store.ListArchivedSessionDirs(ctx)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	archivedSessionDirs := make([]ArchivedSessionDirJSON, 0, len(archivedDirs))
+	for _, d := range archivedDirs {
+		if d.WorktreePath != "" {
+			archivedSessionDirs = append(archivedSessionDirs, ArchivedSessionDirJSON{
+				DirName:   filepath.Base(d.WorktreePath),
+				SessionID: d.ID,
+			})
+		}
+	}
+
 	// Fetch all sessions across all workspaces in a single query
 	// Pass false to exclude archived sessions from dashboard data
 	allSessions, err := h.store.ListAllSessions(ctx, false)
@@ -577,8 +601,9 @@ func (h *Handlers) GetDashboardData(w http.ResponseWriter, r *http.Request) {
 	// Early return if no sessions
 	if len(allSessions) == 0 {
 		writeJSON(w, DashboardData{
-			Workspaces: repos,
-			Sessions:   []*SessionWithConversations{},
+			Workspaces:          repos,
+			Sessions:            []*SessionWithConversations{},
+			ArchivedSessionDirs: archivedSessionDirs,
 		})
 		return
 	}
@@ -654,8 +679,9 @@ func (h *Handlers) GetDashboardData(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, DashboardData{
-		Workspaces: repos,
-		Sessions:   sessionsWithConvs,
+		Workspaces:          repos,
+		Sessions:            sessionsWithConvs,
+		ArchivedSessionDirs: archivedSessionDirs,
 	})
 }
 

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -793,6 +793,35 @@ func (s *SQLiteStore) ListAllSessions(ctx context.Context, includeArchived bool)
 	return sessions, nil
 }
 
+// ArchivedSessionDir holds the minimal info needed to register an archived session with the file watcher.
+type ArchivedSessionDir struct {
+	ID           string
+	WorktreePath string
+}
+
+// ListArchivedSessionDirs returns id and worktree_path for archived sessions.
+// This is a lightweight query used to register archived worktrees with the file watcher.
+func (s *SQLiteStore) ListArchivedSessionDirs(ctx context.Context) ([]ArchivedSessionDir, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, worktree_path FROM sessions WHERE archived = 1`)
+	if err != nil {
+		return nil, fmt.Errorf("ListArchivedSessionDirs: %w", err)
+	}
+	defer rows.Close()
+
+	var dirs []ArchivedSessionDir
+	for rows.Next() {
+		var d ArchivedSessionDir
+		if err := rows.Scan(&d.ID, &d.WorktreePath); err != nil {
+			return nil, fmt.Errorf("ListArchivedSessionDirs scan: %w", err)
+		}
+		dirs = append(dirs, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ListArchivedSessionDirs rows: %w", err)
+	}
+	return dirs, nil
+}
+
 func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, updates func(*models.Session)) error {
 	// Read current state outside retry to avoid stale data on retry
 	session, err := s.getSessionNoLock(ctx, id)

--- a/backend/store/sqlite_test.go
+++ b/backend/store/sqlite_test.go
@@ -448,6 +448,43 @@ func TestListAllSessions_ReadsArchivedField(t *testing.T) {
 	assert.True(t, sessions[0].Archived, "Archived field should be read from DB")
 }
 
+func TestListArchivedSessionDirs(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	createTestRepo(t, s, "ws-1")
+
+	// Create three sessions, archive two of them
+	createTestSession(t, s, "s1", "ws-1")
+	createTestSession(t, s, "s2", "ws-1")
+	createTestSession(t, s, "s3", "ws-1")
+
+	// Set worktree paths and archive s1 and s3
+	require.NoError(t, s.UpdateSession(ctx, "s1", func(sess *models.Session) {
+		sess.WorktreePath = "/worktrees/session-s1"
+		sess.Archived = true
+	}))
+	require.NoError(t, s.UpdateSession(ctx, "s2", func(sess *models.Session) {
+		sess.WorktreePath = "/worktrees/session-s2"
+	}))
+	require.NoError(t, s.UpdateSession(ctx, "s3", func(sess *models.Session) {
+		sess.WorktreePath = "/worktrees/session-s3"
+		sess.Archived = true
+	}))
+
+	dirs, err := s.ListArchivedSessionDirs(ctx)
+	require.NoError(t, err)
+	assert.Len(t, dirs, 2, "should return only archived sessions")
+
+	// Verify returned data
+	dirMap := make(map[string]string)
+	for _, d := range dirs {
+		dirMap[d.ID] = d.WorktreePath
+	}
+	assert.Equal(t, "/worktrees/session-s1", dirMap["s1"])
+	assert.Equal(t, "/worktrees/session-s3", dirMap["s3"])
+	assert.NotContains(t, dirMap, "s2", "non-archived session should not be returned")
+}
+
 func TestUpdateSession_SetArchived(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -498,6 +498,13 @@ export default function Home() {
           }
         }
 
+        // Register archived sessions so the file watcher doesn't log noise for their worktrees
+        if (dashboardData.archivedSessionDirs) {
+          for (const entry of dashboardData.archivedSessionDirs) {
+            registerSession(entry.dirName, entry.sessionId);
+          }
+        }
+
         // Map conversations (already included in the batch response)
         const allConversations = dashboardData.sessions.flatMap(s =>
           s.conversations.map(conversationToConversation)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1150,9 +1150,15 @@ export interface SessionWithConversationsDTO extends SessionDTO {
   conversations: ConversationDTO[];
 }
 
+export interface ArchivedSessionDirDTO {
+  dirName: string;
+  sessionId: string;
+}
+
 export interface DashboardDataDTO {
   workspaces: RepoDTO[];
   sessions: SessionWithConversationsDTO[];
+  archivedSessionDirs?: ArchivedSessionDirDTO[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Archived sessions have worktrees on disk (they're restorable) but weren't registered with the Tauri file watcher, causing noisy "Ignoring event for unregistered session" debug logs on every file change event
- Adds a lightweight `ListArchivedSessionDirs` query (only `id` + `worktree_path`) to the SQLite store
- Extends the dashboard API response with `archivedSessionDirs` so the frontend registers them with the watcher at startup — archived sessions stay hidden from the UI

## Test plan
- [x] `go test ./...` — all backend tests pass, including new `TestListArchivedSessionDirs`
- [x] `go build ./...` — backend compiles cleanly
- [x] `npm run build` — frontend compiles cleanly
- [ ] Run `make dev`, archive a session, restart the app, and confirm "Ignoring event for unregistered session" logs no longer appear for that session

🤖 Generated with [Claude Code](https://claude.com/claude-code)