### PR TITLE
fix: handle missing worktree paths gracefully

### DIFF
--- a/backend/server/errors.go
+++ b/backend/server/errors.go
@@ -15,14 +15,15 @@ type APIError struct {
 
 // Error codes for categorization
 const (
-	ErrCodeValidation      = "VALIDATION_ERROR"
-	ErrCodeNotFound        = "NOT_FOUND"
-	ErrCodeConflict        = "CONFLICT"
-	ErrCodeInternal        = "INTERNAL_ERROR"
-	ErrCodeUnauthorized    = "UNAUTHORIZED"
-	ErrCodeBadGateway      = "BAD_GATEWAY"
-	ErrCodePayloadTooLarge  = "PAYLOAD_TOO_LARGE"
+	ErrCodeValidation         = "VALIDATION_ERROR"
+	ErrCodeNotFound           = "NOT_FOUND"
+	ErrCodeConflict           = "CONFLICT"
+	ErrCodeInternal           = "INTERNAL_ERROR"
+	ErrCodeUnauthorized       = "UNAUTHORIZED"
+	ErrCodeBadGateway         = "BAD_GATEWAY"
+	ErrCodePayloadTooLarge    = "PAYLOAD_TOO_LARGE"
 	ErrCodeServiceUnavailable = "SERVICE_UNAVAILABLE"
+	ErrCodeWorktreeNotFound   = "WORKTREE_NOT_FOUND"
 )
 
 // writeError writes a JSON error response and logs the internal error server-side
@@ -84,4 +85,22 @@ func writeServiceUnavailable(w http.ResponseWriter, msg string) {
 // writePayloadTooLarge writes a 413 payload too large error response
 func writePayloadTooLarge(w http.ResponseWriter, msg string) {
 	writeError(w, http.StatusRequestEntityTooLarge, ErrCodePayloadTooLarge, msg, nil)
+}
+
+// writeWorktreeNotFound writes a 410 Gone response for worktree paths that no longer exist on disk.
+// The frontend uses the WORKTREE_NOT_FOUND code to stop polling and show a specific message.
+func writeWorktreeNotFound(w http.ResponseWriter, path string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusGone)
+	if err := json.NewEncoder(w).Encode(struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+		Path  string `json:"path"`
+	}{
+		Error: "worktree path no longer exists",
+		Code:  ErrCodeWorktreeNotFound,
+		Path:  path,
+	}); err != nil {
+		logger.Error.Errorf("Failed to encode worktree-not-found response: %v", err)
+	}
 }

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -621,6 +621,20 @@ func (h *Handlers) getSessionAndWorkspace(ctx context.Context, sessionID string)
 	return session, workingPath, baseRef, nil
 }
 
+// checkWorktreePath verifies that the given worktree path exists on disk.
+// Returns true if the path is missing and a 410 response was written.
+// Handlers should return early when this returns true.
+func checkWorktreePath(w http.ResponseWriter, path string) bool {
+	if path == "" {
+		return false
+	}
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		writeWorktreeNotFound(w, path)
+		return true
+	}
+	return false
+}
+
 // computeSessionStats calculates total additions/deletions for a session's worktree.
 // Returns nil if the session has no worktree path or no changes.
 func (h *Handlers) computeSessionStats(ctx context.Context, session *models.Session, workspaceBranch string) *models.SessionStats {
@@ -1831,6 +1845,9 @@ func (h *Handlers) GetSessionGitStatus(w http.ResponseWriter, r *http.Request) {
 		writeNotFound(w, "session")
 		return
 	}
+	if checkWorktreePath(w, workingPath) {
+		return
+	}
 
 	// Get comprehensive git status
 	status, err := h.repoManager.GetStatus(ctx, workingPath, baseRef)
@@ -1914,6 +1931,9 @@ func (h *Handlers) GetSessionFileDiff(w http.ResponseWriter, r *http.Request) {
 	}
 	if session == nil {
 		writeNotFound(w, "session")
+		return
+	}
+	if checkWorktreePath(w, workingPath) {
 		return
 	}
 
@@ -2559,6 +2579,9 @@ func (h *Handlers) GetSessionFileContent(w http.ResponseWriter, r *http.Request)
 		writeNotFound(w, "session")
 		return
 	}
+	if checkWorktreePath(w, session.WorktreePath) {
+		return
+	}
 
 	// Get file path from query parameter
 	filePath := r.URL.Query().Get("path")
@@ -2619,6 +2642,9 @@ func (h *Handlers) ListSessionFiles(w http.ResponseWriter, r *http.Request) {
 	}
 	if session == nil {
 		writeNotFound(w, "session")
+		return
+	}
+	if checkWorktreePath(w, session.WorktreePath) {
 		return
 	}
 
@@ -2705,6 +2731,9 @@ func (h *Handlers) SaveFile(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if session.WorktreePath != "" {
+			if checkWorktreePath(w, session.WorktreePath) {
+				return
+			}
 			basePath = session.WorktreePath
 		}
 	}
@@ -3802,6 +3831,9 @@ func (h *Handlers) GeneratePRDescription(w http.ResponseWriter, r *http.Request)
 		writeNotFound(w, "session")
 		return
 	}
+	if checkWorktreePath(w, workingPath) {
+		return
+	}
 
 	// Get commits ahead of base
 	commits, err := h.repoManager.GetCommitsAheadOfBase(ctx, workingPath, baseRef)
@@ -3890,6 +3922,9 @@ func (h *Handlers) CreatePR(w http.ResponseWriter, r *http.Request) {
 	}
 	if session == nil {
 		writeNotFound(w, "session")
+		return
+	}
+	if checkWorktreePath(w, workingPath) {
 		return
 	}
 
@@ -4152,6 +4187,9 @@ func (h *Handlers) GetSessionBranchSyncStatus(w http.ResponseWriter, r *http.Req
 		writeNotFound(w, "session")
 		return
 	}
+	if checkWorktreePath(w, session.WorktreePath) {
+		return
+	}
 
 	// Get sync status using effective target branch
 	targetBranch := session.EffectiveTargetBranch()
@@ -4204,6 +4242,9 @@ func (h *Handlers) SyncSessionBranch(w http.ResponseWriter, r *http.Request) {
 	}
 	if session == nil {
 		writeNotFound(w, "session")
+		return
+	}
+	if checkWorktreePath(w, session.WorktreePath) {
 		return
 	}
 
@@ -4261,6 +4302,9 @@ func (h *Handlers) AbortSessionSync(w http.ResponseWriter, r *http.Request) {
 	}
 	if session == nil {
 		writeNotFound(w, "session")
+		return
+	}
+	if checkWorktreePath(w, session.WorktreePath) {
 		return
 	}
 

--- a/src/components/panels/GitStatusSection.tsx
+++ b/src/components/panels/GitStatusSection.tsx
@@ -14,6 +14,7 @@ import {
   Circle,
   AlertTriangle,
   XCircle,
+  FolderX,
   Loader2,
   RefreshCw,
   ChevronDown,
@@ -22,7 +23,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { GitStatusDTO } from '@/lib/api';
+import { ErrorCode, type GitStatusDTO } from '@/lib/api';
 
 interface DropdownAction {
   icon: LucideIcon;
@@ -326,7 +327,7 @@ interface GitStatusSectionProps {
 
 export function GitStatusSection({ onSendMessage }: GitStatusSectionProps) {
   const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
-  const { status, loading, error, refetch } = useGitStatus(selectedWorkspaceId, selectedSessionId);
+  const { status, loading, error, errorCode, refetch } = useGitStatus(selectedWorkspaceId, selectedSessionId);
 
   // Wrapper that handles missing callback
   const sendMessage = (content: string) => {
@@ -346,6 +347,17 @@ export function GitStatusSection({ onSendMessage }: GitStatusSectionProps) {
   }
 
   if (error) {
+    if (errorCode === ErrorCode.WORKTREE_NOT_FOUND) {
+      return (
+        <div className="h-full flex flex-col items-center justify-center gap-2 p-4">
+          <FolderX className="h-5 w-5 text-muted-foreground" />
+          <p className="text-xs text-muted-foreground text-center">
+            Worktree directory no longer exists
+          </p>
+        </div>
+      );
+    }
+
     return (
       <div className="h-full flex flex-col items-center justify-center gap-2 p-4">
         <XCircle className="h-5 w-5 text-text-error" />

--- a/src/hooks/useGitStatus.ts
+++ b/src/hooks/useGitStatus.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getGitStatus, GitStatusDTO } from '@/lib/api';
+import { getGitStatus, GitStatusDTO, ApiError, ErrorCode } from '@/lib/api';
 import { GIT_STATUS_POLL_INTERVAL_MS } from '@/lib/constants';
 import { useAppStore } from '@/stores/appStore';
 
@@ -9,6 +9,7 @@ interface UseGitStatusResult {
   status: GitStatusDTO | null;
   loading: boolean;
   error: string | null;
+  errorCode: string | null;
   refetch: () => Promise<void>;
 }
 
@@ -20,6 +21,7 @@ interface UseGitStatusResult {
  * - Polls periodically (every 30 seconds)
  * - Refetches on file change events via the centralized lastFileChange store
  * - Debounces rapid file changes
+ * - Stops polling on permanent errors (e.g. WORKTREE_NOT_FOUND)
  */
 export function useGitStatus(
   workspaceId: string | null,
@@ -28,6 +30,7 @@ export function useGitStatus(
   const [status, setStatus] = useState<GitStatusDTO | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
 
   // Subscribe to centralized file change events from the store
   const lastFileChange = useAppStore((s) => s.lastFileChange);
@@ -35,6 +38,8 @@ export function useGitStatus(
   // Refs for debouncing and cleanup
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isMountedRef = useRef(false);
+  // Track permanent errors so polling stops
+  const permanentErrorRef = useRef(false);
 
   // Fetch git status
   const fetchStatus = useCallback(async () => {
@@ -44,17 +49,31 @@ export function useGitStatus(
       return;
     }
 
+    // Skip fetch if we already hit a permanent error
+    if (permanentErrorRef.current) return;
+
     try {
       const data = await getGitStatus(workspaceId, sessionId);
       if (isMountedRef.current) {
         setStatus(data);
         setError(null);
+        setErrorCode(null);
         setLoading(false);
       }
     } catch (err) {
       if (isMountedRef.current) {
-        console.error('Failed to fetch git status:', err);
+        const isPermanent =
+          err instanceof ApiError && err.code === ErrorCode.WORKTREE_NOT_FOUND;
+
+        if (isPermanent) {
+          permanentErrorRef.current = true;
+        }
+
+        if (!isPermanent) {
+          console.error('Failed to fetch git status:', err);
+        }
         setError(err instanceof Error ? err.message : 'Failed to fetch git status');
+        setErrorCode(err instanceof ApiError ? (err.code ?? null) : null);
         setLoading(false);
       }
     }
@@ -62,6 +81,7 @@ export function useGitStatus(
 
   // Debounced refetch for file change events
   const debouncedRefetch = useCallback(() => {
+    if (permanentErrorRef.current) return;
     if (debounceTimeoutRef.current) {
       clearTimeout(debounceTimeoutRef.current);
     }
@@ -75,6 +95,11 @@ export function useGitStatus(
     setLoading(true);
     await fetchStatus();
   }, [fetchStatus]);
+
+  // Reset permanent error flag when session changes
+  useEffect(() => {
+    permanentErrorRef.current = false;
+  }, [workspaceId, sessionId]);
 
   // Initial fetch and fetch on session change
   useEffect(() => {
@@ -97,7 +122,9 @@ export function useGitStatus(
     if (!workspaceId || !sessionId) return;
 
     const interval = setInterval(() => {
-      fetchStatus();
+      if (!permanentErrorRef.current) {
+        fetchStatus();
+      }
     }, GIT_STATUS_POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
@@ -111,5 +138,5 @@ export function useGitStatus(
     }
   }, [lastFileChange, workspaceId, debouncedRefetch]);
 
-  return { status, loading, error, refetch };
+  return { status, loading, error, errorCode, refetch };
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,6 +25,8 @@ export const API_BASE = typeof window !== 'undefined' && (window as Window & { _
 
 // Custom error class for API errors
 export class ApiError extends Error {
+  public code?: string;
+
   constructor(
     message: string,
     public status: number,
@@ -32,8 +34,25 @@ export class ApiError extends Error {
   ) {
     super(message);
     this.name = 'ApiError';
+
+    // Try to parse a structured error code from the JSON response body
+    if (response) {
+      try {
+        const parsed = JSON.parse(response);
+        if (parsed.code) {
+          this.code = parsed.code;
+        }
+      } catch {
+        // Response is not JSON, ignore
+      }
+    }
   }
 }
+
+/** Well-known backend error codes */
+export const ErrorCode = {
+  WORKTREE_NOT_FOUND: 'WORKTREE_NOT_FOUND',
+} as const;
 
 // Fetch helper that adds authentication token for Tauri builds
 // Also catches network-level TypeErrors (e.g. server unreachable) and


### PR DESCRIPTION
## Summary
- Sessions referencing deleted worktree directories caused continuous 500 errors from the git-status polling endpoint (every 30s), generating console noise and unnecessary backend load
- Added `checkWorktreePath` helper that returns **410 Gone** with `WORKTREE_NOT_FOUND` error code when a worktree path no longer exists on disk
- Applied the check to 10 handlers: `GetSessionGitStatus`, `GetSessionFileDiff`, `GetSessionFileContent`, `ListSessionFiles`, `SaveFile`, `GetSessionBranchSyncStatus`, `SyncSessionBranch`, `AbortSessionSync`, `GeneratePRDescription`, `CreatePR`
- Frontend `ApiError` now parses structured error codes from JSON responses
- `useGitStatus` hook stops polling on permanent errors (WORKTREE_NOT_FOUND)
- `GitStatusSection` shows a specific "Worktree directory no longer exists" message with `FolderX` icon

## Test plan
- [ ] `cd backend && go build ./...` — compiles
- [ ] `cd backend && go test ./...` — all tests pass
- [ ] `npm run lint` (on changed files) — no new warnings
- [ ] `npm run build` — frontend builds successfully
- [ ] Start app, navigate to a session with a missing worktree path
  - [ ] Backend returns 410 instead of 500
  - [ ] No repeated polling after the first 410
  - [ ] Frontend shows "Worktree directory no longer exists" with folder icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)