### PR TITLE
fix: Changes Panel now updates when target branch changes

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -322,6 +322,8 @@ export function ChangesPanel() {
 
   // Track branch for refetching changes when branch is renamed
   const currentBranch = currentSession?.branch;
+  // Track target branch for refetching changes when target branch changes
+  const currentTargetBranch = currentSession?.targetBranch;
 
   // Calculate todo counts for badge
   const totalPendingTodos = agentTodos.filter((t) => t.status !== 'completed').length;
@@ -417,7 +419,7 @@ export function ChangesPanel() {
         return () => { cancelled = true; clearTimeout(id); };
       }
     }
-  }, [selectedTab, selectedWorkspaceId, selectedSessionId, currentBranch]);
+  }, [selectedTab, selectedWorkspaceId, selectedSessionId, currentBranch, currentTargetBranch]);
 
   // Refetch changes when branch sync completes (rebase/merge)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixed the Changes Panel not updating when selecting a different Target Branch
- Added `targetBranch` to the useEffect dependency array that fetches changes

## Root Cause
The `useEffect` in `ChangesPanel.tsx` that fetches changes depended on `currentBranch` (the session's working branch), but not `targetBranch`. When the user selected a new target branch, the store updated but the effect didn't re-run because `targetBranch` wasn't in the dependencies.

## Test plan
- [ ] Open a session with the Changes tab visible
- [ ] Select a different Target Branch from the dropdown
- [ ] Verify the Changes Panel updates immediately without needing to switch tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)