### PR TITLE
fix: prevent infinite spinner from tool tracking race condition (CM-73)

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -849,27 +849,28 @@ function handleMessage(message: SDKMessage): void {
         for (const block of content) {
           if (block.type === "tool_result") {
             const toolInfo = activeTools.get(block.tool_use_id);
-            if (toolInfo) {
-              // Flush any buffered text before tool ends
-              flushBlockBuffer();
 
-              const duration = Date.now() - toolInfo.startTime;
-              // Determine success from content
-              const isError = block.is_error === true;
-              let summary = "";
+            // Flush any buffered text before tool ends
+            // Safe for untracked tools — flushBlockBuffer is a no-op when buffer is empty
+            flushBlockBuffer();
 
-              // Try to extract a summary from the result
-              if (typeof block.content === "string") {
-                summary = block.content.slice(0, 100);
-              } else if (Array.isArray(block.content)) {
-                const textContent = block.content.find(
-                  (c: { type: string }) => c.type === "text"
-                );
-                if (textContent && "text" in textContent) {
-                  summary = (textContent as { text: string }).text.slice(0, 100);
-                }
+            const isError = block.is_error === true;
+            let summary = "";
+
+            // Try to extract a summary from the result
+            if (typeof block.content === "string") {
+              summary = block.content.slice(0, 100);
+            } else if (Array.isArray(block.content)) {
+              const textContent = block.content.find(
+                (c: { type: string }) => c.type === "text"
+              );
+              if (textContent && "text" in textContent) {
+                summary = (textContent as { text: string }).text.slice(0, 100);
               }
+            }
 
+            if (toolInfo) {
+              const duration = Date.now() - toolInfo.startTime;
               trackToolEnd(duration);
               emit({
                 type: "tool_end",
@@ -879,8 +880,22 @@ function handleMessage(message: SDKMessage): void {
                 summary,
                 duration,
               });
-
               activeTools.delete(block.tool_use_id);
+            } else {
+              // Race condition: tool_result arrived but tool_start was never tracked.
+              // Emit tool_end anyway to prevent infinite spinner on frontend.
+              console.warn(
+                `[WARNING] tool_result for untracked tool_use_id: ${block.tool_use_id}`
+              );
+              emit({
+                type: "tool_end",
+                id: block.tool_use_id,
+                tool: "Unknown",
+                success: !isError,
+                summary,
+                duration: 0,
+                untracked: true,
+              });
             }
           }
         }

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -609,6 +609,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     selectConversation,
     setStreaming,
     setAwaitingPlanApproval,
+    clearActiveTools,
   } = useAppStore();
   const { error: showError } = useToast();
 
@@ -1115,6 +1116,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       await stopConversation(selectedConversationId);
       setStreaming(selectedConversationId, false);
       updateConversation(selectedConversationId, { status: 'idle' });
+      clearActiveTools(selectedConversationId);
     } catch (error) {
       console.error('Failed to stop conversation:', error);
       showError('Failed to stop conversation. Please try again.');

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -204,18 +204,31 @@ export function useWebSocket(enabled: boolean = true) {
         // Complete active tool with success/summary info
         // For Bash tools, also capture stdout/stderr
         if (event?.id) {
-          // Check tool name BEFORE completing (to avoid race condition with state update)
           const activeTool = store.activeTools[conversationId]?.find(t => t.id === event.id);
-          const isExitPlanMode = activeTool?.tool === 'ExitPlanMode';
-
           const stdout = event.stdout as string | undefined;
           const stderr = event.stderr as string | undefined;
-          store.completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr);
 
-          // Clear awaiting plan approval when ExitPlanMode completes
-          if (isExitPlanMode) {
-            store.setAwaitingPlanApproval(conversationId, false);
+          if (activeTool) {
+            // Normal path: tool exists in state
+            const isExitPlanMode = activeTool.tool === 'ExitPlanMode';
+            store.completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr);
+
+            if (isExitPlanMode) {
+              store.setAwaitingPlanApproval(conversationId, false);
+            }
+          } else if (event.tool) {
+            // Race condition recovery: tool_end arrived but tool wasn't in state.
+            // Create a synthetic completed entry so the timeline shows it as finished.
+            console.warn(`[WebSocket] tool_end for untracked tool: ${event.id} (${event.tool})`);
+            store.addActiveTool(conversationId, {
+              id: event.id,
+              tool: event.tool as string,
+              startTime: Date.now(),
+              untracked: true,
+            }, { skipTimeout: true });
+            store.completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr);
           }
+          // If no tool name and not in state, silently skip - tool was never shown to user
         }
         break;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,6 +118,7 @@ export interface ActiveTool {
   summary?: string;
   stdout?: string;
   stderr?: string;
+  untracked?: boolean; // Tool result arrived without matching tool_start (race condition recovery)
 }
 
 // Setup info for system messages

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -27,6 +27,32 @@ import type {
 // Maximum number of file tabs before LRU eviction kicks in
 const MAX_FILE_TABS = 10;
 
+// Timeout tracking for orphaned tool cleanup
+const toolTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+// Maximum time a tool can be active before forced completion (5 minutes)
+const TOOL_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Clear all tool timeouts for a given conversation */
+function clearToolTimeoutsForConversation(conversationId: string, tools: { id: string }[]) {
+  for (const tool of tools) {
+    const key = `${conversationId}:${tool.id}`;
+    const timeout = toolTimeouts.get(key);
+    if (timeout) {
+      clearTimeout(timeout);
+      toolTimeouts.delete(key);
+    }
+  }
+}
+
+/** Clear all tool timeouts globally (for HMR, tests, or app teardown) */
+export function clearAllToolTimeouts() {
+  for (const timeout of toolTimeouts.values()) {
+    clearTimeout(timeout);
+  }
+  toolTimeouts.clear();
+}
+
 // Default streaming state for a conversation (avoids repeating defaults across actions)
 const DEFAULT_STREAMING: StreamingState = {
   text: '',
@@ -226,7 +252,7 @@ interface AppState {
   clearThinking: (conversationId: string) => void;
   setPlanModeActive: (conversationId: string, active: boolean) => void;
   setAwaitingPlanApproval: (conversationId: string, awaiting: boolean) => void;
-  addActiveTool: (conversationId: string, tool: ActiveTool) => void;
+  addActiveTool: (conversationId: string, tool: ActiveTool, opts?: { skipTimeout?: boolean }) => void;
   completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string) => void;
   clearActiveTools: (conversationId: string) => void;
 
@@ -952,54 +978,130 @@ updateFileTabContent: (id, content) => set((state) => ({
       awaitingPlanApproval: awaiting,
     }),
   })),
-  addActiveTool: (conversationId, tool) => set((state) => ({
-    activeTools: {
-      ...state.activeTools,
-      [conversationId]: [...(state.activeTools[conversationId] || []), tool],
-    },
-    // Seal current text segment so next text creates a new segment after this tool
-    streamingState: updateStreamingConv(state.streamingState, conversationId, {
-      currentSegmentId: null,
-    }),
-  })),
-  completeActiveTool: (conversationId, toolId, success, summary, stdout, stderr) => set((state) => ({
-    activeTools: {
-      ...state.activeTools,
-      [conversationId]: (state.activeTools[conversationId] || []).map((t) =>
-        t.id === toolId
-          ? { ...t, endTime: Date.now(), success, summary, stdout, stderr }
-          : t
-      ),
-    },
-  })),
-  clearActiveTools: (conversationId) => set((state) => ({
-    activeTools: {
-      ...state.activeTools,
-      [conversationId]: [],
-    },
-  })),
+  addActiveTool: (conversationId, tool, opts) => {
+    // Set up timeout to force-complete orphaned tools (skip for synthetic entries that will be completed immediately)
+    if (!opts?.skipTimeout) {
+      const timeoutKey = `${conversationId}:${tool.id}`;
+      const existing = toolTimeouts.get(timeoutKey);
+      if (existing) clearTimeout(existing);
+
+      const timeout = setTimeout(() => {
+        toolTimeouts.delete(timeoutKey);
+        const current = useAppStore.getState().activeTools[conversationId] || [];
+        const stillActive = current.find(t => t.id === tool.id && !t.endTime);
+        if (stillActive) {
+          console.warn(`[Store] Tool timeout: ${tool.tool} (${tool.id}) - forcing completion after ${TOOL_TIMEOUT_MS}ms`);
+          useAppStore.getState().completeActiveTool(
+            conversationId, tool.id, false, 'Tool timed out', undefined, undefined
+          );
+        }
+      }, TOOL_TIMEOUT_MS);
+      toolTimeouts.set(timeoutKey, timeout);
+    }
+
+    return set((state) => ({
+      activeTools: {
+        ...state.activeTools,
+        [conversationId]: [...(state.activeTools[conversationId] || []), tool],
+      },
+      // Seal current text segment so next text creates a new segment after this tool
+      streamingState: updateStreamingConv(state.streamingState, conversationId, {
+        currentSegmentId: null,
+      }),
+    }));
+  },
+  completeActiveTool: (conversationId, toolId, success, summary, stdout, stderr) => {
+    // Clear the timeout for this tool
+    const timeoutKey = `${conversationId}:${toolId}`;
+    const timeout = toolTimeouts.get(timeoutKey);
+    if (timeout) {
+      clearTimeout(timeout);
+      toolTimeouts.delete(timeoutKey);
+    }
+
+    return set((state) => {
+      const tools = state.activeTools[conversationId] || [];
+      if (!tools.some(t => t.id === toolId)) {
+        return {}; // Tool not found - no-op (idempotent)
+      }
+      return {
+        activeTools: {
+          ...state.activeTools,
+          [conversationId]: tools.map((t) =>
+            t.id === toolId
+              ? { ...t, endTime: Date.now(), success, summary, stdout, stderr }
+              : t
+          ),
+        },
+      };
+    });
+  },
+  clearActiveTools: (conversationId) => {
+    // Clear all timeouts for this conversation's tools
+    const tools = useAppStore.getState().activeTools[conversationId] || [];
+    clearToolTimeoutsForConversation(conversationId, tools);
+
+    return set((state) => ({
+      activeTools: {
+        ...state.activeTools,
+        [conversationId]: [],
+      },
+    }));
+  },
 
   // Atomic streaming finalization - creates message and clears streaming in one update
   // This prevents the data loss bug where streaming text could be cleared before message is saved
-  finalizeStreamingMessage: (conversationId, metadata) => set((state) => {
-    const streaming = state.streamingState[conversationId];
+  finalizeStreamingMessage: (conversationId, metadata) => {
+    // Clear tool timeouts before clearing active tools
+    const currentTools = useAppStore.getState().activeTools[conversationId] || [];
+    clearToolTimeoutsForConversation(conversationId, currentTools);
 
-    // Build cleared streaming state (preserve planModeActive)
-    const clearedStreaming = {
-      text: '',
-      segments: [],
-      currentSegmentId: null,
-      isStreaming: false,
-      error: null,
-      thinking: null,
-      isThinking: false,
-      planModeActive: streaming?.planModeActive || false,
-      awaitingPlanApproval: false,
-    };
+    return set((state) => {
+      const streaming = state.streamingState[conversationId];
 
-    // If no streaming text, just clear the state
-    if (!streaming?.text) {
+      // Build cleared streaming state (preserve planModeActive)
+      const clearedStreaming = {
+        text: '',
+        segments: [],
+        currentSegmentId: null,
+        isStreaming: false,
+        error: null,
+        thinking: null,
+        isThinking: false,
+        planModeActive: streaming?.planModeActive || false,
+        awaitingPlanApproval: false,
+      };
+
+      // If no streaming text, just clear the state
+      if (!streaming?.text) {
+        return {
+          streamingState: {
+            ...state.streamingState,
+            [conversationId]: clearedStreaming,
+          },
+          activeTools: {
+            ...state.activeTools,
+            [conversationId]: [],
+          },
+        };
+      }
+
+      // Create the message from streaming text
+      const newMessage: Message = {
+        id: `msg-${Date.now()}`,
+        conversationId,
+        role: 'assistant',
+        content: streaming.text,
+        timestamp: new Date().toISOString(),
+        durationMs: metadata.durationMs,
+        toolUsage: metadata.toolUsage,
+        runSummary: metadata.runSummary,
+        ...(streaming.thinking ? { thinkingContent: streaming.thinking } : {}),
+      };
+
+      // Atomically: add message AND clear streaming state
       return {
+        messages: [...state.messages, newMessage],
         streamingState: {
           ...state.streamingState,
           [conversationId]: clearedStreaming,
@@ -1009,34 +1111,8 @@ updateFileTabContent: (id, content) => set((state) => ({
           [conversationId]: [],
         },
       };
-    }
-
-    // Create the message from streaming text
-    const newMessage: Message = {
-      id: `msg-${Date.now()}`,
-      conversationId,
-      role: 'assistant',
-      content: streaming.text,
-      timestamp: new Date().toISOString(),
-      durationMs: metadata.durationMs,
-      toolUsage: metadata.toolUsage,
-      runSummary: metadata.runSummary,
-      ...(streaming.thinking ? { thinkingContent: streaming.thinking } : {}),
-    };
-
-    // Atomically: add message AND clear streaming state
-    return {
-      messages: [...state.messages, newMessage],
-      streamingState: {
-        ...state.streamingState,
-        [conversationId]: clearedStreaming,
-      },
-      activeTools: {
-        ...state.activeTools,
-        [conversationId]: [],
-      },
-    };
-  }),
+    });
+  },
 
   // Todo actions
   setAgentTodos: (conversationId, todos) => set((state) => ({


### PR DESCRIPTION
## Summary
Fixes a race condition where `tool_end` events arrive before (or without) matching `tool_start` events, causing infinite spinners in the UI. Implements three layers of defensive protection: synthetic tool_end emission at the agent-runner level, synthetic tool creation at the WebSocket handler level, and a 5-minute timeout safety net in the Zustand store.

## Changes
- **agent-runner**: Emit `tool_end` for untracked tools to signal frontend immediately
- **WebSocket handler**: Create synthetic completed tool entries for late-arriving events
- **Zustand store**: Add 5-minute timeout to force-complete orphaned tools
- **Code review improvements**: Fixed indentation, added skipTimeout option to avoid timer churn, reordered state updates for consistency

## Testing
Compile and lint pass. Ready for testing against race condition scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)