### PR TITLE
feat: Upgrade Claude Agent SDK to 0.2.32 and add Opus 4.6 model support

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chatml-agent-runner",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.29",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.29.tgz",
-      "integrity": "sha512-b+655n4ZqqAiMQEL3P44e9UurkI7WWanWTQQQTEcKngL5YCjjXExEPEJRxrmqp8mQXs0kLErZhObx0ZuwibOhA==",
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.32.tgz",
+      "integrity": "sha512-8AtsSx/M9jxd0ihS08eqa7VireTEuwQy0i1+6ZJX93LECT6Svlf47dPJiAm7JB+BhVMmwTfQeS6x1akIcCfvbQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.29",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -126,6 +126,10 @@ const betas = betasArg ? betasArg.split(',').map(s => s.trim()) as ("context-1m-
 const model = getArg("--model");
 const fallbackModel = getArg("--fallback-model");
 
+// Task 9: Debug Options (SDK v0.2.30+)
+const sdkDebug = hasFlag("--sdk-debug");
+const sdkDebugFile = getArg("--sdk-debug-file");
+
 // Instructions (e.g., from conversation summaries)
 import { readFileSync } from "fs";
 let instructions: string | undefined;
@@ -958,6 +962,7 @@ async function main(): Promise<void> {
     cwd,
     resuming: !!resumeSessionId,
     forking: forkSession,
+    model: model || "(default)",
   });
 
   // Set up the event-driven input queue
@@ -1056,8 +1061,9 @@ async function main(): Promise<void> {
         // Resume a previous session if requested (first turn loads its state)
         resume: resumeSessionId,
         forkSession,
-        // Pass through DEBUG_CLAUDE_AGENT_SDK if set in environment
-        ...(process.env.DEBUG_CLAUDE_AGENT_SDK ? { env: { ...process.env, DEBUG_CLAUDE_AGENT_SDK: process.env.DEBUG_CLAUDE_AGENT_SDK } } : {}),
+        // Debug options (SDK v0.2.30+)
+        debug: sdkDebug || !!process.env.DEBUG_CLAUDE_AGENT_SDK,
+        debugFile: sdkDebugFile,
         stderr: (data: string) => {
           console.error(`[CLI stderr] ${data.trimEnd()}`);
           emit({ type: "agent_stderr", data });
@@ -1332,6 +1338,7 @@ function handleMessage(message: SDKMessage): void {
           success: true,
           subtype: "success",
           summary: resultMsg.result,
+          stopReason: resultMsg.stop_reason,
           cost: resultMsg.total_cost_usd,
           turns: resultMsg.num_turns,
           durationMs: resultMsg.duration_ms,
@@ -1359,6 +1366,7 @@ function handleMessage(message: SDKMessage): void {
           type: "result",
           success: false,
           subtype: resultMsg.subtype,
+          stopReason: resultMsg.stop_reason,
           errors: resultErrors,
           cost: resultMsg.total_cost_usd,
           turns: resultMsg.num_turns,

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -94,6 +94,13 @@ type StartConversationOptions struct {
 
 // StartConversation creates and starts a new conversation within a session
 func (m *Manager) StartConversation(ctx context.Context, sessionID, conversationType, initialMessage string, opts *StartConversationOptions) (*models.Conversation, error) {
+	// Debug: log model being requested
+	if opts != nil && opts.Model != "" {
+		fmt.Printf("[agent/manager] StartConversation: model=%s\n", opts.Model)
+	} else {
+		fmt.Printf("[agent/manager] StartConversation: no model specified\n")
+	}
+
 	sessionWithWs, err := m.store.GetSessionWithWorkspace(ctx, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session: %w", err)
@@ -666,6 +673,10 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 			restartOpts.ConversationID = convID
 		}
 		restartOpts.Workdir = session.WorktreePath
+		// Restore model from conversation record if not already set
+		if restartOpts.Model == "" && conv.Model != "" {
+			restartOpts.Model = conv.Model
+		}
 		// Clear instructions: the temp file has been cleaned up and the content is not
 		// preserved. This is acceptable because --resume carries the SDK's full context
 		// (including original instructions). If the session ID is also unavailable

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -220,6 +220,7 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	}
 
 	// Spawn the Node agent runner
+	fmt.Printf("[agent/process] Starting agent with args: %v\n", args)
 	cmd := exec.CommandContext(ctx, "node", args...)
 	cmd.Dir = opts.Workdir
 

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -3113,17 +3113,6 @@ func (h *Handlers) ListConversations(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, convs)
 }
 
-// validModels is the allowlist of accepted model identifiers.
-var validModels = map[string]bool{
-	"claude-opus-4-5-20251101":  true,
-	"claude-sonnet-4-20250514":  true,
-	"claude-haiku-4-5-20251001": true,
-}
-
-func isValidModel(model string) bool {
-	return model == "" || validModels[model]
-}
-
 type CreateConversationRequest struct {
 	Type              string              `json:"type"`              // "task", "review", "chat"
 	Message           string              `json:"message"`           // Initial message (optional)
@@ -3156,11 +3145,6 @@ func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
 	// Default to "task" type if not specified
 	if req.Type == "" {
 		req.Type = "task"
-	}
-
-	if !isValidModel(req.Model) {
-		writeValidationError(w, fmt.Sprintf("invalid model: %s", req.Model))
-		return
 	}
 
 	// Build instructions from attached summaries
@@ -3323,23 +3307,18 @@ func (h *Handlers) SendConversationMessage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if !isValidModel(req.Model) {
-		writeValidationError(w, fmt.Sprintf("invalid model: %s", req.Model))
-		return
-	}
-
 	// Switch model if specified
 	if req.Model != "" {
+		// Always persist model to DB first - this ensures auto-restart will use the correct model
+		if err := h.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
+			c.Model = req.Model
+		}); err != nil {
+			logger.Handlers.Warnf("Failed to persist model for conv %s: %v", convID, err)
+		}
+		// Also try to update running process if there is one
 		if err := h.agentManager.SetConversationModel(convID, req.Model); err != nil {
-			logger.Handlers.Warnf("Failed to set model for conv %s: %v", convID, err)
-			// Don't persist to DB if the process switch failed — keeps DB and process in sync
-		} else {
-			// Persist model to conversation record only on successful process switch
-			if err := h.store.UpdateConversation(ctx, convID, func(c *models.Conversation) {
-				c.Model = req.Model
-			}); err != nil {
-				logger.Handlers.Warnf("Failed to persist model for conv %s: %v", convID, err)
-			}
+			// Not an error - process may not be running yet, auto-restart will use DB value
+			logger.Handlers.Debugf("Model change won't apply to running process for conv %s: %v", convID, err)
 		}
 	}
 

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -71,9 +71,9 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
 }
 
 const MODELS = [
-  { id: 'claude-opus-4-5-20251101', name: 'Opus 4.5', icon: Snowflake, supportsThinking: true },
-  { id: 'claude-sonnet-4-20250514', name: 'Sonnet 4', icon: Snowflake, supportsThinking: true },
-  { id: 'claude-haiku-4-5-20251001', name: 'Haiku 4.5', icon: Snowflake, supportsThinking: false },
+  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', icon: Snowflake, supportsThinking: true, badge: 'NEW' as const },
+  { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5', icon: Snowflake, supportsThinking: true },
+  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', icon: Snowflake, supportsThinking: true },
 ];
 
 // Models that support extended thinking mode (derived from MODELS)
@@ -766,6 +766,11 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                 >
                   <model.icon className="size-3.5" />
                   {model.name}
+                  {'badge' in model && model.badge && (
+                    <span className="ml-1.5 rounded-sm bg-emerald-500 px-1.5 py-px text-[10px] font-semibold text-white">
+                      {model.badge}
+                    </span>
+                  )}
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -255,13 +255,13 @@ function ChatSettings() {
       <SettingsRow title="Default model" description="Model for new chats">
         <div className="flex gap-2">
           <Select value={defaultModel} onValueChange={setDefaultModel}>
-            <SelectTrigger className="w-32">
+            <SelectTrigger className="w-52">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="claude-opus-4-5-20251101">Opus 4.5</SelectItem>
-              <SelectItem value="claude-sonnet-4-20250514">Sonnet 4</SelectItem>
-              <SelectItem value="claude-haiku-4-5-20251001">Haiku 4.5</SelectItem>
+              <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
+              <SelectItem value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</SelectItem>
+              <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
             </SelectContent>
           </Select>
           <Select
@@ -282,13 +282,13 @@ function ChatSettings() {
       <SettingsRow title="Review model" description="Model for code reviews">
         <div className="flex gap-2">
           <Select value={reviewModel} onValueChange={setReviewModel}>
-            <SelectTrigger className="w-32">
+            <SelectTrigger className="w-52">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="claude-opus-4-5-20251101">Opus 4.5</SelectItem>
-              <SelectItem value="claude-sonnet-4-20250514">Sonnet 4</SelectItem>
-              <SelectItem value="claude-haiku-4-5-20251001">Haiku 4.5</SelectItem>
+              <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
+              <SelectItem value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</SelectItem>
+              <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -32,12 +32,12 @@ describe('settingsStore', () => {
 
   describe('reviewModel', () => {
     beforeEach(() => {
-      useSettingsStore.setState({ reviewModel: 'claude-opus-4-5-20251101' });
+      useSettingsStore.setState({ reviewModel: 'claude-opus-4-6' });
     });
 
-    it('should have a default value of claude-opus-4-5-20251101', () => {
+    it('should have a default value of claude-opus-4-6', () => {
       const { reviewModel } = useSettingsStore.getState();
-      expect(reviewModel).toBe('claude-opus-4-5-20251101');
+      expect(reviewModel).toBe('claude-opus-4-6');
     });
 
     it('should update reviewModel when setReviewModel is called', () => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -171,7 +171,7 @@ export const useSettingsStore = create<SettingsState>()(
       // Default values
       confirmCloseActiveTab: true,
       confirmArchiveDirtySession: true,
-      defaultModel: 'claude-opus-4-5-20251101',
+      defaultModel: 'claude-opus-4-6',
       defaultThinking: true,
       maxThinkingTokens: 10000,
       showThinkingBlocks: true,
@@ -180,7 +180,7 @@ export const useSettingsStore = create<SettingsState>()(
       soundEffects: false,
       soundEffectType: 'chime',
       sendWithEnter: true,
-      reviewModel: 'claude-opus-4-5-20251101',
+      reviewModel: 'claude-opus-4-6',
       defaultPlanMode: false,
       autoConvertLongText: true,
       showChatCost: true,


### PR DESCRIPTION
## Summary

- Upgrade `@anthropic-ai/claude-agent-sdk` from 0.2.29 to 0.2.32
- Add `stop_reason` to result events for better completion tracking
- Add `--sdk-debug` and `--sdk-debug-file` CLI options for SDK debugging
- Update model list with Claude Opus 4.6, Sonnet 4.5, Haiku 4.5
- Add NEW badge to Opus 4.6 in model selector
- Remove backend model validation to allow new models without code changes
- Fix model persistence for new sessions (model now saved to DB before process starts, ensuring auto-restart uses correct model)

## Test plan

- [x] Verified SDK upgrade compiles and tests pass
- [x] Verified selecting Opus 4.6 in new session correctly passes model to agent
- [x] Verified NEW badge displays correctly in model dropdown
- [ ] Manual testing of all model selections in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)