### PR TITLE
feat: streaming snapshot recovery on WebSocket reconnect (H3)

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -41,26 +41,42 @@ function resolveToolPreset(preset: string): { allowedTools?: string[]; disallowe
 
 // CLI arguments
 const args = process.argv.slice(2);
-const cwdIndex = args.indexOf("--cwd");
-const conversationIdIndex = args.indexOf("--conversation-id");
-const resumeIndex = args.indexOf("--resume");
-const forkIndex = args.indexOf("--fork");
 
-const cwd = cwdIndex !== -1 ? args[cwdIndex + 1] : process.cwd();
-const conversationId = conversationIdIndex !== -1 ? args[conversationIdIndex + 1] : "default";
-const resumeSessionId = resumeIndex !== -1 ? args[resumeIndex + 1] : undefined;
-const forkSession = forkIndex !== -1;
-const linearIssueIndex = args.indexOf("--linear-issue");
-const toolPresetIndex = args.indexOf("--tool-preset");
+// Safe arg getter: returns the value after a flag, or undefined if missing/out of bounds
+function getArg(flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx + 1 >= args.length) return undefined;
+  return args[idx + 1];
+}
 
-const linearIssue = linearIssueIndex !== -1 ? args[linearIssueIndex + 1] : undefined;
-const toolPreset = toolPresetIndex !== -1 ? args[toolPresetIndex + 1] as "full" | "read-only" | "no-bash" | "safe-edit" : "full";
-const enableCheckpointingIndex = args.indexOf("--enable-checkpointing");
-const enableCheckpointing = enableCheckpointingIndex !== -1;
+function hasFlag(flag: string): boolean {
+  return args.indexOf(flag) !== -1;
+}
+
+function getNumericArg(flag: string): number | undefined {
+  const val = getArg(flag);
+  if (val === undefined) return undefined;
+  // Always use parseFloat — integer values parse fine with it, and this avoids
+  // a fragile heuristic for deciding float vs int based on flag name.
+  const num = parseFloat(val);
+  if (isNaN(num)) {
+    console.error(`Invalid numeric value for ${flag}: "${val}". Ignoring.`);
+    return undefined;
+  }
+  return num;
+}
+
+const cwd = getArg("--cwd") || process.cwd();
+const conversationId = getArg("--conversation-id") || "default";
+const resumeSessionId = getArg("--resume");
+const forkSession = hasFlag("--fork");
+
+const linearIssue = getArg("--linear-issue");
+const toolPreset = (getArg("--tool-preset") || "full") as "full" | "read-only" | "no-bash" | "safe-edit";
+const enableCheckpointing = hasFlag("--enable-checkpointing");
 
 // Task 4: Structured Output Support
-const structuredOutputIndex = args.indexOf("--structured-output");
-const structuredOutputSchema = structuredOutputIndex !== -1 ? args[structuredOutputIndex + 1] : undefined;
+const structuredOutputSchema = getArg("--structured-output");
 
 // Parse schema if provided
 let outputFormat: { type: 'json_schema'; schema: Record<string, unknown> } | undefined;
@@ -68,64 +84,60 @@ if (structuredOutputSchema) {
   try {
     outputFormat = { type: 'json_schema', schema: JSON.parse(structuredOutputSchema) as Record<string, unknown> };
   } catch (e) {
-    emit({ type: "warning", message: `Invalid structured output schema: ${e}` });
+    // Log to stderr since emit() before ready event may confuse the Go parser
+    console.error(`Invalid structured output schema: ${e}`);
   }
 }
 
 // Target branch for PR base and sync operations
-const targetBranchIndex = args.indexOf("--target-branch");
-const targetBranch = targetBranchIndex !== -1 ? args[targetBranchIndex + 1] : undefined;
+const targetBranch = getArg("--target-branch");
 
 // Task 5: Budget Controls
-const maxBudgetIndex = args.indexOf("--max-budget-usd");
-const maxTurnsIndex = args.indexOf("--max-turns");
-const maxThinkingTokensIndex = args.indexOf("--max-thinking-tokens");
-
-const maxBudgetUsd = maxBudgetIndex !== -1 ? parseFloat(args[maxBudgetIndex + 1]) : undefined;
-const maxTurns = maxTurnsIndex !== -1 ? parseInt(args[maxTurnsIndex + 1], 10) : undefined;
-const maxThinkingTokens = maxThinkingTokensIndex !== -1 ? parseInt(args[maxThinkingTokensIndex + 1], 10) : undefined;
+const maxBudgetUsd = getNumericArg("--max-budget-usd");
+const maxTurns = getNumericArg("--max-turns");
+const maxThinkingTokens = getNumericArg("--max-thinking-tokens");
 
 // Permission mode (e.g., "plan" for plan mode at startup)
 const validPermissionModes = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk"] as const;
 type PermissionMode = typeof validPermissionModes[number];
-const permissionModeIndex = args.indexOf("--permission-mode");
 let initialPermissionMode: PermissionMode = "bypassPermissions";
-if (permissionModeIndex !== -1 && permissionModeIndex + 1 < args.length) {
-  const value = args[permissionModeIndex + 1];
-  if ((validPermissionModes as readonly string[]).includes(value)) {
-    initialPermissionMode = value as PermissionMode;
-  } else {
-    console.error(`Invalid --permission-mode value: "${value}". Using default "bypassPermissions".`);
+{
+  const value = getArg("--permission-mode");
+  if (value) {
+    if ((validPermissionModes as readonly string[]).includes(value)) {
+      initialPermissionMode = value as PermissionMode;
+    } else {
+      console.error(`Invalid --permission-mode value: "${value}". Using default "bypassPermissions".`);
+    }
   }
 }
 
 // Task 6: Settings Sources Configuration
-const settingSourcesIndex = args.indexOf("--setting-sources");
-const settingSourcesArg = settingSourcesIndex !== -1 ? args[settingSourcesIndex + 1] : undefined;
+const settingSourcesArg = getArg("--setting-sources");
 const settingSources = settingSourcesArg
   ? settingSourcesArg.split(',').map(s => s.trim()) as ('project' | 'user' | 'local')[]
   : undefined;
 
 // Task 7: Beta Features Flag
-const betasIndex = args.indexOf("--betas");
-const betasArg = betasIndex !== -1 ? args[betasIndex + 1] : undefined;
+const betasArg = getArg("--betas");
 const betas = betasArg ? betasArg.split(',').map(s => s.trim()) as ("context-1m-2025-08-07")[] : undefined;
 
 // Task 8: Model Configuration
-const modelIndex = args.indexOf("--model");
-const fallbackModelIndex = args.indexOf("--fallback-model");
-const model = modelIndex !== -1 ? args[modelIndex + 1] : undefined;
-const fallbackModel = fallbackModelIndex !== -1 ? args[fallbackModelIndex + 1] : undefined;
+const model = getArg("--model");
+const fallbackModel = getArg("--fallback-model");
 
 // Instructions (e.g., from conversation summaries)
 import { readFileSync } from "fs";
-const instructionsFileIndex = args.indexOf("--instructions-file");
 let instructions: string | undefined;
-if (instructionsFileIndex !== -1 && instructionsFileIndex + 1 < args.length) {
-  try {
-    instructions = readFileSync(args[instructionsFileIndex + 1], "utf-8");
-  } catch (e) {
-    emit({ type: "warning", message: `Failed to read instructions file: ${e}` });
+{
+  const instructionsFilePath = getArg("--instructions-file");
+  if (instructionsFilePath) {
+    try {
+      instructions = readFileSync(instructionsFilePath, "utf-8");
+    } catch (e) {
+      // Log to stderr since emit() may not be safe before ready event
+      console.error(`Failed to read instructions file: ${e}`);
+    }
   }
 }
 
@@ -165,6 +177,11 @@ interface InputMessage {
   // User question response fields
   questionRequestId?: string;
   answers?: Record<string, string>;
+}
+
+// Escape a string for use in XML attribute values
+function escapeXmlAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 // Track if we've suggested a name yet
@@ -224,46 +241,75 @@ async function* createMessageStream(): AsyncGenerator<SDKUserMessage> {
           break;
         }
 
-        // Handle runtime control commands
+        // Handle runtime control commands — each wrapped in its own try/catch
+        // to prevent SDK errors from being misreported as JSON parse errors.
         if (input.type === "interrupt" && queryRef) {
-          await queryRef.interrupt();
-          emit({ type: "interrupted" });
+          try {
+            await queryRef.interrupt();
+            emit({ type: "interrupted" });
+          } catch (cmdErr) {
+            emit({ type: "command_error", command: "interrupt", error: String(cmdErr) });
+          }
           continue;
         }
 
         if (input.type === "set_model" && queryRef && input.model) {
-          await queryRef.setModel(input.model);
-          emit({ type: "model_changed", model: input.model });
+          try {
+            await queryRef.setModel(input.model);
+            emit({ type: "model_changed", model: input.model });
+          } catch (cmdErr) {
+            emit({ type: "command_error", command: "set_model", error: String(cmdErr) });
+          }
           continue;
         }
 
         if (input.type === "set_permission_mode" && queryRef && input.permissionMode) {
-          await queryRef.setPermissionMode(input.permissionMode as "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk");
-          emit({ type: "permission_mode_changed", mode: input.permissionMode });
+          try {
+            await queryRef.setPermissionMode(input.permissionMode as "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk");
+            emit({ type: "permission_mode_changed", mode: input.permissionMode });
+          } catch (cmdErr) {
+            emit({ type: "command_error", command: "set_permission_mode", error: String(cmdErr) });
+          }
           continue;
         }
 
         if (input.type === "get_supported_models" && queryRef) {
-          const models = await queryRef.supportedModels();
-          emit({ type: "supported_models", models });
+          try {
+            const models = await queryRef.supportedModels();
+            emit({ type: "supported_models", models });
+          } catch (cmdErr) {
+            emit({ type: "command_error", command: "get_supported_models", error: String(cmdErr) });
+          }
           continue;
         }
 
         if (input.type === "get_supported_commands" && queryRef) {
-          const commands = await queryRef.supportedCommands();
-          emit({ type: "supported_commands", commands });
+          try {
+            const commands = await queryRef.supportedCommands();
+            emit({ type: "supported_commands", commands });
+          } catch (cmdErr) {
+            emit({ type: "command_error", command: "get_supported_commands", error: String(cmdErr) });
+          }
           continue;
         }
 
         if (input.type === "get_mcp_status" && queryRef) {
-          const status = await queryRef.mcpServerStatus();
-          emit({ type: "mcp_status", servers: status });
+          try {
+            const status = await queryRef.mcpServerStatus();
+            emit({ type: "mcp_status", servers: status });
+          } catch (cmdErr) {
+            emit({ type: "command_error", command: "get_mcp_status", error: String(cmdErr) });
+          }
           continue;
         }
 
         if (input.type === "get_account_info" && queryRef) {
-          const info = await queryRef.accountInfo();
-          emit({ type: "account_info", info });
+          try {
+            const info = await queryRef.accountInfo();
+            emit({ type: "account_info", info });
+          } catch (cmdErr) {
+            emit({ type: "command_error", command: "get_account_info", error: String(cmdErr) });
+          }
           continue;
         }
 
@@ -328,10 +374,10 @@ async function* createMessageStream(): AsyncGenerator<SDKUserMessage> {
                 // Escape any occurrences of the closing tag to prevent injection
                 content = content.replace(/<\/attached_file>/g, "&lt;/attached_file&gt;");
                 const lineInfo = attachment.lineCount ? ` lines="${attachment.lineCount}"` : "";
-                const pathInfo = attachment.path ? ` path="${attachment.path}"` : "";
+                const pathInfo = attachment.path ? ` path="${escapeXmlAttr(attachment.path)}"` : "";
                 contentBlocks.push({
                   type: "text",
-                  text: `<attached_file name="${attachment.name}"${pathInfo}${lineInfo}>\n${content}\n</attached_file>`
+                  text: `<attached_file name="${escapeXmlAttr(attachment.name)}"${pathInfo}${lineInfo}>\n${content}\n</attached_file>`
                 });
               }
             }
@@ -394,6 +440,7 @@ function extractNameSuggestion(text: string): string | null {
 
 // Buffer for block-level streaming (emit on paragraph breaks)
 let blockBuffer = "";
+const BLOCK_BUFFER_MAX_SIZE = 4096; // Flush even without paragraph break to ensure progressive rendering
 
 function processTextChunk(text: string): void {
   blockBuffer += text;
@@ -410,6 +457,12 @@ function processTextChunk(text: string): void {
     if (block.trim()) {
       emit({ type: "assistant_text", content: block + "\n\n" });
     }
+  }
+
+  // Force flush if buffer exceeds max size (e.g., large code blocks without paragraph breaks)
+  if (blockBuffer.length > BLOCK_BUFFER_MAX_SIZE) {
+    emit({ type: "assistant_text", content: blockBuffer });
+    blockBuffer = "";
   }
 
   // Try to suggest a name after accumulating some text
@@ -623,10 +676,17 @@ const askUserQuestionHook: HookCallback = async (input) => {
     sessionId: currentSessionId,
   });
 
-  // Wait indefinitely for user response (no timeout — user answers or cancels)
+  // Wait for user response with a safety timeout matching the hook timeout
   try {
     const answers = await new Promise<Record<string, string>>((resolve, reject) => {
       pendingQuestionRequests.set(requestId, { resolve, reject });
+      // Safety timeout to prevent infinite hang if Go backend crashes/restarts
+      setTimeout(() => {
+        if (pendingQuestionRequests.has(requestId)) {
+          pendingQuestionRequests.delete(requestId);
+          reject(new Error("User question timed out after 24 hours"));
+        }
+      }, ASK_USER_QUESTION_HOOK_TIMEOUT_S * 1000);
     });
 
     // Allow tool execution with answers populated
@@ -903,9 +963,10 @@ function handleMessage(message: SDKMessage): void {
             } else {
               // Race condition: tool_result arrived but tool_start was never tracked.
               // Emit tool_end anyway to prevent infinite spinner on frontend.
-              console.warn(
-                `[WARNING] tool_result for untracked tool_use_id: ${block.tool_use_id}`
-              );
+              emit({
+                type: "warning",
+                message: `tool_result for untracked tool_use_id: ${block.tool_use_id}`,
+              });
               emit({
                 type: "tool_end",
                 id: block.tool_use_id,
@@ -1122,7 +1183,24 @@ async function cleanup(reason: string): Promise<void> {
     pendingQuestionRequests.delete(requestId);
   }
 
-  // 3. Interrupt the query if active
+  // 3. Emit tool_end for any in-flight tools to prevent infinite spinners on frontend
+  for (const [toolId, toolInfo] of activeTools) {
+    const duration = Date.now() - toolInfo.startTime;
+    emit({
+      type: "tool_end",
+      id: toolId,
+      tool: toolInfo.tool,
+      success: false,
+      summary: `Interrupted: ${reason}`,
+      duration,
+    });
+  }
+  activeTools.clear();
+
+  // 4. Flush any remaining buffered text
+  flushBlockBuffer();
+
+  // 5. Interrupt the query if active
   if (queryRef) {
     try {
       await queryRef.interrupt();
@@ -1131,10 +1209,10 @@ async function cleanup(reason: string): Promise<void> {
     }
   }
 
-  // 4. Close readline
+  // 6. Close readline
   closeReadline();
 
-  // 5. Emit shutdown event
+  // 7. Emit shutdown event
   emit({ type: "shutdown", reason });
 }
 

--- a/agent-runner/src/mcp/context.ts
+++ b/agent-runner/src/mcp/context.ts
@@ -69,16 +69,17 @@ export class WorkspaceContext {
   }
 
   private fetchGitState(): GitState {
+    const gitOpts = { cwd: this.cwd, encoding: "utf-8" as const, timeout: 10000 };
     try {
-      const branch = execSync("git rev-parse --abbrev-ref HEAD", { cwd: this.cwd, encoding: "utf-8" }).trim();
+      const branch = execSync("git rev-parse --abbrev-ref HEAD", gitOpts).trim();
       const baseBranch = this.targetBranch;
-      const status = execSync("git status --porcelain", { cwd: this.cwd, encoding: "utf-8" });
+      const status = execSync("git status --porcelain", gitOpts);
       const uncommittedChanges = status.trim().length > 0;
 
       let aheadBy = 0;
       let behindBy = 0;
       try {
-        const counts = execSync(`git rev-list --left-right --count ${baseBranch}...HEAD`, { cwd: this.cwd, encoding: "utf-8" }).trim();
+        const counts = execSync(`git rev-list --left-right --count ${baseBranch}...HEAD`, gitOpts).trim();
         const [behind, ahead] = counts.split("\t").map(Number);
         aheadBy = ahead || 0;
         behindBy = behind || 0;
@@ -95,7 +96,7 @@ export class WorkspaceContext {
   private detectBaseBranch(): string {
     try {
       // Check for common base branch names
-      const branches = execSync("git branch -r", { cwd: this.cwd, encoding: "utf-8" });
+      const branches = execSync("git branch -r", { cwd: this.cwd, encoding: "utf-8", timeout: 10000 });
       if (branches.includes("origin/main")) return "origin/main";
       if (branches.includes("origin/master")) return "origin/master";
       return "main";
@@ -127,7 +128,7 @@ export class WorkspaceContext {
 
     // 2. Branch name pattern (feat/LIN-123-description)
     try {
-      const branch = execSync("git rev-parse --abbrev-ref HEAD", { cwd: options.cwd, encoding: "utf-8" }).trim();
+      const branch = execSync("git rev-parse --abbrev-ref HEAD", { cwd: options.cwd, encoding: "utf-8", timeout: 10000 }).trim();
       const match = branch.match(/([A-Z]+-\d+)/);
       if (match) {
         return match[1];
@@ -138,7 +139,7 @@ export class WorkspaceContext {
 
     // 3. Recent commit messages
     try {
-      const logs = execSync("git log -5 --oneline", { cwd: options.cwd, encoding: "utf-8" });
+      const logs = execSync("git log -5 --oneline", { cwd: options.cwd, encoding: "utf-8", timeout: 10000 });
       const match = logs.match(/([A-Z]+-\d+)/);
       if (match) {
         return match[1];

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -15,6 +16,8 @@ import (
 	"github.com/chatml/chatml-backend/store"
 	"github.com/google/uuid"
 )
+
+const snapshotDebounceInterval = 500 * time.Millisecond
 
 // Legacy handlers (for backwards compatibility)
 type OutputHandler func(agentID string, line string)
@@ -242,6 +245,63 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	var currentAssistantMessage string
 	var lastReportedDrops uint64
 
+	// Streaming snapshot state for reconnection recovery
+	activeToolsMap := make(map[string]ActiveToolEntry)
+	var currentThinking string
+	var isThinking bool
+	var snapshotDirty bool
+
+	// Debounced snapshot flush: 500ms after last state change
+	snapshotTimer := time.NewTimer(snapshotDebounceInterval)
+	snapshotTimer.Stop() // Don't start until first state change
+	defer snapshotTimer.Stop()
+
+	// flushSnapshot writes the current streaming state to the DB
+	flushSnapshot := func() {
+		if !snapshotDirty {
+			return
+		}
+		// Build active tools slice from map
+		tools := make([]ActiveToolEntry, 0, len(activeToolsMap))
+		for _, t := range activeToolsMap {
+			tools = append(tools, t)
+		}
+		snapshot := StreamingSnapshot{
+			Text:           currentAssistantMessage,
+			ActiveTools:    tools,
+			Thinking:       currentThinking,
+			IsThinking:     isThinking,
+			PlanModeActive: proc.IsPlanModeActive(),
+		}
+		data, err := json.Marshal(snapshot)
+		if err != nil {
+			logger.Manager.Errorf("Failed to marshal streaming snapshot for conv %s: %v", convID, err)
+			return
+		}
+		if err := m.store.SetStreamingSnapshot(ctx, convID, data); err != nil {
+			logger.Manager.Errorf("Failed to store streaming snapshot for conv %s: %v", convID, err)
+			return
+		}
+		snapshotDirty = false
+	}
+
+	// markSnapshotDirty sets the dirty flag and resets the debounce timer.
+	// We drain before reset to avoid the documented timer.Reset footgun: if the
+	// timer already fired, the channel has a pending value that could cause a
+	// spurious flush on the next select iteration. In practice flushSnapshot()
+	// is a no-op when !snapshotDirty so a double-flush is harmless, but draining
+	// keeps the behavior predictable.
+	markSnapshotDirty := func() {
+		snapshotDirty = true
+		if !snapshotTimer.Stop() {
+			select {
+			case <-snapshotTimer.C:
+			default:
+			}
+		}
+		snapshotTimer.Reset(snapshotDebounceInterval)
+	}
+
 	// Periodically check for dropped messages and emit warnings out-of-band.
 	// This bypasses the process output channel, so warnings are delivered even
 	// when the output channel is congested (which is exactly when drops occur).
@@ -267,11 +327,36 @@ outer:
 			switch event.Type {
 			case EventTypeAssistantText:
 				currentAssistantMessage += event.Content
+				markSnapshotDirty()
 
 			case EventTypeToolStart:
-				// Record tool start (will be updated on tool_end)
+				activeToolsMap[event.ID] = ActiveToolEntry{
+					ID:        event.ID,
+					Tool:      event.Tool,
+					StartTime: time.Now().Unix(),
+				}
+				markSnapshotDirty()
+
+			case EventTypeSessionIdUpdate:
+				// Track the session ID so restarts can resume the correct session
+				if event.SessionID != "" {
+					proc.SetSessionID(event.SessionID)
+				}
+
+			case EventTypePermModeChanged:
+				// Keep plan mode state in sync with agent-runner
+				proc.SetPlanModeFromEvent(event.Mode == "plan")
+				markSnapshotDirty()
+
+			case EventTypeThinking, EventTypeThinkingDelta:
+				currentThinking += event.Content
+				isThinking = true
+				markSnapshotDirty()
 
 			case EventTypeToolEnd:
+				delete(activeToolsMap, event.ID)
+				markSnapshotDirty()
+
 				// Store tool action in summary
 				if err := m.store.AddToolActionToConversation(ctx, convID, models.ToolAction{
 					ID:      event.ID,
@@ -311,6 +396,17 @@ outer:
 					}
 					currentAssistantMessage = ""
 				}
+				// Clear thinking on completion
+				currentThinking = ""
+				isThinking = false
+				activeToolsMap = make(map[string]ActiveToolEntry)
+				snapshotDirty = false // No need to flush — we're about to clear
+
+				// Clear snapshot directly (skipping flush: the snapshot is about to be
+				// removed anyway, so writing an intermediate state is wasted I/O).
+				if err := m.store.ClearStreamingSnapshot(ctx, convID); err != nil {
+					logger.Manager.Errorf("Failed to clear streaming snapshot for conv %s: %v", convID, err)
+				}
 			}
 
 			// Forward event to handler
@@ -326,6 +422,10 @@ outer:
 					m.onOutput(convID, formatted)
 				}
 			}
+
+		case <-snapshotTimer.C:
+			// Debounce timer fired — flush snapshot to DB
+			flushSnapshot()
 
 		case <-dropCheckTicker.C:
 			// Check for new drops and emit warning out-of-band
@@ -358,6 +458,19 @@ outer:
 		}
 	}
 
+	// Clear snapshot on process exit — but only if this process is still the current
+	// one in the map. If a new process has already been started (via SendConversationMessage),
+	// clearing now would wipe the new process's snapshot.
+	m.mu.RLock()
+	currentProc, exists := m.convProcesses[convID]
+	isStaleHandler := exists && currentProc != proc
+	m.mu.RUnlock()
+	if !isStaleHandler {
+		if err := m.store.ClearStreamingSnapshot(ctx, convID); err != nil {
+			logger.Manager.Errorf("Failed to clear streaming snapshot on exit for conv %s: %v", convID, err)
+		}
+	}
+
 	// Emit final drop stats if any drops occurred
 	finalDrops := proc.DroppedMessages()
 	if finalDrops > 0 {
@@ -385,12 +498,23 @@ func (m *Manager) handleConversationCompletion(convID string, proc *Process) {
 		return
 	}
 
-	var newStatus string
-	if proc.ExitError() != nil {
-		newStatus = models.ConversationStatusIdle // Error, but can retry
+	exitErr := proc.ExitError()
+	if exitErr != nil {
+		logger.Manager.Warnf("Conversation %s process exited with error: %v", convID, exitErr)
 	} else {
-		newStatus = models.ConversationStatusIdle // Completed turn, waiting for next message
+		logger.Manager.Infof("Conversation %s process exited cleanly", convID)
 	}
+
+	// Remove completed process from map to prevent unbounded growth.
+	// The process is kept accessible via the local variable for status updates.
+	m.mu.Lock()
+	// Only remove if this is still the same process (another restart may have replaced it)
+	if current, ok := m.convProcesses[convID]; ok && current == proc {
+		delete(m.convProcesses, convID)
+	}
+	m.mu.Unlock()
+
+	newStatus := models.ConversationStatusIdle
 
 	if err := m.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
 		c.Status = newStatus
@@ -406,14 +530,31 @@ func (m *Manager) handleConversationCompletion(convID string, proc *Process) {
 
 // SendConversationMessage sends a follow-up message to an existing conversation
 func (m *Manager) SendConversationMessage(ctx context.Context, convID, message string, attachments []models.Attachment) error {
-	m.mu.RLock()
+	// Use full Lock for the check-and-restart sequence to prevent two concurrent
+	// callers from both seeing a dead process and each creating a new one (race condition).
+	m.mu.Lock()
 	proc, ok := m.convProcesses[convID]
-	m.mu.RUnlock()
+	needsRestart := !ok || proc.IsStopped() || !proc.IsRunning()
 
-	// Check if process exists, hasn't been stopped, and is running.
-	// IsStopped() catches explicit stops; IsRunning() catches natural exits.
-	if !ok || proc.IsStopped() || !proc.IsRunning() {
-		// Process not running, need to restart it
+	if needsRestart {
+		// Capture previous exit error for logging before we replace the process
+		var prevExitErr error
+		if ok && proc != nil {
+			prevExitErr = proc.ExitError()
+		}
+
+		// Retrieve original options from the old process (if any) so we preserve
+		// configuration like model, target branch, tool preset, budget limits, etc.
+		var restartOpts ProcessOptions
+		if ok && proc != nil {
+			restartOpts = proc.Options()
+		}
+
+		// Release lock for DB calls. Note: two concurrent callers can both reach
+		// this point. The double-check after re-acquiring the lock (below) ensures
+		// only one actually starts a new process.
+		m.mu.Unlock()
+
 		conv, err := m.store.GetConversation(ctx, convID)
 		if err != nil {
 			return fmt.Errorf("failed to get conversation: %w", err)
@@ -430,31 +571,73 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 			return fmt.Errorf("session not found: %s", conv.SessionID)
 		}
 
-		// Create new process
-		proc = NewProcess(convID, session.WorktreePath, convID)
+		// Build restart options: reuse original config but update workdir and
+		// set up session resume using the last known session ID.
+		if restartOpts.ID == "" {
+			// No previous process options (first start via this path) — use minimal config
+			restartOpts.ID = convID
+			restartOpts.ConversationID = convID
+		}
+		restartOpts.Workdir = session.WorktreePath
+		// Clear instructions: the temp file has been cleaned up and the content is not
+		// preserved. This is acceptable because --resume carries the SDK's full context
+		// (including original instructions). If the session ID is also unavailable
+		// (e.g., process crashed before emitting session_id_update), the restart will
+		// lack original instructions — an acceptable degradation for a crash scenario.
+		restartOpts.Instructions = ""
+		// Resume the previous session if we have a session ID
+		if ok && proc != nil {
+			if sid := proc.GetSessionID(); sid != "" {
+				restartOpts.ResumeSession = sid
+			}
+		}
+
+		logger.Manager.Infof("Auto-restarting process for conversation %s (previous exit error: %v)", convID, prevExitErr)
+
+		// Cancel any pending user questions from the old process so the frontend
+		// doesn't show a stale question UI pointing at the dead process.
+		if m.onConversationEvent != nil {
+			m.onConversationEvent(convID, &AgentEvent{
+				Type:   "user_question_cancelled",
+				Reason: "process_restart",
+			})
+		}
+
+		newProc := NewProcessWithOptions(restartOpts)
 
 		m.mu.Lock()
-		m.convProcesses[convID] = proc
+		// Check again — another goroutine may have restarted while we were doing DB calls
+		if existingProc, exists := m.convProcesses[convID]; exists && existingProc.IsRunning() {
+			m.mu.Unlock()
+			// Another goroutine already restarted — use that process instead
+			proc = existingProc
+		} else {
+			m.convProcesses[convID] = newProc
+			m.mu.Unlock()
+
+			if err := newProc.Start(); err != nil {
+				return fmt.Errorf("failed to restart agent process: %w", err)
+			}
+
+			// Set up handlers for the new process
+			go m.handleConversationOutput(convID, newProc)
+			go m.handleConversationCompletion(convID, newProc)
+
+			// Update status
+			if err := m.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
+				c.Status = models.ConversationStatusActive
+				c.UpdatedAt = time.Now()
+			}); err != nil {
+				logger.Manager.Errorf("Failed to update conversation status to active: %v", err)
+			}
+			if m.onConversationStatus != nil {
+				m.onConversationStatus(convID, models.ConversationStatusActive)
+			}
+
+			proc = newProc
+		}
+	} else {
 		m.mu.Unlock()
-
-		if err := proc.Start(); err != nil {
-			return fmt.Errorf("failed to restart agent process: %w", err)
-		}
-
-		// Set up handlers for the new process
-		go m.handleConversationOutput(convID, proc)
-		go m.handleConversationCompletion(convID, proc)
-
-		// Update status
-		if err := m.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
-			c.Status = models.ConversationStatusActive
-			c.UpdatedAt = time.Now()
-		}); err != nil {
-			logger.Manager.Errorf("Failed to update conversation status to active: %v", err)
-		}
-		if m.onConversationStatus != nil {
-			m.onConversationStatus(convID, models.ConversationStatusActive)
-		}
 	}
 
 	// Store user message with attachments

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -114,6 +114,9 @@ type AgentEvent struct {
 	RawInput     string `json:"rawInput,omitempty"`
 	ErrorDetails string `json:"errorDetails,omitempty"`
 
+	// Command error fields
+	Command string `json:"command,omitempty"`
+
 	// User question fields (AskUserQuestion tool)
 	RequestID string         `json:"requestId,omitempty"`
 	Questions []UserQuestion `json:"questions,omitempty"`
@@ -221,6 +224,9 @@ const (
 	// User question events (AskUserQuestion tool)
 	EventTypeUserQuestionRequest = "user_question_request"
 	EventTypeUserQuestionTimeout = "user_question_timeout"
+
+	// Command error (SDK runtime command failed)
+	EventTypeCommandError = "command_error"
 )
 
 // TodoItem represents a single todo item from the agent's TodoWrite tool
@@ -242,6 +248,23 @@ type UserQuestion struct {
 type UserQuestionOption struct {
 	Label       string `json:"label"`
 	Description string `json:"description"`
+}
+
+// StreamingSnapshot captures the current streaming state for reconnection recovery.
+// Periodically flushed to DB so the frontend can restore its view on WebSocket reconnect.
+type StreamingSnapshot struct {
+	Text           string            `json:"text"`
+	ActiveTools    []ActiveToolEntry `json:"activeTools"`
+	Thinking       string            `json:"thinking,omitempty"`
+	IsThinking     bool              `json:"isThinking"`
+	PlanModeActive bool              `json:"planModeActive"`
+}
+
+// ActiveToolEntry represents a tool currently in-flight during streaming.
+type ActiveToolEntry struct {
+	ID        string `json:"id"`
+	Tool      string `json:"tool"`
+	StartTime int64  `json:"startTime"`
 }
 
 // ParseAgentLine parses a line of JSON output from the agent-runner

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -70,6 +70,7 @@ type Process struct {
 	planModeActive  bool // Tracks whether the process is in plan mode
 	droppedMessages    atomic.Uint64 // Count of messages dropped due to full output buffer
 	instructionsFile   string        // Temp file for instructions, cleaned up on stop
+	opts               ProcessOptions // Original options for restart
 }
 
 // InputMessage represents a message sent to the agent runner via stdin
@@ -181,11 +182,18 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	if opts.Instructions != "" {
 		// Write to temp file to avoid shell arg length limits
 		tmpFile, err := os.CreateTemp("", "chatml-instructions-*.txt")
-		if err == nil {
-			_, _ = tmpFile.WriteString(opts.Instructions)
-			tmpFile.Close()
-			instructionsFile = tmpFile.Name()
-			args = append(args, "--instructions-file", instructionsFile)
+		if err != nil {
+			logger.Process.Errorf("[%s] Failed to create instructions temp file: %v", opts.ID, err)
+		} else {
+			if _, writeErr := tmpFile.WriteString(opts.Instructions); writeErr != nil {
+				logger.Process.Errorf("[%s] Failed to write instructions to temp file: %v", opts.ID, writeErr)
+				tmpFile.Close()
+				_ = os.Remove(tmpFile.Name())
+			} else {
+				tmpFile.Close()
+				instructionsFile = tmpFile.Name()
+				args = append(args, "--instructions-file", instructionsFile)
+			}
 		}
 	}
 
@@ -234,6 +242,7 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 		done:             make(chan struct{}),
 		planModeActive:   opts.PlanMode,
 		instructionsFile: instructionsFile,
+		opts:             opts,
 	}
 }
 
@@ -279,15 +288,24 @@ func (p *Process) Start() error {
 		// Increase buffer for large JSON events
 		buf := make([]byte, 0, 1024*1024)
 		scanner.Buffer(buf, 10*1024*1024)
+		timer := time.NewTimer(processOutputTimeout)
+		defer timer.Stop()
 		for scanner.Scan() {
+			timer.Reset(processOutputTimeout)
 			select {
 			case p.output <- scanner.Text():
-				// Successfully queued
-			case <-time.After(processOutputTimeout):
+				// Successfully queued — stop the timer to avoid leak
+				if !timer.Stop() {
+					<-timer.C
+				}
+			case <-timer.C:
 				// Buffer full after timeout - downstream reader is persistently slow
 				dropped := p.droppedMessages.Add(1)
 				logger.Process.Warnf("[%s] Output buffer full after %v timeout, dropping stdout message (total dropped: %d)", p.ID, processOutputTimeout, dropped)
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			logger.Process.Errorf("[%s] stdout scanner error (possible line exceeding 10MB buffer): %v", p.ID, err)
 		}
 	}()
 
@@ -300,15 +318,24 @@ func (p *Process) Start() error {
 			outputWg.Done()
 		}()
 		scanner := bufio.NewScanner(stderr)
+		timer := time.NewTimer(processOutputTimeout)
+		defer timer.Stop()
 		for scanner.Scan() {
+			timer.Reset(processOutputTimeout)
 			select {
 			case p.output <- "[stderr] " + scanner.Text():
-				// Successfully queued
-			case <-time.After(processOutputTimeout):
+				// Successfully queued — stop the timer to avoid leak
+				if !timer.Stop() {
+					<-timer.C
+				}
+			case <-timer.C:
 				// Buffer full after timeout - downstream reader is persistently slow
 				dropped := p.droppedMessages.Add(1)
 				logger.Process.Warnf("[%s] Output buffer full after %v timeout, dropping stderr message (total dropped: %d)", p.ID, processOutputTimeout, dropped)
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			logger.Process.Errorf("[%s] stderr scanner error: %v", p.ID, err)
 		}
 	}()
 
@@ -585,4 +612,17 @@ func (p *Process) GetSessionID() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.SessionID
+}
+
+// Options returns the ProcessOptions used to create this process.
+// Useful for re-creating a process with the same configuration on restart.
+func (p *Process) Options() ProcessOptions {
+	return p.opts
+}
+
+// SetPlanModeFromEvent updates the planModeActive state from an output event.
+func (p *Process) SetPlanModeFromEvent(active bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.planModeActive = active
 }

--- a/backend/agent/streaming_snapshot_test.go
+++ b/backend/agent/streaming_snapshot_test.go
@@ -1,0 +1,301 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestProcessWithChannel creates a minimal Process with a writable output channel.
+// Callers must close the channel when done to signal the output handler to exit.
+func newTestProcessWithChannel(t *testing.T) (*Process, chan string) {
+	t.Helper()
+	ch := make(chan string, 100)
+	proc := &Process{
+		ID:     "test-proc",
+		output: ch,
+		done:   make(chan struct{}),
+	}
+	return proc, ch
+}
+
+// sendJSONEvent marshals an event and writes it to the channel.
+func sendJSONEvent(t *testing.T, ch chan string, event map[string]interface{}) {
+	t.Helper()
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	ch <- string(data)
+}
+
+func TestHandleConversationOutput_SnapshotOnAssistantText(t *testing.T) {
+	manager, s := setupTestManager(t)
+	ctx := context.Background()
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	proc, ch := newTestProcessWithChannel(t)
+
+	// Send assistant_text events
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "Hello "})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "world!"})
+
+	// Close channel to end the output handler
+	close(ch)
+
+	// Run the output handler synchronously
+	manager.handleConversationOutput("conv-1", proc)
+
+	// After handler exits, snapshot should be cleared (process exited)
+	snapshot, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Nil(t, snapshot, "snapshot should be cleared after process exit")
+}
+
+func TestHandleConversationOutput_SnapshotTracksToolState(t *testing.T) {
+	manager, s := setupTestManager(t)
+	ctx := context.Background()
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	proc, ch := newTestProcessWithChannel(t)
+
+	// Capture events to verify they're forwarded
+	var capturedEvents []*AgentEvent
+	manager.SetConversationEventHandler(func(convID string, event *AgentEvent) {
+		capturedEvents = append(capturedEvents, event)
+	})
+
+	// Send text + tool_start + tool_end sequence then close
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "Let me check "})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "tool_start", "id": "tool-1", "tool": "Bash"})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "tool_end", "id": "tool-1", "tool": "Bash", "success": true, "summary": "ran ls"})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "Done."})
+	close(ch)
+
+	manager.handleConversationOutput("conv-1", proc)
+
+	// Verify events were forwarded
+	assert.True(t, len(capturedEvents) >= 4, "expected at least 4 events forwarded")
+
+	// Snapshot cleared on exit
+	snapshot, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Nil(t, snapshot)
+}
+
+func TestHandleConversationOutput_SnapshotClearedOnResult(t *testing.T) {
+	manager, s := setupTestManager(t)
+	ctx := context.Background()
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	proc, ch := newTestProcessWithChannel(t)
+
+	// Send text then result
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "Final answer."})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "result", "content": "done"})
+	close(ch)
+
+	manager.handleConversationOutput("conv-1", proc)
+
+	// Snapshot should be cleared because result event clears it
+	snapshot, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Nil(t, snapshot)
+
+	// But the message should be persisted
+	page, err := s.GetConversationMessages(ctx, "conv-1", nil, 50)
+	require.NoError(t, err)
+	assert.True(t, len(page.Messages) >= 1, "expected at least 1 persisted message")
+}
+
+func TestHandleConversationOutput_SnapshotClearedOnComplete(t *testing.T) {
+	manager, s := setupTestManager(t)
+	ctx := context.Background()
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	proc, ch := newTestProcessWithChannel(t)
+
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "Some text."})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "complete"})
+	close(ch)
+
+	manager.handleConversationOutput("conv-1", proc)
+
+	snapshot, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Nil(t, snapshot)
+}
+
+func TestHandleConversationOutput_DebouncedFlush(t *testing.T) {
+	manager, s := setupTestManager(t)
+	ctx := context.Background()
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	proc, ch := newTestProcessWithChannel(t)
+
+	// Run handler in goroutine since we need the channel to stay open
+	done := make(chan struct{})
+	go func() {
+		manager.handleConversationOutput("conv-1", proc)
+		close(done)
+	}()
+
+	// Send some text
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "Hello "})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "world!"})
+
+	// Wait for debounce interval + margin
+	time.Sleep(snapshotDebounceInterval + 200*time.Millisecond)
+
+	// Snapshot should have been flushed
+	snapshot, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, snapshot, "snapshot should be flushed after debounce interval")
+
+	var parsed StreamingSnapshot
+	require.NoError(t, json.Unmarshal(snapshot, &parsed))
+	assert.Equal(t, "Hello world!", parsed.Text)
+	assert.Empty(t, parsed.ActiveTools)
+	assert.False(t, parsed.IsThinking)
+
+	// Close channel to terminate
+	close(ch)
+	<-done
+}
+
+func TestHandleConversationOutput_SnapshotIncludesActiveTools(t *testing.T) {
+	manager, s := setupTestManager(t)
+	ctx := context.Background()
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	proc, ch := newTestProcessWithChannel(t)
+
+	done := make(chan struct{})
+	go func() {
+		manager.handleConversationOutput("conv-1", proc)
+		close(done)
+	}()
+
+	// Send text + tool_start (tool stays active)
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "assistant_text", "content": "Running command..."})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "tool_start", "id": "t1", "tool": "Bash"})
+
+	// Wait for debounce
+	time.Sleep(snapshotDebounceInterval + 200*time.Millisecond)
+
+	snapshot, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+
+	var parsed StreamingSnapshot
+	require.NoError(t, json.Unmarshal(snapshot, &parsed))
+	assert.Equal(t, "Running command...", parsed.Text)
+	assert.Len(t, parsed.ActiveTools, 1)
+	assert.Equal(t, "t1", parsed.ActiveTools[0].ID)
+	assert.Equal(t, "Bash", parsed.ActiveTools[0].Tool)
+
+	close(ch)
+	<-done
+}
+
+func TestHandleConversationOutput_SnapshotIncludesThinking(t *testing.T) {
+	manager, s := setupTestManager(t)
+	ctx := context.Background()
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	proc, ch := newTestProcessWithChannel(t)
+
+	done := make(chan struct{})
+	go func() {
+		manager.handleConversationOutput("conv-1", proc)
+		close(done)
+	}()
+
+	// Send thinking events
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "thinking", "content": "Let me think"})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "thinking_delta", "content": " about this..."})
+
+	time.Sleep(snapshotDebounceInterval + 200*time.Millisecond)
+
+	snapshot, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+
+	var parsed StreamingSnapshot
+	require.NoError(t, json.Unmarshal(snapshot, &parsed))
+	assert.Equal(t, "Let me think about this...", parsed.Thinking)
+	assert.True(t, parsed.IsThinking)
+
+	close(ch)
+	<-done
+}
+
+func TestHandleConversationOutput_ToolEndRemovesFromSnapshot(t *testing.T) {
+	manager, s := setupTestManager(t)
+	ctx := context.Background()
+
+	createTestRepo(t, s, "repo-1")
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	proc, ch := newTestProcessWithChannel(t)
+
+	done := make(chan struct{})
+	go func() {
+		manager.handleConversationOutput("conv-1", proc)
+		close(done)
+	}()
+
+	// Start two tools
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "tool_start", "id": "t1", "tool": "Bash"})
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "tool_start", "id": "t2", "tool": "Read"})
+
+	time.Sleep(snapshotDebounceInterval + 200*time.Millisecond)
+
+	// Verify both tools in snapshot
+	snapshot, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	var parsed StreamingSnapshot
+	require.NoError(t, json.Unmarshal(snapshot, &parsed))
+	assert.Len(t, parsed.ActiveTools, 2)
+
+	// End one tool
+	sendJSONEvent(t, ch, map[string]interface{}{"type": "tool_end", "id": "t1", "tool": "Bash", "success": true, "summary": "ok"})
+
+	time.Sleep(snapshotDebounceInterval + 200*time.Millisecond)
+
+	// Only one tool should remain
+	snapshot, err = s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	require.NoError(t, json.Unmarshal(snapshot, &parsed))
+	assert.Len(t, parsed.ActiveTools, 1)
+	assert.Equal(t, "t2", parsed.ActiveTools[0].ID)
+
+	close(ch)
+	<-done
+}

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -3034,6 +3034,25 @@ func (h *Handlers) GetConversation(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, conv)
 }
 
+// GetStreamingSnapshot returns the current streaming snapshot for a conversation.
+// Used by the frontend to restore its view after WebSocket reconnection.
+func (h *Handlers) GetStreamingSnapshot(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	convID := chi.URLParam(r, "convId")
+	data, err := h.store.GetStreamingSnapshot(ctx, convID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if data == nil {
+		writeJSON(w, nil)
+		return
+	}
+	// data is already JSON — write it directly
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
+}
+
 func (h *Handlers) GetConversationMessages(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	convID := chi.URLParam(r, "convId")

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -162,6 +162,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Get("/{convId}/messages", h.GetConversationMessages)
 		r.With(messageRateLimiter).Post("/{convId}/messages", h.SendConversationMessage)
 		r.Post("/{convId}/stop", h.StopConversation)
+		r.Get("/{convId}/streaming-snapshot", h.GetStreamingSnapshot)
 		r.Get("/{convId}/drop-stats", h.GetConversationDropStats)
 		r.Post("/{convId}/rewind", h.RewindConversation)
 		r.Post("/{convId}/plan-mode", h.SetConversationPlanMode)

--- a/backend/server/streaming_snapshot_test.go
+++ b/backend/server/streaming_snapshot_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chatml/chatml-backend/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStreamingSnapshot_ReturnsSnapshot(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	repoPath := createTestGitRepo(t)
+	createTestRepo(t, s, "repo-1", repoPath)
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	// Store a snapshot
+	snapshot := agent.StreamingSnapshot{
+		Text: "Hello from the agent",
+		ActiveTools: []agent.ActiveToolEntry{
+			{ID: "tool-1", Tool: "Bash", StartTime: 1706000001},
+		},
+		Thinking:       "analyzing the problem",
+		IsThinking:     true,
+		PlanModeActive: false,
+	}
+	data, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+	require.NoError(t, s.SetStreamingSnapshot(t.Context(), "conv-1", data))
+
+	// Request the snapshot
+	req := httptest.NewRequest("GET", "/api/conversations/conv-1/streaming-snapshot", nil)
+	req = withChiContext(req, map[string]string{"convId": "conv-1"})
+	w := httptest.NewRecorder()
+
+	h.GetStreamingSnapshot(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var got agent.StreamingSnapshot
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "Hello from the agent", got.Text)
+	assert.Len(t, got.ActiveTools, 1)
+	assert.Equal(t, "Bash", got.ActiveTools[0].Tool)
+	assert.Equal(t, "analyzing the problem", got.Thinking)
+	assert.True(t, got.IsThinking)
+	assert.False(t, got.PlanModeActive)
+}
+
+func TestGetStreamingSnapshot_ReturnsNullWhenEmpty(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	repoPath := createTestGitRepo(t)
+	createTestRepo(t, s, "repo-1", repoPath)
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	// Don't set any snapshot — default is empty
+	req := httptest.NewRequest("GET", "/api/conversations/conv-1/streaming-snapshot", nil)
+	req = withChiContext(req, map[string]string{"convId": "conv-1"})
+	w := httptest.NewRecorder()
+
+	h.GetStreamingSnapshot(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "null\n", w.Body.String())
+}
+
+func TestGetStreamingSnapshot_ReturnsNullForMissingConversation(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("GET", "/api/conversations/nonexistent/streaming-snapshot", nil)
+	req = withChiContext(req, map[string]string{"convId": "nonexistent"})
+	w := httptest.NewRecorder()
+
+	h.GetStreamingSnapshot(w, req)
+
+	// Nonexistent conversation returns null (no row = nil snapshot)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "null\n", w.Body.String())
+}
+
+func TestGetStreamingSnapshot_AfterClear(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	repoPath := createTestGitRepo(t)
+	createTestRepo(t, s, "repo-1", repoPath)
+	createTestSession(t, s, "sess-1", "repo-1")
+	createTestConversation(t, s, "conv-1", "sess-1")
+
+	// Set then clear
+	data := []byte(`{"text":"some text","activeTools":[],"isThinking":false,"planModeActive":false}`)
+	require.NoError(t, s.SetStreamingSnapshot(t.Context(), "conv-1", data))
+	require.NoError(t, s.ClearStreamingSnapshot(t.Context(), "conv-1"))
+
+	req := httptest.NewRequest("GET", "/api/conversations/conv-1/streaming-snapshot", nil)
+	req = withChiContext(req, map[string]string{"convId": "conv-1"})
+	w := httptest.NewRecorder()
+
+	h.GetStreamingSnapshot(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "null\n", w.Body.String())
+}

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -559,6 +559,21 @@ func (s *SQLiteStore) runMigrations() error {
 		logger.SQLite.Infof("Migration: Added model column to conversations")
 	}
 
+	// Migration: Add streaming_snapshot column to conversations if it doesn't exist
+	err = s.db.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('conversations') WHERE name = 'streaming_snapshot'
+	`).Scan(&count)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		_, err = s.db.Exec(`ALTER TABLE conversations ADD COLUMN streaming_snapshot TEXT NOT NULL DEFAULT ''`)
+		if err != nil {
+			return err
+		}
+		logger.SQLite.Infof("Migration: Added streaming_snapshot column to conversations")
+	}
+
 	// Migration: Convert 'todo' task_status to 'backlog' (todo status was removed)
 	err = s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE task_status = 'todo'`).Scan(&count)
 	if err != nil {
@@ -1927,6 +1942,50 @@ func (s *SQLiteStore) AddToolActionToConversation(ctx context.Context, convID st
 		}
 
 		return tx.Commit()
+	})
+}
+
+// ============================================================================
+// Streaming Snapshot methods
+// ============================================================================
+
+// SetStreamingSnapshot stores a JSON snapshot of the current streaming state for a conversation.
+// Used for reconnection recovery — the frontend can fetch this to restore its view.
+func (s *SQLiteStore) SetStreamingSnapshot(ctx context.Context, convID string, snapshot []byte) error {
+	return RetryDBExec(ctx, "SetStreamingSnapshot", DefaultRetryConfig(), func(ctx context.Context) error {
+		_, err := s.db.ExecContext(ctx,
+			`UPDATE conversations SET streaming_snapshot = ? WHERE id = ?`,
+			string(snapshot), convID)
+		return err
+	})
+}
+
+// GetStreamingSnapshot retrieves the stored streaming snapshot for a conversation.
+// Returns nil if no snapshot exists (empty string in DB).
+func (s *SQLiteStore) GetStreamingSnapshot(ctx context.Context, convID string) ([]byte, error) {
+	var snapshot string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT streaming_snapshot FROM conversations WHERE id = ?`,
+		convID).Scan(&snapshot)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if snapshot == "" {
+		return nil, nil
+	}
+	return []byte(snapshot), nil
+}
+
+// ClearStreamingSnapshot removes the streaming snapshot for a conversation.
+func (s *SQLiteStore) ClearStreamingSnapshot(ctx context.Context, convID string) error {
+	return RetryDBExec(ctx, "ClearStreamingSnapshot", DefaultRetryConfig(), func(ctx context.Context) error {
+		_, err := s.db.ExecContext(ctx,
+			`UPDATE conversations SET streaming_snapshot = '' WHERE id = ?`,
+			convID)
+		return err
 	})
 }
 

--- a/backend/store/streaming_snapshot_test.go
+++ b/backend/store/streaming_snapshot_test.go
@@ -1,0 +1,196 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetStreamingSnapshot_Basic(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	repo := createTestRepo(t, s, "repo-1")
+	session := createTestSession(t, s, "sess-1", repo.ID)
+	conv := createTestConversation(t, s, "conv-1", session.ID)
+
+	snapshot := map[string]interface{}{
+		"text":        "Hello world",
+		"activeTools": []interface{}{},
+		"isThinking":  false,
+	}
+	data, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+
+	err = s.SetStreamingSnapshot(ctx, conv.ID, data)
+	require.NoError(t, err)
+
+	got, err := s.GetStreamingSnapshot(ctx, conv.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(got, &parsed))
+	assert.Equal(t, "Hello world", parsed["text"])
+}
+
+func TestGetStreamingSnapshot_EmptyReturnsNil(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	repo := createTestRepo(t, s, "repo-1")
+	session := createTestSession(t, s, "sess-1", repo.ID)
+	createTestConversation(t, s, "conv-1", session.ID)
+
+	// Never set a snapshot — default is empty string
+	got, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestGetStreamingSnapshot_NonexistentConversation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetStreamingSnapshot(ctx, "nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestClearStreamingSnapshot(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	repo := createTestRepo(t, s, "repo-1")
+	session := createTestSession(t, s, "sess-1", repo.ID)
+	conv := createTestConversation(t, s, "conv-1", session.ID)
+
+	// Set a snapshot
+	data := []byte(`{"text":"some content","activeTools":[],"isThinking":false}`)
+	require.NoError(t, s.SetStreamingSnapshot(ctx, conv.ID, data))
+
+	// Verify it exists
+	got, err := s.GetStreamingSnapshot(ctx, conv.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// Clear it
+	require.NoError(t, s.ClearStreamingSnapshot(ctx, conv.ID))
+
+	// Verify it's gone
+	got, err = s.GetStreamingSnapshot(ctx, conv.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestSetStreamingSnapshot_Overwrite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	repo := createTestRepo(t, s, "repo-1")
+	session := createTestSession(t, s, "sess-1", repo.ID)
+	conv := createTestConversation(t, s, "conv-1", session.ID)
+
+	// Set initial snapshot
+	data1 := []byte(`{"text":"first","activeTools":[],"isThinking":false}`)
+	require.NoError(t, s.SetStreamingSnapshot(ctx, conv.ID, data1))
+
+	// Overwrite with new snapshot
+	data2 := []byte(`{"text":"second","activeTools":[{"id":"t1","tool":"Bash","startTime":1234}],"isThinking":true}`)
+	require.NoError(t, s.SetStreamingSnapshot(ctx, conv.ID, data2))
+
+	got, err := s.GetStreamingSnapshot(ctx, conv.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(got, &parsed))
+	assert.Equal(t, "second", parsed["text"])
+	assert.True(t, parsed["isThinking"].(bool))
+
+	tools := parsed["activeTools"].([]interface{})
+	assert.Len(t, tools, 1)
+}
+
+func TestClearStreamingSnapshot_AlreadyEmpty(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	repo := createTestRepo(t, s, "repo-1")
+	session := createTestSession(t, s, "sess-1", repo.ID)
+	createTestConversation(t, s, "conv-1", session.ID)
+
+	// Clear when already empty — should not error
+	err := s.ClearStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+}
+
+func TestSetStreamingSnapshot_LargeContent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	repo := createTestRepo(t, s, "repo-1")
+	session := createTestSession(t, s, "sess-1", repo.ID)
+	conv := createTestConversation(t, s, "conv-1", session.ID)
+
+	// Simulate a large assistant message (~100KB)
+	largeText := make([]byte, 100*1024)
+	for i := range largeText {
+		largeText[i] = 'a' + byte(i%26)
+	}
+
+	snapshot := map[string]interface{}{
+		"text":           string(largeText),
+		"activeTools":    []interface{}{},
+		"isThinking":     false,
+		"planModeActive": false,
+	}
+	data, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+
+	require.NoError(t, s.SetStreamingSnapshot(ctx, conv.ID, data))
+
+	got, err := s.GetStreamingSnapshot(ctx, conv.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(got, &parsed))
+	assert.Len(t, parsed["text"], 100*1024)
+}
+
+func TestStreamingSnapshot_MultipleConversations(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	repo := createTestRepo(t, s, "repo-1")
+	session := createTestSession(t, s, "sess-1", repo.ID)
+	createTestConversation(t, s, "conv-1", session.ID)
+	createTestConversation(t, s, "conv-2", session.ID)
+
+	// Set different snapshots for different conversations
+	data1 := []byte(`{"text":"conv1 text","activeTools":[],"isThinking":false}`)
+	data2 := []byte(`{"text":"conv2 text","activeTools":[],"isThinking":true}`)
+	require.NoError(t, s.SetStreamingSnapshot(ctx, "conv-1", data1))
+	require.NoError(t, s.SetStreamingSnapshot(ctx, "conv-2", data2))
+
+	// Verify they're independent
+	got1, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	got2, err := s.GetStreamingSnapshot(ctx, "conv-2")
+	require.NoError(t, err)
+
+	var p1, p2 map[string]interface{}
+	require.NoError(t, json.Unmarshal(got1, &p1))
+	require.NoError(t, json.Unmarshal(got2, &p2))
+
+	assert.Equal(t, "conv1 text", p1["text"])
+	assert.Equal(t, "conv2 text", p2["text"])
+
+	// Clear one, other should remain
+	require.NoError(t, s.ClearStreamingSnapshot(ctx, "conv-1"))
+
+	got1, err = s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Nil(t, got1)
+
+	got2, err = s.GetStreamingSnapshot(ctx, "conv-2")
+	require.NoError(t, err)
+	assert.NotNil(t, got2)
+}

--- a/docs/plans/2026-02-02-streaming-snapshot-recovery-design.md
+++ b/docs/plans/2026-02-02-streaming-snapshot-recovery-design.md
@@ -1,0 +1,166 @@
+# H3: Streaming Snapshot Recovery on WebSocket Reconnect
+
+## Problem
+
+When the WebSocket disconnects and reconnects while an agent is still streaming, the frontend loses all content received before the disconnect. The backend accumulates `assistant_text` in a Go variable (`currentAssistantMessage`) but only persists to the DB on `result`/`complete`. The frontend's streaming state is in-memory and gets cleared. Existing reconciliation only checks "is the process still running?" — if yes, it does nothing, leaving the UI empty.
+
+## Solution: Backend Streaming Snapshots
+
+The backend periodically snapshots the current streaming state to the DB. On reconnect, the frontend fetches the snapshot to restore its streaming view.
+
+## Data Model
+
+New column on `conversations` table:
+
+```sql
+ALTER TABLE conversations ADD COLUMN streaming_snapshot TEXT DEFAULT '';
+```
+
+Snapshot JSON structure:
+
+```json
+{
+  "text": "full accumulated assistant text so far",
+  "activeTools": [
+    { "id": "tool_use_abc", "tool": "Bash", "startTime": 1706000001 }
+  ],
+  "thinking": "current thinking content if any",
+  "isThinking": false,
+  "planModeActive": false
+}
+```
+
+Not included in snapshot (by design):
+- **Segments/timeline** — purely a frontend rendering concern. The recovered text is displayed as a single block. New events after reconnect append normally.
+
+## Backend Changes
+
+### 1. Store Layer (`backend/store/`)
+
+New methods on `SQLiteStore`:
+
+```go
+func (s *SQLiteStore) SetStreamingSnapshot(ctx context.Context, convID string, snapshot []byte) error
+func (s *SQLiteStore) GetStreamingSnapshot(ctx context.Context, convID string) ([]byte, error)
+func (s *SQLiteStore) ClearStreamingSnapshot(ctx context.Context, convID string) error
+```
+
+### 2. Output Handler (`backend/agent/manager.go`)
+
+Expand `handleConversationOutput` to track tool and thinking state alongside text, with debounced snapshot flushing:
+
+```go
+const snapshotDebounceInterval = 500 * time.Millisecond
+```
+
+State tracked:
+- `currentAssistantMessage` (string) — already exists
+- `activeToolsMap` (map[string]activeToolEntry) — new, maintained on tool_start/tool_end
+- `currentThinking` (string) — new, maintained on thinking_delta/thinking
+- `isThinking` (bool) — new
+- `snapshotDirty` (bool) — new, set true on any state change
+
+Flush strategy (debounced, not fixed ticker):
+- On any state-changing event: set `snapshotDirty = true`, reset a 500ms timer
+- When timer fires (500ms after last event): if dirty, flush snapshot to DB
+- On terminal events (`result`/`complete`/`error`): flush immediately, then clear snapshot
+- On output handler exit (process died): persist remaining message + clear snapshot
+
+### 3. New REST Endpoint
+
+`GET /api/conversations/{convId}/streaming-snapshot`
+
+Returns the stored snapshot JSON, or `null` if no active streaming snapshot exists.
+
+### 4. Parser Types (`backend/agent/parser.go`)
+
+New Go struct:
+
+```go
+type StreamingSnapshot struct {
+    Text         string            `json:"text"`
+    ActiveTools  []ActiveToolEntry `json:"activeTools"`
+    Thinking     string            `json:"thinking,omitempty"`
+    IsThinking   bool              `json:"isThinking"`
+    PlanModeActive bool            `json:"planModeActive"`
+}
+
+type ActiveToolEntry struct {
+    ID        string `json:"id"`
+    Tool      string `json:"tool"`
+    StartTime int64  `json:"startTime"`
+}
+```
+
+## Frontend Changes
+
+### 1. New API Function (`src/lib/api.ts`)
+
+```typescript
+export async function getStreamingSnapshot(convId: string): Promise<StreamingSnapshot | null>
+```
+
+### 2. Updated Reconciliation (`src/hooks/useWebSocket.ts`)
+
+Updated `reconcileStreamingState()`:
+
+```
+For each conversation the frontend thinks is streaming:
+
+  a) If NOT active on server (agent finished during disconnect):
+     → Same as today: clear streaming state, reload messages from DB
+
+  b) If STILL active on server:
+     → Fetch GET /api/conversations/{convId}/streaming-snapshot
+     → If snapshot has text:
+        - Restore streamingState.text from snapshot.text
+        - Create a single segment from the snapshot text
+        - Restore activeTools from snapshot.activeTools
+        - Restore thinking from snapshot.thinking
+        - Keep isStreaming = true
+        - Resume receiving WebSocket events normally
+     → If snapshot is empty/null:
+        - Reload messages from DB as safety net (covers the race
+          where result was just persisted but process hasn't exited yet)
+        - Keep isStreaming = true, let result/complete event finalize
+```
+
+## Edge Cases
+
+### Agent finishes during disconnect
+Process exits → removed from `convProcesses` → frontend takes "not active" path → reloads messages from DB. Works correctly with existing reconciliation.
+
+### Agent finishes between snapshot-clear and process-exit
+Frontend reconnects, sees process "active," fetches snapshot → empty. Fallback: reload messages from DB, which has the just-persisted final message.
+
+### Agent crashes (SIGKILL, no result event)
+`handleConversationOutput` exit path persists remaining `currentAssistantMessage` to DB (existing behavior, lines 349-358 of manager.go). Snapshot cleared on exit. Frontend takes "not active" path, reloads from DB.
+
+### Duplicate text after reconnect
+No overlap: the backend continues emitting NEW `assistant_text` events from where it left off. The frontend has the snapshot (up to 500ms stale) + new events. At most 500ms of text is missing (between last flush and disconnect). Acceptable trade-off.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `backend/store/sqlite.go` | Add streaming_snapshot column, Set/Get/Clear methods |
+| `backend/agent/manager.go` | Expand handleConversationOutput with tool/thinking tracking + debounced flush |
+| `backend/agent/parser.go` | Add StreamingSnapshot and ActiveToolEntry types |
+| `backend/server/routes.go` | Add GET streaming-snapshot endpoint |
+| `backend/server/handlers.go` | Add GetStreamingSnapshot handler |
+| `src/lib/api.ts` | Add getStreamingSnapshot() function |
+| `src/hooks/useWebSocket.ts` | Update reconcileStreamingState() with snapshot fetch + restore |
+| `src/stores/appStore.ts` | Add restoreStreamingFromSnapshot() method |
+
+## Related
+
+- **CM-103**: Reliable delivery for critical events (H4) — separate issue for polling-based fallback when events are dropped while connected
+- **M8**: Wait for ready event before first message — deferred, separate concern
+
+## Testing
+
+1. Start a conversation, let agent stream for a few seconds
+2. Kill the WebSocket connection (browser DevTools → Network → offline)
+3. Wait 2-3 seconds, re-enable network
+4. Verify: accumulated text is restored, agent continues streaming normally
+5. Edge case: disconnect and reconnect after agent finishes → verify messages reload correctly

--- a/src/hooks/__tests__/useWebSocket.snapshot.test.ts
+++ b/src/hooks/__tests__/useWebSocket.snapshot.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../__mocks__/server';
+import { useAppStore } from '@/stores/appStore';
+import {
+  getActiveStreamingConversations,
+  getConversationMessages,
+  getStreamingSnapshot,
+  toStoreMessage,
+} from '@/lib/api';
+import type { StreamingSnapshotDTO } from '@/lib/api';
+
+const API_BASE = 'http://localhost:9876';
+const CONV_ACTIVE = 'conv-active-1';
+const CONV_FINISHED = 'conv-finished-1';
+
+/**
+ * Tests for the streaming snapshot recovery feature (H3).
+ *
+ * When the WebSocket disconnects and reconnects while an agent is still streaming,
+ * the frontend fetches a snapshot from the backend to restore its streaming view.
+ *
+ * Tests cover:
+ * 1. getStreamingSnapshot API function
+ * 2. restoreStreamingFromSnapshot store method
+ * 3. Full reconciliation flow with snapshot recovery
+ */
+
+describe('useWebSocket — streaming snapshot recovery', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      streamingState: {},
+      activeTools: {},
+      conversations: [],
+      messages: [],
+    });
+  });
+
+  // ==========================================================================
+  // API: getStreamingSnapshot
+  // ==========================================================================
+
+  describe('getStreamingSnapshot API', () => {
+    it('returns snapshot data from backend', async () => {
+      const snapshotData: StreamingSnapshotDTO = {
+        text: 'Hello world so far',
+        activeTools: [{ id: 'tool-1', tool: 'Bash', startTime: 1706000001 }],
+        thinking: 'analyzing...',
+        isThinking: true,
+        planModeActive: false,
+      };
+
+      server.use(
+        http.get(`${API_BASE}/api/conversations/${CONV_ACTIVE}/streaming-snapshot`, () => {
+          return HttpResponse.json(snapshotData);
+        }),
+      );
+
+      const result = await getStreamingSnapshot(CONV_ACTIVE);
+      expect(result).toEqual(snapshotData);
+    });
+
+    it('returns null when no snapshot exists', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/${CONV_ACTIVE}/streaming-snapshot`, () => {
+          return HttpResponse.json(null);
+        }),
+      );
+
+      const result = await getStreamingSnapshot(CONV_ACTIVE);
+      expect(result).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Store: restoreStreamingFromSnapshot
+  // ==========================================================================
+
+  describe('restoreStreamingFromSnapshot store method', () => {
+    it('restores text as a single segment', () => {
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+
+      store.restoreStreamingFromSnapshot(CONV_ACTIVE, {
+        text: 'Recovered assistant text',
+        activeTools: [],
+        isThinking: false,
+        planModeActive: false,
+      });
+
+      const state = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(state?.text).toBe('Recovered assistant text');
+      expect(state?.isStreaming).toBe(true);
+      expect(state?.segments).toHaveLength(1);
+      expect(state?.segments[0].text).toBe('Recovered assistant text');
+      expect(state?.segments[0].id).toMatch(/^recovered-/);
+      expect(state?.currentSegmentId).toBe(state?.segments[0].id);
+    });
+
+    it('restores active tools with timestamp conversion', () => {
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+
+      store.restoreStreamingFromSnapshot(CONV_ACTIVE, {
+        text: 'some text',
+        activeTools: [
+          { id: 'tool-1', tool: 'Bash', startTime: 1706000001 },
+          { id: 'tool-2', tool: 'Read', startTime: 1706000005 },
+        ],
+        isThinking: false,
+        planModeActive: false,
+      });
+
+      const tools = useAppStore.getState().activeTools[CONV_ACTIVE];
+      expect(tools).toHaveLength(2);
+      expect(tools[0].id).toBe('tool-1');
+      expect(tools[0].tool).toBe('Bash');
+      // Backend sends seconds, frontend expects milliseconds
+      expect(tools[0].startTime).toBe(1706000001000);
+      expect(tools[1].id).toBe('tool-2');
+      expect(tools[1].tool).toBe('Read');
+      expect(tools[1].startTime).toBe(1706000005000);
+    });
+
+    it('restores thinking state', () => {
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+
+      store.restoreStreamingFromSnapshot(CONV_ACTIVE, {
+        text: 'some text',
+        activeTools: [],
+        thinking: 'deep analysis of the problem...',
+        isThinking: true,
+        planModeActive: false,
+      });
+
+      const state = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(state?.thinking).toBe('deep analysis of the problem...');
+      expect(state?.isThinking).toBe(true);
+    });
+
+    it('restores plan mode state', () => {
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+
+      store.restoreStreamingFromSnapshot(CONV_ACTIVE, {
+        text: 'planning...',
+        activeTools: [],
+        isThinking: false,
+        planModeActive: true,
+      });
+
+      const state = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(state?.planModeActive).toBe(true);
+    });
+
+    it('handles empty text and no tools gracefully', () => {
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+
+      store.restoreStreamingFromSnapshot(CONV_ACTIVE, {
+        text: '',
+        activeTools: [],
+        isThinking: false,
+        planModeActive: false,
+      });
+
+      const state = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(state?.text).toBe('');
+      expect(state?.segments).toHaveLength(1);
+      expect(state?.isStreaming).toBe(true);
+      expect(useAppStore.getState().activeTools[CONV_ACTIVE]).toHaveLength(0);
+    });
+
+    it('overwrites previous streaming state', () => {
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+      store.appendStreamingText(CONV_ACTIVE, 'old stale text');
+
+      // Restore from snapshot — should replace stale state
+      store.restoreStreamingFromSnapshot(CONV_ACTIVE, {
+        text: 'fresh recovered text',
+        activeTools: [],
+        isThinking: false,
+        planModeActive: false,
+      });
+
+      const state = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(state?.text).toBe('fresh recovered text');
+      // Should have a single recovered segment, not the old one
+      expect(state?.segments).toHaveLength(1);
+      expect(state?.segments[0].text).toBe('fresh recovered text');
+    });
+  });
+
+  // ==========================================================================
+  // End-to-end reconciliation with snapshot recovery
+  // ==========================================================================
+
+  describe('end-to-end reconciliation with snapshot recovery', () => {
+    /**
+     * Replicates the full reconcileStreamingState logic from useWebSocket.ts
+     * including the new snapshot recovery path for still-active conversations.
+     */
+    async function reconcileStreamingState() {
+      const store = useAppStore.getState();
+
+      const locallyStreaming = Object.entries(store.streamingState)
+        .filter(([, state]) => state.isStreaming)
+        .map(([convId]) => convId);
+
+      if (locallyStreaming.length === 0) return;
+
+      try {
+        const { conversationIds: serverActive } = await getActiveStreamingConversations();
+        const serverActiveSet = new Set(serverActive);
+
+        for (const convId of locallyStreaming) {
+          if (!serverActiveSet.has(convId)) {
+            // Agent finished — clear state and reload messages
+            store.clearStreamingText(convId);
+            store.clearActiveTools(convId);
+            store.clearThinking(convId);
+            store.updateConversation(convId, { status: 'completed' });
+
+            try {
+              const page = await getConversationMessages(convId);
+              const messages = page.messages.map(m => toStoreMessage(m, convId));
+              store.setMessagePage(convId, messages, page.hasMore, page.oldestPosition ?? 0, page.totalCount);
+            } catch {
+              // Swallow
+            }
+          } else {
+            // Agent still active — restore from snapshot
+            try {
+              const snapshot = await getStreamingSnapshot(convId);
+              if (snapshot && snapshot.text) {
+                store.restoreStreamingFromSnapshot(convId, snapshot);
+              } else {
+                try {
+                  const page = await getConversationMessages(convId);
+                  const messages = page.messages.map(m => toStoreMessage(m, convId));
+                  store.setMessagePage(convId, messages, page.hasMore, page.oldestPosition ?? 0, page.totalCount);
+                } catch {
+                  // Swallow
+                }
+              }
+            } catch {
+              // Swallow
+            }
+          }
+        }
+      } catch {
+        // Swallow
+      }
+    }
+
+    it('restores streaming view from snapshot for still-active conversations', async () => {
+      useAppStore.setState({
+        conversations: [
+          { id: CONV_ACTIVE, sessionId: 's1', type: 'task' as const, name: '', status: 'active' as const, messages: [], toolSummary: [], createdAt: '', updatedAt: '' },
+        ],
+      });
+
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+      store.appendStreamingText(CONV_ACTIVE, 'stale partial text');
+
+      server.use(
+        http.get(`${API_BASE}/api/conversations/active-streaming`, () => {
+          return HttpResponse.json({ conversationIds: [CONV_ACTIVE] });
+        }),
+        http.get(`${API_BASE}/api/conversations/${CONV_ACTIVE}/streaming-snapshot`, () => {
+          return HttpResponse.json({
+            text: 'Full recovered text from backend',
+            activeTools: [{ id: 'tool-1', tool: 'Bash', startTime: 1706000001 }],
+            thinking: 'thinking content',
+            isThinking: true,
+            planModeActive: false,
+          } satisfies StreamingSnapshotDTO);
+        }),
+      );
+
+      await reconcileStreamingState();
+
+      const state = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(state?.text).toBe('Full recovered text from backend');
+      expect(state?.isStreaming).toBe(true);
+      expect(state?.thinking).toBe('thinking content');
+      expect(state?.isThinking).toBe(true);
+
+      const tools = useAppStore.getState().activeTools[CONV_ACTIVE];
+      expect(tools).toHaveLength(1);
+      expect(tools[0].tool).toBe('Bash');
+    });
+
+    it('clears finished conversations and restores active ones in same reconciliation', async () => {
+      useAppStore.setState({
+        conversations: [
+          { id: CONV_ACTIVE, sessionId: 's1', type: 'task' as const, name: '', status: 'active' as const, messages: [], toolSummary: [], createdAt: '', updatedAt: '' },
+          { id: CONV_FINISHED, sessionId: 's2', type: 'task' as const, name: '', status: 'active' as const, messages: [], toolSummary: [], createdAt: '', updatedAt: '' },
+        ],
+      });
+
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+      store.appendStreamingText(CONV_ACTIVE, 'partial...');
+      store.setStreaming(CONV_FINISHED, true);
+      store.appendStreamingText(CONV_FINISHED, 'also partial...');
+
+      server.use(
+        http.get(`${API_BASE}/api/conversations/active-streaming`, () => {
+          // CONV_ACTIVE still running, CONV_FINISHED done
+          return HttpResponse.json({ conversationIds: [CONV_ACTIVE] });
+        }),
+        http.get(`${API_BASE}/api/conversations/${CONV_ACTIVE}/streaming-snapshot`, () => {
+          return HttpResponse.json({
+            text: 'Recovered active text',
+            activeTools: [],
+            isThinking: false,
+            planModeActive: false,
+          } satisfies StreamingSnapshotDTO);
+        }),
+        http.get(`${API_BASE}/api/conversations/${CONV_FINISHED}/messages`, () => {
+          return HttpResponse.json({
+            messages: [
+              { id: 'msg-1', role: 'assistant', content: 'Final answer', timestamp: new Date().toISOString(), position: 1 },
+            ],
+            hasMore: false,
+            totalCount: 1,
+            oldestPosition: 1,
+          });
+        }),
+      );
+
+      await reconcileStreamingState();
+
+      // CONV_ACTIVE: restored from snapshot
+      const activeState = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(activeState?.text).toBe('Recovered active text');
+      expect(activeState?.isStreaming).toBe(true);
+
+      // CONV_FINISHED: cleared and messages reloaded
+      const finishedState = useAppStore.getState().streamingState[CONV_FINISHED];
+      expect(finishedState?.isStreaming).toBe(false);
+      expect(finishedState?.text).toBe('');
+
+      const finishedConv = useAppStore.getState().conversations.find(c => c.id === CONV_FINISHED);
+      expect(finishedConv?.status).toBe('completed');
+
+      const msgs = useAppStore.getState().messages.filter(m => m.conversationId === CONV_FINISHED);
+      expect(msgs).toHaveLength(1);
+    });
+
+    it('falls back to message reload when snapshot is empty for still-active conversation', async () => {
+      useAppStore.setState({
+        conversations: [
+          { id: CONV_ACTIVE, sessionId: 's1', type: 'task' as const, name: '', status: 'active' as const, messages: [], toolSummary: [], createdAt: '', updatedAt: '' },
+        ],
+      });
+
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+
+      server.use(
+        http.get(`${API_BASE}/api/conversations/active-streaming`, () => {
+          return HttpResponse.json({ conversationIds: [CONV_ACTIVE] });
+        }),
+        http.get(`${API_BASE}/api/conversations/${CONV_ACTIVE}/streaming-snapshot`, () => {
+          // Empty snapshot — race condition where result was just persisted
+          return HttpResponse.json(null);
+        }),
+        http.get(`${API_BASE}/api/conversations/${CONV_ACTIVE}/messages`, () => {
+          return HttpResponse.json({
+            messages: [
+              { id: 'msg-1', role: 'assistant', content: 'Just finished answer', timestamp: new Date().toISOString(), position: 1 },
+            ],
+            hasMore: false,
+            totalCount: 1,
+            oldestPosition: 1,
+          });
+        }),
+      );
+
+      await reconcileStreamingState();
+
+      // Messages should be reloaded as fallback
+      const msgs = useAppStore.getState().messages.filter(m => m.conversationId === CONV_ACTIVE);
+      expect(msgs).toHaveLength(1);
+
+      // Streaming should still be active (agent process hasn't exited)
+      const state = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(state?.isStreaming).toBe(true);
+    });
+
+    it('handles snapshot API error gracefully', async () => {
+      const store = useAppStore.getState();
+      store.setStreaming(CONV_ACTIVE, true);
+      store.appendStreamingText(CONV_ACTIVE, 'some text');
+
+      server.use(
+        http.get(`${API_BASE}/api/conversations/active-streaming`, () => {
+          return HttpResponse.json({ conversationIds: [CONV_ACTIVE] });
+        }),
+        http.get(`${API_BASE}/api/conversations/${CONV_ACTIVE}/streaming-snapshot`, () => {
+          return HttpResponse.error();
+        }),
+      );
+
+      // Should not throw
+      await reconcileStreamingState();
+
+      // Streaming state should be unchanged (error path doesn't modify)
+      const state = useAppStore.getState().streamingState[CONV_ACTIVE];
+      expect(state?.isStreaming).toBe(true);
+      expect(state?.text).toContain('some text');
+    });
+  });
+});

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -12,7 +12,7 @@ import {
 import { getAuthToken } from '@/lib/auth-token';
 import { getBackendPort, getBackendPortSync } from '@/lib/backend-port';
 import { useConnectionStore } from '@/stores/connectionStore';
-import { getConversationDropStats, getActiveStreamingConversations, getConversationMessages, toStoreMessage } from '@/lib/api';
+import { getConversationDropStats, getActiveStreamingConversations, getConversationMessages, getStreamingSnapshot, toStoreMessage } from '@/lib/api';
 import { notifyDesktop, getConversationLabel } from '@/hooks/useDesktopNotifications';
 
 // Safely coerce an unknown value to a number, returning undefined for non-numeric values.
@@ -453,7 +453,8 @@ export function useWebSocket(enabled: boolean = true) {
   }, []);
 
   // After a WebSocket reconnection, reconcile frontend streaming state with backend reality.
-  // If the agent finished while we were disconnected, clear orphaned streaming state and reload messages.
+  // If the agent finished while disconnected: clear orphaned streaming state and reload messages.
+  // If the agent is still active: fetch the streaming snapshot to restore the view.
   const reconcileStreamingState = useCallback(async () => {
     const store = getStore();
 
@@ -482,6 +483,30 @@ export function useWebSocket(enabled: boolean = true) {
             store.setMessagePage(convId, messages, page.hasMore, page.oldestPosition ?? 0, page.totalCount);
           } catch (err) {
             console.warn(`Failed to reload messages for ${convId} after reconnect:`, err);
+          }
+        } else {
+          // Agent still active — restore streaming view from snapshot.
+          // Note: the snapshot may be up to 500ms stale (debounce interval). Text
+          // emitted between the last flush and the disconnect is lost. New WebSocket
+          // events after reconnect append from where the backend left off, so there's
+          // no duplication — just a small gap.
+          try {
+            const snapshot = await getStreamingSnapshot(convId);
+            if (snapshot && snapshot.text) {
+              store.restoreStreamingFromSnapshot(convId, snapshot);
+            } else {
+              // No snapshot (race: result just persisted but process hasn't exited yet)
+              // Reload messages as safety net, keep streaming active
+              try {
+                const page = await getConversationMessages(convId);
+                const messages = page.messages.map(m => toStoreMessage(m, convId));
+                store.setMessagePage(convId, messages, page.hasMore, page.oldestPosition ?? 0, page.totalCount);
+              } catch (innerErr) {
+                console.warn(`Failed to reload messages for ${convId} during snapshot fallback:`, innerErr);
+              }
+            }
+          } catch (err) {
+            console.warn(`Failed to fetch streaming snapshot for ${convId}:`, err);
           }
         }
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1006,6 +1006,19 @@ export async function getActiveStreamingConversations(): Promise<{ conversationI
   return handleResponse(res);
 }
 
+export interface StreamingSnapshotDTO {
+  text: string;
+  activeTools: { id: string; tool: string; startTime: number }[];
+  thinking?: string;
+  isThinking: boolean;
+  planModeActive: boolean;
+}
+
+export async function getStreamingSnapshot(convId: string): Promise<StreamingSnapshotDTO | null> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/streaming-snapshot`);
+  return handleResponse(res);
+}
+
 export async function deleteConversation(convId: string): Promise<void> {
   const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}`, { method: 'DELETE' });
   await handleVoidResponse(res, 'Failed to delete conversation');

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -295,6 +295,13 @@ interface AppState {
   addActiveTool: (conversationId: string, tool: ActiveTool, opts?: { skipTimeout?: boolean }) => void;
   completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string) => void;
   clearActiveTools: (conversationId: string) => void;
+  restoreStreamingFromSnapshot: (conversationId: string, snapshot: {
+    text: string;
+    activeTools: { id: string; tool: string; startTime: number }[];
+    thinking?: string;
+    isThinking: boolean;
+    planModeActive: boolean;
+  }) => void;
 
   // Atomic streaming finalization - creates message and clears streaming in one update
   finalizeStreamingMessage: (
@@ -1147,6 +1154,30 @@ updateFileTabContent: (id, content) => set((state) => ({
       activeTools: {
         ...state.activeTools,
         [conversationId]: [],
+      },
+    }));
+  },
+  restoreStreamingFromSnapshot: (conversationId, snapshot) => {
+    // Restore streaming state from a backend snapshot after WebSocket reconnection.
+    // Creates a single segment from the recovered text so existing rendering works.
+    const segmentId = `recovered-${conversationId}-${crypto.randomUUID()}`;
+    set((state) => ({
+      streamingState: updateStreamingConv(state.streamingState, conversationId, {
+        text: snapshot.text,
+        segments: [{ id: segmentId, text: snapshot.text, timestamp: Date.now() }],
+        currentSegmentId: segmentId,
+        isStreaming: true,
+        thinking: snapshot.thinking || null,
+        isThinking: snapshot.isThinking,
+        planModeActive: snapshot.planModeActive,
+      }),
+      activeTools: {
+        ...state.activeTools,
+        [conversationId]: snapshot.activeTools.map((t) => ({
+          id: t.id,
+          tool: t.tool,
+          startTime: t.startTime * 1000, // Convert seconds to ms
+        })),
       },
     }));
   },


### PR DESCRIPTION
## Summary

Implements streaming snapshot recovery (H3): when WebSocket disconnects during agent streaming, the frontend now fetches a snapshot from the backend to restore its view. The backend periodically persists streaming state (text, active tools, thinking) with a 500ms debounce interval. On reconnect, the frontend reconciliation logic fetches the snapshot and restores the streaming UI.

Also includes quality-of-life improvements: agent-runner CLI arg parsing is now more robust, error handling is more granular, and process restart now preserves configuration (model, tool preset, budget) and resumes the previous SDK session when available.

## Test Plan

- Run Go tests: `cd backend && go test ./agent ./server ./store -run Snapshot`
- Run frontend tests: `npx vitest run src/hooks/__tests__/useWebSocket.snapshot.test.ts`
- Manual: start a conversation, let agent stream for 2-3 seconds, kill WebSocket (DevTools → Network → offline), re-enable network → verify streaming text is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)