### PR TITLE
style: use text-base for Conversation area

### DIFF
--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -87,7 +87,7 @@ export const MessageBlock = memo(function MessageBlock({
           {message.attachments && message.attachments.length > 0 && (
             <AttachmentGrid attachments={message.attachments} readOnly />
           )}
-          <p className="text-md leading-relaxed whitespace-pre-wrap">
+          <p className="text-base leading-relaxed whitespace-pre-wrap">
             {highlightedContent || message.content}
           </p>
         </div>
@@ -141,7 +141,7 @@ export const MessageBlock = memo(function MessageBlock({
           <ContextMenu>
             <ContextMenuTrigger asChild>
               <div className="group relative">
-                <div className="prose prose-base dark:prose-invert max-w-none text-md leading-relaxed prose-p:my-3 prose-pre:my-2 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:font-semibold prose-headings:my-2 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-ul:marker:text-primary prose-ol:marker:text-primary">
+                <div className="prose prose-base dark:prose-invert max-w-none text-base leading-relaxed prose-p:my-3 prose-pre:my-2 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:font-semibold prose-headings:my-2 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-ul:marker:text-primary prose-ol:marker:text-primary">
                   <ErrorBoundary
                     section="MessageContent"
                     fallback={

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -257,7 +257,7 @@ export function StreamingMessage({ conversationId }: StreamingMessageProps) {
               return (
                 <div
                   key={item.id}
-                  className="prose prose-base dark:prose-invert max-w-none text-md leading-relaxed prose-p:my-3 prose-pre:my-2 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:font-semibold prose-headings:my-2 prose-ul:marker:text-primary prose-ol:marker:text-primary"
+                  className="prose prose-base dark:prose-invert max-w-none text-base leading-relaxed prose-p:my-3 prose-pre:my-2 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:font-semibold prose-headings:my-2 prose-ul:marker:text-primary prose-ol:marker:text-primary"
                 >
                   <CachedMarkdown
                     cacheKey={`seg:${item.id}`}

--- a/src/components/shared/SystemInfoCard.tsx
+++ b/src/components/shared/SystemInfoCard.tsx
@@ -21,7 +21,7 @@ export function SystemInfoCard({ setupInfo, className }: SystemInfoCardProps) {
   return (
     <div
       className={cn(
-        'rounded-lg border border-purple-400/20 bg-purple-500/10 dark:border-purple-400/20 dark:bg-purple-500/10 px-3 py-2 text-sm',
+        'rounded-lg border border-purple-400/20 bg-purple-500/10 dark:border-purple-400/20 dark:bg-purple-500/10 px-3 py-2 text-base',
         className
       )}
     >
@@ -29,7 +29,7 @@ export function SystemInfoCard({ setupInfo, className }: SystemInfoCardProps) {
         You are in a new copy of your codebase called{' '}
         <span className="font-medium text-foreground">{sessionName}</span>
       </p>
-      <div className="space-y-1.5 text-xs text-muted-foreground">
+      <div className="space-y-1.5 text-base text-muted-foreground">
         <div className="flex items-center gap-2">
           <GitBranch className="w-3.5 h-3.5 shrink-0" />
           <span>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Updates the Conversation UI to use `text-base` font size consistently across:
- setupInfo block (session/branch information)
- Composer Input textarea
- Streaming messages (assistant/user message content)

## Test Plan
- [ ] Visual inspection in Conversation area shows uniform text-base sizing
- [ ] `make dev` builds successfully
- [ ] setupInfo card displays properly
- [ ] Composer input renders at correct size
- [ ] Streaming messages render at correct size

🤖 Generated with [Claude Code](https://claude.com/claude-code)