### PR TITLE
feat: add customizable review prompt overrides (CM-80)

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -3492,6 +3492,81 @@ func (h *Handlers) SetPRTemplate(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]string{"status": "ok"})
 }
 
+// getReviewPrompts reads review prompt overrides from the given settings key.
+func (h *Handlers) getReviewPrompts(w http.ResponseWriter, ctx context.Context, key string) {
+	value, found, err := h.store.GetSetting(ctx, key)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if !found {
+		writeJSON(w, map[string]any{"prompts": map[string]string{}})
+		return
+	}
+
+	var prompts map[string]string
+	if err := json.Unmarshal([]byte(value), &prompts); err != nil {
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "corrupted review prompts data", err)
+		return
+	}
+
+	writeJSON(w, map[string]any{"prompts": prompts})
+}
+
+// setReviewPrompts writes review prompt overrides to the given settings key.
+func (h *Handlers) setReviewPrompts(w http.ResponseWriter, r *http.Request, key string) {
+	ctx := r.Context()
+
+	var req struct {
+		Prompts map[string]string `json:"prompts"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	if len(req.Prompts) == 0 {
+		if err := h.store.DeleteSetting(ctx, key); err != nil {
+			writeDBError(w, err)
+			return
+		}
+	} else {
+		data, err := json.Marshal(req.Prompts)
+		if err != nil {
+			writeValidationError(w, "failed to encode prompts")
+			return
+		}
+		if err := h.store.SetSetting(ctx, key, string(data)); err != nil {
+			writeDBError(w, err)
+			return
+		}
+	}
+
+	writeJSON(w, map[string]string{"status": "ok"})
+}
+
+// GetReviewPrompts returns the global custom review prompt overrides
+func (h *Handlers) GetReviewPrompts(w http.ResponseWriter, r *http.Request) {
+	h.getReviewPrompts(w, r.Context(), "review-prompts")
+}
+
+// SetReviewPrompts updates the global custom review prompt overrides
+func (h *Handlers) SetReviewPrompts(w http.ResponseWriter, r *http.Request) {
+	h.setReviewPrompts(w, r, "review-prompts")
+}
+
+// GetWorkspaceReviewPrompts returns the per-workspace custom review prompt overrides
+func (h *Handlers) GetWorkspaceReviewPrompts(w http.ResponseWriter, r *http.Request) {
+	workspaceID := chi.URLParam(r, "id")
+	h.getReviewPrompts(w, r.Context(), fmt.Sprintf("review-prompts:%s", workspaceID))
+}
+
+// SetWorkspaceReviewPrompts updates the per-workspace custom review prompt overrides
+func (h *Handlers) SetWorkspaceReviewPrompts(w http.ResponseWriter, r *http.Request) {
+	workspaceID := chi.URLParam(r, "id")
+	h.setReviewPrompts(w, r, fmt.Sprintf("review-prompts:%s", workspaceID))
+}
+
 // GetSessionBranchSyncStatus returns how far behind the session is from origin/main
 func (h *Handlers) GetSessionBranchSyncStatus(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -2157,6 +2157,207 @@ func TestSetPRTemplate_InvalidBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// ============================================================================
+// Review Prompts Settings Tests
+// ============================================================================
+
+func TestGetReviewPrompts_Empty(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("GET", "/api/settings/review-prompts", nil)
+	w := httptest.NewRecorder()
+
+	h.GetReviewPrompts(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]any{}, resp["prompts"].(map[string]any))
+}
+
+func TestSetReviewPrompts_Success(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	prompts := map[string]any{"prompts": map[string]string{"quick": "Also check accessibility"}}
+	body, _ := json.Marshal(prompts)
+	req := httptest.NewRequest("PUT", "/api/settings/review-prompts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.SetReviewPrompts(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify it was saved
+	req2 := httptest.NewRequest("GET", "/api/settings/review-prompts", nil)
+	w2 := httptest.NewRecorder()
+
+	h.GetReviewPrompts(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	p := resp["prompts"].(map[string]any)
+	assert.Equal(t, "Also check accessibility", p["quick"])
+}
+
+func TestSetReviewPrompts_EmptyDeletes(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.SetSetting(ctx, "review-prompts", `{"quick":"old"}`))
+
+	body, _ := json.Marshal(map[string]any{"prompts": map[string]string{}})
+	req := httptest.NewRequest("PUT", "/api/settings/review-prompts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.SetReviewPrompts(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify deleted
+	req2 := httptest.NewRequest("GET", "/api/settings/review-prompts", nil)
+	w2 := httptest.NewRecorder()
+	h.GetReviewPrompts(w2, req2)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]any{}, resp["prompts"].(map[string]any))
+}
+
+func TestSetReviewPrompts_InvalidBody(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("PUT", "/api/settings/review-prompts", bytes.NewReader([]byte("invalid")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.SetReviewPrompts(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetWorkspaceReviewPrompts_Empty(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/settings/review-prompts", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetWorkspaceReviewPrompts(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]any{}, resp["prompts"].(map[string]any))
+}
+
+func TestSetWorkspaceReviewPrompts_Success(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	prompts := map[string]any{"prompts": map[string]string{"security": "Check OWASP top 10"}}
+	body, _ := json.Marshal(prompts)
+	req := httptest.NewRequest("PUT", "/api/repos/ws-1/settings/review-prompts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.SetWorkspaceReviewPrompts(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify saved
+	req2 := httptest.NewRequest("GET", "/api/repos/ws-1/settings/review-prompts", nil)
+	req2 = withChiContext(req2, map[string]string{"id": "ws-1"})
+	w2 := httptest.NewRecorder()
+
+	h.GetWorkspaceReviewPrompts(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	p := resp["prompts"].(map[string]any)
+	assert.Equal(t, "Check OWASP top 10", p["security"])
+}
+
+func TestSetWorkspaceReviewPrompts_IsolatedPerWorkspace(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	// Set for ws-1
+	body1, _ := json.Marshal(map[string]any{"prompts": map[string]string{"quick": "ws1 instructions"}})
+	req1 := httptest.NewRequest("PUT", "/api/repos/ws-1/settings/review-prompts", bytes.NewReader(body1))
+	req1.Header.Set("Content-Type", "application/json")
+	req1 = withChiContext(req1, map[string]string{"id": "ws-1"})
+	w1 := httptest.NewRecorder()
+	h.SetWorkspaceReviewPrompts(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// ws-2 should still be empty
+	req2 := httptest.NewRequest("GET", "/api/repos/ws-2/settings/review-prompts", nil)
+	req2 = withChiContext(req2, map[string]string{"id": "ws-2"})
+	w2 := httptest.NewRecorder()
+	h.GetWorkspaceReviewPrompts(w2, req2)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]any{}, resp["prompts"].(map[string]any))
+}
+
+func TestReviewPrompts_GlobalAndWorkspaceIsolated(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	// Set a global prompt
+	globalBody, _ := json.Marshal(map[string]any{"prompts": map[string]string{"quick": "global instructions"}})
+	req1 := httptest.NewRequest("PUT", "/api/settings/review-prompts", bytes.NewReader(globalBody))
+	req1.Header.Set("Content-Type", "application/json")
+	w1 := httptest.NewRecorder()
+	h.SetReviewPrompts(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// Workspace endpoint should still be empty
+	req2 := httptest.NewRequest("GET", "/api/repos/ws-1/settings/review-prompts", nil)
+	req2 = withChiContext(req2, map[string]string{"id": "ws-1"})
+	w2 := httptest.NewRecorder()
+	h.GetWorkspaceReviewPrompts(w2, req2)
+
+	var wsResp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &wsResp))
+	assert.Equal(t, map[string]any{}, wsResp["prompts"].(map[string]any))
+
+	// Set a workspace prompt
+	wsBody, _ := json.Marshal(map[string]any{"prompts": map[string]string{"security": "workspace instructions"}})
+	req3 := httptest.NewRequest("PUT", "/api/repos/ws-1/settings/review-prompts", bytes.NewReader(wsBody))
+	req3.Header.Set("Content-Type", "application/json")
+	req3 = withChiContext(req3, map[string]string{"id": "ws-1"})
+	w3 := httptest.NewRecorder()
+	h.SetWorkspaceReviewPrompts(w3, req3)
+	assert.Equal(t, http.StatusOK, w3.Code)
+
+	// Global should still only have "quick", not "security"
+	req4 := httptest.NewRequest("GET", "/api/settings/review-prompts", nil)
+	w4 := httptest.NewRecorder()
+	h.GetReviewPrompts(w4, req4)
+
+	var globalResp map[string]any
+	require.NoError(t, json.Unmarshal(w4.Body.Bytes(), &globalResp))
+	gp := globalResp["prompts"].(map[string]any)
+	assert.Equal(t, "global instructions", gp["quick"])
+	assert.Nil(t, gp["security"])
+}
+
+func TestGetReviewPrompts_CorruptedData(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	// Store invalid JSON
+	require.NoError(t, s.SetSetting(ctx, "review-prompts", "not-json"))
+
+	req := httptest.NewRequest("GET", "/api/settings/review-prompts", nil)
+	w := httptest.NewRecorder()
+	h.GetReviewPrompts(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 func TestGeneratePRDescription_NoAIClient(t *testing.T) {
 	h, _ := setupTestHandlers(t) // handlers created with nil aiClient
 

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -97,6 +97,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Post("/{id}/sessions/{sessionId}/pr/create", h.CreatePR)
 		r.Get("/{id}/settings/pr-template", h.GetPRTemplate)
 		r.Put("/{id}/settings/pr-template", h.SetPRTemplate)
+		r.Get("/{id}/settings/review-prompts", h.GetWorkspaceReviewPrompts)
+		r.Put("/{id}/settings/review-prompts", h.SetWorkspaceReviewPrompts)
 		r.Get("/{id}/sessions/{sessionId}/branch-sync", h.GetSessionBranchSyncStatus)
 		r.Post("/{id}/sessions/{sessionId}/branch-sync", h.SyncSessionBranch)
 		r.Post("/{id}/sessions/{sessionId}/branch-sync/abort", h.AbortSessionSync)
@@ -154,6 +156,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	// Settings endpoints
 	r.Get("/api/settings/workspaces-base-dir", h.GetWorkspacesBaseDir)
 	r.Put("/api/settings/workspaces-base-dir", h.SetWorkspacesBaseDir)
+	r.Get("/api/settings/review-prompts", h.GetReviewPrompts)
+	r.Put("/api/settings/review-prompts", h.SetReviewPrompts)
 
 	// Attachment endpoints
 	r.Get("/api/attachments/{attachmentId}/data", h.GetAttachmentData)

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -67,13 +67,17 @@ import { PrioritySelector } from '@/components/shared/PrioritySelector';
 // ---------------------------------------------------------------------------
 
 const REVIEW_TYPES = [
-  { icon: Zap, title: 'Quick Scan', description: 'Fast pass over changes — catch obvious issues and typos' },
-  { icon: Search, title: 'Deep Review', description: 'Thorough line-by-line analysis with detailed feedback' },
-  { icon: Shield, title: 'Security Audit', description: 'Focus on vulnerabilities, auth gaps, and injection risks' },
-  { icon: Gauge, title: 'Performance', description: 'Check for regressions, memory leaks, and slow paths' },
-  { icon: Boxes, title: 'Architecture', description: 'Evaluate design patterns, coupling, and separation of concerns' },
-  { icon: GitMerge, title: 'Pre-merge Check', description: 'Final review before merge — verify tests, conflicts, and coverage' },
+  { icon: Zap, title: 'Quick Scan', key: 'quick', description: 'Fast pass over changes — catch obvious issues and typos' },
+  { icon: Search, title: 'Deep Review', key: 'deep', description: 'Thorough line-by-line analysis with detailed feedback' },
+  { icon: Shield, title: 'Security Audit', key: 'security', description: 'Focus on vulnerabilities, auth gaps, and injection risks' },
+  { icon: Gauge, title: 'Performance', key: 'performance', description: 'Check for regressions, memory leaks, and slow paths' },
+  { icon: Boxes, title: 'Architecture', key: 'architecture', description: 'Evaluate design patterns, coupling, and separation of concerns' },
+  { icon: GitMerge, title: 'Pre-merge Check', key: 'premerge', description: 'Final review before merge — verify tests, conflicts, and coverage' },
 ] as const;
+
+function dispatchReview(type: string) {
+  window.dispatchEvent(new CustomEvent('start-review', { detail: { type } }));
+}
 
 // ---------------------------------------------------------------------------
 // SessionTitle — inline editable title using session.task
@@ -161,6 +165,7 @@ export function SessionToolbarContent() {
   const { success: showSuccess, error: showError, warning: showWarning } = useToast();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showCreatePRDialog, setShowCreatePRDialog] = useState(false);
+  const [reviewPopoverOpen, setReviewPopoverOpen] = useState(false);
   const { requestArchive, dialogProps: archiveDialogProps } = useArchiveSession({
     onSuccess: () => showSuccess('Session archived'),
     onError: () => showError('Failed to archive session'),
@@ -314,11 +319,12 @@ export function SessionToolbarContent() {
                 variant={reviewVariant}
                 size="sm"
                 className="h-6 px-2 gap-1.5 text-xs rounded-r-none rounded-l-sm border-r-0 transition-none"
+                onClick={() => dispatchReview('quick')}
               >
                 <Eye className="h-3.5 w-3.5" />
                 Review
               </Button>
-              <Popover>
+              <Popover open={reviewPopoverOpen} onOpenChange={setReviewPopoverOpen}>
                 <PopoverTrigger asChild>
                   <Button
                     variant={reviewVariant}
@@ -336,6 +342,10 @@ export function SessionToolbarContent() {
                     <button
                       key={type.title}
                       className="w-full text-left rounded-md px-3 py-2.5 hover:bg-accent transition-colors"
+                      onClick={() => {
+                        dispatchReview(type.key);
+                        setReviewPopoverOpen(false);
+                      }}
                     >
                       <div className="flex items-start gap-3">
                         <type.icon className="h-4 w-4 mt-0.5 text-muted-foreground" />
@@ -411,7 +421,7 @@ export function SessionToolbarContent() {
         ),
       },
     };
-  }, [selectedWorkspace, selectedSession, selectedWorkspaceId, handleGitActionMessage, handleNewConversation, handleCopyBranch, handleArchive, requestArchive, handleTaskStatusChange, handlePriorityChange]);
+  }, [selectedWorkspace, selectedSession, selectedWorkspaceId, handleGitActionMessage, handleNewConversation, handleCopyBranch, handleArchive, requestArchive, handleTaskStatusChange, handlePriorityChange, reviewPopoverOpen]);
 
   useMainToolbarContent(toolbarConfig);
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -35,8 +35,11 @@ import {
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { openFolderDialog, setMinimizeToTray, requestNotificationPermission } from '@/lib/tauri';
-import { getWorkspacesBasePath, setWorkspacesBasePath } from '@/lib/api';
+import { getWorkspacesBasePath, setWorkspacesBasePath, getGlobalReviewPrompts, setGlobalReviewPrompts } from '@/lib/api';
 import { EDITOR_THEMES } from '@/lib/monacoThemes';
+import { REVIEW_PROMPTS, REVIEW_TYPE_META } from '@/hooks/useReviewTrigger';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/toast';
 
 interface SettingsPageProps {
   onBack: () => void;
@@ -46,6 +49,7 @@ type SettingsCategory =
   | 'chat'
   | 'appearance'
   | 'git'
+  | 'review'
   | 'env'
   | 'claude-code'
   | 'account'
@@ -65,6 +69,7 @@ const mainNavItems: NavItem[] = [
   { id: 'chat', label: 'Chat', icon: <MessageSquare className="w-3.5 h-3.5" /> },
   { id: 'appearance', label: 'Appearance', icon: <Palette className="w-3.5 h-3.5" /> },
   { id: 'git', label: 'Git', icon: <GitBranch className="w-3.5 h-3.5" /> },
+  { id: 'review', label: 'Review', icon: <Eye className="w-3.5 h-3.5" /> },
   { id: 'env', label: 'Env', icon: <FileCode className="w-3.5 h-3.5" /> },
   { id: 'claude-code', label: 'Claude Code', icon: <Bot className="w-3.5 h-3.5" /> },
   { id: 'account', label: 'Account', icon: <User className="w-3.5 h-3.5" /> },
@@ -171,6 +176,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
             {selectedCategory === 'chat' && <ChatSettings />}
             {selectedCategory === 'appearance' && <AppearanceSettings />}
             {selectedCategory === 'git' && <GitSettings />}
+            {selectedCategory === 'review' && <ReviewSettings />}
             {selectedCategory === 'env' && <EnvSettings />}
             {selectedCategory === 'claude-code' && <ClaudeCodeSettings />}
             {selectedCategory === 'account' && <AccountSettings />}
@@ -804,6 +810,80 @@ function UpdatesSettings() {
       <p className="text-sm text-muted-foreground">
         ChatML is up to date.
       </p>
+    </div>
+  );
+}
+
+function ReviewSettings() {
+  const [prompts, setPrompts] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const { error: showError } = useToast();
+
+  useEffect(() => {
+    getGlobalReviewPrompts()
+      .then((data) => {
+        setPrompts(data);
+        setSaved(data);
+      })
+      .catch(() => {
+        showError('Failed to load review prompts');
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const hasChanges = JSON.stringify(prompts) !== JSON.stringify(saved);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      // Filter out empty strings before saving
+      const cleaned: Record<string, string> = {};
+      for (const [k, v] of Object.entries(prompts)) {
+        if (v.trim()) cleaned[k] = v.trim();
+      }
+      await setGlobalReviewPrompts(cleaned);
+      setPrompts(cleaned);
+      setSaved(cleaned);
+    } catch {
+      showError('Failed to save review prompts');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-1">Review</h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        Add custom instructions that will be appended to each review type&apos;s default prompt.
+        These apply globally. Per-workspace overrides can be set in workspace settings.
+      </p>
+
+      <div className="space-y-5">
+        {REVIEW_TYPE_META.map(({ key, label, placeholder }) => (
+          <div key={key}>
+            <label className="text-[13px] font-medium block mb-1.5">{label}</label>
+            <p className="text-[11px] text-muted-foreground mb-1.5 line-clamp-1">
+              Default: {REVIEW_PROMPTS[key]?.slice(0, 80)}…
+            </p>
+            <Textarea
+              className="text-[13px] min-h-[60px]"
+              placeholder={placeholder}
+              value={prompts[key] || ''}
+              onChange={(e) => setPrompts((prev) => ({ ...prev, [key]: e.target.value }))}
+            />
+          </div>
+        ))}
+      </div>
+
+      {hasChanges && (
+        <div className="mt-4 flex justify-end">
+          <Button size="sm" disabled={saving} onClick={handleSave}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -1,27 +1,41 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import { getRepoDetails, type RepoDetailsDTO } from '@/lib/api';
+import {
+  getRepoDetails,
+  type RepoDetailsDTO,
+  getGlobalReviewPrompts,
+  getWorkspaceReviewPrompts,
+  setWorkspaceReviewPrompts,
+} from '@/lib/api';
+import { REVIEW_PROMPTS, REVIEW_TYPE_META } from '@/hooks/useReviewTrigger';
+import { useToast } from '@/components/ui/toast';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import {
   ArrowLeft,
+  Eye,
   GitBranch,
   FolderOpen,
   Globe,
   ExternalLink,
 } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface WorkspaceSettingsProps {
   workspaceId: string;
   onBack: () => void;
 }
 
+type WorkspaceSettingsSection = 'repository' | 'review';
+
 export function WorkspaceSettings({ workspaceId, onBack }: WorkspaceSettingsProps) {
   const workspaces = useAppStore((s) => s.workspaces);
   const workspace = workspaces.find((w) => w.id === workspaceId);
   const [repoDetails, setRepoDetails] = useState<RepoDetailsDTO | null>(null);
+  const [section, setSection] = useState<WorkspaceSettingsSection>('repository');
 
   // Fetch repo details on mount
   useEffect(() => {
@@ -79,6 +93,30 @@ export function WorkspaceSettings({ workspaceId, onBack }: WorkspaceSettingsProp
               <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
                 {workspace.name}
               </div>
+              <Button
+                variant={section === 'repository' ? 'secondary' : 'ghost'}
+                size="sm"
+                className={cn(
+                  'w-full justify-start gap-2 h-7 text-[12px]',
+                  section === 'repository' && 'bg-sidebar-accent',
+                )}
+                onClick={() => setSection('repository')}
+              >
+                <FolderOpen className="w-3.5 h-3.5" />
+                Repository
+              </Button>
+              <Button
+                variant={section === 'review' ? 'secondary' : 'ghost'}
+                size="sm"
+                className={cn(
+                  'w-full justify-start gap-2 h-7 text-[12px]',
+                  section === 'review' && 'bg-sidebar-accent',
+                )}
+                onClick={() => setSection('review')}
+              >
+                <Eye className="w-3.5 h-3.5" />
+                Review
+              </Button>
             </div>
           </div>
         </ScrollArea>
@@ -91,69 +129,166 @@ export function WorkspaceSettings({ workspaceId, onBack }: WorkspaceSettingsProp
 
         <ScrollArea className="flex-1">
           <div className="max-w-2xl mx-auto py-8 px-8">
-            {/* Repository Info Section */}
-            <div className="mb-8">
-              <h2 className="text-xl font-semibold mb-5">Repository</h2>
-
-              <div className="space-y-4">
-                <div className="flex items-start gap-3 py-3 border-b border-border/50">
-                  <FolderOpen className="w-4 h-4 mt-0.5 text-muted-foreground" />
-                  <div className="flex-1">
-                    <h4 className="text-[13px] font-medium">Path</h4>
-                    <p className="text-[12px] text-muted-foreground mt-0.5 font-mono">
-                      {workspace.path}
-                    </p>
-                  </div>
-                </div>
-
-                {repoDetails?.workspacesPath && (
-                  <div className="flex items-start gap-3 py-3 border-b border-border/50">
-                    <FolderOpen className="w-4 h-4 mt-0.5 text-muted-foreground" />
-                    <div className="flex-1">
-                      <h4 className="text-[13px] font-medium">Workspaces Path</h4>
-                      <p className="text-[12px] text-muted-foreground mt-0.5 font-mono">
-                        {repoDetails.workspacesPath}
-                      </p>
-                    </div>
-                  </div>
-                )}
-
-                <div className="flex items-start gap-3 py-3 border-b border-border/50">
-                  <GitBranch className="w-4 h-4 mt-0.5 text-muted-foreground" />
-                  <div className="flex-1">
-                    <h4 className="text-[13px] font-medium">Default Branch</h4>
-                    <p className="text-[12px] text-muted-foreground mt-0.5">
-                      {workspace.defaultBranch || 'main'}
-                    </p>
-                  </div>
-                </div>
-
-                {repoDetails?.remoteUrl && (
-                  <div className="flex items-start gap-3 py-3 border-b border-border/50">
-                    <Globe className="w-4 h-4 mt-0.5 text-muted-foreground" />
-                    <div className="flex-1">
-                      <h4 className="text-[13px] font-medium">Remote Origin</h4>
-                      <div className="flex items-center gap-2 mt-0.5">
-                        <p className="text-[12px] text-muted-foreground font-mono">
-                          git+{repoDetails.remoteUrl}.git
-                        </p>
-                        <a
-                          href={repoDetails.remoteUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-primary hover:text-primary/80 transition-colors"
-                        >
-                          <ExternalLink className="w-3 h-3" />
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
+            {section === 'repository' && (
+              <RepositorySection workspace={workspace} repoDetails={repoDetails} />
+            )}
+            {section === 'review' && (
+              <WorkspaceReviewSettings workspaceId={workspaceId} />
+            )}
           </div>
         </ScrollArea>
       </div>
+    </div>
+  );
+}
+
+function RepositorySection({
+  workspace,
+  repoDetails,
+}: {
+  workspace: { name: string; path: string; defaultBranch: string };
+  repoDetails: RepoDetailsDTO | null;
+}) {
+  return (
+    <div className="mb-8">
+      <h2 className="text-xl font-semibold mb-5">Repository</h2>
+
+      <div className="space-y-4">
+        <div className="flex items-start gap-3 py-3 border-b border-border/50">
+          <FolderOpen className="w-4 h-4 mt-0.5 text-muted-foreground" />
+          <div className="flex-1">
+            <h4 className="text-[13px] font-medium">Path</h4>
+            <p className="text-[12px] text-muted-foreground mt-0.5 font-mono">
+              {workspace.path}
+            </p>
+          </div>
+        </div>
+
+        {repoDetails?.workspacesPath && (
+          <div className="flex items-start gap-3 py-3 border-b border-border/50">
+            <FolderOpen className="w-4 h-4 mt-0.5 text-muted-foreground" />
+            <div className="flex-1">
+              <h4 className="text-[13px] font-medium">Workspaces Path</h4>
+              <p className="text-[12px] text-muted-foreground mt-0.5 font-mono">
+                {repoDetails.workspacesPath}
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-start gap-3 py-3 border-b border-border/50">
+          <GitBranch className="w-4 h-4 mt-0.5 text-muted-foreground" />
+          <div className="flex-1">
+            <h4 className="text-[13px] font-medium">Default Branch</h4>
+            <p className="text-[12px] text-muted-foreground mt-0.5">
+              {workspace.defaultBranch || 'main'}
+            </p>
+          </div>
+        </div>
+
+        {repoDetails?.remoteUrl && (
+          <div className="flex items-start gap-3 py-3 border-b border-border/50">
+            <Globe className="w-4 h-4 mt-0.5 text-muted-foreground" />
+            <div className="flex-1">
+              <h4 className="text-[13px] font-medium">Remote Origin</h4>
+              <div className="flex items-center gap-2 mt-0.5">
+                <p className="text-[12px] text-muted-foreground font-mono">
+                  git+{repoDetails.remoteUrl}.git
+                </p>
+                <a
+                  href={repoDetails.remoteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:text-primary/80 transition-colors"
+                >
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceReviewSettings({ workspaceId }: { workspaceId: string }) {
+  const [prompts, setPrompts] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState<Record<string, string>>({});
+  const [globalPrompts, setGlobalPrompts] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const { error: showError } = useToast();
+
+  useEffect(() => {
+    Promise.all([
+      getWorkspaceReviewPrompts(workspaceId).catch(() => ({} as Record<string, string>)),
+      getGlobalReviewPrompts().catch(() => ({} as Record<string, string>)),
+    ]).then(([ws, gl]) => {
+      setPrompts(ws);
+      setSaved(ws);
+      setGlobalPrompts(gl);
+    });
+  }, [workspaceId]);
+
+  const hasChanges = JSON.stringify(prompts) !== JSON.stringify(saved);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const cleaned: Record<string, string> = {};
+      for (const [k, v] of Object.entries(prompts)) {
+        if (v.trim()) cleaned[k] = v.trim();
+      }
+      await setWorkspaceReviewPrompts(workspaceId, cleaned);
+      setPrompts(cleaned);
+      setSaved(cleaned);
+    } catch {
+      showError('Failed to save review prompts');
+    } finally {
+      setSaving(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, prompts]);
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-1">Review Prompts</h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        Override the global review prompt settings for this workspace.
+        Leave empty to use the global default.
+      </p>
+
+      <div className="space-y-5">
+        {REVIEW_TYPE_META.map(({ key, label, placeholder }) => {
+          const globalOverride = globalPrompts[key];
+          const effectivePlaceholder = globalOverride
+            ? `Global: ${globalOverride.slice(0, 60)}…`
+            : placeholder;
+
+          return (
+            <div key={key}>
+              <label className="text-[13px] font-medium block mb-1.5">{label}</label>
+              <p className="text-[11px] text-muted-foreground mb-1.5 line-clamp-1">
+                Default: {REVIEW_PROMPTS[key]?.slice(0, 80)}…
+              </p>
+              <Textarea
+                className="text-[13px] min-h-[60px]"
+                placeholder={effectivePlaceholder}
+                value={prompts[key] || ''}
+                onChange={(e) => setPrompts((prev) => ({ ...prev, [key]: e.target.value }))}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {hasChanges && (
+        <div className="mt-4 flex justify-end">
+          <Button size="sm" disabled={saving} onClick={handleSave}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -1,6 +1,10 @@
 import { useEffect } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import { createConversation } from '@/lib/api';
+import {
+  createConversation,
+  getGlobalReviewPrompts,
+  getWorkspaceReviewPrompts,
+} from '@/lib/api';
 import { useSelectedIds } from '@/stores/selectors';
 
 const REVIEW_PROMPTS: Record<string, string> = {
@@ -10,11 +14,51 @@ const REVIEW_PROMPTS: Record<string, string> = {
     'Do a thorough code review of all changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each issue found. Check for bugs, performance problems, security issues, error handling gaps, and code quality. Be detailed and specific.',
   security:
     'Perform a security audit on the changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each security concern. Look for injection vulnerabilities, authentication/authorization issues, data exposure, insecure defaults, and other OWASP top 10 risks.',
+  performance:
+    'Review the changes in this session for performance issues. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each concern. Look for unnecessary re-renders, memory leaks, expensive computations in hot paths, missing memoization, N+1 queries, and blocking operations. Call get_review_comment_stats at the end to summarize.',
+  architecture:
+    'Review the changes in this session for architectural quality. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each concern. Evaluate separation of concerns, coupling between modules, adherence to existing patterns in the codebase, SOLID principles, and appropriate abstractions. Call get_review_comment_stats at the end to summarize.',
+  premerge:
+    'Perform a final pre-merge check on the changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each issue. Check for leftover TODOs, console.logs, debug code, commented-out code, missing error handling, incomplete implementations, and anything that should not be merged. Call get_review_comment_stats at the end to summarize.',
 };
 
+const REVIEW_TYPE_META: { key: string; label: string; placeholder: string }[] = [
+  { key: 'quick', label: 'Quick Scan', placeholder: 'e.g., Also check for accessibility issues' },
+  { key: 'deep', label: 'Deep Review', placeholder: 'e.g., Pay attention to test coverage gaps' },
+  { key: 'security', label: 'Security Audit', placeholder: 'e.g., Check for OWASP top 10 specifically' },
+  { key: 'performance', label: 'Performance', placeholder: 'e.g., Watch for unnecessary re-renders in React' },
+  { key: 'architecture', label: 'Architecture', placeholder: 'e.g., We follow hexagonal architecture' },
+  { key: 'premerge', label: 'Pre-merge Check', placeholder: 'e.g., Ensure all TODO comments reference a ticket' },
+];
+
 /**
- * Listens for `start-review` CustomEvents (dispatched by slash commands and command palette)
- * and creates a review conversation with the appropriate prompt.
+ * Fetches global and per-workspace overrides and merges them.
+ * Per-workspace overrides take precedence over global.
+ */
+async function fetchMergedOverrides(workspaceId: string): Promise<Record<string, string>> {
+  const [global, workspace] = await Promise.all([
+    getGlobalReviewPrompts().catch(() => ({} as Record<string, string>)),
+    getWorkspaceReviewPrompts(workspaceId).catch(() => ({} as Record<string, string>)),
+  ]);
+  const merged: Record<string, string> = {};
+  for (const key of Object.keys(REVIEW_PROMPTS)) {
+    const ws = workspace[key];
+    const gl = global[key];
+    if (ws) {
+      merged[key] = ws;
+    } else if (gl) {
+      merged[key] = gl;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Listens for `start-review` CustomEvents (dispatched by slash commands, command palette,
+ * and toolbar review buttons) and creates a review conversation with the appropriate prompt.
+ *
+ * Fetches global and per-workspace custom prompt overrides inline when the review
+ * is triggered, then appends them to the built-in default prompt.
  */
 export function useReviewTrigger() {
   const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
@@ -31,7 +75,20 @@ export function useReviewTrigger() {
     const handler = async (e: Event) => {
       const customEvent = e as CustomEvent<{ type?: string }>;
       const reviewType = customEvent.detail?.type || 'quick';
-      const message = REVIEW_PROMPTS[reviewType] || REVIEW_PROMPTS.quick;
+      const basePrompt = REVIEW_PROMPTS[reviewType] || REVIEW_PROMPTS.quick;
+
+      // Fetch overrides inline to avoid stale-cache race condition
+      let extra: string | undefined;
+      try {
+        const overrides = await fetchMergedOverrides(selectedWorkspaceId);
+        extra = overrides[reviewType];
+      } catch {
+        // Use base prompt without overrides
+      }
+
+      const message = extra
+        ? `${basePrompt}\n\nAdditional instructions:\n${extra}`
+        : basePrompt;
 
       try {
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
@@ -75,3 +132,6 @@ export function useReviewTrigger() {
     };
   }, [selectedWorkspaceId, selectedSessionId, addConversation, addMessage, selectConversation, setStreaming]);
 }
+
+/** Exported for use in settings UI */
+export { REVIEW_PROMPTS, REVIEW_TYPE_META };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1492,3 +1492,45 @@ export async function setPRTemplate(workspaceId: string, template: string): Prom
   );
   await handleVoidResponse(res, 'Failed to save PR template');
 }
+
+// ---------------------------------------------------------------------------
+// Review Prompt Overrides
+// ---------------------------------------------------------------------------
+
+export async function getGlobalReviewPrompts(): Promise<Record<string, string>> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/review-prompts`);
+  const data = await handleResponse<{ prompts: Record<string, string> }>(res);
+  return data.prompts;
+}
+
+export async function setGlobalReviewPrompts(prompts: Record<string, string>): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/review-prompts`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompts }),
+  });
+  await handleVoidResponse(res, 'Failed to save review prompts');
+}
+
+export async function getWorkspaceReviewPrompts(workspaceId: string): Promise<Record<string, string>> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/settings/review-prompts`
+  );
+  const data = await handleResponse<{ prompts: Record<string, string> }>(res);
+  return data.prompts;
+}
+
+export async function setWorkspaceReviewPrompts(
+  workspaceId: string,
+  prompts: Record<string, string>,
+): Promise<void> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/settings/review-prompts`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompts }),
+    },
+  );
+  await handleVoidResponse(res, 'Failed to save workspace review prompts');
+}


### PR DESCRIPTION
## Summary
- Add global and per-workspace custom review prompt overrides
- Users can append additional instructions to each review type (quick, deep, security, performance, architecture, pre-merge)
- Backend handlers refactored to use shared helpers; overrides fetched inline when reviews triggered to avoid stale-cache races
- Settings UI includes error toasts and shared review type metadata

## Test plan
- Go tests: global/workspace isolation, corrupted data handling, save/load happy paths
- Frontend lint passes with 0 errors
- Review trigger fetches overrides inline; custom prompts apply even on first click

🤖 Generated with [Claude Code](https://claude.com/claude-code)