### PR TITLE
fix: guard against undefined setupScripts/runScripts in ScriptsPanel

### DIFF
--- a/src/components/panels/ScriptsPanel.tsx
+++ b/src/components/panels/ScriptsPanel.tsx
@@ -179,7 +179,7 @@ export function ScriptsPanel() {
   }
 
   // Empty state: no config
-  const hasConfig = config && (config.setupScripts.length > 0 || Object.keys(config.runScripts).length > 0);
+  const hasConfig = config && ((config.setupScripts?.length ?? 0) > 0 || Object.keys(config.runScripts ?? {}).length > 0);
   if (!hasConfig) {
     return (
       <div className="h-full flex items-center justify-center">


### PR DESCRIPTION
## Summary
- Fixed `TypeError: undefined is not an object (evaluating 'config.setupScripts.length')` in `ScriptsPanel.tsx`
- Added optional chaining and nullish coalescing to the `hasConfig` guard so it handles configs where `setupScripts` or `runScripts` are undefined

## Test plan
- [ ] Open the app with a workspace that has no scripts configured
- [ ] Verify the ScriptsPanel renders the empty state without errors
- [ ] Open a workspace with scripts configured and verify they display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)