### PR TITLE
fix: validate persisted tab IDs against backend data before restoring

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -529,17 +529,37 @@ export default function Home() {
         const hasPersistedTab = ENABLE_BROWSER_TABS && activeTab && tabState!.tabOrder.length > 0 &&
           (activeTab.selectedWorkspaceId || activeTab.contentView.type !== 'conversation');
 
-        if (hasPersistedTab) {
-          // Restore from persisted active tab
-          if (activeTab.selectedWorkspaceId) {
+        // Validate persisted IDs against loaded data before restoring
+        const workspaceValid = hasPersistedTab && activeTab.selectedWorkspaceId &&
+          mappedWorkspaces.some(w => w.id === activeTab.selectedWorkspaceId);
+        const sessionValid = hasPersistedTab && activeTab.selectedSessionId &&
+          allSessions.some(s => s.id === activeTab.selectedSessionId);
+        // Only validate conversation if its session is also valid
+        const conversationValid = sessionValid && activeTab.selectedConversationId &&
+          allConversations.some(c => c.id === activeTab.selectedConversationId);
+        // For non-conversation views that carry a workspaceId, validate it exists
+        const contentViewWorkspaceId = activeTab?.contentView &&
+          'workspaceId' in activeTab.contentView
+          ? (activeTab.contentView as { workspaceId?: string }).workspaceId
+          : undefined;
+        const contentViewWorkspaceValid = contentViewWorkspaceId
+          ? mappedWorkspaces.some(w => w.id === contentViewWorkspaceId)
+          : true; // views without workspaceId (global-dashboard, repositories, session-manager) are always valid
+        const hasValidPersistedState = workspaceValid || sessionValid ||
+          (hasPersistedTab && activeTab.contentView.type !== 'conversation' && contentViewWorkspaceValid);
+
+        if (hasValidPersistedState) {
+          // Restore only IDs that still exist in backend data
+          if (workspaceValid) {
             selectWorkspace(activeTab.selectedWorkspaceId);
+            // If workspace is valid but session is stale, select first available session in this workspace
+            if (!sessionValid) {
+              const fallbackSession = allSessions.find(s => s.workspaceId === activeTab.selectedWorkspaceId);
+              if (fallbackSession) selectSession(fallbackSession.id);
+            }
           }
-          if (activeTab.selectedSessionId) {
-            selectSession(activeTab.selectedSessionId);
-          }
-          if (activeTab.selectedConversationId) {
-            selectConversation(activeTab.selectedConversationId);
-          }
+          if (sessionValid) selectSession(activeTab.selectedSessionId);
+          if (conversationValid) selectConversation(activeTab.selectedConversationId);
           useSettingsStore.getState().setContentView(activeTab!.contentView);
           useNavigationStore.getState().setActiveTabId(tabState!.activeTabId);
         } else if (mappedWorkspaces.length > 0) {


### PR DESCRIPTION
## Summary

- Validates persisted workspace/session/conversation IDs from localStorage against freshly loaded backend data before restoring them on app startup
- Prevents "session not found" errors when `~/.chatml` is deleted but browser tab state remains in localStorage
- Falls back to first available session when workspace is valid but persisted session is stale
- Validates `contentView.workspaceId` for non-conversation views (workspace-dashboard, branches, pr-dashboard)

## Problem

When `~/.chatml` is deleted and the app reopens, the `tabStore` (persisted in localStorage) still holds IDs from the previous state. The app restored these stale IDs without checking they exist, causing:

1. `selectSession(deletedSessionId)` called with a non-existent ID
2. Render logic sees `selectedSessionId` is truthy, skips EmptyView
3. ConversationArea tries to load messages → "session not found" error

## Test plan

- [ ] Delete `~/.chatml`, reopen app → should show EmptyView instead of error
- [ ] Normal restart (without deleting `~/.chatml`) → persisted tabs still restore correctly
- [ ] Delete a workspace's sessions from backend, reopen → workspace selected, first remaining session auto-selected
- [ ] Persisted non-conversation view (e.g. workspace-dashboard) with deleted workspace → falls through to defaults
- [ ] `npm run lint && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)