### PR TITLE
Memoize filtered skills and installed count in SkillsStore

### DIFF
--- a/src/components/skills/SkillsStore.tsx
+++ b/src/components/skills/SkillsStore.tsx
@@ -126,16 +126,31 @@ export function SkillsStore() {
     uninstallSkill,
     setSelectedCategory,
     setSearchQuery,
-    getFilteredSkills,
-    getInstalledSkills,
   } = useSkillsStore();
 
   useEffect(() => {
     fetchSkills();
   }, [fetchSkills]);
 
-  const filteredSkills = getFilteredSkills();
-  const installedCount = getInstalledSkills().length;
+  const filteredSkills = useMemo(() => {
+    return skills.filter((skill) => {
+      if (selectedCategory && skill.category !== selectedCategory) return false;
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        return (
+          skill.name.toLowerCase().includes(q) ||
+          skill.description.toLowerCase().includes(q) ||
+          skill.author.toLowerCase().includes(q)
+        );
+      }
+      return true;
+    });
+  }, [skills, selectedCategory, searchQuery]);
+
+  const installedCount = useMemo(
+    () => skills.filter((s) => s.installed).length,
+    [skills]
+  );
   const { error: showError } = useToast();
 
   // Toolbar configuration

--- a/src/stores/skillsStore.ts
+++ b/src/stores/skillsStore.ts
@@ -16,13 +16,9 @@ interface SkillsState {
   uninstallSkill: (skillId: string) => Promise<void>;
   setSelectedCategory: (category: SkillCategory | null) => void;
   setSearchQuery: (query: string) => void;
-
-  // Selectors
-  getFilteredSkills: () => SkillDTO[];
-  getInstalledSkills: () => SkillDTO[];
 }
 
-export const useSkillsStore = create<SkillsState>((set, get) => ({
+export const useSkillsStore = create<SkillsState>((set) => ({
   skills: [],
   isLoading: false,
   error: null,
@@ -74,24 +70,4 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
 
   setSelectedCategory: (category) => set({ selectedCategory: category }),
   setSearchQuery: (query) => set({ searchQuery: query }),
-
-  getFilteredSkills: () => {
-    const { skills, selectedCategory, searchQuery } = get();
-    return skills.filter((skill) => {
-      if (selectedCategory && skill.category !== selectedCategory) return false;
-      if (searchQuery) {
-        const q = searchQuery.toLowerCase();
-        return (
-          skill.name.toLowerCase().includes(q) ||
-          skill.description.toLowerCase().includes(q) ||
-          skill.author.toLowerCase().includes(q)
-        );
-      }
-      return true;
-    });
-  },
-
-  getInstalledSkills: () => {
-    return get().skills.filter((s) => s.installed);
-  },
 }));


### PR DESCRIPTION
Moves derived state computation from Zustand store selectors to component-level useMemo hooks for improved performance. Filtered results and installed count now properly memoize based on actual dependency changes rather than recomputing on every render.

Removes getFilteredSkills and getInstalledSkills from the store and inlines the filtering logic into the SkillsStore component with proper memoization.

- Performance: Prevents unnecessary filtering operations
- Simplicity: Store now only handles state and actions