### PR TITLE
fix: eliminate N+1 queries in skill handler endpoints

### DIFF
--- a/backend/server/skill_handlers.go
+++ b/backend/server/skill_handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/chatml/chatml-backend/logger"
 	"github.com/chatml/chatml-backend/models"
 	"github.com/chatml/chatml-backend/skills"
 	"github.com/go-chi/chi/v5"
@@ -16,15 +15,11 @@ func (h *Handlers) ListSkills(w http.ResponseWriter, r *http.Request) {
 	category := r.URL.Query().Get("category")
 	search := r.URL.Query().Get("search")
 
-	// Get installed skill IDs
-	installedIDs, err := h.store.ListInstalledSkillIDs(ctx)
+	// Get all installed skills with timestamps in a single query
+	installedSkills, err := h.store.ListInstalledSkillsWithTimestamps(ctx)
 	if err != nil {
 		writeDBError(w, err)
 		return
-	}
-	installedSet := make(map[string]bool)
-	for _, id := range installedIDs {
-		installedSet[id] = true
 	}
 
 	// Filter skills based on query params
@@ -35,14 +30,11 @@ func (h *Handlers) ListSkills(w http.ResponseWriter, r *http.Request) {
 	for _, skill := range filteredSkills {
 		swis := models.SkillWithInstallStatus{
 			Skill:     skill,
-			Installed: installedSet[skill.ID],
+			Installed: false,
 		}
-		if swis.Installed {
-			installedAt, err := h.store.GetSkillInstalledAt(ctx, skill.ID)
-			if err != nil {
-				logger.Handlers.Warnf("Failed to get skill install time for %s: %v", skill.ID, err)
-			}
-			swis.InstalledAt = installedAt
+		if installedAt, ok := installedSkills[skill.ID]; ok {
+			swis.Installed = true
+			swis.InstalledAt = &installedAt
 		}
 		result = append(result, swis)
 	}
@@ -55,30 +47,23 @@ func (h *Handlers) ListSkills(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) ListInstalledSkills(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	installedIDs, err := h.store.ListInstalledSkillIDs(ctx)
+	// Get all installed skills with timestamps in a single query
+	installedSkills, err := h.store.ListInstalledSkillsWithTimestamps(ctx)
 	if err != nil {
 		writeDBError(w, err)
 		return
 	}
 
-	idSet := make(map[string]bool)
-	for _, id := range installedIDs {
-		idSet[id] = true
-	}
-
-	result := make([]models.SkillWithInstallStatus, 0)
+	result := make([]models.SkillWithInstallStatus, 0, len(installedSkills))
 	for _, skill := range skills.BuiltInSkills {
-		if !idSet[skill.ID] {
+		installedAt, ok := installedSkills[skill.ID]
+		if !ok {
 			continue
-		}
-		installedAt, err := h.store.GetSkillInstalledAt(ctx, skill.ID)
-		if err != nil {
-			logger.Handlers.Warnf("Failed to get skill install time for %s: %v", skill.ID, err)
 		}
 		result = append(result, models.SkillWithInstallStatus{
 			Skill:       skill,
 			Installed:   true,
-			InstalledAt: installedAt,
+			InstalledAt: &installedAt,
 		})
 	}
 

--- a/backend/store/skills.go
+++ b/backend/store/skills.go
@@ -2,30 +2,10 @@ package store
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/google/uuid"
 )
-
-// ListInstalledSkillIDs returns the IDs of all installed skills
-func (s *SQLiteStore) ListInstalledSkillIDs(ctx context.Context) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT skill_id FROM user_skill_preferences`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		ids = append(ids, id)
-	}
-	return ids, rows.Err()
-}
 
 // InstallSkill records a skill as installed
 func (s *SQLiteStore) InstallSkill(ctx context.Context, skillID string) error {
@@ -44,15 +24,22 @@ func (s *SQLiteStore) UninstallSkill(ctx context.Context, skillID string) error 
 	return err
 }
 
-// GetSkillInstalledAt returns when a skill was installed (nil if not installed)
-func (s *SQLiteStore) GetSkillInstalledAt(ctx context.Context, skillID string) (*time.Time, error) {
-	var installedAt time.Time
-	err := s.db.QueryRowContext(ctx, `SELECT installed_at FROM user_skill_preferences WHERE skill_id = ?`, skillID).Scan(&installedAt)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
+// ListInstalledSkillsWithTimestamps returns a map of skill_id -> installed_at for all installed skills
+func (s *SQLiteStore) ListInstalledSkillsWithTimestamps(ctx context.Context) (map[string]time.Time, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT skill_id, installed_at FROM user_skill_preferences`)
 	if err != nil {
 		return nil, err
 	}
-	return &installedAt, nil
+	defer rows.Close()
+
+	result := make(map[string]time.Time)
+	for rows.Next() {
+		var skillID string
+		var installedAt time.Time
+		if err := rows.Scan(&skillID, &installedAt); err != nil {
+			return nil, err
+		}
+		result[skillID] = installedAt
+	}
+	return result, rows.Err()
 }


### PR DESCRIPTION
Refactors ListSkills and ListInstalledSkills to fetch all installed skill timestamps in a single database query instead of one query per skill.

Changes:
- Replace two separate DB calls with ListInstalledSkillsWithTimestamps for efficiency
- Remove unused ListInstalledSkillIDs and GetSkillInstalledAt methods
- Add capacity hint to result slice in ListInstalledSkills

Fixes CM-111