### PR TITLE
feat: add skills store to workspace sidebar (CM-104)

### DIFF
--- a/backend/models/skill.go
+++ b/backend/models/skill.go
@@ -1,0 +1,51 @@
+package models
+
+import "time"
+
+// SkillCategory represents a category of skills
+type SkillCategory string
+
+const (
+	SkillCategoryDevelopment    SkillCategory = "development"
+	SkillCategoryDocumentation  SkillCategory = "documentation"
+	SkillCategoryVersionControl SkillCategory = "version-control"
+)
+
+// ValidSkillCategories is the set of valid skill category values
+var ValidSkillCategories = map[SkillCategory]bool{
+	SkillCategoryDevelopment:    true,
+	SkillCategoryDocumentation:  true,
+	SkillCategoryVersionControl: true,
+}
+
+// Skill represents a skill definition in the catalog
+type Skill struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Category    SkillCategory `json:"category"`
+	Author      string        `json:"author"`
+	Version     string        `json:"version"`
+	Preview     string        `json:"preview"`     // Short preview of what the skill does
+	UsageCount  int           `json:"usageCount"`  // Global usage counter
+	Rating      float32       `json:"rating"`      // 0-5 star rating
+	RatingCount int           `json:"ratingCount"` // Number of ratings
+	SkillPath   string        `json:"skillPath"`   // Relative path within .claude/skills/
+	Content     string        `json:"-"`           // The actual skill file content (not sent in API)
+	CreatedAt   time.Time     `json:"createdAt"`
+	UpdatedAt   time.Time     `json:"updatedAt"`
+}
+
+// UserSkillPreference tracks which skills a user has installed
+type UserSkillPreference struct {
+	ID          string    `json:"id"`
+	SkillID     string    `json:"skillId"`
+	InstalledAt time.Time `json:"installedAt"`
+}
+
+// SkillWithInstallStatus combines skill data with user's install status
+type SkillWithInstallStatus struct {
+	Skill
+	Installed   bool       `json:"installed"`
+	InstalledAt *time.Time `json:"installedAt,omitempty"`
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -218,6 +218,15 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		})
 	}
 
+	// Skills catalog endpoints
+	r.Route("/api/skills", func(r chi.Router) {
+		r.Get("/", h.ListSkills)
+		r.Get("/installed", h.ListInstalledSkills)
+		r.Post("/{id}/install", h.InstallSkill)
+		r.Delete("/{id}/uninstall", h.UninstallSkill)
+		r.Get("/{id}/content", h.GetSkillContent)
+	})
+
 	// Wire up agent manager callbacks (legacy)
 	agentMgr.SetOutputHandler(func(agentID, line string) {
 		hub.Broadcast(Event{

--- a/backend/server/skill_handlers.go
+++ b/backend/server/skill_handlers.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/chatml/chatml-backend/logger"
+	"github.com/chatml/chatml-backend/models"
+	"github.com/chatml/chatml-backend/skills"
+	"github.com/go-chi/chi/v5"
+)
+
+// ListSkills returns the full skill catalog with install status
+func (h *Handlers) ListSkills(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	category := r.URL.Query().Get("category")
+	search := r.URL.Query().Get("search")
+
+	// Get installed skill IDs
+	installedIDs, err := h.store.ListInstalledSkillIDs(ctx)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	installedSet := make(map[string]bool)
+	for _, id := range installedIDs {
+		installedSet[id] = true
+	}
+
+	// Filter skills based on query params
+	filteredSkills := skills.FilterSkills(category, search)
+
+	// Build response with install status
+	result := make([]models.SkillWithInstallStatus, 0, len(filteredSkills))
+	for _, skill := range filteredSkills {
+		swis := models.SkillWithInstallStatus{
+			Skill:     skill,
+			Installed: installedSet[skill.ID],
+		}
+		if swis.Installed {
+			installedAt, err := h.store.GetSkillInstalledAt(ctx, skill.ID)
+			if err != nil {
+				logger.Handlers.Warnf("Failed to get skill install time for %s: %v", skill.ID, err)
+			}
+			swis.InstalledAt = installedAt
+		}
+		result = append(result, swis)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// ListInstalledSkills returns only installed skills
+func (h *Handlers) ListInstalledSkills(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	installedIDs, err := h.store.ListInstalledSkillIDs(ctx)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+
+	idSet := make(map[string]bool)
+	for _, id := range installedIDs {
+		idSet[id] = true
+	}
+
+	result := make([]models.SkillWithInstallStatus, 0)
+	for _, skill := range skills.BuiltInSkills {
+		if !idSet[skill.ID] {
+			continue
+		}
+		installedAt, err := h.store.GetSkillInstalledAt(ctx, skill.ID)
+		if err != nil {
+			logger.Handlers.Warnf("Failed to get skill install time for %s: %v", skill.ID, err)
+		}
+		result = append(result, models.SkillWithInstallStatus{
+			Skill:       skill,
+			Installed:   true,
+			InstalledAt: installedAt,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// InstallSkill installs a skill (records preference)
+func (h *Handlers) InstallSkill(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	skillID := chi.URLParam(r, "id")
+
+	// Find skill in catalog
+	skill := skills.GetSkillByID(skillID)
+	if skill == nil {
+		writeNotFound(w, "skill")
+		return
+	}
+
+	// Record installation in DB
+	if err := h.store.InstallSkill(ctx, skillID); err != nil {
+		writeDBError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]bool{"success": true})
+}
+
+// UninstallSkill removes a skill installation
+func (h *Handlers) UninstallSkill(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	skillID := chi.URLParam(r, "id")
+
+	if err := h.store.UninstallSkill(ctx, skillID); err != nil {
+		writeDBError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]bool{"success": true})
+}
+
+// GetSkillContent returns the content of a specific skill (for copying to worktree)
+func (h *Handlers) GetSkillContent(w http.ResponseWriter, r *http.Request) {
+	skillID := chi.URLParam(r, "id")
+
+	skill := skills.GetSkillByID(skillID)
+	if skill == nil {
+		writeNotFound(w, "skill")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"id":        skill.ID,
+		"name":      skill.Name,
+		"skillPath": skill.SkillPath,
+		"content":   skill.Content,
+	})
+}

--- a/backend/skills/catalog.go
+++ b/backend/skills/catalog.go
@@ -1,0 +1,417 @@
+package skills
+
+import (
+	"strings"
+	"time"
+
+	"github.com/chatml/chatml-backend/models"
+)
+
+// BuiltInSkills is the hardcoded catalog of available skills.
+// Note: UsageCount, Rating, and RatingCount are placeholder values for UI display.
+// These are not dynamically tracked and serve as mock data for the skills store UI.
+var BuiltInSkills = []models.Skill{
+	// Development Workflows
+	{
+		ID:          "tdd-workflow",
+		Name:        "Test-Driven Development",
+		Description: "A rigorous TDD workflow that guides you through writing tests first, then implementation, following the Red-Green-Refactor cycle.",
+		Category:    models.SkillCategoryDevelopment,
+		Author:      "ChatML Team",
+		Version:     "1.0.0",
+		Preview:     "Red-Green-Refactor cycle with automated test generation",
+		UsageCount:  1250,
+		Rating:      4.7,
+		RatingCount: 89,
+		SkillPath:   "tdd-workflow.md",
+		Content:     tddWorkflowContent,
+		CreatedAt:   time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC),
+	},
+	{
+		ID:          "systematic-debugging",
+		Name:        "Systematic Debugging",
+		Description: "A structured approach to debugging that helps identify root causes through hypothesis testing and log analysis.",
+		Category:    models.SkillCategoryDevelopment,
+		Author:      "ChatML Team",
+		Version:     "1.0.0",
+		Preview:     "Structured debugging with hypothesis testing",
+		UsageCount:  980,
+		Rating:      4.5,
+		RatingCount: 67,
+		SkillPath:   "systematic-debugging.md",
+		Content:     systematicDebuggingContent,
+		CreatedAt:   time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2025, 1, 18, 0, 0, 0, 0, time.UTC),
+	},
+	{
+		ID:          "code-review",
+		Name:        "Code Review Assistant",
+		Description: "Thorough code review skill that checks for bugs, security issues, performance problems, and adherence to best practices.",
+		Category:    models.SkillCategoryDevelopment,
+		Author:      "ChatML Team",
+		Version:     "1.0.0",
+		Preview:     "Comprehensive code review with security and performance checks",
+		UsageCount:  856,
+		Rating:      4.6,
+		RatingCount: 54,
+		SkillPath:   "code-review.md",
+		Content:     codeReviewContent,
+		CreatedAt:   time.Date(2025, 1, 16, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2025, 1, 22, 0, 0, 0, 0, time.UTC),
+	},
+
+	// Documentation & Planning
+	{
+		ID:          "brainstorming",
+		Name:        "Brainstorming",
+		Description: "Structured brainstorming skill that helps explore ideas, requirements, and design options before implementation.",
+		Category:    models.SkillCategoryDocumentation,
+		Author:      "ChatML Team",
+		Version:     "1.0.0",
+		Preview:     "Explore requirements and design before coding",
+		UsageCount:  723,
+		Rating:      4.4,
+		RatingCount: 41,
+		SkillPath:   "brainstorming.md",
+		Content:     brainstormingContent,
+		CreatedAt:   time.Date(2025, 1, 17, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2025, 1, 19, 0, 0, 0, 0, time.UTC),
+	},
+	{
+		ID:          "writing-plans",
+		Name:        "Writing Implementation Plans",
+		Description: "Create detailed implementation plans with clear steps, dependencies, and verification criteria.",
+		Category:    models.SkillCategoryDocumentation,
+		Author:      "ChatML Team",
+		Version:     "1.0.0",
+		Preview:     "Detailed implementation plans with clear steps",
+		UsageCount:  612,
+		Rating:      4.3,
+		RatingCount: 38,
+		SkillPath:   "writing-plans.md",
+		Content:     writingPlansContent,
+		CreatedAt:   time.Date(2025, 1, 18, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2025, 1, 21, 0, 0, 0, 0, time.UTC),
+	},
+
+	// Version Control
+	{
+		ID:          "git-commit-helper",
+		Name:        "Git Commit Helper",
+		Description: "Helps create well-structured git commits with meaningful messages following conventional commit format.",
+		Category:    models.SkillCategoryVersionControl,
+		Author:      "ChatML Team",
+		Version:     "1.0.0",
+		Preview:     "Conventional commits with meaningful messages",
+		UsageCount:  1456,
+		Rating:      4.8,
+		RatingCount: 112,
+		SkillPath:   "git-commit-helper.md",
+		Content:     gitCommitHelperContent,
+		CreatedAt:   time.Date(2025, 1, 14, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2025, 1, 23, 0, 0, 0, 0, time.UTC),
+	},
+	{
+		ID:          "pr-creation",
+		Name:        "Pull Request Creation",
+		Description: "Create well-documented pull requests with clear descriptions, test plans, and review guidelines.",
+		Category:    models.SkillCategoryVersionControl,
+		Author:      "ChatML Team",
+		Version:     "1.0.0",
+		Preview:     "Well-documented PRs with clear descriptions",
+		UsageCount:  934,
+		Rating:      4.5,
+		RatingCount: 73,
+		SkillPath:   "pr-creation.md",
+		Content:     prCreationContent,
+		CreatedAt:   time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC),
+	},
+	{
+		ID:          "branch-management",
+		Name:        "Branch Management",
+		Description: "Best practices for git branch management including naming conventions, merging strategies, and cleanup.",
+		Category:    models.SkillCategoryVersionControl,
+		Author:      "ChatML Team",
+		Version:     "1.0.0",
+		Preview:     "Branch naming, merging, and cleanup best practices",
+		UsageCount:  567,
+		Rating:      4.2,
+		RatingCount: 29,
+		SkillPath:   "branch-management.md",
+		Content:     branchManagementContent,
+		CreatedAt:   time.Date(2025, 1, 19, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2025, 1, 24, 0, 0, 0, 0, time.UTC),
+	},
+}
+
+// GetSkillByID returns a skill by its ID, or nil if not found
+func GetSkillByID(id string) *models.Skill {
+	for i := range BuiltInSkills {
+		if BuiltInSkills[i].ID == id {
+			return &BuiltInSkills[i]
+		}
+	}
+	return nil
+}
+
+// FilterSkills filters skills by category and search query
+func FilterSkills(category string, search string) []models.Skill {
+	var result []models.Skill
+	searchLower := strings.ToLower(search)
+
+	for _, skill := range BuiltInSkills {
+		// Filter by category
+		if category != "" && string(skill.Category) != category {
+			continue
+		}
+		// Filter by search (name, description, author)
+		if search != "" {
+			nameLower := strings.ToLower(skill.Name)
+			descLower := strings.ToLower(skill.Description)
+			authorLower := strings.ToLower(skill.Author)
+			if !strings.Contains(nameLower, searchLower) &&
+				!strings.Contains(descLower, searchLower) &&
+				!strings.Contains(authorLower, searchLower) {
+				continue
+			}
+		}
+		result = append(result, skill)
+	}
+	return result
+}
+
+// Skill content as embedded strings
+const tddWorkflowContent = `---
+name: test-driven-development
+description: Use when implementing any feature or bugfix, before writing implementation code
+---
+
+# Test-Driven Development Workflow
+
+Follow the Red-Green-Refactor cycle:
+
+## 1. Red Phase - Write Failing Test
+- Write a test that describes the desired behavior
+- Run the test to confirm it fails
+- The failure message should clearly indicate what's missing
+
+## 2. Green Phase - Make Test Pass
+- Write the minimum code needed to pass the test
+- Don't optimize or add extra features
+- Focus only on making the test green
+
+## 3. Refactor Phase - Improve Code
+- Clean up the implementation
+- Remove duplication
+- Improve naming and structure
+- Ensure tests still pass
+
+## Guidelines
+- One test at a time
+- Small incremental steps
+- Tests should be fast and isolated
+- Test behavior, not implementation details
+`
+
+const systematicDebuggingContent = `---
+name: systematic-debugging
+description: Use when encountering any bug, test failure, or unexpected behavior
+---
+
+# Systematic Debugging
+
+## 1. Reproduce the Issue
+- Document exact steps to reproduce
+- Note the expected vs actual behavior
+- Identify the minimal reproduction case
+
+## 2. Form Hypotheses
+- List possible causes (most likely first)
+- Consider recent changes
+- Check related code paths
+
+## 3. Test Hypotheses
+- Add logging/breakpoints strategically
+- Test one hypothesis at a time
+- Eliminate possibilities systematically
+
+## 4. Fix and Verify
+- Apply the fix
+- Verify the original issue is resolved
+- Check for regressions
+- Add tests to prevent recurrence
+`
+
+const codeReviewContent = `---
+name: code-review
+description: Use when reviewing code changes for quality, security, and best practices
+---
+
+# Code Review Checklist
+
+## Correctness
+- [ ] Logic is correct and handles edge cases
+- [ ] Error handling is appropriate
+- [ ] No race conditions or concurrency issues
+
+## Security
+- [ ] No SQL injection, XSS, or command injection
+- [ ] Sensitive data is protected
+- [ ] Authentication/authorization is correct
+
+## Performance
+- [ ] No N+1 queries or unnecessary loops
+- [ ] Resources are properly released
+- [ ] Caching is used where appropriate
+
+## Maintainability
+- [ ] Code is readable and well-organized
+- [ ] No unnecessary complexity
+- [ ] Tests cover the changes
+`
+
+const brainstormingContent = `---
+name: brainstorming
+description: Use before any creative work - creating features, building components, adding functionality
+---
+
+# Brainstorming Skill
+
+## 1. Understand the Goal
+- What problem are we solving?
+- Who is the user?
+- What are the constraints?
+
+## 2. Explore Options
+- Generate multiple approaches
+- Consider trade-offs
+- Think about edge cases
+
+## 3. Evaluate and Decide
+- Compare options against requirements
+- Consider implementation complexity
+- Choose the best approach
+
+## 4. Document Decision
+- Record the chosen approach
+- Note why alternatives were rejected
+- List any open questions
+`
+
+const writingPlansContent = `---
+name: writing-plans
+description: Use when you have a spec or requirements for a multi-step task
+---
+
+# Writing Implementation Plans
+
+## Plan Structure
+
+### Overview
+- Brief description of what will be implemented
+- Key goals and constraints
+
+### Steps
+For each step include:
+1. Clear description of what to do
+2. Files to create/modify
+3. Dependencies on other steps
+4. Verification criteria
+
+### Verification
+- How to test the implementation
+- Expected outcomes
+- Edge cases to consider
+`
+
+const gitCommitHelperContent = `---
+name: git-commit-helper
+description: Use when creating git commits
+---
+
+# Git Commit Helper
+
+## Commit Message Format
+
+type(scope): subject
+
+body (optional)
+
+footer (optional)
+
+## Types
+- feat: New feature
+- fix: Bug fix
+- docs: Documentation
+- style: Formatting
+- refactor: Code restructuring
+- test: Adding tests
+- chore: Maintenance
+
+## Guidelines
+- Subject line under 50 characters
+- Use imperative mood ("Add" not "Added")
+- Explain why, not what
+- Reference issues when relevant
+`
+
+const prCreationContent = `---
+name: pr-creation
+description: Use when creating pull requests
+---
+
+# Pull Request Creation
+
+## PR Title
+- Clear, concise summary
+- Include ticket number if applicable
+- Use imperative mood
+
+## PR Description
+
+### Summary
+Brief overview of changes
+
+### Changes Made
+- List key changes
+- Explain architectural decisions
+
+### Test Plan
+- How to test the changes
+- Expected behavior
+
+### Screenshots
+Include if UI changes
+
+## Checklist
+- [ ] Tests pass
+- [ ] Documentation updated
+- [ ] No breaking changes (or documented)
+`
+
+const branchManagementContent = `---
+name: branch-management
+description: Use for git branch operations
+---
+
+# Branch Management
+
+## Branch Naming
+- feature/description - new features
+- fix/description - bug fixes
+- refactor/description - code restructuring
+- docs/description - documentation
+
+## Best Practices
+- Keep branches short-lived
+- Rebase frequently from main
+- Delete branches after merge
+- Use descriptive names
+
+## Merge Strategy
+- Squash for feature branches
+- Merge for release branches
+- Rebase for keeping history clean
+`

--- a/backend/store/skills.go
+++ b/backend/store/skills.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ListInstalledSkillIDs returns the IDs of all installed skills
+func (s *SQLiteStore) ListInstalledSkillIDs(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT skill_id FROM user_skill_preferences`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// InstallSkill records a skill as installed
+func (s *SQLiteStore) InstallSkill(ctx context.Context, skillID string) error {
+	id := uuid.New().String()
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO user_skill_preferences (id, skill_id, installed_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(skill_id) DO NOTHING
+	`, id, skillID, time.Now())
+	return err
+}
+
+// UninstallSkill removes a skill from installed list
+func (s *SQLiteStore) UninstallSkill(ctx context.Context, skillID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM user_skill_preferences WHERE skill_id = ?`, skillID)
+	return err
+}
+
+// GetSkillInstalledAt returns when a skill was installed (nil if not installed)
+func (s *SQLiteStore) GetSkillInstalledAt(ctx context.Context, skillID string) (*time.Time, error) {
+	var installedAt time.Time
+	err := s.db.QueryRowContext(ctx, `SELECT installed_at FROM user_skill_preferences WHERE skill_id = ?`, skillID).Scan(&installedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &installedAt, nil
+}

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -623,6 +623,23 @@ func (s *SQLiteStore) runMigrations() error {
 		logger.SQLite.Infof("Migration: Added remote, branch_prefix, custom_prefix columns to repos")
 	}
 
+	// Migration: Create user_skill_preferences table if it doesn't exist
+	_, err = s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS user_skill_preferences (
+			id TEXT PRIMARY KEY,
+			skill_id TEXT NOT NULL UNIQUE,
+			installed_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_user_skill_preferences_skill_id ON user_skill_preferences(skill_id)`)
+	if err != nil {
+		return err
+	}
+	logger.SQLite.Infof("Migration: user_skill_preferences table ready")
+
 	return nil
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,6 +132,7 @@
   --nav-icon-sessions: oklch(0.60 0.15 55);
   --nav-icon-branches: oklch(0.55 0.15 155);
   --nav-icon-prs: oklch(0.55 0.15 300);
+  --nav-icon-skills: oklch(0.65 0.18 85);
 }
 
 .dark {
@@ -209,6 +210,7 @@
   --nav-icon-sessions: #fb923c;
   --nav-icon-branches: #4ade80;
   --nav-icon-prs: #a78bfa;
+  --nav-icon-skills: #fbbf24;
 }
 
 @theme inline {
@@ -252,6 +254,7 @@
   --color-nav-icon-sessions: var(--nav-icon-sessions);
   --color-nav-icon-branches: var(--nav-icon-branches);
   --color-nav-icon-prs: var(--nav-icon-prs);
+  --color-nav-icon-skills: var(--nav-icon-skills);
 
   /* AI Semantic Colors */
   --color-ai-thinking: var(--ai-thinking);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,6 +61,7 @@ import { RepositoriesDashboard } from '@/components/dashboards/RepositoriesDashb
 import { GlobalDashboard } from '@/components/dashboards/GlobalDashboard';
 import { WorkspaceDashboard } from '@/components/dashboards/workspace-dashboard';
 import { SessionManager } from '@/components/session-manager';
+import { SkillsStore } from '@/components/skills/SkillsStore';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ToastProvider, useToast } from '@/components/ui/toast';
 import { StreamingWarningHandler } from '@/components/shared/StreamingWarningHandler';
@@ -1292,6 +1293,9 @@ export default function Home() {
                 )}
                 {contentView.type === 'session-manager' && (
                   <SessionManager />
+                )}
+                {contentView.type === 'skills-store' && (
+                  <SkillsStore />
                 )}
                 {contentView.type === 'workspace-dashboard' && (
                   <WorkspaceDashboard

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -80,6 +80,7 @@ import {
   Bot,
   Circle,
   Clock,
+  Sparkles,
 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
@@ -461,6 +462,28 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
               : "text-muted-foreground group-hover:text-foreground"
           )}>
             Sessions
+          </span>
+        </div>
+        <div
+          className={cn(
+            "group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer",
+            contentView.type === 'skills-store'
+              ? "bg-surface-2 text-foreground"
+              : "hover:bg-surface-1"
+          )}
+          onClick={() => navigate({ contentView: { type: 'skills-store' } })}
+        >
+          <Sparkles className={cn(
+            "w-4 h-4",
+            contentView.type === 'skills-store' ? "text-nav-icon-skills" : "text-nav-icon-skills/70"
+          )} />
+          <span className={cn(
+            "text-base font-medium",
+            contentView.type === 'skills-store'
+              ? "text-foreground"
+              : "text-muted-foreground group-hover:text-foreground"
+          )}>
+            Skills
           </span>
         </div>
       </div>

--- a/src/components/skills/SkillsStore.tsx
+++ b/src/components/skills/SkillsStore.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useEffect, useMemo, useCallback, useState } from 'react';
+import { useSkillsStore } from '@/stores/skillsStore';
+import { FullContentLayout } from '@/components/layout/FullContentLayout';
+import { useMainToolbarContent } from '@/hooks/useMainToolbarContent';
+import { useToast } from '@/components/ui/toast';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Sparkles,
+  Search,
+  Code,
+  FileText,
+  GitBranch,
+  Star,
+  Download,
+  Check,
+  RefreshCw,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { SkillDTO, SkillCategory } from '@/lib/api';
+
+const CATEGORY_OPTIONS: { value: SkillCategory | 'all'; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
+  { value: 'all', label: 'All Skills', icon: Sparkles },
+  { value: 'development', label: 'Development', icon: Code },
+  { value: 'documentation', label: 'Documentation', icon: FileText },
+  { value: 'version-control', label: 'Version Control', icon: GitBranch },
+];
+
+interface SkillCardProps {
+  skill: SkillDTO;
+  onInstallToggle: (skillId: string, isInstalled: boolean) => Promise<void>;
+}
+
+function SkillCard({ skill, onInstallToggle }: SkillCardProps) {
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const handleToggle = async () => {
+    setIsUpdating(true);
+    try {
+      await onInstallToggle(skill.id, skill.installed);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const categoryIcon = {
+    development: Code,
+    documentation: FileText,
+    'version-control': GitBranch,
+  }[skill.category];
+  const CategoryIcon = categoryIcon;
+
+  return (
+    <div className="bg-surface-1 rounded-lg p-4 border border-border/50 hover:border-border transition-colors">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <div className="p-1.5 rounded-md bg-amber-500/10">
+            <CategoryIcon className="h-4 w-4 text-nav-icon-skills" />
+          </div>
+          <div>
+            <h3 className="font-medium">{skill.name}</h3>
+            <p className="text-xs text-muted-foreground">{skill.author}</p>
+          </div>
+        </div>
+        {skill.installed && (
+          <Badge variant="secondary" className="shrink-0 gap-1">
+            <Check className="h-3 w-3" />
+            Installed
+          </Badge>
+        )}
+      </div>
+
+      {/* Description */}
+      <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+        {skill.description}
+      </p>
+
+      {/* Stats */}
+      <div className="flex items-center gap-4 text-xs text-muted-foreground mb-3">
+        <span className="flex items-center gap-1">
+          <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
+          {skill.rating.toFixed(1)} ({skill.ratingCount})
+        </span>
+        <span className="flex items-center gap-1">
+          <Download className="h-3 w-3" />
+          {skill.usageCount.toLocaleString()}
+        </span>
+      </div>
+
+      {/* Actions */}
+      <Button
+        variant={skill.installed ? 'outline' : 'default'}
+        size="sm"
+        className="w-full"
+        onClick={handleToggle}
+        disabled={isUpdating}
+      >
+        {isUpdating ? (
+          <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+        ) : skill.installed ? (
+          'Uninstall'
+        ) : (
+          <>
+            <Download className="h-3.5 w-3.5 mr-1.5" />
+            Install
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}
+
+export function SkillsStore() {
+  const {
+    skills,
+    isLoading,
+    error,
+    selectedCategory,
+    searchQuery,
+    fetchSkills,
+    installSkill,
+    uninstallSkill,
+    setSelectedCategory,
+    setSearchQuery,
+    getFilteredSkills,
+    getInstalledSkills,
+  } = useSkillsStore();
+
+  useEffect(() => {
+    fetchSkills();
+  }, [fetchSkills]);
+
+  const filteredSkills = getFilteredSkills();
+  const installedCount = getInstalledSkills().length;
+  const { error: showError } = useToast();
+
+  // Toolbar configuration
+  const toolbarConfig = useMemo(() => ({
+    titlePosition: 'center' as const,
+    title: (
+      <span className="flex items-center gap-1.5 shrink-0">
+        <Sparkles className="h-4 w-4 text-nav-icon-skills" />
+        <h1 className="text-base font-semibold">Skills Store</h1>
+      </span>
+    ),
+    bottom: {
+      title: (
+        <span className="text-sm text-muted-foreground">
+          {filteredSkills.length} {filteredSkills.length === 1 ? 'skill' : 'skills'} available
+          {installedCount > 0 && (
+            <span className="text-nav-icon-skills ml-2">{installedCount} installed</span>
+          )}
+        </span>
+      ),
+      titlePosition: 'left' as const,
+      actions: (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={() => fetchSkills()}
+          disabled={isLoading}
+          title="Refresh"
+        >
+          <RefreshCw className={cn('h-3.5 w-3.5', isLoading && 'animate-spin')} />
+        </Button>
+      ),
+    },
+  }), [filteredSkills.length, installedCount, isLoading, fetchSkills]);
+  useMainToolbarContent(toolbarConfig);
+
+  const handleInstallToggle = useCallback(async (skillId: string, isInstalled: boolean) => {
+    try {
+      if (isInstalled) {
+        await uninstallSkill(skillId);
+      } else {
+        await installSkill(skillId);
+      }
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to update skill');
+    }
+  }, [installSkill, uninstallSkill, showError]);
+
+  return (
+    <FullContentLayout>
+      <div className="h-full flex flex-col overflow-hidden">
+        {/* Search and Filter Bar */}
+        <div className="p-4 border-b border-border/50 space-y-3">
+          {/* Search */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search skills..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+
+          {/* Category Filter */}
+          <div className="flex items-center gap-2 overflow-x-auto pb-1">
+            {CATEGORY_OPTIONS.map((opt) => {
+              const isActive = opt.value === 'all'
+                ? selectedCategory === null
+                : selectedCategory === opt.value;
+              const Icon = opt.icon;
+              return (
+                <Button
+                  key={opt.value}
+                  variant={isActive ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setSelectedCategory(opt.value === 'all' ? null : opt.value)}
+                  className="shrink-0"
+                >
+                  <Icon className="h-3.5 w-3.5 mr-1.5" />
+                  {opt.label}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Skills Grid */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {isLoading && skills.length === 0 ? (
+            <div className="flex items-center justify-center h-full">
+              <RefreshCw className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <div className="text-center py-12">
+              <p className="text-destructive">{error}</p>
+              <Button variant="outline" onClick={() => fetchSkills()} className="mt-4">
+                Retry
+              </Button>
+            </div>
+          ) : filteredSkills.length === 0 ? (
+            <div className="text-center py-12">
+              <Sparkles className="h-12 w-12 text-muted-foreground/50 mx-auto mb-4" />
+              <p className="text-muted-foreground">No skills found</p>
+              {searchQuery && (
+                <Button
+                  variant="link"
+                  onClick={() => setSearchQuery('')}
+                  className="mt-2"
+                >
+                  Clear search
+                </Button>
+              )}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {filteredSkills.map((skill) => (
+                <SkillCard
+                  key={skill.id}
+                  skill={skill}
+                  onInstallToggle={handleInstallToggle}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </FullContentLayout>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1841,3 +1841,78 @@ export async function getScriptRuns(workspaceId: string, sessionId: string): Pro
   );
   return handleResponse<ScriptRun[]>(res);
 }
+
+// ============================================================================
+// Skills API
+// ============================================================================
+
+export type SkillCategory = 'development' | 'documentation' | 'version-control';
+
+export interface SkillDTO {
+  id: string;
+  name: string;
+  description: string;
+  category: SkillCategory;
+  author: string;
+  version: string;
+  preview: string;
+  usageCount: number;
+  rating: number;
+  ratingCount: number;
+  skillPath: string;
+  createdAt: string;
+  updatedAt: string;
+  installed: boolean;
+  installedAt?: string;
+}
+
+export interface SkillListParams {
+  category?: string;
+  search?: string;
+}
+
+export interface SkillContentResponse {
+  id: string;
+  name: string;
+  skillPath: string;
+  content: string;
+}
+
+// List all skills with optional filtering
+export async function listSkills(params?: SkillListParams): Promise<SkillDTO[]> {
+  const queryParams = new URLSearchParams();
+  if (params?.category) queryParams.set('category', params.category);
+  if (params?.search) queryParams.set('search', params.search);
+  const qs = queryParams.toString();
+  const url = `${getApiBase()}/api/skills${qs ? `?${qs}` : ''}`;
+  const res = await fetchWithAuth(url);
+  return handleResponse<SkillDTO[]>(res);
+}
+
+// List only installed skills
+export async function listInstalledSkills(): Promise<SkillDTO[]> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/skills/installed`);
+  return handleResponse<SkillDTO[]>(res);
+}
+
+// Install a skill
+export async function installSkill(skillId: string): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/skills/${skillId}/install`, {
+    method: 'POST',
+  });
+  await handleVoidResponse(res, 'Failed to install skill');
+}
+
+// Uninstall a skill
+export async function uninstallSkill(skillId: string): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/skills/${skillId}/uninstall`, {
+    method: 'DELETE',
+  });
+  await handleVoidResponse(res, 'Failed to uninstall skill');
+}
+
+// Get skill content (for copying to worktree)
+export async function getSkillContent(skillId: string): Promise<SkillContentResponse> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/skills/${skillId}/content`);
+  return handleResponse<SkillContentResponse>(res);
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -37,7 +37,8 @@ export type ContentView =
   | { type: 'pr-dashboard'; workspaceId?: string }
   | { type: 'branches'; workspaceId: string }
   | { type: 'repositories' }
-  | { type: 'session-manager' };
+  | { type: 'session-manager' }
+  | { type: 'skills-store' };
 
 // Panel layout type - maps panel id to size (percentage)
 export type PanelLayout = Record<string, number>;

--- a/src/stores/skillsStore.ts
+++ b/src/stores/skillsStore.ts
@@ -1,0 +1,97 @@
+import { create } from 'zustand';
+import * as api from '@/lib/api';
+import type { SkillDTO, SkillCategory, SkillListParams } from '@/lib/api';
+
+interface SkillsState {
+  // State
+  skills: SkillDTO[];
+  isLoading: boolean;
+  error: string | null;
+  selectedCategory: SkillCategory | null;
+  searchQuery: string;
+
+  // Actions
+  fetchSkills: (params?: SkillListParams) => Promise<void>;
+  installSkill: (skillId: string) => Promise<void>;
+  uninstallSkill: (skillId: string) => Promise<void>;
+  setSelectedCategory: (category: SkillCategory | null) => void;
+  setSearchQuery: (query: string) => void;
+
+  // Selectors
+  getFilteredSkills: () => SkillDTO[];
+  getInstalledSkills: () => SkillDTO[];
+}
+
+export const useSkillsStore = create<SkillsState>((set, get) => ({
+  skills: [],
+  isLoading: false,
+  error: null,
+  selectedCategory: null,
+  searchQuery: '',
+
+  fetchSkills: async (params) => {
+    set({ isLoading: true, error: null });
+    try {
+      const skills = await api.listSkills(params);
+      set({ skills, isLoading: false });
+    } catch (err) {
+      const message = err instanceof api.ApiError ? err.message : 'Failed to fetch skills';
+      set({ error: message, isLoading: false });
+    }
+  },
+
+  installSkill: async (skillId) => {
+    try {
+      await api.installSkill(skillId);
+      // Update local state
+      set((state) => ({
+        skills: state.skills.map((s) =>
+          s.id === skillId ? { ...s, installed: true, installedAt: new Date().toISOString() } : s
+        ),
+      }));
+    } catch (err) {
+      const message = err instanceof api.ApiError ? err.message : 'Failed to install skill';
+      set({ error: message });
+      throw err;
+    }
+  },
+
+  uninstallSkill: async (skillId) => {
+    try {
+      await api.uninstallSkill(skillId);
+      // Update local state
+      set((state) => ({
+        skills: state.skills.map((s) =>
+          s.id === skillId ? { ...s, installed: false, installedAt: undefined } : s
+        ),
+      }));
+    } catch (err) {
+      const message = err instanceof api.ApiError ? err.message : 'Failed to uninstall skill';
+      set({ error: message });
+      throw err;
+    }
+  },
+
+  setSelectedCategory: (category) => set({ selectedCategory: category }),
+  setSearchQuery: (query) => set({ searchQuery: query }),
+
+  getFilteredSkills: () => {
+    const { skills, selectedCategory, searchQuery } = get();
+    return skills.filter((skill) => {
+      if (selectedCategory && skill.category !== selectedCategory) return false;
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        return (
+          skill.name.toLowerCase().includes(q) ||
+          skill.description.toLowerCase().includes(q) ||
+          skill.author.toLowerCase().includes(q)
+        );
+      }
+      return true;
+    });
+  },
+
+  getInstalledSkills: () => {
+    return get().skills.filter((s) => s.installed);
+  },
+}));


### PR DESCRIPTION
## Summary

Add a Skills Store feature that displays available skills in the workspace sidebar. Users can browse, search, filter by category, and install/uninstall skills from a centralized skills catalog.

## Changes

- Backend: New skills catalog with 7 predefined skills, REST API endpoints for listing/installing/uninstalling skills
- Frontend: Skills Store UI with search, category filtering, and installation management
- Database: SQLite migration for user_skill_preferences table
- Includes error logging improvements and toast feedback for user interactions

## Test Plan

1. Navigate to Skills section in sidebar
2. Search and filter skills by category
3. Install/uninstall skills
4. Verify error notifications appear on failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)