### PR TITLE
feat: sort pinned sessions to top of workspace sidebar

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -174,16 +174,22 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
   };
 
   const getWorkspaceSessions = (workspaceId: string) => {
-    return sessions.filter((s) => {
-      if (s.workspaceId !== workspaceId || s.archived) return false;
-      if (!searchTerm) return true;
-      const term = searchTerm.toLowerCase();
-      return (
-        s.name.toLowerCase().includes(term) ||
-        s.branch?.toLowerCase().includes(term) ||
-        s.task?.toLowerCase().includes(term)
-      );
-    });
+    return sessions
+      .filter((s) => {
+        if (s.workspaceId !== workspaceId || s.archived) return false;
+        if (!searchTerm) return true;
+        const term = searchTerm.toLowerCase();
+        return (
+          s.name.toLowerCase().includes(term) ||
+          s.branch?.toLowerCase().includes(term) ||
+          s.task?.toLowerCase().includes(term)
+        );
+      })
+      .sort((a, b) => {
+        if (a.pinned && !b.pinned) return -1;
+        if (!a.pinned && b.pinned) return 1;
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      });
   };
 
   const getInitial = (name: string) => {


### PR DESCRIPTION
## Summary
Adds stable sorting to pinned sessions in the workspace sidebar. Pinned sessions now appear at the top, with non-pinned sessions below. Sessions with the same pinned state are sorted by most recently updated first.

## Changes
- Modified `getWorkspaceSessions()` to sort sessions by pinned status
- Added `updatedAt` tiebreaker for deterministic ordering
- Improved code formatting with method chaining

Closes CM-22