### PR TITLE
fix: skip stale macOS FSEvents for deleted worktree directories

### DIFF
--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -158,6 +158,13 @@ pub fn start_global_watcher(
                                     }
                                 };
 
+                            // Skip events for directories that no longer exist on disk.
+                            // macOS FSEvents can deliver stale historical events for
+                            // deleted directories when a new watcher subscribes.
+                            if !watcher_base_path.join(&session_dir).exists() {
+                                continue;
+                            }
+
                             // Look up the workspace_id for this session (read lock only)
                             let workspace_id = match thread_sessions.read() {
                                 Ok(s) => s.get(&session_dir).cloned(),


### PR DESCRIPTION
## Summary
- macOS FSEvents delivers historical events from its persistent journal when a new watcher subscribes, including events for directories that no longer exist on disk
- This caused noisy DEBUG log spam (`Ignoring event for unregistered session: ...`) for old session names (e.g. `mcmurdo`, `casablanca`, `portland`) after `~/.chatml/` was deleted and recreated
- Added a simple `exists()` check on the session directory before processing the event, silently skipping stale entries

## Test plan
- [ ] Delete `~/.chatml/workspaces/` and recreate it
- [ ] Launch app and verify no "Ignoring event for unregistered session" log spam
- [ ] Create a new session and verify file watcher events still work for real directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)