### PR TITLE
feat: create session from PR or branch (CM-96)

### DIFF
--- a/backend/git/worktree.go
+++ b/backend/git/worktree.go
@@ -12,6 +12,12 @@ import (
 // ErrDirectoryExists indicates a name collision during atomic directory creation
 var ErrDirectoryExists = errors.New("directory already exists")
 
+// ErrBranchAlreadyCheckedOut indicates the branch is already in use by another worktree
+var ErrBranchAlreadyCheckedOut = errors.New("branch is already checked out in another worktree")
+
+// ErrLocalBranchExists indicates the local branch already exists (but is not checked out in a worktree)
+var ErrLocalBranchExists = errors.New("local branch already exists")
+
 // WorkspacesBaseDir returns the default base directory for session worktrees: ~/.chatml/workspaces
 func WorkspacesBaseDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
@@ -117,6 +123,52 @@ func (wm *WorktreeManager) CreateInExistingDir(ctx context.Context, repoPath, wo
 	}
 
 	return worktreePath, branchName, baseCommit, nil
+}
+
+// CheckoutExistingBranchInDir creates a worktree that checks out an existing remote branch.
+// Unlike CreateInExistingDir which creates a new branch with -b, this checks out an existing
+// remote branch (e.g. origin/feature-branch) and creates a local tracking branch.
+// The directory must already exist (created atomically by caller).
+// Returns the worktree path, local branch name, and the base commit SHA.
+func (wm *WorktreeManager) CheckoutExistingBranchInDir(ctx context.Context, repoPath, worktreePath, remoteBranch string) (string, string, string, error) {
+	// Fetch the specific branch from origin (targeted fetch is faster than fetching all refs)
+	cmd, cancel := gitCmdWithContext(ctx, repoPath, "fetch", "origin", remoteBranch)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		cancel()
+		return "", "", "", fmt.Errorf("failed to fetch origin: %s: %w", string(out), err)
+	}
+	cancel()
+
+	// Resolve the remote branch ref to get the base commit SHA
+	remoteRef := fmt.Sprintf("origin/%s", remoteBranch)
+	cmd, cancel = gitCmdWithContext(ctx, repoPath, "rev-parse", remoteRef)
+	out, err := cmd.Output()
+	cancel()
+	if err != nil {
+		return "", "", "", fmt.Errorf("remote branch '%s' not found on origin: %w", remoteBranch, err)
+	}
+	baseCommit := strings.TrimSpace(string(out))
+
+	// Create worktree with a local tracking branch using -b.
+	// "git worktree add -b <branch> --track <path> <remote-ref>" creates a local branch
+	// tracking the remote. Possible errors:
+	// - "already checked out" / "is already used by worktree" → branch is in use by another worktree
+	// - "already exists" → local branch exists but is not checked out in a worktree
+	cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "add", "-b", remoteBranch, "--track", worktreePath, remoteRef)
+	defer cancel()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		errMsg := string(out)
+		if strings.Contains(errMsg, "already checked out") ||
+			strings.Contains(errMsg, "is already used by worktree") {
+			return "", "", "", fmt.Errorf("%w: %s", ErrBranchAlreadyCheckedOut, errMsg)
+		}
+		if strings.Contains(errMsg, "already exists") {
+			return "", "", "", fmt.Errorf("%w: %s", ErrLocalBranchExists, errMsg)
+		}
+		return "", "", "", fmt.Errorf("failed to create worktree: %s: %w", errMsg, err)
+	}
+
+	return worktreePath, remoteBranch, baseCommit, nil
 }
 
 func (wm *WorktreeManager) Remove(ctx context.Context, repoPath, agentID string) error {

--- a/backend/git/worktree_test.go
+++ b/backend/git/worktree_test.go
@@ -466,6 +466,96 @@ func TestCreateInExistingDir_Success(t *testing.T) {
 }
 
 // ============================================================================
+// CheckoutExistingBranchInDir Tests
+// ============================================================================
+
+func TestCheckoutExistingBranchInDir_Success(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	wm := NewWorktreeManager()
+
+	// Create a branch and push it to origin so it exists as a remote branch
+	runGit(t, repoPath, "checkout", "-b", "feature/existing-branch")
+	writeFile(t, repoPath, "feature.txt", "feature content\n")
+	runGit(t, repoPath, "add", ".")
+	runGit(t, repoPath, "commit", "-m", "Add feature")
+	runGit(t, repoPath, "push", "origin", "feature/existing-branch")
+
+	// Go back to main so the branch isn't checked out
+	runGit(t, repoPath, "checkout", "main")
+	// Delete the local branch so only the remote ref exists
+	runGit(t, repoPath, "branch", "-D", "feature/existing-branch")
+
+	// Create directory first (simulating atomic creation)
+	sessionDir := filepath.Join(t.TempDir(), "test-session")
+	require.NoError(t, os.Mkdir(sessionDir, 0755))
+
+	// Checkout the existing remote branch
+	worktreePath, branch, baseCommit, err := wm.CheckoutExistingBranchInDir(context.Background(), repoPath, sessionDir, "feature/existing-branch")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		wm.RemoveAtPath(context.Background(), repoPath, sessionDir, "feature/existing-branch")
+	})
+
+	// Verify results
+	assert.Equal(t, sessionDir, worktreePath)
+	assert.Equal(t, "feature/existing-branch", branch)
+	assert.Len(t, baseCommit, 40, "base commit should be a valid SHA")
+
+	// Verify worktree is functional (has .git file)
+	gitFile := filepath.Join(sessionDir, ".git")
+	assert.FileExists(t, gitFile)
+
+	// Verify the feature file exists in the worktree
+	assert.FileExists(t, filepath.Join(sessionDir, "feature.txt"))
+}
+
+func TestCheckoutExistingBranchInDir_BranchNotFound(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	wm := NewWorktreeManager()
+
+	sessionDir := filepath.Join(t.TempDir(), "test-session")
+	require.NoError(t, os.Mkdir(sessionDir, 0755))
+
+	_, _, _, err := wm.CheckoutExistingBranchInDir(context.Background(), repoPath, sessionDir, "nonexistent-branch")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-branch")
+}
+
+func TestCheckoutExistingBranchInDir_LocalBranchExists(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	wm := NewWorktreeManager()
+
+	// Create a branch and push it to origin
+	runGit(t, repoPath, "checkout", "-b", "feature/shared-branch")
+	writeFile(t, repoPath, "shared.txt", "shared content\n")
+	runGit(t, repoPath, "add", ".")
+	runGit(t, repoPath, "commit", "-m", "Add shared")
+	runGit(t, repoPath, "push", "origin", "feature/shared-branch")
+	runGit(t, repoPath, "checkout", "main")
+	runGit(t, repoPath, "branch", "-D", "feature/shared-branch")
+
+	// First checkout should succeed — this creates the local branch
+	sessionDir1 := filepath.Join(t.TempDir(), "session-1")
+	require.NoError(t, os.Mkdir(sessionDir1, 0755))
+	_, _, _, err := wm.CheckoutExistingBranchInDir(context.Background(), repoPath, sessionDir1, "feature/shared-branch")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		wm.RemoveAtPath(context.Background(), repoPath, sessionDir1, "feature/shared-branch")
+	})
+
+	// Second checkout of the same branch fails because the local branch already exists
+	// (git worktree add -b errors with "already exists" when -b tries to create a branch
+	// that was already created by the first worktree)
+	sessionDir2 := filepath.Join(t.TempDir(), "session-2")
+	require.NoError(t, os.Mkdir(sessionDir2, 0755))
+	_, _, _, err = wm.CheckoutExistingBranchInDir(context.Background(), repoPath, sessionDir2, "feature/shared-branch")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrLocalBranchExists)
+}
+
+// ============================================================================
 // WorkspacesBaseDirWithOverride Tests
 // ============================================================================
 

--- a/backend/github/pr_status.go
+++ b/backend/github/pr_status.go
@@ -190,6 +190,116 @@ func (c *Client) GetPRDetails(ctx context.Context, owner, repo string, prNumber 
 	return details, nil
 }
 
+// PRFullDetails contains extended pull request information for session context
+type PRFullDetails struct {
+	Number       int       `json:"number"`
+	State        string    `json:"state"`
+	Title        string    `json:"title"`
+	HTMLURL      string    `json:"htmlUrl"`
+	Body         string    `json:"body"`
+	Branch       string    `json:"branch"`     // head ref (source branch)
+	BaseBranch   string    `json:"baseBranch"` // base ref (target branch)
+	IsDraft      bool      `json:"isDraft"`
+	Labels       []string  `json:"labels"`
+	Reviewers    []string  `json:"reviewers"`
+	Additions    int       `json:"additions"`
+	Deletions    int       `json:"deletions"`
+	ChangedFiles int       `json:"changedFiles"`
+}
+
+// githubPRFull extends the API response to decode additional fields
+type githubPRFull struct {
+	Number         int    `json:"number"`
+	State          string `json:"state"`
+	Title          string `json:"title"`
+	HTMLURL        string `json:"html_url"`
+	Body           string `json:"body"`
+	Draft          bool   `json:"draft"`
+	Additions      int    `json:"additions"`
+	Deletions      int    `json:"deletions"`
+	ChangedFiles   int    `json:"changed_files"`
+	Head           struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	RequestedReviewers []struct {
+		Login string `json:"login"`
+	} `json:"requested_reviewers"`
+}
+
+// GetPRFullDetails fetches extended pull request information including body, branch refs,
+// labels, reviewers, and diff stats. Used for the "create session from PR" flow.
+func (c *Client) GetPRFullDetails(ctx context.Context, owner, repo string, prNumber int) (*PRFullDetails, error) {
+	token := c.GetToken()
+	if token == "" {
+		return nil, fmt.Errorf("not authenticated")
+	}
+
+	prURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.apiURL, owner, repo, prNumber)
+	req, err := http.NewRequestWithContext(ctx, "GET", prURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating PR request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching PR: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("PR #%d not found in %s/%s", prNumber, owner, repo)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("GitHub returned %d (body unreadable: %v)", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
+	}
+
+	var pr githubPRFull
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, fmt.Errorf("decoding PR: %w", err)
+	}
+
+	labels := make([]string, len(pr.Labels))
+	for i, l := range pr.Labels {
+		labels[i] = l.Name
+	}
+
+	reviewers := make([]string, len(pr.RequestedReviewers))
+	for i, r := range pr.RequestedReviewers {
+		reviewers[i] = r.Login
+	}
+
+	return &PRFullDetails{
+		Number:       pr.Number,
+		State:        pr.State,
+		Title:        pr.Title,
+		HTMLURL:      pr.HTMLURL,
+		Body:         pr.Body,
+		Branch:       pr.Head.Ref,
+		BaseBranch:   pr.Base.Ref,
+		IsDraft:      pr.Draft,
+		Labels:       labels,
+		Reviewers:    reviewers,
+		Additions:    pr.Additions,
+		Deletions:    pr.Deletions,
+		ChangedFiles: pr.ChangedFiles,
+	}, nil
+}
+
 // GetPRDetailsBatch fetches details for multiple PRs concurrently with rate limiting.
 // Returns a map of PR number -> PRDetails and a slice of PR numbers that failed to fetch.
 // Uses goroutines with a semaphore to avoid overwhelming the GitHub API (default maxConcurrent is 5).

--- a/backend/github/pr_status_test.go
+++ b/backend/github/pr_status_test.go
@@ -462,3 +462,140 @@ func TestClient_FindPRForBranch_NotAuthenticated(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not authenticated")
 }
+
+// ============================================================================
+// GetPRFullDetails Tests
+// ============================================================================
+
+func TestClient_GetPRFullDetails_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/testowner/testrepo/pulls/42", r.URL.Path)
+		require.Equal(t, "Bearer test_token", r.Header.Get("Authorization"))
+
+		pr := map[string]interface{}{
+			"number":        42,
+			"state":         "open",
+			"title":         "Add new feature",
+			"html_url":      "https://github.com/testowner/testrepo/pull/42",
+			"body":          "This PR adds a great new feature.\n\nCloses #10",
+			"draft":         false,
+			"additions":     150,
+			"deletions":     30,
+			"changed_files": 5,
+			"head": map[string]string{
+				"ref": "feature/new-thing",
+				"sha": "abc123",
+			},
+			"base": map[string]string{
+				"ref": "main",
+			},
+			"labels": []map[string]string{
+				{"name": "enhancement"},
+				{"name": "needs-review"},
+			},
+			"requested_reviewers": []map[string]string{
+				{"login": "reviewer1"},
+				{"login": "reviewer2"},
+			},
+		}
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	details, err := client.GetPRFullDetails(context.Background(), "testowner", "testrepo", 42)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+
+	require.Equal(t, 42, details.Number)
+	require.Equal(t, "open", details.State)
+	require.Equal(t, "Add new feature", details.Title)
+	require.Equal(t, "https://github.com/testowner/testrepo/pull/42", details.HTMLURL)
+	require.Equal(t, "This PR adds a great new feature.\n\nCloses #10", details.Body)
+	require.Equal(t, "feature/new-thing", details.Branch)
+	require.Equal(t, "main", details.BaseBranch)
+	require.False(t, details.IsDraft)
+	require.Equal(t, 150, details.Additions)
+	require.Equal(t, 30, details.Deletions)
+	require.Equal(t, 5, details.ChangedFiles)
+	require.Equal(t, []string{"enhancement", "needs-review"}, details.Labels)
+	require.Equal(t, []string{"reviewer1", "reviewer2"}, details.Reviewers)
+}
+
+func TestClient_GetPRFullDetails_DraftPR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := map[string]interface{}{
+			"number":        7,
+			"state":         "open",
+			"title":         "WIP: Draft feature",
+			"html_url":      "https://github.com/testowner/testrepo/pull/7",
+			"body":          "",
+			"draft":         true,
+			"additions":     10,
+			"deletions":     0,
+			"changed_files": 1,
+			"head":          map[string]string{"ref": "draft-branch", "sha": "def456"},
+			"base":          map[string]string{"ref": "develop"},
+			"labels":        []map[string]string{},
+			"requested_reviewers": []map[string]string{},
+		}
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	details, err := client.GetPRFullDetails(context.Background(), "testowner", "testrepo", 7)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+
+	require.True(t, details.IsDraft)
+	require.Equal(t, "", details.Body)
+	require.Equal(t, "develop", details.BaseBranch)
+	require.Empty(t, details.Labels)
+	require.Empty(t, details.Reviewers)
+}
+
+func TestClient_GetPRFullDetails_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	_, err := client.GetPRFullDetails(context.Background(), "testowner", "testrepo", 999)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestClient_GetPRFullDetails_NotAuthenticated(t *testing.T) {
+	client := NewClient("", "")
+
+	_, err := client.GetPRFullDetails(context.Background(), "testowner", "testrepo", 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authenticated")
+}
+
+func TestClient_GetPRFullDetails_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message": "API rate limit exceeded"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	_, err := client.GetPRFullDetails(context.Background(), "testowner", "testrepo", 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+}

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -1096,6 +1097,10 @@ type CreateSessionRequest struct {
 	WorktreePath string `json:"worktreePath,omitempty"`
 	// Task is an optional description of what this session is for
 	Task string `json:"task,omitempty"`
+	// CheckoutExisting checks out an existing remote branch instead of creating a new one
+	CheckoutExisting bool `json:"checkoutExisting,omitempty"`
+	// SystemMessage is optional custom content for the initial system message (e.g. PR context)
+	SystemMessage string `json:"systemMessage,omitempty"`
 }
 
 func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
@@ -1114,6 +1119,11 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	var req CreateSessionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	if req.CheckoutExisting && req.Branch == "" {
+		writeValidationError(w, "branch is required when checkoutExisting is true")
 		return
 	}
 
@@ -1203,12 +1213,27 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	defer h.sessionLocks.Unlock(sessionPath)
 
 	// Create git worktree in the atomically created directory
-	worktreePath, branchName, baseCommitSHA, err := h.worktreeManager.CreateInExistingDir(ctx, repo.Path, sessionPath, branchName)
+	var worktreePath, baseCommitSHA string
+	if req.CheckoutExisting {
+		// Checkout an existing remote branch (e.g. a PR branch)
+		worktreePath, branchName, baseCommitSHA, err = h.worktreeManager.CheckoutExistingBranchInDir(ctx, repo.Path, sessionPath, branchName)
+	} else {
+		// Create a new branch (default behavior)
+		worktreePath, branchName, baseCommitSHA, err = h.worktreeManager.CreateInExistingDir(ctx, repo.Path, sessionPath, branchName)
+	}
 	if err != nil {
 		// Rollback: remove the atomically created directory and cache entry
 		h.sessionNameCache.Remove(sessionName)
 		if removeErr := os.RemoveAll(sessionPath); removeErr != nil {
 			logger.Handlers.Warnf("Failed to rollback session directory %s: %v", sessionPath, removeErr)
+		}
+		if errors.Is(err, git.ErrBranchAlreadyCheckedOut) {
+			writeConflict(w, fmt.Sprintf("branch '%s' is already checked out in another session", branchName))
+			return
+		}
+		if errors.Is(err, git.ErrLocalBranchExists) {
+			writeConflict(w, fmt.Sprintf("local branch '%s' already exists; delete it first or use a different branch name", branchName))
+			return
 		}
 		writeInternalError(w, "failed to create worktree", err)
 		return
@@ -1292,7 +1317,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	setupMsg := models.Message{
 		ID:      uuid.New().String()[:8],
 		Role:    "system",
-		Content: "",
+		Content: req.SystemMessage,
 		SetupInfo: &models.SetupInfo{
 			SessionName:  sess.Name,
 			BranchName:   sess.Branch,
@@ -3888,6 +3913,107 @@ type PRDashboardItem struct {
 	ChecksTotal  int `json:"checksTotal"`
 	ChecksPassed int `json:"checksPassed"`
 	ChecksFailed int `json:"checksFailed"`
+}
+
+// prURLPattern matches GitHub PR URLs like https://github.com/owner/repo/pull/123
+var prURLPattern = regexp.MustCompile(`github\.com/([^/]+)/([^/]+)/pull/(\d+)`)
+
+type ResolvePRRequest struct {
+	URL string `json:"url"`
+}
+
+type ResolvePRResponse struct {
+	Owner              string   `json:"owner"`
+	Repo               string   `json:"repo"`
+	PRNumber           int      `json:"prNumber"`
+	Title              string   `json:"title"`
+	Body               string   `json:"body"`
+	Branch             string   `json:"branch"`
+	BaseBranch         string   `json:"baseBranch"`
+	State              string   `json:"state"`
+	IsDraft            bool     `json:"isDraft"`
+	Labels             []string `json:"labels"`
+	Reviewers          []string `json:"reviewers"`
+	Additions          int      `json:"additions"`
+	Deletions          int      `json:"deletions"`
+	ChangedFiles       int      `json:"changedFiles"`
+	MatchedWorkspaceID string   `json:"matchedWorkspaceId,omitempty"`
+	HTMLURL            string   `json:"htmlUrl"`
+}
+
+// ResolvePR parses a GitHub PR URL and returns detailed PR information plus matched workspace
+func (h *Handlers) ResolvePR(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if h.ghClient == nil {
+		writeValidationError(w, "GitHub client not configured")
+		return
+	}
+
+	var req ResolvePRRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	// Parse PR URL
+	matches := prURLPattern.FindStringSubmatch(req.URL)
+	if matches == nil || len(matches) < 4 {
+		writeValidationError(w, "invalid GitHub PR URL: expected format github.com/owner/repo/pull/number")
+		return
+	}
+
+	owner := matches[1]
+	repoName := matches[2]
+	prNumber, err := strconv.Atoi(matches[3])
+	if err != nil {
+		writeValidationError(w, "invalid PR number in URL")
+		return
+	}
+
+	// Fetch full PR details from GitHub
+	prDetails, err := h.ghClient.GetPRFullDetails(ctx, owner, repoName, prNumber)
+	if err != nil {
+		writeInternalError(w, "failed to fetch PR details", err)
+		return
+	}
+
+	// Try to match the PR's repo to a registered workspace
+	var matchedWorkspaceID string
+	repos, err := h.store.ListRepos(ctx)
+	if err == nil {
+		for _, repo := range repos {
+			repoOwner, repoRepo, err := h.repoManager.GetGitHubRemote(ctx, repo.Path)
+			if err != nil {
+				continue
+			}
+			if strings.EqualFold(repoOwner, owner) && strings.EqualFold(repoRepo, repoName) {
+				matchedWorkspaceID = repo.ID
+				break
+			}
+		}
+	}
+
+	resp := ResolvePRResponse{
+		Owner:              owner,
+		Repo:               repoName,
+		PRNumber:           prDetails.Number,
+		Title:              prDetails.Title,
+		Body:               prDetails.Body,
+		Branch:             prDetails.Branch,
+		BaseBranch:         prDetails.BaseBranch,
+		State:              prDetails.State,
+		IsDraft:            prDetails.IsDraft,
+		Labels:             prDetails.Labels,
+		Reviewers:          prDetails.Reviewers,
+		Additions:          prDetails.Additions,
+		Deletions:          prDetails.Deletions,
+		ChangedFiles:       prDetails.ChangedFiles,
+		MatchedWorkspaceID: matchedWorkspaceID,
+		HTMLURL:            prDetails.HTMLURL,
+	}
+
+	writeJSON(w, resp)
 }
 
 // ListPRs returns all open PRs across workspaces fetched directly from GitHub

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/chatml/chatml-backend/agent"
 	"github.com/chatml/chatml-backend/ai"
 	"github.com/chatml/chatml-backend/git"
+	"github.com/chatml/chatml-backend/github"
 	"github.com/chatml/chatml-backend/models"
 	"github.com/chatml/chatml-backend/store"
 	"github.com/stretchr/testify/assert"
@@ -2899,4 +2900,446 @@ func TestGetActiveStreamingConversations_MixedProcesses(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, result["conversationIds"], 1)
 	assert.Contains(t, result["conversationIds"], "conv-running")
+}
+
+// ============================================================================
+// ResolvePR Handler Tests
+// ============================================================================
+
+// setupTestHandlersWithGitHub creates handlers with a mock GitHub client for testing
+func setupTestHandlersWithGitHub(t *testing.T, ghServer *httptest.Server) (*Handlers, *store.SQLiteStore) {
+	t.Helper()
+
+	sqliteStore, err := store.NewSQLiteStoreInMemory()
+	require.NoError(t, err)
+
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
+
+	ghClient := github.NewClient("", "")
+	ghClient.SetAPIURL(ghServer.URL)
+	ghClient.SetToken("test_token")
+
+	t.Cleanup(func() {
+		sqliteStore.Close()
+		prCache.Close()
+	})
+
+	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, ghClient, prCache, nil, nil, nil)
+
+	return handlers, sqliteStore
+}
+
+func TestResolvePR_Success(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/myorg/myrepo/pulls/42", r.URL.Path)
+
+		pr := map[string]interface{}{
+			"number":        42,
+			"state":         "open",
+			"title":         "Add authentication",
+			"html_url":      "https://github.com/myorg/myrepo/pull/42",
+			"body":          "Adds OAuth2 authentication flow",
+			"draft":         false,
+			"additions":     200,
+			"deletions":     50,
+			"changed_files": 8,
+			"head":          map[string]string{"ref": "feature/auth", "sha": "abc123"},
+			"base":          map[string]string{"ref": "main"},
+			"labels": []map[string]string{
+				{"name": "feature"},
+			},
+			"requested_reviewers": []map[string]string{
+				{"login": "alice"},
+			},
+		}
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer ghServer.Close()
+
+	h, _ := setupTestHandlersWithGitHub(t, ghServer)
+
+	body, _ := json.Marshal(ResolvePRRequest{URL: "https://github.com/myorg/myrepo/pull/42"})
+	req := httptest.NewRequest("POST", "/api/resolve-pr", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.ResolvePR(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ResolvePRResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, "myorg", resp.Owner)
+	assert.Equal(t, "myrepo", resp.Repo)
+	assert.Equal(t, 42, resp.PRNumber)
+	assert.Equal(t, "Add authentication", resp.Title)
+	assert.Equal(t, "Adds OAuth2 authentication flow", resp.Body)
+	assert.Equal(t, "feature/auth", resp.Branch)
+	assert.Equal(t, "main", resp.BaseBranch)
+	assert.Equal(t, "open", resp.State)
+	assert.False(t, resp.IsDraft)
+	assert.Equal(t, 200, resp.Additions)
+	assert.Equal(t, 50, resp.Deletions)
+	assert.Equal(t, 8, resp.ChangedFiles)
+	assert.Equal(t, []string{"feature"}, resp.Labels)
+	assert.Equal(t, []string{"alice"}, resp.Reviewers)
+	assert.Equal(t, "https://github.com/myorg/myrepo/pull/42", resp.HTMLURL)
+	// No workspace registered, so matchedWorkspaceId should be empty
+	assert.Empty(t, resp.MatchedWorkspaceID)
+}
+
+func TestResolvePR_MatchesWorkspace(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := map[string]interface{}{
+			"number":              10,
+			"state":               "open",
+			"title":               "Test PR",
+			"html_url":            "https://github.com/testowner/testrepo/pull/10",
+			"body":                "Test body",
+			"draft":               false,
+			"additions":           5,
+			"deletions":           2,
+			"changed_files":       1,
+			"head":                map[string]string{"ref": "test-branch", "sha": "sha1"},
+			"base":                map[string]string{"ref": "main"},
+			"labels":              []map[string]string{},
+			"requested_reviewers": []map[string]string{},
+		}
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer ghServer.Close()
+
+	h, s := setupTestHandlersWithGitHub(t, ghServer)
+
+	// Create a git repo with a github remote that matches the PR URL
+	repoPath := createTestGitRepo(t)
+	// Set origin to a GitHub URL so GetGitHubRemote can parse it
+	runGit(t, repoPath, "remote", "set-url", "origin", "https://github.com/testowner/testrepo.git")
+
+	createTestRepo(t, s, "workspace-1", repoPath)
+
+	body, _ := json.Marshal(ResolvePRRequest{URL: "https://github.com/testowner/testrepo/pull/10"})
+	req := httptest.NewRequest("POST", "/api/resolve-pr", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.ResolvePR(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ResolvePRResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, "workspace-1", resp.MatchedWorkspaceID)
+}
+
+func TestResolvePR_InvalidURL(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("GitHub API should not be called for invalid URLs")
+	}))
+	defer ghServer.Close()
+
+	h, _ := setupTestHandlersWithGitHub(t, ghServer)
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"empty URL", ""},
+		{"not a GitHub URL", "https://gitlab.com/org/repo/pull/1"},
+		{"missing PR number", "https://github.com/org/repo/pull/"},
+		{"not a PR URL", "https://github.com/org/repo/issues/1"},
+		{"random text", "not-a-url-at-all"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(ResolvePRRequest{URL: tc.url})
+			req := httptest.NewRequest("POST", "/api/resolve-pr", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			h.ResolvePR(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+
+			var apiErr APIError
+			err := json.Unmarshal(w.Body.Bytes(), &apiErr)
+			require.NoError(t, err)
+			assert.Equal(t, ErrCodeValidation, apiErr.Code)
+		})
+	}
+}
+
+func TestResolvePR_InvalidRequestBody(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("GitHub API should not be called for invalid request body")
+	}))
+	defer ghServer.Close()
+
+	h, _ := setupTestHandlersWithGitHub(t, ghServer)
+
+	req := httptest.NewRequest("POST", "/api/resolve-pr", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.ResolvePR(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestResolvePR_NoGitHubClient(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	body, _ := json.Marshal(ResolvePRRequest{URL: "https://github.com/org/repo/pull/1"})
+	req := httptest.NewRequest("POST", "/api/resolve-pr", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.ResolvePR(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestResolvePR_GitHubAPIError(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ghServer.Close()
+
+	h, _ := setupTestHandlersWithGitHub(t, ghServer)
+
+	body, _ := json.Marshal(ResolvePRRequest{URL: "https://github.com/org/repo/pull/999"})
+	req := httptest.NewRequest("POST", "/api/resolve-pr", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.ResolvePR(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ============================================================================
+// CreateSession with CheckoutExisting Tests
+// ============================================================================
+
+func TestCreateSession_CheckoutExisting_Success(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	// Create a real git repo with a remote branch to checkout
+	repoPath := createTestGitRepo(t)
+	repo := createTestRepo(t, s, "ws-1", repoPath)
+
+	// Create a feature branch on origin
+	// First get the origin path from the repo
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = repoPath
+	originOut, err := cmd.Output()
+	require.NoError(t, err)
+	originPath := strings.TrimSpace(string(originOut))
+
+	// Clone origin to a temp dir, create a branch, push it
+	cloneDir := t.TempDir()
+	runGit(t, cloneDir, "clone", originPath, ".")
+	runGit(t, cloneDir, "config", "user.email", "test@test.com")
+	runGit(t, cloneDir, "config", "user.name", "Test User")
+	runGit(t, cloneDir, "checkout", "-b", "feature/existing-pr")
+	writeFile(t, cloneDir, "feature.txt", "new feature content")
+	runGit(t, cloneDir, "add", ".")
+	runGit(t, cloneDir, "commit", "-m", "Add feature")
+	runGit(t, cloneDir, "push", "origin", "feature/existing-pr")
+
+	// Clean up test session directory after test
+	t.Cleanup(func() {
+		workspacesDir, _ := git.WorkspacesBaseDir()
+		entries, _ := os.ReadDir(workspacesDir)
+		for _, entry := range entries {
+			if entry.IsDir() {
+				os.RemoveAll(filepath.Join(workspacesDir, entry.Name()))
+			}
+		}
+	})
+
+	body, _ := json.Marshal(CreateSessionRequest{
+		Name:             "test-checkout-session",
+		Branch:           "feature/existing-pr",
+		CheckoutExisting: true,
+		Task:             "Review the PR",
+		SystemMessage:    "## PR Context\nThis is a test PR",
+	})
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/sessions", bytes.NewReader(body))
+	req = withChiContext(req, map[string]string{"id": repo.ID})
+	w := httptest.NewRecorder()
+
+	h.CreateSession(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "Response: %s", w.Body.String())
+
+	var sess models.Session
+	err = json.Unmarshal(w.Body.Bytes(), &sess)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-checkout-session", sess.Name)
+	assert.Equal(t, "feature/existing-pr", sess.Branch)
+	assert.NotEmpty(t, sess.WorktreePath)
+	assert.Equal(t, "Review the PR", sess.Task)
+}
+
+func TestCreateSession_CheckoutExisting_BranchNotFound(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	repoPath := createTestGitRepo(t)
+	repo := createTestRepo(t, s, "ws-1", repoPath)
+
+	// Clean up
+	t.Cleanup(func() {
+		workspacesDir, _ := git.WorkspacesBaseDir()
+		entries, _ := os.ReadDir(workspacesDir)
+		for _, entry := range entries {
+			if entry.IsDir() {
+				os.RemoveAll(filepath.Join(workspacesDir, entry.Name()))
+			}
+		}
+	})
+
+	body, _ := json.Marshal(CreateSessionRequest{
+		Name:             "test-nonexistent",
+		Branch:           "nonexistent-branch",
+		CheckoutExisting: true,
+	})
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/sessions", bytes.NewReader(body))
+	req = withChiContext(req, map[string]string{"id": repo.ID})
+	w := httptest.NewRecorder()
+
+	h.CreateSession(w, req)
+
+	// Should fail because the remote branch doesn't exist
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCreateSession_CheckoutExisting_SystemMessageStored(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	// Create a real git repo with a remote branch
+	repoPath := createTestGitRepo(t)
+	repo := createTestRepo(t, s, "ws-1", repoPath)
+
+	// Create a feature branch on origin
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = repoPath
+	originOut, err := cmd.Output()
+	require.NoError(t, err)
+	originPath := strings.TrimSpace(string(originOut))
+
+	cloneDir := t.TempDir()
+	runGit(t, cloneDir, "clone", originPath, ".")
+	runGit(t, cloneDir, "config", "user.email", "test@test.com")
+	runGit(t, cloneDir, "config", "user.name", "Test User")
+	runGit(t, cloneDir, "checkout", "-b", "feature/sys-msg-test")
+	writeFile(t, cloneDir, "test.txt", "content")
+	runGit(t, cloneDir, "add", ".")
+	runGit(t, cloneDir, "commit", "-m", "Test commit")
+	runGit(t, cloneDir, "push", "origin", "feature/sys-msg-test")
+
+	t.Cleanup(func() {
+		workspacesDir, _ := git.WorkspacesBaseDir()
+		entries, _ := os.ReadDir(workspacesDir)
+		for _, entry := range entries {
+			if entry.IsDir() {
+				os.RemoveAll(filepath.Join(workspacesDir, entry.Name()))
+			}
+		}
+	})
+
+	systemMsg := "## PR #42: Add auth\n**Branch:** feature/sys-msg-test → main\n**Changes:** +200 -50 across 8 files"
+
+	body, _ := json.Marshal(CreateSessionRequest{
+		Name:             "test-sys-msg",
+		Branch:           "feature/sys-msg-test",
+		CheckoutExisting: true,
+		SystemMessage:    systemMsg,
+	})
+	req := httptest.NewRequest("POST", "/api/repos/ws-1/sessions", bytes.NewReader(body))
+	req = withChiContext(req, map[string]string{"id": repo.ID})
+	w := httptest.NewRecorder()
+
+	h.CreateSession(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "Response: %s", w.Body.String())
+
+	var sess models.Session
+	err = json.Unmarshal(w.Body.Bytes(), &sess)
+	require.NoError(t, err)
+
+	// Verify the session was created with the correct branch
+	assert.Equal(t, "feature/sys-msg-test", sess.Branch)
+
+	// Verify system message was stored - fetch the conversation and its messages
+	ctx := context.Background()
+	conversations, err := s.ListConversations(ctx, sess.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, conversations, "session should have at least one conversation")
+
+	// Get messages from the first conversation
+	msgPage, err := s.GetConversationMessages(ctx, conversations[0].ID, nil, 100)
+	require.NoError(t, err)
+
+	// Find the system message
+	foundSystemMsg := false
+	for _, msg := range msgPage.Messages {
+		if msg.Role == "system" && msg.Content == systemMsg {
+			foundSystemMsg = true
+			break
+		}
+	}
+	assert.True(t, foundSystemMsg, "System message should be stored in the conversation")
+}
+
+func TestResolvePR_URLVariants(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pr := map[string]interface{}{
+			"number":              1,
+			"state":               "open",
+			"title":               "Test",
+			"html_url":            "https://github.com/org/repo/pull/1",
+			"body":                "",
+			"draft":               false,
+			"additions":           0,
+			"deletions":           0,
+			"changed_files":       0,
+			"head":                map[string]string{"ref": "branch", "sha": "sha"},
+			"base":                map[string]string{"ref": "main"},
+			"labels":              []map[string]string{},
+			"requested_reviewers": []map[string]string{},
+		}
+		json.NewEncoder(w).Encode(pr)
+	}))
+	defer ghServer.Close()
+
+	h, _ := setupTestHandlersWithGitHub(t, ghServer)
+
+	// Various valid PR URL formats
+	urls := []string{
+		"https://github.com/org/repo/pull/1",
+		"http://github.com/org/repo/pull/1",
+		"github.com/org/repo/pull/1",
+		"https://github.com/org/repo/pull/1/files",
+		"https://github.com/org/repo/pull/1/commits",
+	}
+
+	for _, url := range urls {
+		t.Run(url, func(t *testing.T) {
+			body, _ := json.Marshal(ResolvePRRequest{URL: url})
+			req := httptest.NewRequest("POST", "/api/resolve-pr", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			h.ResolvePR(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code, "URL %s should be accepted", url)
+		})
+	}
 }

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -64,6 +64,9 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	// PR Dashboard endpoint
 	r.Get("/api/prs", h.ListPRs)
 
+	// Resolve PR from URL (for "create session from PR" flow)
+	r.Post("/api/resolve-pr", h.ResolvePR)
+
 	// Avatar lookup endpoint
 	r.Get("/api/avatars", h.GetAvatars)
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,7 @@ import { BottomTerminal } from '@/components/layout/BottomTerminal';
 import { MainToolbar, ContentActionBar } from '@/components/layout/MainToolbar';
 import { SidebarToolbar } from '@/components/layout/SidebarToolbar';
 import { AddWorkspaceModal } from '@/components/dialogs/AddWorkspaceModal';
+import { CreateFromPRModal } from '@/components/dialogs/CreateFromPRModal';
 import { CloneFromUrlDialog } from '@/components/dialogs/CloneFromUrlDialog';
 import { QuickStartDialog } from '@/components/dialogs/QuickStartDialog';
 import { FilePicker } from '@/components/dialogs/FilePicker';
@@ -152,6 +153,7 @@ export default function Home() {
     setMounted(true);
   }, []);
   const [showAddWorkspace, setShowAddWorkspace] = useState(false);
+  const [showCreateFromPR, setShowCreateFromPR] = useState(false);
   const [showWorkspaceSettings, setShowWorkspaceSettings] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [leftSidebarCollapsed, setLeftSidebarCollapsed] = useState(false);
@@ -426,6 +428,14 @@ export default function Home() {
   // Keyboard shortcut: Cmd+/ to show shortcuts dialog
   useShortcut('shortcutsDialog', useCallback(() => {
     setShowShortcuts((prev) => !prev);
+  }, []));
+
+  useShortcut('addWorkspace', useCallback(() => {
+    setShowAddWorkspace(true);
+  }, []));
+
+  useShortcut('createFromPR', useCallback(() => {
+    setShowCreateFromPR(true);
   }, []));
 
   // Map backend Repo to frontend Workspace
@@ -1046,6 +1056,7 @@ export default function Home() {
     const handleSpawnAgent = () => handleNewSession();
     const handleNewConv = () => handleNewConversation();
     const handleAddWorkspace = () => setShowAddWorkspace(true);
+    const handleCreateFromPR = () => setShowCreateFromPR(true);
     const handleToggleTheme = () => {
       setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
     };
@@ -1064,6 +1075,7 @@ export default function Home() {
     window.addEventListener('spawn-agent', handleSpawnAgent);
     window.addEventListener('new-conversation', handleNewConv);
     window.addEventListener('add-workspace', handleAddWorkspace);
+    window.addEventListener('create-from-pr', handleCreateFromPR);
     window.addEventListener('toggle-theme', handleToggleTheme);
     window.addEventListener('toggle-left-panel', handleToggleLeftPanel);
     window.addEventListener('toggle-right-panel', handleToggleRightPanel);
@@ -1075,6 +1087,7 @@ export default function Home() {
       window.removeEventListener('spawn-agent', handleSpawnAgent);
       window.removeEventListener('new-conversation', handleNewConv);
       window.removeEventListener('add-workspace', handleAddWorkspace);
+      window.removeEventListener('create-from-pr', handleCreateFromPR);
       window.removeEventListener('toggle-theme', handleToggleTheme);
       window.removeEventListener('toggle-left-panel', handleToggleLeftPanel);
       window.removeEventListener('toggle-right-panel', handleToggleRightPanel);
@@ -1369,6 +1382,12 @@ export default function Home() {
         <AddWorkspaceModal
           isOpen={showAddWorkspace}
           onClose={() => setShowAddWorkspace(false)}
+        />
+
+        {/* Create Session from PR/Branch Modal */}
+        <CreateFromPRModal
+          isOpen={showCreateFromPR}
+          onClose={() => setShowCreateFromPR(false)}
         />
 
         {/* Clone from URL Dialog */}

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -191,6 +191,15 @@ const COMMANDS: Command[] = [
     action: () => window.dispatchEvent(new CustomEvent('new-conversation')),
   },
   {
+    id: 'create-from-pr',
+    category: 'Actions',
+    label: 'New Session from PR/Branch',
+    icon: GitPullRequest,
+    shortcutId: 'createFromPR',
+    keywords: ['pull request', 'pr', 'branch', 'checkout', 'review'],
+    action: () => window.dispatchEvent(new CustomEvent('create-from-pr')),
+  },
+  {
     id: 'add-repository',
     category: 'Actions',
     label: 'Add Repository',

--- a/src/components/dialogs/CreateFromPRModal.tsx
+++ b/src/components/dialogs/CreateFromPRModal.tsx
@@ -1,0 +1,494 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useAppStore } from '@/stores/appStore';
+import { useShallow } from 'zustand/react/shallow';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { navigate } from '@/lib/navigation';
+import {
+  resolvePR,
+  createSession as createSessionApi,
+  listConversations as listConversationsApi,
+  listBranches,
+  mapSessionDTO,
+} from '@/lib/api';
+import type { ResolvePRResponse } from '@/lib/api';
+import type { SetupInfo } from '@/lib/types';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  GitPullRequest,
+  GitBranch,
+  AlertCircle,
+  Loader2,
+  Plus,
+  Minus,
+  FileCode,
+  Users,
+} from 'lucide-react';
+
+interface CreateFromPRModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const PR_URL_PATTERN = /github\.com\/[^/]+\/[^/]+\/pull\/\d+/;
+
+function buildPRSystemMessage(pr: ResolvePRResponse): string {
+  const lines = [
+    `## PR #${pr.prNumber}: ${pr.title}`,
+    `**Branch:** ${pr.branch} \u2192 ${pr.baseBranch}`,
+    `**Status:** ${pr.state}${pr.isDraft ? ' (Draft)' : ''}`,
+    `**Changes:** +${pr.additions} -${pr.deletions} across ${pr.changedFiles} files`,
+  ];
+  if (pr.reviewers.length > 0) {
+    lines.push(`**Reviewers:** ${pr.reviewers.join(', ')}`);
+  }
+  if (pr.labels.length > 0) {
+    lines.push(`**Labels:** ${pr.labels.join(', ')}`);
+  }
+  lines.push('', '### Description', pr.body || 'No description provided.');
+  return lines.join('\n');
+}
+
+interface BranchInfo {
+  name: string;
+  lastCommitDate: string;
+  lastAuthor: string;
+  lastCommitSubject: string;
+  aheadMain: number;
+  behindMain: number;
+}
+
+export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
+  const [tab, setTab] = useState<string>('pr');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // PR tab state
+  const [prUrl, setPrUrl] = useState('');
+  const [prDetails, setPrDetails] = useState<ResolvePRResponse | null>(null);
+  const [prLoading, setPrLoading] = useState(false);
+  const [prError, setPrError] = useState('');
+
+  // Branch tab state
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>('');
+  const [branches, setBranches] = useState<BranchInfo[]>([]);
+  const [branchSearch, setBranchSearch] = useState('');
+  const [branchLoading, setBranchLoading] = useState(false);
+  const [selectedBranch, setSelectedBranch] = useState<string>('');
+
+  const { workspaces, addSession, addConversation } = useAppStore(
+    useShallow((s) => ({
+      workspaces: s.workspaces,
+      addSession: s.addSession,
+      addConversation: s.addConversation,
+    }))
+  );
+  const currentWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const { expandWorkspace } = useSettingsStore();
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setPrUrl('');
+      setPrDetails(null);
+      setPrError('');
+      setPrLoading(false);
+      setError('');
+      setLoading(false);
+      setBranches([]);
+      setBranchSearch('');
+      setSelectedBranch('');
+      setSelectedWorkspaceId(currentWorkspaceId || '');
+    }
+  }, [isOpen, currentWorkspaceId]);
+
+  // Resolve PR when URL changes (debounced with abort on cleanup)
+  useEffect(() => {
+    if (!prUrl || !PR_URL_PATTERN.test(prUrl)) {
+      setPrDetails(null);
+      setPrError('');
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setPrLoading(true);
+      setPrError('');
+      setPrDetails(null);
+      try {
+        const details = await resolvePR(prUrl);
+        if (cancelled) return;
+        setPrDetails(details);
+        // Auto-select matched workspace
+        if (details.matchedWorkspaceId) {
+          setSelectedWorkspaceId(details.matchedWorkspaceId);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setPrError(err instanceof Error ? err.message : 'Failed to resolve PR');
+      } finally {
+        if (!cancelled) setPrLoading(false);
+      }
+    }, 500);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [prUrl]);
+
+  // Fetch branches when workspace changes (branch tab)
+  useEffect(() => {
+    if (tab !== 'branch' || !selectedWorkspaceId) {
+      setBranches([]);
+      return;
+    }
+
+    const fetchBranches = async () => {
+      setBranchLoading(true);
+      try {
+        const result = await listBranches(selectedWorkspaceId, {
+          includeRemote: true,
+          search: branchSearch || undefined,
+          sortBy: 'date',
+          limit: 50,
+        });
+        // Combine session and other branches, filter out session/* branches
+        const allBranches = [...result.sessionBranches, ...result.otherBranches]
+          .filter((b) => b.isRemote && !b.name.startsWith('session/'))
+          .map((b) => ({
+            name: b.name,
+            lastCommitDate: b.lastCommitDate,
+            lastAuthor: b.lastAuthor,
+            lastCommitSubject: b.lastCommitSubject,
+            aheadMain: b.aheadMain,
+            behindMain: b.behindMain,
+          }));
+        setBranches(allBranches);
+      } catch {
+        setBranches([]);
+      } finally {
+        setBranchLoading(false);
+      }
+    };
+
+    const timer = setTimeout(fetchBranches, 300);
+    return () => clearTimeout(timer);
+  }, [tab, selectedWorkspaceId, branchSearch]);
+
+  const createSessionAndNavigate = useCallback(async (
+    workspaceId: string,
+    params: { branch: string; checkoutExisting: boolean; task?: string; systemMessage?: string },
+  ) => {
+    setLoading(true);
+    setError('');
+    try {
+      const session = await createSessionApi(workspaceId, params);
+
+      addSession(mapSessionDTO(session));
+
+      const conversations = await listConversationsApi(workspaceId, session.id);
+      conversations.forEach((conv) => {
+        addConversation({
+          id: conv.id,
+          sessionId: conv.sessionId,
+          type: conv.type,
+          name: conv.name,
+          status: conv.status,
+          messages: conv.messages.map((m) => ({
+            id: m.id,
+            conversationId: conv.id,
+            role: m.role as 'user' | 'assistant' | 'system',
+            content: m.content,
+            setupInfo: (m as { setupInfo?: SetupInfo }).setupInfo,
+            timestamp: m.timestamp,
+          })),
+          toolSummary: conv.toolSummary,
+          createdAt: conv.createdAt,
+          updatedAt: conv.updatedAt,
+        });
+      });
+
+      expandWorkspace(workspaceId);
+      navigate({
+        workspaceId,
+        sessionId: session.id,
+        contentView: { type: 'conversation' },
+      });
+
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create session');
+    } finally {
+      setLoading(false);
+    }
+  }, [addSession, addConversation, expandWorkspace, onClose]);
+
+  const createSessionFromPR = useCallback(async () => {
+    if (!prDetails || !selectedWorkspaceId) return;
+    await createSessionAndNavigate(selectedWorkspaceId, {
+      branch: prDetails.branch,
+      checkoutExisting: true,
+      task: `${prDetails.title}\n\n${prDetails.body || ''}`.trim(),
+      systemMessage: buildPRSystemMessage(prDetails),
+    });
+  }, [prDetails, selectedWorkspaceId, createSessionAndNavigate]);
+
+  const createSessionFromBranch = useCallback(async () => {
+    if (!selectedBranch || !selectedWorkspaceId) return;
+    await createSessionAndNavigate(selectedWorkspaceId, {
+      branch: selectedBranch,
+      checkoutExisting: true,
+    });
+  }, [selectedBranch, selectedWorkspaceId, createSessionAndNavigate]);
+
+  const canSubmitPR = prDetails && selectedWorkspaceId && !loading;
+  const canSubmitBranch = selectedBranch && selectedWorkspaceId && !loading;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitPullRequest className="w-5 h-5" />
+            New Session from PR / Branch
+          </DialogTitle>
+          <DialogDescription>
+            Create a session that checks out an existing branch.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs value={tab} onValueChange={setTab}>
+          <TabsList>
+            <TabsTrigger value="pr" className="gap-1.5">
+              <GitPullRequest className="w-3.5 h-3.5" />
+              From PR
+            </TabsTrigger>
+            <TabsTrigger value="branch" className="gap-1.5">
+              <GitBranch className="w-3.5 h-3.5" />
+              From Branch
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="pr">
+            <div className="space-y-3 py-2">
+              <Input
+                value={prUrl}
+                onChange={(e) => setPrUrl(e.target.value)}
+                placeholder="https://github.com/owner/repo/pull/123"
+                className="font-mono text-sm"
+                autoFocus
+              />
+
+              {prLoading && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Loading PR details...
+                </div>
+              )}
+
+              {prError && (
+                <div className="flex items-center gap-2 text-sm text-destructive bg-destructive/10 p-3 rounded-lg">
+                  <AlertCircle className="w-4 h-4 shrink-0" />
+                  {prError}
+                </div>
+              )}
+
+              {prDetails && (
+                <div className="space-y-2 rounded-lg border p-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="font-medium text-sm leading-snug">
+                      #{prDetails.prNumber} {prDetails.title}
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      {prDetails.isDraft && (
+                        <Badge variant="outline" className="text-[10px]">Draft</Badge>
+                      )}
+                      <Badge
+                        variant={prDetails.state === 'open' ? 'default' : 'secondary'}
+                        className="text-[10px]"
+                      >
+                        {prDetails.state}
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                    <span className="flex items-center gap-1 font-mono">
+                      <GitBranch className="w-3 h-3" />
+                      {prDetails.branch}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Plus className="w-3 h-3 text-green-500" />
+                      {prDetails.additions}
+                      <Minus className="w-3 h-3 text-red-500" />
+                      {prDetails.deletions}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <FileCode className="w-3 h-3" />
+                      {prDetails.changedFiles} files
+                    </span>
+                    {prDetails.reviewers.length > 0 && (
+                      <span className="flex items-center gap-1">
+                        <Users className="w-3 h-3" />
+                        {prDetails.reviewers.join(', ')}
+                      </span>
+                    )}
+                  </div>
+
+                  {prDetails.labels.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {prDetails.labels.map((label) => (
+                        <Badge key={label} variant="outline" className="text-[10px]">
+                          {label}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+
+                  {!prDetails.matchedWorkspaceId && workspaces.length > 0 && (
+                    <div className="space-y-1.5 pt-1">
+                      <p className="text-xs text-amber-500">
+                        No matching workspace found. Select one:
+                      </p>
+                      <Select value={selectedWorkspaceId} onValueChange={setSelectedWorkspaceId}>
+                        <SelectTrigger className="h-8 text-xs">
+                          <SelectValue placeholder="Select workspace" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {workspaces.map((ws) => (
+                            <SelectItem key={ws.id} value={ws.id} className="text-xs">
+                              {ws.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+
+                  {prDetails.matchedWorkspaceId && (
+                    <p className="text-xs text-muted-foreground">
+                      Workspace: {workspaces.find((w) => w.id === prDetails.matchedWorkspaceId)?.name}
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="branch">
+            <div className="space-y-3 py-2">
+              <Select value={selectedWorkspaceId} onValueChange={(v) => { setSelectedWorkspaceId(v); setSelectedBranch(''); }}>
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue placeholder="Select workspace" />
+                </SelectTrigger>
+                <SelectContent>
+                  {workspaces.map((ws) => (
+                    <SelectItem key={ws.id} value={ws.id} className="text-xs">
+                      {ws.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {selectedWorkspaceId && (
+                <>
+                  <Input
+                    value={branchSearch}
+                    onChange={(e) => setBranchSearch(e.target.value)}
+                    placeholder="Search branches..."
+                    className="text-sm h-8"
+                  />
+
+                  <ScrollArea className="h-48 rounded-lg border">
+                    {branchLoading ? (
+                      <div className="flex items-center justify-center h-full py-8">
+                        <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+                      </div>
+                    ) : branches.length === 0 ? (
+                      <div className="flex items-center justify-center h-full py-8 text-xs text-muted-foreground">
+                        No remote branches found
+                      </div>
+                    ) : (
+                      <div className="p-1">
+                        {branches.map((branch) => (
+                          <button
+                            key={branch.name}
+                            className={`w-full text-left px-2 py-1.5 rounded text-xs transition-colors ${
+                              selectedBranch === branch.name
+                                ? 'bg-accent text-accent-foreground'
+                                : 'hover:bg-accent/50'
+                            }`}
+                            onClick={() => setSelectedBranch(branch.name)}
+                          >
+                            <div className="flex items-center justify-between">
+                              <span className="font-mono truncate">{branch.name}</span>
+                              <span className="text-[10px] text-muted-foreground shrink-0 ml-2">
+                                {branch.lastAuthor}
+                              </span>
+                            </div>
+                            <div className="text-[10px] text-muted-foreground truncate mt-0.5">
+                              {branch.lastCommitSubject}
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </ScrollArea>
+                </>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        {error && (
+          <div className="flex items-center gap-2 text-sm text-destructive bg-destructive/10 p-3 rounded-lg">
+            <AlertCircle className="w-4 h-4 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          {tab === 'pr' ? (
+            <Button
+              onClick={createSessionFromPR}
+              disabled={!canSubmitPR}
+            >
+              {loading ? 'Creating...' : 'Create Session'}
+            </Button>
+          ) : (
+            <Button
+              onClick={createSessionFromBranch}
+              disabled={!canSubmitBranch}
+            >
+              {loading ? 'Creating...' : 'Create Session'}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dialogs/__tests__/CreateFromPRModal.test.tsx
+++ b/src/components/dialogs/__tests__/CreateFromPRModal.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../__mocks__/server';
+import { CreateFromPRModal } from '../CreateFromPRModal';
+import { useAppStore } from '@/stores/appStore';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockPRResponse = {
+  owner: 'testorg',
+  repo: 'testrepo',
+  prNumber: 42,
+  title: 'Add authentication',
+  body: 'Adds OAuth2 flow for login',
+  branch: 'feature/auth',
+  baseBranch: 'main',
+  state: 'open',
+  isDraft: false,
+  labels: ['enhancement'],
+  reviewers: ['alice'],
+  additions: 200,
+  deletions: 50,
+  changedFiles: 8,
+  matchedWorkspaceId: 'workspace-1',
+  htmlUrl: 'https://github.com/testorg/testrepo/pull/42',
+};
+
+// Mock navigation
+vi.mock('@/lib/navigation', () => ({
+  navigate: vi.fn(),
+}));
+
+describe('CreateFromPRModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Set up workspaces in store
+    useAppStore.setState({
+      workspaces: [
+        {
+          id: 'workspace-1',
+          name: 'test-repo',
+          path: '/repos/test-repo',
+          defaultBranch: 'main',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      selectedWorkspaceId: 'workspace-1',
+    });
+
+    // Default handler for resolve-pr (never called unless URL is valid)
+    server.use(
+      http.post(`${API_BASE}/api/resolve-pr`, () => {
+        return HttpResponse.json(mockPRResponse);
+      })
+    );
+  });
+
+  it('renders with two tabs: From PR and From Branch', () => {
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    expect(screen.getByText('From PR')).toBeInTheDocument();
+    expect(screen.getByText('From Branch')).toBeInTheDocument();
+  });
+
+  it('renders the dialog title', () => {
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    expect(screen.getByText(/New Session from PR/)).toBeInTheDocument();
+  });
+
+  it('shows PR URL input on the PR tab', () => {
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    expect(
+      screen.getByPlaceholderText('https://github.com/owner/repo/pull/123')
+    ).toBeInTheDocument();
+  });
+
+  it('shows PR details after entering a valid PR URL', async () => {
+    const user = userEvent.setup();
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText(
+      'https://github.com/owner/repo/pull/123'
+    );
+    await user.type(input, 'https://github.com/testorg/testrepo/pull/42');
+
+    // Wait for debounced API call and rendering
+    await waitFor(
+      () => {
+        expect(screen.getByText(/Add authentication/)).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+
+    // Check branch name is displayed in the PR details
+    expect(screen.getByText('feature/auth')).toBeInTheDocument();
+  });
+
+  it('shows error when PR resolution fails', async () => {
+    server.use(
+      http.post(`${API_BASE}/api/resolve-pr`, () => {
+        return HttpResponse.json(
+          { error: 'PR not found' },
+          { status: 404 }
+        );
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText(
+      'https://github.com/owner/repo/pull/123'
+    );
+    await user.type(input, 'https://github.com/testorg/testrepo/pull/999');
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/Failed to resolve PR|PR not found/)).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(<CreateFromPRModal isOpen={false} onClose={vi.fn()} />);
+
+    expect(
+      screen.queryByText(/New Session from PR/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables Create Session button when no PR is resolved', () => {
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    const createButton = screen.getByRole('button', {
+      name: /Create Session/i,
+    });
+    expect(createButton).toBeDisabled();
+  });
+
+  it('shows the Branch tab content when clicked', async () => {
+    const user = userEvent.setup();
+
+    // Mock branches endpoint
+    server.use(
+      http.get(`${API_BASE}/api/repos/:workspaceId/branches`, () => {
+        return HttpResponse.json({
+          branches: [
+            {
+              name: 'feature/cool-thing',
+              lastCommitDate: new Date().toISOString(),
+              lastAuthor: 'dev',
+              lastCommitSubject: 'Add cool thing',
+              aheadMain: 3,
+              behindMain: 0,
+            },
+          ],
+        });
+      })
+    );
+
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    // Click on the Branch tab
+    await user.click(screen.getByText('From Branch'));
+
+    // Should show workspace selector and branch search
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('Search branches...')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows draft badge for draft PRs', async () => {
+    server.use(
+      http.post(`${API_BASE}/api/resolve-pr`, () => {
+        return HttpResponse.json({
+          ...mockPRResponse,
+          isDraft: true,
+        });
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText(
+      'https://github.com/owner/repo/pull/123'
+    );
+    await user.type(input, 'https://github.com/testorg/testrepo/pull/42');
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Draft')).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+  });
+});

--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -9,6 +9,7 @@ import {
   createConversation,
   setConversationPlanMode,
   approvePlan,
+  resolvePR,
 } from '../api';
 
 const API_BASE = 'http://localhost:9876';
@@ -336,5 +337,116 @@ describe('Plan Mode API', () => {
 
       await expect(approvePlan('conv-1')).rejects.toThrow();
     });
+  });
+});
+
+// ============================================================================
+// ResolvePR API Tests
+// ============================================================================
+
+describe('ResolvePR API', () => {
+  const mockPRResponse = {
+    owner: 'testorg',
+    repo: 'testrepo',
+    prNumber: 42,
+    title: 'Add authentication',
+    body: 'Adds OAuth2 flow',
+    branch: 'feature/auth',
+    baseBranch: 'main',
+    state: 'open',
+    isDraft: false,
+    labels: ['enhancement'],
+    reviewers: ['reviewer1'],
+    additions: 200,
+    deletions: 50,
+    changedFiles: 8,
+    matchedWorkspaceId: 'workspace-123',
+    htmlUrl: 'https://github.com/testorg/testrepo/pull/42',
+  };
+
+  it('resolves a PR URL successfully', async () => {
+    server.use(
+      http.post(`${API_BASE}/api/resolve-pr`, async ({ request }) => {
+        const body = await request.json() as { url: string };
+        expect(body.url).toBe('https://github.com/testorg/testrepo/pull/42');
+        return HttpResponse.json(mockPRResponse);
+      })
+    );
+
+    const result = await resolvePR('https://github.com/testorg/testrepo/pull/42');
+
+    expect(result.owner).toBe('testorg');
+    expect(result.repo).toBe('testrepo');
+    expect(result.prNumber).toBe(42);
+    expect(result.title).toBe('Add authentication');
+    expect(result.body).toBe('Adds OAuth2 flow');
+    expect(result.branch).toBe('feature/auth');
+    expect(result.baseBranch).toBe('main');
+    expect(result.state).toBe('open');
+    expect(result.isDraft).toBe(false);
+    expect(result.labels).toEqual(['enhancement']);
+    expect(result.reviewers).toEqual(['reviewer1']);
+    expect(result.additions).toBe(200);
+    expect(result.deletions).toBe(50);
+    expect(result.changedFiles).toBe(8);
+    expect(result.matchedWorkspaceId).toBe('workspace-123');
+    expect(result.htmlUrl).toBe('https://github.com/testorg/testrepo/pull/42');
+  });
+
+  it('resolves a PR with no matched workspace', async () => {
+    server.use(
+      http.post(`${API_BASE}/api/resolve-pr`, () => {
+        return HttpResponse.json({
+          ...mockPRResponse,
+          matchedWorkspaceId: null,
+        });
+      })
+    );
+
+    const result = await resolvePR('https://github.com/other/repo/pull/1');
+    expect(result.matchedWorkspaceId).toBeNull();
+  });
+
+  it('rejects on invalid PR URL', async () => {
+    server.use(
+      http.post(`${API_BASE}/api/resolve-pr`, () => {
+        return HttpResponse.json(
+          { error: 'invalid GitHub PR URL' },
+          { status: 400 }
+        );
+      })
+    );
+
+    await expect(resolvePR('not-a-valid-url')).rejects.toThrow();
+  });
+
+  it('rejects on server error', async () => {
+    server.use(
+      http.post(`${API_BASE}/api/resolve-pr`, () => {
+        return HttpResponse.json(
+          { error: 'failed to fetch PR details' },
+          { status: 500 }
+        );
+      })
+    );
+
+    await expect(
+      resolvePR('https://github.com/org/repo/pull/999')
+    ).rejects.toThrow();
+  });
+
+  it('rejects when not authenticated', async () => {
+    server.use(
+      http.post(`${API_BASE}/api/resolve-pr`, () => {
+        return HttpResponse.json(
+          { error: 'GitHub client not configured' },
+          { status: 400 }
+        );
+      })
+    );
+
+    await expect(
+      resolvePR('https://github.com/org/repo/pull/1')
+    ).rejects.toThrow();
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -265,7 +265,7 @@ export async function listSessions(workspaceId: string, includeArchived?: boolea
 
 export async function createSession(
   workspaceId: string,
-  data: { name?: string; branch?: string; worktreePath?: string; task?: string } = {}
+  data: { name?: string; branch?: string; worktreePath?: string; task?: string; checkoutExisting?: boolean; systemMessage?: string } = {}
 ): Promise<SessionDTO> {
   const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions`, {
     method: 'POST',
@@ -353,6 +353,35 @@ export async function listBranches(
   const url = `${getApiBase()}/api/repos/${workspaceId}/branches${queryString ? `?${queryString}` : ''}`;
   const res = await fetchWithAuth(url);
   return handleResponse<BranchListResponse>(res);
+}
+
+// Resolve PR from URL
+export interface ResolvePRResponse {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  title: string;
+  body: string;
+  branch: string;
+  baseBranch: string;
+  state: string;
+  isDraft: boolean;
+  labels: string[];
+  reviewers: string[];
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  matchedWorkspaceId: string | null;
+  htmlUrl: string;
+}
+
+export async function resolvePR(url: string): Promise<ResolvePRResponse> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/resolve-pr`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url }),
+  });
+  return handleResponse<ResolvePRResponse>(res);
 }
 
 // Branch cleanup types and API

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -59,6 +59,13 @@ export const SHORTCUTS: Shortcut[] = [
     category: 'General',
   },
   {
+    id: 'createFromPR',
+    key: 'o',
+    modifiers: ['meta', 'shift'],
+    label: 'New session from PR/Branch',
+    category: 'General',
+  },
+  {
     id: 'resetLayouts',
     key: 'r',
     modifiers: ['meta', 'shift'],


### PR DESCRIPTION
## Summary

Add ability to create a session by checking out an existing remote branch from a GitHub PR URL or branch picker. Includes new ResolvePR endpoint, CheckoutExistingBranchInDir worktree method, and CreateFromPRModal UI with two tabs. Properly differentiates branch error conditions and includes PR context in the initial system message.

## Changes

- **Backend**: New `GetPRFullDetails()` GitHub API client method, `CheckoutExistingBranchInDir()` worktree method, `ResolvePR` HTTP handler
- **Frontend**: CreateFromPRModal component with PR URL tab and branch browser tab, session creation helpers
- **Tests**: Full test coverage for new endpoints and components
- **Bug fixes**: Import ordering, targeted git fetch, better error classification for branch conflicts

## Test plan

- Run `go test ./...` to verify all backend tests pass
- Run `npm run build` to verify TypeScript compilation
- Test PR resolution with valid/invalid URLs
- Test session creation from PR with matched/unmatched workspaces
- Test branch checkout error handling (branch not found, already exists, already checked out)