### PR TITLE
fix: prevent sessions from protected branches

### DIFF
--- a/backend/git/cleanup.go
+++ b/backend/git/cleanup.go
@@ -17,12 +17,9 @@ const (
 	CategorySafe     CleanupCategory = "safe"
 )
 
-// protectedBranchNames are branches that should never be deleted
-var protectedBranchNames = map[string]bool{
-	"main":    true,
-	"master":  true,
-	"develop": true,
-}
+// protectedBranchNames references the shared protected branch names.
+// These branches should never be deleted or used for sessions.
+var protectedBranchNames = ProtectedBranchNames
 
 // CleanupCandidate represents a branch that has been analyzed for cleanup
 type CleanupCandidate struct {

--- a/backend/git/protected.go
+++ b/backend/git/protected.go
@@ -1,0 +1,16 @@
+package git
+
+// ProtectedBranchNames contains branch names that sessions should never use.
+// These are typically the main/default branches that should not be checked out
+// in isolated worktrees for session work.
+var ProtectedBranchNames = map[string]bool{
+	"main":    true,
+	"master":  true,
+	"develop": true,
+}
+
+// IsProtectedBranch checks if a branch name is protected.
+// Protected branches cannot be used for session worktrees.
+func IsProtectedBranch(name string) bool {
+	return ProtectedBranchNames[name]
+}

--- a/backend/git/protected_test.go
+++ b/backend/git/protected_test.go
@@ -1,0 +1,22 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsProtectedBranch(t *testing.T) {
+	// Protected branches should return true
+	assert.True(t, IsProtectedBranch("main"))
+	assert.True(t, IsProtectedBranch("master"))
+	assert.True(t, IsProtectedBranch("develop"))
+
+	// Non-protected branches should return false
+	assert.False(t, IsProtectedBranch("feature/new-thing"))
+	assert.False(t, IsProtectedBranch("fix/bug-123"))
+	assert.False(t, IsProtectedBranch("session/happy-panda"))
+	assert.False(t, IsProtectedBranch("dev")) // not the same as develop
+	assert.False(t, IsProtectedBranch("main-feature"))
+	assert.False(t, IsProtectedBranch(""))
+}

--- a/backend/git/worktree.go
+++ b/backend/git/worktree.go
@@ -138,6 +138,11 @@ func (wm *WorktreeManager) CreateInExistingDir(ctx context.Context, repoPath, wo
 // The directory must already exist (created atomically by caller).
 // Returns the worktree path, local branch name, and the base commit SHA.
 func (wm *WorktreeManager) CheckoutExistingBranchInDir(ctx context.Context, repoPath, worktreePath, remoteBranch string) (string, string, string, error) {
+	// Reject protected branches (main, master, develop) to prevent sessions from using them
+	if IsProtectedBranch(remoteBranch) {
+		return "", "", "", fmt.Errorf("cannot create session on protected branch '%s'", remoteBranch)
+	}
+
 	// Fetch the specific branch from origin (targeted fetch is faster than fetching all refs)
 	cmd, cancel := gitCmdWithContext(ctx, repoPath, "fetch", "origin", remoteBranch)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/backend/git/worktree_test.go
+++ b/backend/git/worktree_test.go
@@ -593,6 +593,25 @@ func TestCheckoutExistingBranchInDir_LocalBranchExists(t *testing.T) {
 	assert.ErrorIs(t, err, ErrLocalBranchExists)
 }
 
+func TestCheckoutExistingBranchInDir_ProtectedBranch(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	wm := NewWorktreeManager()
+
+	// Test that protected branches are rejected
+	testCases := []string{"main", "master", "develop"}
+	for _, branchName := range testCases {
+		t.Run(branchName, func(t *testing.T) {
+			sessionDir := filepath.Join(t.TempDir(), "session-"+branchName)
+			require.NoError(t, os.Mkdir(sessionDir, 0755))
+
+			_, _, _, err := wm.CheckoutExistingBranchInDir(context.Background(), repoPath, sessionDir, branchName)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "protected branch")
+			assert.Contains(t, err.Error(), branchName)
+		})
+	}
+}
+
 // ============================================================================
 // WorkspacesBaseDirWithOverride Tests
 // ============================================================================

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -1521,6 +1521,17 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate branch is not protected when checking out an existing branch.
+	// Defense-in-depth: CheckoutExistingBranchInDir also validates this, but we
+	// check early here to return a clear validation error before any git operations.
+	if req.CheckoutExisting {
+		branchName := strings.TrimPrefix(req.Branch, "origin/")
+		if git.IsProtectedBranch(branchName) {
+			writeValidationError(w, fmt.Sprintf("cannot create session on protected branch '%s'", branchName))
+			return
+		}
+	}
+
 	// Generate session ID
 	sessionID := uuid.New().String()
 

--- a/src/components/dialogs/CreateFromPRModal.tsx
+++ b/src/components/dialogs/CreateFromPRModal.tsx
@@ -173,9 +173,17 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
           sortBy: 'date',
           limit: 50,
         });
-        // Combine session and other branches, filter out session/* branches
+        // Combine session and other branches, filter out session/* branches and protected branches
+        // Note: Keep this list in sync with backend/git/protected.go
+        const PROTECTED_BRANCHES = ['main', 'master', 'develop'];
         const allBranches = [...result.sessionBranches, ...result.otherBranches]
-          .filter((b) => b.isRemote && !b.name.startsWith('session/'))
+          .filter((b) => {
+            if (!b.isRemote) return false;
+            if (b.name.startsWith('session/')) return false;
+            // Filter out protected branches (main, master, develop)
+            const branchName = b.name.replace(/^origin\//, '');
+            return !PROTECTED_BRANCHES.includes(branchName);
+          })
           .map((b) => ({
             name: b.name,
             lastCommitDate: b.lastCommitDate,


### PR DESCRIPTION
## Summary

Prevents ChatML sessions from being created on protected branches (`main`, `master`, `develop`). This bug allowed users to accidentally check out protected branches when creating sessions via the "Create from PR/Branch" dialog, leading to worktrees on branches that should never be modified.

## Changes

- Creates shared `IsProtectedBranch()` utility in backend
- Validates protected branches during session creation (frontend filtering + backend validation)
- Adds comprehensive tests for the new validation logic

## Related Issue

Fixes the issue where a session worktree ended up on the `main` branch after a rebase operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)