### PR TITLE
fix: suppress benign ResizeObserver loop error in MCP bridge

### DIFF
--- a/src/components/shared/ThemeScript.tsx
+++ b/src/components/shared/ThemeScript.tsx
@@ -28,6 +28,13 @@ export function ThemeScript() {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
+  // Suppress benign ResizeObserver loop error before MCP bridge catches it
+  window.addEventListener('error', function(e) {
+    if (e.message && e.message.indexOf('ResizeObserver loop') !== -1) {
+      e.stopImmediatePropagation();
+    }
+  });
+
   var theme = getTheme();
   var html = document.documentElement;
   var bg = theme === 'dark' ? DARK_BG : LIGHT_BG;


### PR DESCRIPTION
## Summary
- Adds an early global `error` event listener in the `<head>` script to intercept and suppress the benign `ResizeObserver loop completed with undelivered notifications` browser warning
- This prevents the MCP bridge's global error handler from catching it and surfacing it as `[MCP][BRIDGE][UNHANDLED_ERROR]`

## Test plan
- [ ] Verify the `[MCP][BRIDGE][UNHANDLED_ERROR] "ResizeObserver loop completed with undelivered notifications"` console error no longer appears
- [ ] Verify other legitimate errors still surface correctly in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)