### PR TITLE
feat: forward CI failures to AI agent with aggregated context

### DIFF
--- a/backend/server/ci_handlers.go
+++ b/backend/server/ci_handlers.go
@@ -2,8 +2,11 @@ package server
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/chatml/chatml-backend/models"
 	"github.com/go-chi/chi/v5"
@@ -269,6 +272,192 @@ func (h *Handlers) AnalyzeCIFailure(w http.ResponseWriter, r *http.Request) {
 	}
 	if targetJobName != "" {
 		result.Summary += " in job '" + targetJobName + "'"
+	}
+
+	writeJSON(w, result)
+}
+
+// CIFailureContext holds aggregated CI failure information for all failing jobs.
+type CIFailureContext struct {
+	Branch      string             `json:"branch"`
+	FailedRuns  []FailedRunContext `json:"failedRuns"`
+	TotalFailed int                `json:"totalFailed"`
+	Truncated   bool               `json:"truncated"`
+}
+
+// FailedRunContext holds failure details for a single workflow run.
+type FailedRunContext struct {
+	RunID      int64              `json:"runId"`
+	RunName    string             `json:"runName"`
+	RunURL     string             `json:"runUrl"`
+	FailedJobs []FailedJobContext `json:"failedJobs"`
+}
+
+// FailedJobContext holds failure details and truncated logs for a single job.
+type FailedJobContext struct {
+	JobID       int64    `json:"jobId"`
+	JobName     string   `json:"jobName"`
+	JobURL      string   `json:"jobUrl"`
+	FailedSteps []string `json:"failedSteps"`
+	Logs        string   `json:"logs"`
+	LogLines    int      `json:"logLines"`
+	Truncated   bool     `json:"truncated"`
+}
+
+const (
+	maxLogLinesPerJob = 150
+	// maxFailedJobs is the total number of failed jobs collected across all workflow runs.
+	// Jobs beyond this limit are still counted in TotalFailed but their logs are not fetched.
+	maxFailedJobs = 5
+)
+
+// truncateLogLines returns the last n lines of a log string.
+func truncateLogLines(logs string, maxLines int) (string, int, bool) {
+	lines := strings.Split(logs, "\n")
+	totalLines := len(lines)
+	if totalLines <= maxLines {
+		return logs, totalLines, false
+	}
+	truncated := strings.Join(lines[totalLines-maxLines:], "\n")
+	return truncated, totalLines, true
+}
+
+// GetCIFailureContext aggregates CI failure context for a session's branch.
+// Returns failed workflow runs, their failed jobs, failed step names, and truncated logs.
+func (h *Handlers) GetCIFailureContext(w http.ResponseWriter, r *http.Request) {
+	ghCtx, ok := h.resolveGitHubContext(w, r)
+	if !ok {
+		return
+	}
+
+	ctx := r.Context()
+	branch := ghCtx.session.Branch
+
+	// Fetch workflow runs for this branch
+	runs, err := h.ghClient.ListWorkflowRuns(ctx, ghCtx.owner, ghCtx.repo, branch)
+	if err != nil {
+		writeInternalError(w, "failed to list workflow runs", err)
+		return
+	}
+
+	// Find the latest head SHA from completed runs
+	var latestSHA string
+	for _, run := range runs {
+		if run.Status == "completed" {
+			latestSHA = run.HeadSHA
+			break // runs are returned newest first
+		}
+	}
+
+	if latestSHA == "" {
+		writeJSON(w, CIFailureContext{
+			Branch:      branch,
+			FailedRuns:  []FailedRunContext{},
+			TotalFailed: 0,
+		})
+		return
+	}
+
+	// Filter to failed runs from the latest SHA
+	var failedRuns []FailedRunContext
+	totalFailed := 0
+	truncatedOverall := false
+	jobCount := 0
+
+	for _, run := range runs {
+		if run.HeadSHA != latestSHA {
+			continue
+		}
+		if run.Status != "completed" {
+			continue
+		}
+		if run.Conclusion != "failure" && run.Conclusion != "timed_out" {
+			continue
+		}
+
+		// Fetch jobs for this failed run
+		jobs, err := h.ghClient.ListWorkflowJobs(ctx, ghCtx.owner, ghCtx.repo, run.ID)
+		if err != nil {
+			log.Printf("Failed to fetch jobs for run %d: %v", run.ID, err)
+			continue
+		}
+
+		var failedJobs []FailedJobContext
+		for _, job := range jobs {
+			if job.Conclusion != "failure" && job.Conclusion != "timed_out" {
+				continue
+			}
+
+			totalFailed++
+			jobCount++
+			if jobCount > maxFailedJobs {
+				truncatedOverall = true
+				continue
+			}
+
+			// Extract failed step names
+			var failedSteps []string
+			for _, step := range job.Steps {
+				if step.Conclusion == "failure" || step.Conclusion == "timed_out" {
+					failedSteps = append(failedSteps, step.Name)
+				}
+			}
+
+			failedJobs = append(failedJobs, FailedJobContext{
+				JobID:       job.ID,
+				JobName:     job.Name,
+				JobURL:      job.HTMLURL,
+				FailedSteps: failedSteps,
+			})
+		}
+
+		if len(failedJobs) > 0 {
+			failedRuns = append(failedRuns, FailedRunContext{
+				RunID:      run.ID,
+				RunName:    run.Name,
+				RunURL:     run.HTMLURL,
+				FailedJobs: failedJobs,
+			})
+		}
+	}
+
+	// Fetch logs for all failed jobs in parallel.
+	// Each goroutine writes to a distinct slice element so no mutex is needed.
+	var wg sync.WaitGroup
+
+	for i := range failedRuns {
+		for j := range failedRuns[i].FailedJobs {
+			wg.Add(1)
+			go func(runIdx, jobIdx int) {
+				defer wg.Done()
+				job := &failedRuns[runIdx].FailedJobs[jobIdx]
+
+				logs, err := h.ghClient.GetJobLogs(ctx, ghCtx.owner, ghCtx.repo, job.JobID)
+				if err != nil {
+					log.Printf("Failed to fetch logs for job %d: %v", job.JobID, err)
+					job.Logs = "(logs unavailable)"
+					job.LogLines = 0
+					return
+				}
+
+				truncatedLogs, totalLines, wasTruncated := truncateLogLines(logs, maxLogLinesPerJob)
+				job.Logs = truncatedLogs
+				job.LogLines = totalLines
+				job.Truncated = wasTruncated
+			}(i, j)
+		}
+	}
+	wg.Wait()
+
+	result := CIFailureContext{
+		Branch:      branch,
+		FailedRuns:  failedRuns,
+		TotalFailed: totalFailed,
+		Truncated:   truncatedOverall,
+	}
+
+	if result.FailedRuns == nil {
+		result.FailedRuns = []FailedRunContext{}
 	}
 
 	writeJSON(w, result)

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -130,6 +130,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Post("/{id}/sessions/{sessionId}/ci/runs/{runId}/rerun", h.RerunCIWorkflow)
 		r.Get("/{id}/sessions/{sessionId}/ci/jobs/{jobId}/logs", h.GetCIJobLogs)
 		r.Post("/{id}/sessions/{sessionId}/ci/analyze", h.AnalyzeCIFailure)
+		r.Get("/{id}/sessions/{sessionId}/ci/failure-context", h.GetCIFailureContext)
 		// Commit status endpoints
 		r.Post("/{id}/sessions/{sessionId}/status", h.PostCommitStatus)
 		r.Get("/{id}/sessions/{sessionId}/statuses", h.ListCommitStatuses)

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -10,7 +10,9 @@ import {
   createConversation,
   deleteSession as apiDeleteSession,
   toStoreConversation,
+  getCIFailureContext,
 } from '@/lib/api';
+import { formatCIFailureMessage } from '@/lib/check-utils';
 import { useToast } from '@/components/ui/toast';
 import { copyToClipboard, openInVSCode, openInTerminal, showInFinder, unregisterSession, getSessionDirName } from '@/lib/tauri';
 import { DeleteSessionDialog } from '@/components/dialogs/DeleteSessionDialog';
@@ -183,6 +185,39 @@ export function SessionToolbarContent() {
     sendConversationMessage(selectedConversationId, content).catch(console.error);
   }, [selectedConversationId, showWarning]);
 
+  const [fixIssuesLoading, setFixIssuesLoading] = useState(false);
+
+  const handleFixIssues = useCallback(async () => {
+    if (!selectedConversationId || !selectedWorkspaceId || !selectedSessionId) {
+      showWarning('No active conversation');
+      return;
+    }
+
+    setFixIssuesLoading(true);
+    try {
+      const context = await getCIFailureContext(selectedWorkspaceId, selectedSessionId);
+
+      if (context.failedRuns.length === 0) {
+        showWarning('No CI failures found. Checks may have passed.');
+        return;
+      }
+
+      const message = formatCIFailureMessage(context);
+      await sendConversationMessage(selectedConversationId, message);
+    } catch (error) {
+      console.error('Failed to fetch CI failure context:', error);
+      // Fallback to generic message
+      try {
+        await sendConversationMessage(selectedConversationId, 'Fix the failing CI checks');
+        showWarning('Could not fetch CI details. Sent generic request.');
+      } catch {
+        showWarning('Failed to send message to agent.');
+      }
+    } finally {
+      setFixIssuesLoading(false);
+    }
+  }, [selectedConversationId, selectedWorkspaceId, selectedSessionId, showWarning]);
+
   const handleNewConversation = useCallback(async () => {
     if (!selectedWorkspaceId || !selectedSessionId) return;
     try {
@@ -301,6 +336,7 @@ export function SessionToolbarContent() {
               workspaceId={selectedWorkspaceId}
               session={selectedSession}
               onSendMessage={handleGitActionMessage}
+              onFixIssues={handleFixIssues}
               onArchiveSession={requestArchive}
               onCreatePR={() => setShowCreatePRDialog(true)}
             />
@@ -429,7 +465,7 @@ export function SessionToolbarContent() {
         ),
       },
     };
-  }, [selectedWorkspace, selectedSession, selectedWorkspaceId, handleGitActionMessage, handleNewConversation, handleCopyBranch, handleArchive, requestArchive, handleTaskStatusChange, handlePriorityChange, reviewPopoverOpen]);
+  }, [selectedWorkspace, selectedSession, selectedWorkspaceId, handleGitActionMessage, handleFixIssues, handleNewConversation, handleCopyBranch, handleArchive, requestArchive, handleTaskStatusChange, handlePriorityChange, reviewPopoverOpen]);
 
   useMainToolbarContent(toolbarConfig);
 

--- a/src/components/shared/PrimaryActionButton/ActionButton.tsx
+++ b/src/components/shared/PrimaryActionButton/ActionButton.tsx
@@ -16,6 +16,7 @@ export function ActionButton({
   isLoading,
   disabled,
   onSendMessage,
+  onFixIssues,
   onArchiveSession,
   onCreatePR,
   className,
@@ -35,7 +36,10 @@ export function ActionButton({
   const handleClick = () => {
     if (isDisabled) return;
 
-    if (action.type === 'create-pr' && onCreatePR) {
+    if (action.type === 'fix-issues' && onFixIssues) {
+      // Fetch CI failure context and forward to agent
+      onFixIssues();
+    } else if (action.type === 'create-pr' && onCreatePR) {
       // Open PR creation dialog
       onCreatePR();
     } else if (action.type === 'view-pr' && action.prUrl) {

--- a/src/components/shared/PrimaryActionButton/index.tsx
+++ b/src/components/shared/PrimaryActionButton/index.tsx
@@ -17,6 +17,7 @@ interface PrimaryActionButtonProps {
   workspaceId: string | null;
   session: WorktreeSession | null | undefined;
   onSendMessage: (content: string) => void;
+  onFixIssues?: () => void;
   onArchiveSession?: (sessionId: string) => void;
   onCreatePR?: () => void;
   // Optional: pass pre-fetched data to avoid duplicate fetches
@@ -28,6 +29,7 @@ export function PrimaryActionButton({
   workspaceId,
   session,
   onSendMessage,
+  onFixIssues,
   onArchiveSession,
   onCreatePR,
   gitStatus: externalGitStatus,
@@ -75,6 +77,7 @@ export function PrimaryActionButton({
       isLoading={isLoading}
       disabled={isAgentWorking}
       onSendMessage={onSendMessage}
+      onFixIssues={onFixIssues}
       onArchiveSession={onArchiveSession}
       onCreatePR={onCreatePR}
     />

--- a/src/components/shared/PrimaryActionButton/types.ts
+++ b/src/components/shared/PrimaryActionButton/types.ts
@@ -45,6 +45,7 @@ export interface ActionButtonProps {
   isLoading: boolean;
   disabled: boolean;
   onSendMessage: (content: string) => void;
+  onFixIssues?: () => void;
   onArchiveSession?: (sessionId: string) => void;
   onCreatePR?: () => void;
   className?: string;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1469,6 +1469,44 @@ export async function analyzeCIFailure(
 }
 
 // =============================================================================
+// CI Failure Context (aggregated failures for forwarding to AI)
+// =============================================================================
+
+export interface FailedJobContext {
+  jobId: number;
+  jobName: string;
+  jobUrl: string;
+  failedSteps: string[];
+  logs: string;
+  logLines: number;
+  truncated: boolean;
+}
+
+export interface FailedRunContext {
+  runId: number;
+  runName: string;
+  runUrl: string;
+  failedJobs: FailedJobContext[];
+}
+
+export interface CIFailureContextDTO {
+  branch: string;
+  failedRuns: FailedRunContext[];
+  totalFailed: number;
+  truncated: boolean;
+}
+
+export async function getCIFailureContext(
+  workspaceId: string,
+  sessionId: string
+): Promise<CIFailureContextDTO> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/ci/failure-context`
+  );
+  return handleResponse<CIFailureContextDTO>(res);
+}
+
+// =============================================================================
 // Commit Status Types and Functions
 // =============================================================================
 

--- a/src/lib/check-utils.ts
+++ b/src/lib/check-utils.ts
@@ -8,6 +8,7 @@ import {
   Play,
   type LucideIcon,
 } from 'lucide-react';
+import type { CIFailureContextDTO } from '@/lib/api';
 
 export interface StatusInfo {
   icon: LucideIcon;
@@ -63,4 +64,48 @@ export function formatDuration(seconds: number): string {
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;
   return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+/**
+ * Format CI failure context into a structured message for the AI agent.
+ */
+export function formatCIFailureMessage(context: CIFailureContextDTO): string {
+  const parts: string[] = [
+    'Fix the failing CI checks. Here is the failure context:',
+    '',
+  ];
+
+  for (const run of context.failedRuns) {
+    parts.push(`## Workflow: "${run.runName}"`);
+    parts.push('');
+
+    for (const job of run.failedJobs) {
+      parts.push(`### Job: "${job.jobName}" - FAILED`);
+
+      if (job.failedSteps && job.failedSteps.length > 0) {
+        parts.push(`Failed steps: ${job.failedSteps.join(', ')}`);
+      }
+
+      if (job.logs && job.logs !== '(logs unavailable)') {
+        if (job.truncated) {
+          parts.push(`(log truncated, showing tail of ${job.logLines} total lines)`);
+        }
+        parts.push('');
+        parts.push('<logs>');
+        parts.push(job.logs);
+        parts.push('</logs>');
+      } else {
+        parts.push('(logs unavailable)');
+      }
+
+      parts.push('');
+    }
+  }
+
+  if (context.truncated) {
+    parts.push(`Note: ${context.totalFailed} total jobs failed. Only the first 5 are shown above.`);
+    parts.push('');
+  }
+
+  return parts.join('\n');
 }


### PR DESCRIPTION
Add new GetCIFailureContext backend endpoint that aggregates failed CI runs and jobs with truncated logs. Wire up frontend UI in PrimaryActionButton to fetch and format this failure context into a structured message sent to the AI agent.

The endpoint filters to the latest commit SHA, collects up to 5 failed jobs with their logs (last 150 lines each), and tracks the total count. The frontend formats this into a markdown message with clear job/step information for the agent to use when fixing CI failures.

Includes fixes for error handling, constant duplication, and mutex clarity based on code review feedback.