### PR TITLE
feat: add directory listing cache with TTL and fsnotify

### DIFF
--- a/backend/logger/logger.go
+++ b/backend/logger/logger.go
@@ -42,6 +42,9 @@ var (
 	// Scripts
 	Scripts *log.Logger
 
+	// Caching
+	DirCache *log.Logger
+
 	// Utilities
 	Cleanup *log.Logger
 	GitHub  *log.Logger
@@ -124,6 +127,9 @@ func init() {
 
 	// Scripts
 	Scripts = base.WithPrefix(colorAgent.Render("scripts"))
+
+	// Caching
+	DirCache = base.WithPrefix(colorWatch.Render("dir-cache"))
 
 	// Utilities
 	Cleanup = base.WithPrefix(colorUtil.Render("cleanup"))

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/chatml/chatml-backend/scripts"
 	"github.com/chatml/chatml-backend/session"
 	"github.com/chatml/chatml-backend/store"
+	"github.com/fsnotify/fsnotify"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -184,13 +185,172 @@ func (c *BranchCache) cleanupLoop() {
 	}
 }
 
-// DirListingCache provides TTL-based caching for directory listing operations.
-// This reduces filesystem operations for frequently accessed directory trees.
+// dirCacheWatcher uses fsnotify to watch directories and immediately invalidate
+// cache entries when filesystem changes are detected, rather than waiting for TTL.
+type dirCacheWatcher struct {
+	fsw              *fsnotify.Watcher
+	mu               sync.Mutex
+	watches          map[string]int            // path -> reference count
+	pendingPaths     map[string]struct{}        // paths awaiting debounced invalidation
+	debounceTimer    *time.Timer
+	debounceDuration time.Duration
+	invalidateFunc   func(string)               // callback to DirListingCache.InvalidatePath
+	ctx              context.Context
+	cancel           context.CancelFunc
+}
+
+func newDirCacheWatcher(invalidateFunc func(string), debounceDuration time.Duration) (*dirCacheWatcher, error) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create fsnotify watcher: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &dirCacheWatcher{
+		fsw:              fsw,
+		watches:          make(map[string]int),
+		pendingPaths:     make(map[string]struct{}),
+		debounceDuration: debounceDuration,
+		invalidateFunc:   invalidateFunc,
+		ctx:              ctx,
+		cancel:           cancel,
+	}
+	go w.run()
+	return w, nil
+}
+
+func (w *dirCacheWatcher) addWatch(path string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if count, exists := w.watches[path]; exists {
+		w.watches[path] = count + 1
+		return nil
+	}
+
+	if err := w.fsw.Add(path); err != nil {
+		return fmt.Errorf("watch %s: %w", path, err)
+	}
+
+	w.watches[path] = 1
+	logger.DirCache.Debugf("watching %s", path)
+	return nil
+}
+
+func (w *dirCacheWatcher) removeWatch(path string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	count, exists := w.watches[path]
+	if !exists {
+		return
+	}
+
+	if count > 1 {
+		w.watches[path] = count - 1
+		return
+	}
+
+	delete(w.watches, path)
+	if err := w.fsw.Remove(path); err != nil {
+		logger.DirCache.Debugf("remove watch %s: %v", path, err)
+	} else {
+		logger.DirCache.Debugf("unwatched %s", path)
+	}
+}
+
+func (w *dirCacheWatcher) run() {
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case event, ok := <-w.fsw.Events:
+			if !ok {
+				return
+			}
+			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove|fsnotify.Rename) == 0 {
+				continue
+			}
+			// The event path is inside one of the watched root dirs.
+			// Find which watched root it belongs to and schedule invalidation.
+			dir := filepath.Dir(event.Name)
+			w.mu.Lock()
+			for watchedPath := range w.watches {
+				if dir == watchedPath || strings.HasPrefix(dir, watchedPath+string(filepath.Separator)) {
+					w.pendingPaths[watchedPath] = struct{}{}
+				}
+			}
+			w.scheduleFlush()
+			w.mu.Unlock()
+
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return
+			}
+			logger.DirCache.Warnf("fsnotify error: %v", err)
+		}
+	}
+}
+
+// scheduleFlush resets the debounce timer. Must be called with mu held.
+func (w *dirCacheWatcher) scheduleFlush() {
+	if w.debounceTimer != nil {
+		w.debounceTimer.Stop()
+	}
+	w.debounceTimer = time.AfterFunc(w.debounceDuration, w.flush)
+}
+
+func (w *dirCacheWatcher) flush() {
+	if w.ctx.Err() != nil {
+		return
+	}
+
+	w.mu.Lock()
+	paths := w.pendingPaths
+	w.pendingPaths = make(map[string]struct{})
+	w.mu.Unlock()
+
+	for path := range paths {
+		logger.DirCache.Debugf("invalidating cache for %s", path)
+		w.invalidateFunc(path)
+	}
+}
+
+func (w *dirCacheWatcher) close() {
+	w.cancel()
+	w.mu.Lock()
+	if w.debounceTimer != nil {
+		w.debounceTimer.Stop()
+	}
+	w.mu.Unlock()
+	w.fsw.Close()
+}
+
+// extractRootPath extracts the filesystem path from a cache key.
+// Keys are formatted as "repo:/path/to/dir:depth:N" or "session:/path/to/dir:depth:N".
+func extractRootPath(cacheKey string) (string, bool) {
+	parts := strings.SplitN(cacheKey, ":depth:", 2)
+	if len(parts) != 2 {
+		return "", false
+	}
+	pathPart := parts[0]
+	if strings.HasPrefix(pathPart, "repo:") {
+		return strings.TrimPrefix(pathPart, "repo:"), true
+	}
+	if strings.HasPrefix(pathPart, "session:") {
+		return strings.TrimPrefix(pathPart, "session:"), true
+	}
+	return "", false
+}
+
+// DirListingCache provides TTL-based caching for directory listing operations
+// with optional fsnotify-based immediate invalidation on filesystem changes.
 type DirListingCache struct {
 	mu      sync.RWMutex
 	entries map[string]*dirCacheEntry
 	ttl     time.Duration
 	done    chan struct{}
+	watcher *dirCacheWatcher
 }
 
 type dirCacheEntry struct {
@@ -198,20 +358,34 @@ type dirCacheEntry struct {
 	expiresAt time.Time
 }
 
-// NewDirListingCache creates a new directory listing cache with the given TTL
+// NewDirListingCache creates a new directory listing cache with the given TTL.
+// It also starts a filesystem watcher for immediate cache invalidation.
+// If the watcher fails to initialize, the cache falls back to TTL-only mode.
 func NewDirListingCache(ttl time.Duration) *DirListingCache {
 	cache := &DirListingCache{
 		entries: make(map[string]*dirCacheEntry),
 		ttl:     ttl,
 		done:    make(chan struct{}),
 	}
+
+	w, err := newDirCacheWatcher(cache.InvalidatePath, 100*time.Millisecond)
+	if err != nil {
+		logger.DirCache.Warnf("filesystem watcher unavailable, using TTL-only mode: %v", err)
+	} else {
+		cache.watcher = w
+		logger.DirCache.Infof("filesystem watcher active (debounce=100ms)")
+	}
+
 	go cache.cleanupLoop()
 	return cache
 }
 
-// Close stops the cleanup goroutine. Should be called when the cache is no longer needed.
+// Close stops the cleanup goroutine and filesystem watcher.
 func (c *DirListingCache) Close() {
 	close(c.done)
+	if c.watcher != nil {
+		c.watcher.close()
+	}
 }
 
 // Get retrieves a cached directory listing by key
@@ -231,14 +405,22 @@ func (c *DirListingCache) Get(key string) ([]*FileNode, bool) {
 	return entry.data, true
 }
 
-// Set stores a directory listing in the cache
+// Set stores a directory listing in the cache and registers a filesystem watch
+// on the root path for immediate invalidation.
 func (c *DirListingCache) Set(key string, data []*FileNode) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.entries[key] = &dirCacheEntry{
 		data:      data,
 		expiresAt: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+
+	if c.watcher != nil {
+		if rootPath, ok := extractRootPath(key); ok {
+			if err := c.watcher.addWatch(rootPath); err != nil {
+				logger.DirCache.Debugf("watch %s: %v", rootPath, err)
+			}
+		}
 	}
 }
 
@@ -248,14 +430,24 @@ func (c *DirListingCache) Set(key string, data []*FileNode) {
 // starts with basePath to avoid over-invalidation of unrelated paths.
 func (c *DirListingCache) InvalidatePath(basePath string) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
+	var removedPaths []string
 	for key := range c.entries {
 		// Extract path from cache key format "type:path:depth:N"
 		// We need to check if the path portion starts with basePath
 		if strings.HasPrefix(key, "repo:"+basePath) || strings.HasPrefix(key, "session:"+basePath) {
 			delete(c.entries, key)
+			if c.watcher != nil {
+				if rootPath, ok := extractRootPath(key); ok {
+					removedPaths = append(removedPaths, rootPath)
+				}
+			}
 		}
+	}
+	c.mu.Unlock()
+
+	for _, p := range removedPaths {
+		c.watcher.removeWatch(p)
 	}
 }
 
@@ -283,13 +475,23 @@ func (c *DirListingCache) cleanupLoop() {
 // cleanup removes expired entries
 func (c *DirListingCache) cleanup() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
+	var removedPaths []string
 	now := time.Now()
 	for key, entry := range c.entries {
 		if now.After(entry.expiresAt) {
 			delete(c.entries, key)
+			if c.watcher != nil {
+				if rootPath, ok := extractRootPath(key); ok {
+					removedPaths = append(removedPaths, rootPath)
+				}
+			}
 		}
+	}
+	c.mu.Unlock()
+
+	for _, p := range removedPaths {
+		c.watcher.removeWatch(p)
 	}
 }
 

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -4058,3 +4058,144 @@ func TestCreateSession_WithBranchPrefix(t *testing.T) {
 	assert.True(t, strings.HasPrefix(session.Branch, "feature/"),
 		"Expected branch name to start with 'feature/', got: %s", session.Branch)
 }
+
+// ============================================================================
+// DirListingCache Watcher Tests
+// ============================================================================
+
+func TestExtractRootPath(t *testing.T) {
+	tests := []struct {
+		key      string
+		wantPath string
+		wantOK   bool
+	}{
+		{"repo:/Users/me/project:depth:1", "/Users/me/project", true},
+		{"session:/Users/me/worktree:depth:10", "/Users/me/worktree", true},
+		{"repo:/path/with:colons:depth:3", "/path/with:colons", true},
+		{"unknown:/foo:depth:1", "", false},
+		{"invalid-key", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			path, ok := extractRootPath(tt.key)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantPath, path)
+		})
+	}
+}
+
+func TestDirCacheWatcherRefCounting(t *testing.T) {
+	dir := t.TempDir()
+
+	calls := 0
+	w, err := newDirCacheWatcher(func(string) { calls++ }, 50*time.Millisecond)
+	require.NoError(t, err)
+	defer w.close()
+
+	// First add creates the watch
+	require.NoError(t, w.addWatch(dir))
+	assert.Equal(t, 1, w.watches[dir])
+
+	// Second add increments refcount
+	require.NoError(t, w.addWatch(dir))
+	assert.Equal(t, 2, w.watches[dir])
+
+	// First remove decrements but keeps watch
+	w.removeWatch(dir)
+	assert.Equal(t, 1, w.watches[dir])
+
+	// Second remove actually removes the watch
+	w.removeWatch(dir)
+	_, exists := w.watches[dir]
+	assert.False(t, exists)
+}
+
+func TestDirCacheWatcherInvalidatesOnChange(t *testing.T) {
+	dir := t.TempDir()
+
+	invalidated := make(chan string, 10)
+	w, err := newDirCacheWatcher(func(path string) {
+		invalidated <- path
+	}, 50*time.Millisecond)
+	require.NoError(t, err)
+	defer w.close()
+
+	require.NoError(t, w.addWatch(dir))
+
+	// Create a file in the watched directory
+	err = os.WriteFile(filepath.Join(dir, "test.txt"), []byte("hello"), 0644)
+	require.NoError(t, err)
+
+	// Should receive invalidation within a reasonable time
+	select {
+	case path := <-invalidated:
+		assert.Equal(t, dir, path)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cache invalidation")
+	}
+}
+
+func TestDirCacheWatcherDebounce(t *testing.T) {
+	dir := t.TempDir()
+
+	var mu sync.Mutex
+	invalidations := 0
+	w, err := newDirCacheWatcher(func(string) {
+		mu.Lock()
+		invalidations++
+		mu.Unlock()
+	}, 100*time.Millisecond)
+	require.NoError(t, err)
+	defer w.close()
+
+	require.NoError(t, w.addWatch(dir))
+
+	// Rapidly create multiple files
+	for i := 0; i < 5; i++ {
+		err = os.WriteFile(filepath.Join(dir, fmt.Sprintf("file%d.txt", i)), []byte("data"), 0644)
+		require.NoError(t, err)
+	}
+
+	// Wait for debounce to flush
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	count := invalidations
+	mu.Unlock()
+
+	// Should have been debounced to a small number of invalidations (ideally 1)
+	assert.LessOrEqual(t, count, 3, "expected debouncing to reduce invalidation count")
+	assert.GreaterOrEqual(t, count, 1, "expected at least one invalidation")
+}
+
+func TestDirListingCacheWithWatcher(t *testing.T) {
+	dir := t.TempDir()
+
+	cache := NewDirListingCache(5 * time.Minute)
+	defer cache.Close()
+
+	// Watcher should be active
+	require.NotNil(t, cache.watcher)
+
+	// Set a cache entry for this directory
+	key := fmt.Sprintf("repo:%s:depth:1", dir)
+	cache.Set(key, []*FileNode{{Name: "old.txt"}})
+
+	// Verify it's cached
+	data, ok := cache.Get(key)
+	require.True(t, ok)
+	assert.Len(t, data, 1)
+
+	// Create a file to trigger invalidation
+	err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("hello"), 0644)
+	require.NoError(t, err)
+
+	// Wait for debounce + processing
+	time.Sleep(500 * time.Millisecond)
+
+	// Cache entry should be invalidated
+	_, ok = cache.Get(key)
+	assert.False(t, ok, "expected cache entry to be invalidated after filesystem change")
+}


### PR DESCRIPTION
## Summary

Adds filesystem watching via `fsnotify` to the `DirListingCache` for immediate cache invalidation when directories change, complementing the existing TTL-based expiration. Includes debounce logic and graceful fallback to TTL-only mode if filesystem watching is unavailable.

## Key Changes

- Implements `dirCacheWatcher` with reference counting and debouncing
- Cache entries are immediately invalidated on filesystem changes
- Prevents watch leaks by cleaning up watches when entries are evicted
- Adds context check in flush to handle shutdown gracefully

## Test Coverage

Includes 4 new tests covering key scenarios: path extraction, ref counting, event invalidation, debouncing, and integration with the cache.