### PR TITLE
feat: add session status icons and replace todo with in_review

### DIFF
--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -29,7 +29,7 @@ type Session struct {
 	HasMergeConflict bool          `json:"hasMergeConflict,omitempty"`
 	HasCheckFailures bool          `json:"hasCheckFailures,omitempty"`
 	Priority         int           `json:"priority"`             // 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low
-	TaskStatus       string        `json:"taskStatus"`           // backlog, todo, in_progress, done, cancelled
+	TaskStatus       string        `json:"taskStatus"`           // backlog, in_progress, in_review, done, cancelled
 	Pinned           bool          `json:"pinned,omitempty"`
 	Archived             bool   `json:"archived,omitempty"`
 	ArchiveSummary       string `json:"archiveSummary,omitempty"`
@@ -228,8 +228,8 @@ var ValidPriorities = map[int]bool{
 // TaskStatus constants (user-managed workflow state, distinct from agent execution Status)
 const (
 	TaskStatusBacklog    = "backlog"
-	TaskStatusTodo       = "todo"
 	TaskStatusInProgress = "in_progress"
+	TaskStatusInReview   = "in_review"
 	TaskStatusDone       = "done"
 	TaskStatusCancelled  = "cancelled"
 )
@@ -237,8 +237,8 @@ const (
 // ValidTaskStatuses is the set of valid task status values
 var ValidTaskStatuses = map[string]bool{
 	TaskStatusBacklog:    true,
-	TaskStatusTodo:       true,
 	TaskStatusInProgress: true,
+	TaskStatusInReview:   true,
 	TaskStatusDone:       true,
 	TaskStatusCancelled:  true,
 }

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -559,6 +559,19 @@ func (s *SQLiteStore) runMigrations() error {
 		logger.SQLite.Infof("Migration: Added model column to conversations")
 	}
 
+	// Migration: Convert 'todo' task_status to 'backlog' (todo status was removed)
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE task_status = 'todo'`).Scan(&count)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		_, err = s.db.Exec(`UPDATE sessions SET task_status = 'backlog' WHERE task_status = 'todo'`)
+		if err != nil {
+			return err
+		}
+		logger.SQLite.Infof("Migration: Converted %d sessions from 'todo' to 'backlog' task_status", count)
+	}
+
 	return nil
 }
 

--- a/src/components/dashboards/workspace-dashboard/SessionCard.tsx
+++ b/src/components/dashboards/workspace-dashboard/SessionCard.tsx
@@ -4,7 +4,6 @@ import type { WorktreeSession } from '@/lib/types';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import {
-  GitBranch,
   ExternalLink,
   Check,
   X,
@@ -14,7 +13,8 @@ import {
   Plus,
   Minus,
 } from 'lucide-react';
-import { getPriorityOption, getTaskStatusOption } from '@/lib/session-fields';
+import { getPriorityOption } from '@/lib/session-fields';
+import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 
 interface SessionCardProps {
   session: WorktreeSession;
@@ -70,9 +70,7 @@ export function SessionCard({ session, onJumpToSession }: SessionCardProps) {
   };
 
   const prStatus = getPRStatusInfo();
-  const taskStatusOpt = getTaskStatusOption(session.taskStatus);
   const priorityOpt = session.priority > 0 ? getPriorityOption(session.priority) : null;
-  const TaskStatusIcon = taskStatusOpt.icon;
   const PriorityIcon = priorityOpt?.icon;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -108,11 +106,10 @@ export function SessionCard({ session, onJumpToSession }: SessionCardProps) {
           {/* Main content */}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
-              <TaskStatusIcon className={cn('h-3.5 w-3.5 shrink-0', taskStatusOpt.color)} />
+              <TaskStatusIcon status={session.taskStatus} className="h-3.5 w-3.5 shrink-0" />
               {PriorityIcon && priorityOpt && (
                 <PriorityIcon className={cn('h-3.5 w-3.5 shrink-0', priorityOpt.color)} />
               )}
-              <GitBranch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
               <span className="font-medium text-sm truncate">{session.branch}</span>
               {session.pinned && (
                 <Pin className="h-3 w-3 text-muted-foreground shrink-0" />

--- a/src/components/icons/TaskStatusIcon.tsx
+++ b/src/components/icons/TaskStatusIcon.tsx
@@ -1,0 +1,110 @@
+import type { SessionTaskStatus } from '@/lib/types';
+
+interface TaskStatusIconProps {
+  status: SessionTaskStatus;
+  className?: string;
+}
+
+// Linear-style status icons as inline SVGs
+export function TaskStatusIcon({ status, className = 'h-3.5 w-3.5' }: TaskStatusIconProps) {
+  switch (status) {
+    case 'backlog':
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className}>
+          <circle
+            cx="8"
+            cy="8"
+            r="6.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeDasharray="3 2.5"
+            className="text-muted-foreground"
+          />
+        </svg>
+      );
+
+    case 'in_progress':
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className}>
+          <circle
+            cx="8"
+            cy="8"
+            r="6.5"
+            stroke="#EAB308"
+            strokeWidth="1.5"
+          />
+          <path
+            d="M8 1.5A6.5 6.5 0 0 1 14.5 8H8V1.5Z"
+            fill="#EAB308"
+          />
+        </svg>
+      );
+
+    case 'in_review':
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className}>
+          <circle
+            cx="8"
+            cy="8"
+            r="6.5"
+            stroke="#22C55E"
+            strokeWidth="1.5"
+          />
+          <path
+            d="M8 1.5A6.5 6.5 0 0 1 14.5 8 6.5 6.5 0 0 1 8 14.5 6.5 6.5 0 0 1 1.5 8H8V1.5Z"
+            fill="#22C55E"
+          />
+        </svg>
+      );
+
+    case 'done':
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className}>
+          <circle cx="8" cy="8" r="7" fill="#A855F7" />
+          <path
+            d="M5.5 8L7.2 9.7L10.5 6.3"
+            stroke="white"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+
+    case 'cancelled':
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className}>
+          <circle
+            cx="8"
+            cy="8"
+            r="6.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="text-muted-foreground/50"
+          />
+          <path
+            d="M5.75 5.75L10.25 10.25M10.25 5.75L5.75 10.25"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            className="text-muted-foreground/50"
+          />
+        </svg>
+      );
+
+    default:
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className}>
+          <circle
+            cx="8"
+            cy="8"
+            r="6.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeDasharray="3 2.5"
+            className="text-muted-foreground"
+          />
+        </svg>
+      );
+  }
+}

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -81,7 +81,8 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getWorkspaceColor } from '@/lib/workspace-colors';
-import { getPriorityOption, getTaskStatusOption } from '@/lib/session-fields';
+import { getPriorityOption } from '@/lib/session-fields';
+import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 import { useToast } from '@/components/ui/toast';
 import {
   Dialog,
@@ -1060,13 +1061,9 @@ function SessionRow({
               </div>
             )}
           </div>
-          {/* Git icon column */}
+          {/* Task status icon column */}
           <div className="w-4 shrink-0 flex items-start justify-center pt-0.5">
-            {hasPR ? (
-              <GitPullRequest className="w-3.5 h-3.5 text-purple-500" />
-            ) : (
-              <GitBranch className="w-3.5 h-3.5 text-muted-foreground" />
-            )}
+            <TaskStatusIcon status={session.taskStatus} className="w-3.5 h-3.5" />
           </div>
           <div className="flex-1 min-w-0">
             {/* First line: branch name + stats/actions */}
@@ -1121,10 +1118,10 @@ function SessionRow({
             </div>
             {/* Second line: task status · priority · session name · PR info · status */}
             <div className="flex items-center gap-1 mt-0.5 text-sm text-muted-foreground">
-              {session.taskStatus && session.taskStatus !== 'backlog' && (() => {
-                const opt = getTaskStatusOption(session.taskStatus);
-                return <opt.icon className={cn('h-3 w-3 shrink-0', opt.color)} />;
-              })()}
+              {/* PR icon if applicable */}
+              {hasPR && (
+                <GitPullRequest className="h-3 w-3 shrink-0 text-purple-500" />
+              )}
               {session.priority > 0 && (() => {
                 const opt = getPriorityOption(session.priority);
                 return <opt.icon className={cn('h-3 w-3 shrink-0', opt.color)} />;

--- a/src/components/session-manager/WorkspaceTreeItem.tsx
+++ b/src/components/session-manager/WorkspaceTreeItem.tsx
@@ -10,12 +10,11 @@ import {
 import {
   ChevronDown,
   Folder,
-  GitBranch,
-  GitPullRequest,
   CheckCircle2,
   XCircle,
   AlertTriangle,
 } from 'lucide-react';
+import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 
 interface WorkspaceTreeItemProps {
   workspace: Workspace;
@@ -107,13 +106,9 @@ export function WorkspaceTreeItem({
                     onClick={() => onSelectSession(session.id)}
                   >
                     <div className="flex-1 min-w-0">
-                      {/* Branch name */}
+                      {/* Branch name with status icon */}
                       <div className="flex items-center gap-1.5">
-                        {hasPR ? (
-                          <GitPullRequest className="w-3 h-3 text-purple-500 shrink-0" />
-                        ) : (
-                          <GitBranch className="w-3 h-3 text-muted-foreground shrink-0" />
-                        )}
+                        <TaskStatusIcon status={session.taskStatus} className="w-3 h-3 shrink-0" />
                         <span className="text-xs font-medium truncate">
                           {session.branch || session.name}
                         </span>

--- a/src/components/shared/TaskStatusSelector.tsx
+++ b/src/components/shared/TaskStatusSelector.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Check } from 'lucide-react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 
 interface TaskStatusSelectorProps {
   value: SessionTaskStatus;
@@ -29,7 +30,6 @@ export function TaskStatusSelector({
   disabled = false,
 }: TaskStatusSelectorProps) {
   const current = getTaskStatusOption(value);
-  const Icon = current.icon;
   const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
   const btnSize = size === 'sm' ? 'h-6 w-auto' : 'h-7 w-auto';
 
@@ -40,9 +40,9 @@ export function TaskStatusSelector({
       className={cn(btnSize, showLabel ? 'gap-1.5 px-1.5' : 'w-6')}
       disabled={disabled}
     >
-      <Icon className={cn(iconSize, current.color)} />
+      <TaskStatusIcon status={current.value} className={iconSize} />
       {showLabel && (
-        <span className={cn('text-xs', current.color)}>{current.label}</span>
+        <span className="text-xs text-muted-foreground">{current.label}</span>
       )}
     </Button>
   );
@@ -62,21 +62,18 @@ export function TaskStatusSelector({
         )}
       </Tooltip>
       <DropdownMenuContent align="start" className="w-44">
-        {TASK_STATUS_OPTIONS.map((option) => {
-          const OptionIcon = option.icon;
-          return (
-            <DropdownMenuItem
-              key={option.value}
-              onSelect={() => onChange(option.value)}
-            >
-              <OptionIcon className={cn('h-4 w-4', option.color)} />
-              <span className="flex-1">{option.label}</span>
-              {option.value === value && (
-                <Check className="h-3.5 w-3.5 text-muted-foreground" />
-              )}
-            </DropdownMenuItem>
-          );
-        })}
+        {TASK_STATUS_OPTIONS.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            onSelect={() => onChange(option.value)}
+          >
+            <TaskStatusIcon status={option.value} className="h-4 w-4" />
+            <span className="flex-1">{option.label}</span>
+            {option.value === value && (
+              <Check className="h-3.5 w-3.5 text-muted-foreground" />
+            )}
+          </DropdownMenuItem>
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/lib/session-fields.ts
+++ b/src/lib/session-fields.ts
@@ -5,11 +5,6 @@ import {
   ArrowUp,
   Equal,
   ArrowDown,
-  CircleDashed,
-  Circle,
-  CircleDot,
-  CheckCircle2,
-  XCircle,
 } from 'lucide-react';
 import type { SessionPriority, SessionTaskStatus } from './types';
 
@@ -31,16 +26,14 @@ export const PRIORITY_OPTIONS: PriorityOption[] = [
 export interface TaskStatusOption {
   value: SessionTaskStatus;
   label: string;
-  icon: LucideIcon;
-  color: string;
 }
 
 export const TASK_STATUS_OPTIONS: TaskStatusOption[] = [
-  { value: 'backlog', label: 'Backlog', icon: CircleDashed, color: 'text-muted-foreground' },
-  { value: 'todo', label: 'Todo', icon: Circle, color: 'text-foreground/70' },
-  { value: 'in_progress', label: 'In Progress', icon: CircleDot, color: 'text-yellow-500' },
-  { value: 'done', label: 'Done', icon: CheckCircle2, color: 'text-text-success' },
-  { value: 'cancelled', label: 'Cancelled', icon: XCircle, color: 'text-muted-foreground/50' },
+  { value: 'backlog', label: 'Backlog' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'in_review', label: 'In Review' },
+  { value: 'done', label: 'Done' },
+  { value: 'cancelled', label: 'Cancelled' },
 ];
 
 export function getPriorityOption(value: number): PriorityOption {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@
 export type SessionPriority = 0 | 1 | 2 | 3 | 4;
 
 // Session task status (user-managed workflow state, distinct from agent execution status)
-export type SessionTaskStatus = 'backlog' | 'todo' | 'in_progress' | 'done' | 'cancelled';
+export type SessionTaskStatus = 'backlog' | 'in_progress' | 'in_review' | 'done' | 'cancelled';
 
 // Workspace = A repository pointed to a path on disk
 export interface Workspace {


### PR DESCRIPTION
## Summary
- Replace generic Lucide icons with custom Linear-style SVG status icons
- Replace 'todo' task status with 'in_review' for better code review workflow representation
- Promote task status icon to primary visual indicator in session lists
- Make in_review icon visually distinct with 3/4 fill (vs 1/4 for in_progress)
- Add idempotent migration to convert existing 'todo' sessions to 'backlog'

## Test Plan
- [x] Visual inspection of status icons at multiple sizes
- [x] Icon colors and shapes are distinctly different
- [x] Database migration runs safely on startup
- [x] All status selector dropdowns render correctly