### PR TITLE
fix: persist agent session ID for resume on restart

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -365,6 +365,12 @@ outer:
 				// Track the session ID so restarts can resume the correct session
 				if event.SessionID != "" {
 					proc.SetSessionID(event.SessionID)
+					// Persist to DB so the session ID survives process cleanup
+					if err := m.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
+						c.AgentSessionID = event.SessionID
+					}); err != nil {
+						logger.Manager.Errorf("Failed to persist agent session ID for conv %s: %v", convID, err)
+					}
 				}
 
 			case EventTypePermModeChanged:
@@ -647,11 +653,15 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 		// (e.g., process crashed before emitting session_id_update), the restart will
 		// lack original instructions — an acceptable degradation for a crash scenario.
 		restartOpts.Instructions = ""
-		// Resume the previous session if we have a session ID
+		// Resume the previous session if we have a session ID.
+		// Try in-memory first, fall back to DB-persisted value.
 		if ok && proc != nil {
 			if sid := proc.GetSessionID(); sid != "" {
 				restartOpts.ResumeSession = sid
 			}
+		}
+		if restartOpts.ResumeSession == "" && conv.AgentSessionID != "" {
+			restartOpts.ResumeSession = conv.AgentSessionID
 		}
 
 		logger.Manager.Infof("Auto-restarting process for conversation %s (previous exit error: %v)", convID, prevExitErr)

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -97,8 +97,9 @@ type Conversation struct {
 	Type         string       `json:"type"`   // "task", "review", "chat"
 	Name         string       `json:"name"`   // AI-updatable display name
 	Status       string       `json:"status"` // "active", "idle", "completed"
-	Model        string       `json:"model,omitempty"`
-	Messages     []Message    `json:"messages"`
+	Model          string       `json:"model,omitempty"`
+	AgentSessionID string       `json:"agentSessionId,omitempty"` // Claude SDK session ID for resume
+	Messages       []Message    `json:"messages"`
 	MessageCount int          `json:"messageCount,omitempty"`
 	ToolSummary  []ToolAction `json:"toolSummary"`
 	CreatedAt    time.Time    `json:"createdAt"`

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -574,6 +574,21 @@ func (s *SQLiteStore) runMigrations() error {
 		logger.SQLite.Infof("Migration: Added streaming_snapshot column to conversations")
 	}
 
+	// Migration: Add agent_session_id column to conversations (for SDK session resume)
+	err = s.db.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('conversations') WHERE name = 'agent_session_id'
+	`).Scan(&count)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		_, err = s.db.Exec(`ALTER TABLE conversations ADD COLUMN agent_session_id TEXT NOT NULL DEFAULT ''`)
+		if err != nil {
+			return err
+		}
+		logger.SQLite.Infof("Migration: Added agent_session_id column to conversations")
+	}
+
 	// Migration: Convert 'todo' task_status to 'backlog' (todo status was removed)
 	err = s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE task_status = 'todo'`).Scan(&count)
 	if err != nil {
@@ -1156,10 +1171,10 @@ func (s *SQLiteStore) DeleteAgent(ctx context.Context, id string) error {
 func (s *SQLiteStore) AddConversation(ctx context.Context, conv *models.Conversation) error {
 	return RetryDBExec(ctx, "AddConversation", DefaultRetryConfig(), func(ctx context.Context) error {
 		_, err := s.db.ExecContext(ctx, `
-			INSERT INTO conversations (id, session_id, type, name, status, model, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			INSERT INTO conversations (id, session_id, type, name, status, model, agent_session_id, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			conv.ID, conv.SessionID, conv.Type, conv.Name,
-			conv.Status, conv.Model, conv.CreatedAt, conv.UpdatedAt)
+			conv.Status, conv.Model, conv.AgentSessionID, conv.CreatedAt, conv.UpdatedAt)
 		return err
 	})
 }
@@ -1169,10 +1184,10 @@ func (s *SQLiteStore) AddConversation(ctx context.Context, conv *models.Conversa
 func (s *SQLiteStore) GetConversationMeta(ctx context.Context, id string) (*models.Conversation, error) {
 	var conv models.Conversation
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, session_id, type, name, status, model, created_at, updated_at
+		SELECT id, session_id, type, name, status, model, agent_session_id, created_at, updated_at
 		FROM conversations WHERE id = ?`, id).Scan(
 		&conv.ID, &conv.SessionID, &conv.Type, &conv.Name,
-		&conv.Status, &conv.Model, &conv.CreatedAt, &conv.UpdatedAt)
+		&conv.Status, &conv.Model, &conv.AgentSessionID, &conv.CreatedAt, &conv.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -1185,10 +1200,10 @@ func (s *SQLiteStore) GetConversationMeta(ctx context.Context, id string) (*mode
 func (s *SQLiteStore) GetConversation(ctx context.Context, id string) (*models.Conversation, error) {
 	var conv models.Conversation
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, session_id, type, name, status, model, created_at, updated_at
+		SELECT id, session_id, type, name, status, model, agent_session_id, created_at, updated_at
 		FROM conversations WHERE id = ?`, id).Scan(
 		&conv.ID, &conv.SessionID, &conv.Type, &conv.Name,
-		&conv.Status, &conv.Model, &conv.CreatedAt, &conv.UpdatedAt)
+		&conv.Status, &conv.Model, &conv.AgentSessionID, &conv.CreatedAt, &conv.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -1237,7 +1252,7 @@ func (s *SQLiteStore) GetConversation(ctx context.Context, id string) (*models.C
 // Uses 3 queries total regardless of conversation count (1 for conversations + 1 for all messages + 1 for all tool actions).
 func (s *SQLiteStore) ListConversations(ctx context.Context, sessionID string) ([]*models.Conversation, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, session_id, type, name, status, model, created_at, updated_at
+		SELECT id, session_id, type, name, status, model, agent_session_id, created_at, updated_at
 		FROM conversations WHERE session_id = ?`, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("ListConversations: %w", err)
@@ -1250,7 +1265,7 @@ func (s *SQLiteStore) ListConversations(ctx context.Context, sessionID string) (
 	for rows.Next() {
 		var conv models.Conversation
 		if err := rows.Scan(&conv.ID, &conv.SessionID, &conv.Type, &conv.Name,
-			&conv.Status, &conv.Model, &conv.CreatedAt, &conv.UpdatedAt); err != nil {
+			&conv.Status, &conv.Model, &conv.AgentSessionID, &conv.CreatedAt, &conv.UpdatedAt); err != nil {
 			rows.Close()
 			return nil, fmt.Errorf("ListConversations scan: %w", err)
 		}
@@ -1309,7 +1324,7 @@ func (s *SQLiteStore) ListConversationsForSessions(ctx context.Context, sessionI
 
 	// Query all conversations for all sessions in one query
 	query := fmt.Sprintf(`
-		SELECT id, session_id, type, name, status, model, created_at, updated_at
+		SELECT id, session_id, type, name, status, model, agent_session_id, created_at, updated_at
 		FROM conversations WHERE session_id IN (%s)`, strings.Join(placeholders, ","))
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -1323,7 +1338,7 @@ func (s *SQLiteStore) ListConversationsForSessions(ctx context.Context, sessionI
 	for rows.Next() {
 		var conv models.Conversation
 		if err := rows.Scan(&conv.ID, &conv.SessionID, &conv.Type, &conv.Name,
-			&conv.Status, &conv.Model, &conv.CreatedAt, &conv.UpdatedAt); err != nil {
+			&conv.Status, &conv.Model, &conv.AgentSessionID, &conv.CreatedAt, &conv.UpdatedAt); err != nil {
 			rows.Close()
 			return nil, fmt.Errorf("ListConversationsForSessions scan: %w", err)
 		}
@@ -1762,9 +1777,9 @@ func (s *SQLiteStore) UpdateConversation(ctx context.Context, id string, updates
 	// Write back (only conversation table, not messages/tools)
 	_, err = s.db.ExecContext(ctx, `
 		UPDATE conversations SET
-			type = ?, name = ?, status = ?, model = ?, updated_at = ?
+			type = ?, name = ?, status = ?, model = ?, agent_session_id = ?, updated_at = ?
 		WHERE id = ?`,
-		conv.Type, conv.Name, conv.Status, conv.Model, conv.UpdatedAt, id)
+		conv.Type, conv.Name, conv.Status, conv.Model, conv.AgentSessionID, conv.UpdatedAt, id)
 	if err != nil {
 		return fmt.Errorf("UpdateConversation: %w", err)
 	}
@@ -1774,10 +1789,10 @@ func (s *SQLiteStore) UpdateConversation(ctx context.Context, id string, updates
 func (s *SQLiteStore) getConversationNoLock(ctx context.Context, id string) (*models.Conversation, error) {
 	var conv models.Conversation
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, session_id, type, name, status, model, created_at, updated_at
+		SELECT id, session_id, type, name, status, model, agent_session_id, created_at, updated_at
 		FROM conversations WHERE id = ?`, id).Scan(
 		&conv.ID, &conv.SessionID, &conv.Type, &conv.Name,
-		&conv.Status, &conv.Model, &conv.CreatedAt, &conv.UpdatedAt)
+		&conv.Status, &conv.Model, &conv.AgentSessionID, &conv.CreatedAt, &conv.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -136,6 +136,9 @@ pub fn start_global_watcher(
         loop {
             match rx.recv() {
                 Ok(Ok(events)) => {
+                    // Track per-session file counts for summary logging
+                    let mut session_counts: HashMap<String, usize> = HashMap::new();
+
                     for event in events {
                         if event.kind == DebouncedEventKind::Any {
                             let event_path_str = event.path.to_string_lossy().to_string();
@@ -150,10 +153,6 @@ pub fn start_global_watcher(
                                 match extract_session_dir(&watcher_base_path, &event.path) {
                                     Some(dir) => dir,
                                     None => {
-                                        log::debug!(
-                                            "Ignoring event outside session dirs: {}",
-                                            event_path_str
-                                        );
                                         continue;
                                     }
                                 };
@@ -180,10 +179,6 @@ pub fn start_global_watcher(
                             let workspace_id = match workspace_id {
                                 Some(id) => id,
                                 None => {
-                                    log::debug!(
-                                        "Ignoring event for unregistered session: {}",
-                                        session_dir
-                                    );
                                     continue;
                                 }
                             };
@@ -196,11 +191,7 @@ pub fn start_global_watcher(
                                 .map(|p| p.to_string_lossy().to_string())
                                 .unwrap_or_else(|_| event_path_str.clone());
 
-                            log::debug!(
-                                "File changed in session {}: {}",
-                                session_dir,
-                                relative_path
-                            );
+                            *session_counts.entry(session_dir.clone()).or_insert(0) += 1;
 
                             // Emit event to frontend with same payload format
                             if let Some(window) = app_handle.get_webview_window("main") {
@@ -214,6 +205,15 @@ pub fn start_global_watcher(
                                 }
                             }
                         }
+                    }
+
+                    // Log a single summary line per session instead of per-file
+                    for (session, count) in &session_counts {
+                        log::debug!(
+                            "File changes detected in session {}: {} files",
+                            session,
+                            count
+                        );
                     }
                 }
                 Ok(Err(error)) => {


### PR DESCRIPTION
## Summary
- When a conversation's agent process exits, it's deleted from the in-memory map. On restart (e.g., sending a follow-up message), the SDK session ID needed for `--resume` was lost, causing the agent to start a fresh session with no conversation history
- Added `agent_session_id` column to conversations table, persisted on `session_id_update` events
- Restart path now falls back to the DB-persisted session ID when the in-memory process is gone
- Batched per-file watcher DEBUG logs into a single summary line per session to reduce log noise

## Test plan
- [ ] Send a message to a session, wait for agent to finish, then send a follow-up — verify the agent resumes with full context
- [ ] Check logs for `agent_session_id` being stored on `session_id_update`
- [ ] Verify file watcher logs show summary counts instead of individual file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)