### PR TITLE
fix: move useLayoutEffect after selectedSessionId declaration

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -355,22 +355,6 @@ export default function Home() {
     }
   }, [zenMode, leftSidebarCollapsed, rightSidebarCollapsed]);
 
-  // Sync bottom terminal panel collapse state with showBottomTerminal.
-  // Re-runs on session change so a fresh session starts with the correct panel state.
-  // When selectedSession is null the panel is unmounted, so the ref is null and we bail out.
-  useLayoutEffect(() => {
-    const panel = bottomTerminalPanelRef.current;
-    if (!panel) return;
-
-    // Only act if the panel state doesn't match the desired state
-    const isCollapsed = panel.isCollapsed();
-    if (showBottomTerminal && isCollapsed) {
-      panel.expand();
-    } else if (!showBottomTerminal && !isCollapsed) {
-      panel.collapse();
-    }
-  }, [showBottomTerminal, selectedSession?.id]);
-
   // Track left sidebar width for overlay positioning
   useEffect(() => {
     const el = leftSidebarDomRef.current;
@@ -402,6 +386,22 @@ export default function Home() {
   const selectPreviousTab = useAppStore((s) => s.selectPreviousTab);
 
   const { expandWorkspace } = useSettingsStore();
+
+  // Sync bottom terminal panel collapse state with showBottomTerminal.
+  // Re-runs on session change so a fresh session starts with the correct panel state.
+  // When selectedSession is null the panel is unmounted, so the ref is null and we bail out.
+  useLayoutEffect(() => {
+    const panel = bottomTerminalPanelRef.current;
+    if (!panel) return;
+
+    // Only act if the panel state doesn't match the desired state
+    const isCollapsed = panel.isCollapsed();
+    if (showBottomTerminal && isCollapsed) {
+      panel.expand();
+    } else if (!showBottomTerminal && !isCollapsed) {
+      panel.collapse();
+    }
+  }, [showBottomTerminal, selectedSessionId]);
 
   // Computed: selected session for terminal and other uses
   const selectedSession = selectedSessionId


### PR DESCRIPTION
## Summary

- Fixes a `ReferenceError: Cannot access 'selectedSession' before initialization` crash on page load
- The `useLayoutEffect` for syncing the bottom terminal panel referenced `selectedSessionId` in its dependency array before it was declared by `useWorkspaceSelection()`, causing a temporal dead zone error
- Moved the effect below the hook call so the variable is in scope

## Test plan

- [ ] App loads without ReferenceError in console
- [ ] Bottom terminal panel still syncs correctly on session change

🤖 Generated with [Claude Code](https://claude.com/claude-code)