### PR TITLE
fix: replace fmt.Printf debug statements with structured logger

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -94,11 +94,8 @@ type StartConversationOptions struct {
 
 // StartConversation creates and starts a new conversation within a session
 func (m *Manager) StartConversation(ctx context.Context, sessionID, conversationType, initialMessage string, opts *StartConversationOptions) (*models.Conversation, error) {
-	// Debug: log model being requested
 	if opts != nil && opts.Model != "" {
-		fmt.Printf("[agent/manager] StartConversation: model=%s\n", opts.Model)
-	} else {
-		fmt.Printf("[agent/manager] StartConversation: no model specified\n")
+		logger.Manager.Debugf("StartConversation: model=%s", opts.Model)
 	}
 
 	sessionWithWs, err := m.store.GetSessionWithWorkspace(ctx, sessionID)

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -220,7 +220,7 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	}
 
 	// Spawn the Node agent runner
-	fmt.Printf("[agent/process] Starting agent with args: %v\n", args)
+	logger.Process.Debugf("Starting agent with args: %v", args)
 	cmd := exec.CommandContext(ctx, "node", args...)
 	cmd.Dir = opts.Workdir
 

--- a/backend/github/client.go
+++ b/backend/github/client.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/chatml/chatml-backend/logger"
 )
 
 // User represents a GitHub user
@@ -60,7 +62,7 @@ func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier str
 	hasClientID := c.clientID != ""
 	hasClientSecret := c.clientSecret != ""
 	hasCodeVerifier := codeVerifier != ""
-	fmt.Printf("[OAuth] ExchangeCode: clientID=%v, clientSecret=%v, codeVerifier=%v, code_length=%d\n",
+	logger.GitHub.Debugf("ExchangeCode: clientID=%v, clientSecret=%v, codeVerifier=%v, code_length=%d",
 		hasClientID, hasClientSecret, hasCodeVerifier, len(code))
 
 	if !hasClientID {
@@ -100,7 +102,7 @@ func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier str
 		return "", fmt.Errorf("reading response: %w", err)
 	}
 
-	fmt.Printf("[OAuth] GitHub response: status=%d, body=%s\n", resp.StatusCode, string(body))
+	logger.GitHub.Debugf("OAuth response: status=%d, body_length=%d", resp.StatusCode, len(body))
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
@@ -122,7 +124,7 @@ func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier str
 		return "", fmt.Errorf("GitHub error: %s - %s", result.Error, result.ErrorDesc)
 	}
 
-	fmt.Printf("[OAuth] Token exchange successful, scope=%s\n", result.Scope)
+	logger.GitHub.Debugf("Token exchange successful, scope=%s", result.Scope)
 	return result.AccessToken, nil
 }
 

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -538,7 +538,7 @@ func writeJSON(w http.ResponseWriter, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		// Log the error - response headers may already be sent
-		fmt.Printf("[handlers] JSON encode error: %v\n", err)
+		logger.Handlers.Errorf("JSON encode error: %v", err)
 	}
 }
 
@@ -1720,7 +1720,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	rollback := true
 	defer func() {
 		if rollback {
-			fmt.Printf("[handlers] Rolling back worktree creation due to failure: %s\n", worktreePath)
+			logger.Handlers.Warnf("Rolling back worktree creation due to failure: %s", worktreePath)
 			h.sessionNameCache.Remove(sessionName)
 			session.DeleteMetadata(sessionID)
 			// Use background context for cleanup - the original request context may be cancelled
@@ -1744,7 +1744,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := session.WriteMetadata(meta); err != nil {
 		// Log but don't fail - metadata is supplementary
-		fmt.Printf("[handlers] Warning: failed to write session metadata: %v\n", err)
+		logger.Handlers.Warnf("Failed to write session metadata: %v", err)
 	}
 
 	sess := &models.Session{
@@ -3203,7 +3203,7 @@ func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(conv); err != nil {
-		fmt.Printf("[handlers] JSON encode error: %v\n", err)
+		logger.Handlers.Errorf("JSON encode error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces raw `fmt.Printf` debug statements with the project's structured logger (charmbracelet/log) for better production logging practices. Redacted sensitive OAuth response body from debug logs.

## Changes

- **backend/agent/manager.go** - Model selection debugging via logger.Manager.Debugf
- **backend/agent/process.go** - Agent startup args logging via logger.Process.Debugf
- **backend/github/client.go** - OAuth flow debugging via logger.GitHub.Debugf (with body redaction)
- **backend/server/handlers.go** - JSON encoding and metadata errors via logger.Handlers

## Security

Removed full OAuth response body from debug logs to prevent access_token exposure in log files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)