### PR TITLE
fix: defer React root unmount to avoid race condition

### DIFF
--- a/src/lib/monaco/CommentZoneManager.ts
+++ b/src/lib/monaco/CommentZoneManager.ts
@@ -299,8 +299,11 @@ export class CommentZoneManager {
       this.inputZoneId = null;
     }
     if (this.inputRoot) {
-      this.inputRoot.unmount();
+      // Defer unmount to avoid "synchronously unmount a root while React was
+      // already rendering" warning in React 19 when called from useEffect.
+      const root = this.inputRoot;
       this.inputRoot = null;
+      setTimeout(() => root.unmount(), 0);
     }
     if (this.inputObserver) {
       this.inputObserver.disconnect();


### PR DESCRIPTION
## Summary
- Fix React 19 warning: "Attempted to synchronously unmount a root while React was already rendering"
- Defer `root.unmount()` in `CommentZoneManager.hideCommentInput()` via `setTimeout(0)` so it runs after the current render cycle
- The unmount was being called from a `useEffect` cleanup in `MonacoEditor.tsx` while React was still rendering, causing a race condition

## Test plan
- [ ] Open a diff view with comment zones
- [ ] Switch between files / close the editor
- [ ] Verify no console warning about synchronous unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)