### PR TITLE
fix: Changes Panel now respects session target branch

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -614,13 +614,10 @@ func (h *Handlers) getSessionAndWorkspace(ctx context.Context, sessionID string)
 		workingPath = session.WorkspacePath
 	}
 
-	// Determine base ref: prefer BaseCommitSHA, fall back to workspace default branch.
-	// Note: WorkspaceBranch is the repo's default branch (e.g., "main", "master") stored
-	// at workspace creation time - it's not a remote tracking ref like "origin/main".
-	baseRef = session.BaseCommitSHA
-	if baseRef == "" {
-		baseRef = session.DefaultBranch()
-	}
+	// Use the session's effective target branch for diff calculations.
+	// This respects the user's target branch selection (e.g., "origin/develop")
+	// and falls back to "<remote>/<default-branch>" when not set.
+	baseRef = session.EffectiveTargetBranch()
 
 	return session, workingPath, baseRef, nil
 }


### PR DESCRIPTION
## Summary

- Fixed bug where Changes Panel showed diffs against `BaseCommitSHA` or workspace default branch, ignoring the user's target branch selection
- Now uses `EffectiveTargetBranch()` so diffs are calculated against the selected target (e.g., `origin/develop`)
- Ensures consistency with PR creation, sync status, and agent-runner which already use `EffectiveTargetBranch()`

## Test plan

- [ ] Set a session's target branch to something other than the default (e.g., `origin/develop`)
- [ ] Verify the Changes Panel shows diffs against the selected target branch
- [ ] Verify branch commits show commits ahead of the selected target branch
- [ ] Verify file diffs compare against the selected target branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)