### PR TITLE
fix: prevent text selection on every keystroke in session rename

### DIFF
--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, useRef, useEffect } from 'react';
 import { useWorkspaceSelection } from '@/stores/selectors';
 import { useAppStore } from '@/stores/appStore';
 import { useMainToolbarContent } from '@/hooks/useMainToolbarContent';
@@ -95,12 +95,21 @@ function SessionTitle({
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
   const storeUpdateSession = useAppStore((s) => s.updateSession);
 
   const startEditing = useCallback(() => {
     setDraft(session.task ?? '');
     setEditing(true);
   }, [session.task]);
+
+  // Focus and select only once when editing starts
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
 
   const save = useCallback(() => {
     setEditing(false);
@@ -120,12 +129,7 @@ function SessionTitle({
   if (editing) {
     return (
       <input
-        ref={(el) => {
-          if (el) {
-            el.focus();
-            el.select();
-          }
-        }}
+        ref={inputRef}
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={save}


### PR DESCRIPTION
## Summary
- Fixed bug where typing in the session rename input would erase characters
- The inline ref callback was re-running on every render, calling `focus()` and `select()` on each keystroke
- Replaced with a stable `useRef` + `useEffect` pattern that only runs when editing starts

## Test plan
- [ ] Click on a session title to start editing
- [ ] Type a new name and verify characters appear correctly
- [ ] Press Enter to save or Escape to cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)