### PR TITLE
fix: remove orphan worktree cleanup from server startup

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/chatml/chatml-backend/agent"
 	"github.com/chatml/chatml-backend/ai"
 	"github.com/chatml/chatml-backend/branch"
-	"github.com/chatml/chatml-backend/cleanup"
 	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/github"
 	"github.com/chatml/chatml-backend/logger"
@@ -94,15 +93,6 @@ func main() {
 
 	hub := server.NewHub()
 	wm := git.NewWorktreeManager()
-
-	// Clean up orphaned worktrees from previous crashes or failed session creations
-	// Use a timeout to prevent startup from hanging indefinitely on git lock issues
-	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 30*time.Second)
-	if err := cleanup.CleanOrphanedWorktrees(cleanupCtx, s, wm); err != nil {
-		logger.Cleanup.Warnf("Orphan cleanup failed: %v", err)
-		// Non-fatal - continue startup
-	}
-	cleanupCancel()
 
 	agentMgr := agent.NewManager(ctx, s, wm)
 


### PR DESCRIPTION
## Summary
- Removes automatic orphan worktree cleanup that ran at server startup
- Improves startup time and avoids potential for unexpected data loss
- The cleanup package is preserved for a future admin endpoint

## Test plan
- [ ] Verify backend builds and starts without errors
- [ ] Verify session creation/deletion still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)