### PR TITLE
feat: Add symlink protection for user command file reads

### DIFF
--- a/backend/server/command_handlers.go
+++ b/backend/server/command_handlers.go
@@ -69,6 +69,12 @@ func (h *Handlers) ListUserCommands(w http.ResponseWriter, r *http.Request) {
 		name := strings.TrimSuffix(entry.Name(), ".md")
 		fullPath := filepath.Join(commandsDir, entry.Name())
 
+		// Skip symlinks to prevent reading files outside the worktree
+		if entry.Type()&os.ModeSymlink != 0 {
+			logger.Handlers.Warnf("Skipping symlink command file %s", fullPath)
+			continue
+		}
+
 		content, err := os.ReadFile(fullPath)
 		if err != nil {
 			logger.Handlers.Warnf("Failed to read command file %s: %v", fullPath, err)

--- a/backend/server/command_handlers_test.go
+++ b/backend/server/command_handlers_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListUserCommands(t *testing.T) {
+	t.Run("returns commands from .claude/commands", func(t *testing.T) {
+		h, s := setupTestHandlers(t)
+
+		createTestRepo(t, s, "ws-1", "/path/to/repo")
+		_, worktreePath := createTestSessionWithWorktree(t, s, "sess-1", "ws-1")
+
+		// Create .claude/commands directory with a command file
+		commandsDir := filepath.Join(worktreePath, ".claude", "commands")
+		require.NoError(t, os.MkdirAll(commandsDir, 0755))
+		writeFile(t, commandsDir, "deploy.md", "# Deploy to production\nRun the deploy script.")
+
+		req := httptest.NewRequest("GET", "/api/sessions/sess-1/commands", nil)
+		req = withChiContext(req, map[string]string{"sessionId": "sess-1"})
+		w := httptest.NewRecorder()
+
+		h.ListUserCommands(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var commands []UserCommand
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &commands))
+		assert.Len(t, commands, 1)
+		assert.Equal(t, "deploy", commands[0].Name)
+		assert.Equal(t, "Deploy to production", commands[0].Description)
+		assert.Contains(t, commands[0].Content, "Deploy to production")
+	})
+
+	t.Run("skips symlinked command files", func(t *testing.T) {
+		h, s := setupTestHandlers(t)
+
+		createTestRepo(t, s, "ws-1", "/path/to/repo")
+		_, worktreePath := createTestSessionWithWorktree(t, s, "sess-1", "ws-1")
+
+		commandsDir := filepath.Join(worktreePath, ".claude", "commands")
+		require.NoError(t, os.MkdirAll(commandsDir, 0755))
+
+		// Create a real command file
+		writeFile(t, commandsDir, "real.md", "# Real command")
+
+		// Create a file outside the worktree and symlink to it
+		outsideDir := t.TempDir()
+		outsideFile := filepath.Join(outsideDir, "secret.txt")
+		require.NoError(t, os.WriteFile(outsideFile, []byte("secret data"), 0644))
+		require.NoError(t, os.Symlink(outsideFile, filepath.Join(commandsDir, "evil.md")))
+
+		req := httptest.NewRequest("GET", "/api/sessions/sess-1/commands", nil)
+		req = withChiContext(req, map[string]string{"sessionId": "sess-1"})
+		w := httptest.NewRecorder()
+
+		h.ListUserCommands(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var commands []UserCommand
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &commands))
+		// Only the real command should be returned, symlink should be skipped
+		assert.Len(t, commands, 1)
+		assert.Equal(t, "real", commands[0].Name)
+	})
+
+	t.Run("skips non-md files", func(t *testing.T) {
+		h, s := setupTestHandlers(t)
+
+		createTestRepo(t, s, "ws-1", "/path/to/repo")
+		_, worktreePath := createTestSessionWithWorktree(t, s, "sess-1", "ws-1")
+
+		commandsDir := filepath.Join(worktreePath, ".claude", "commands")
+		require.NoError(t, os.MkdirAll(commandsDir, 0755))
+
+		writeFile(t, commandsDir, "command.md", "# Valid command")
+		writeFile(t, commandsDir, "notes.txt", "Not a command")
+		writeFile(t, commandsDir, "script.sh", "#!/bin/bash")
+
+		req := httptest.NewRequest("GET", "/api/sessions/sess-1/commands", nil)
+		req = withChiContext(req, map[string]string{"sessionId": "sess-1"})
+		w := httptest.NewRecorder()
+
+		h.ListUserCommands(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var commands []UserCommand
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &commands))
+		assert.Len(t, commands, 1)
+		assert.Equal(t, "command", commands[0].Name)
+	})
+
+	t.Run("returns empty list when commands directory does not exist", func(t *testing.T) {
+		h, s := setupTestHandlers(t)
+
+		createTestRepo(t, s, "ws-1", "/path/to/repo")
+		createTestSessionWithWorktree(t, s, "sess-1", "ws-1")
+
+		req := httptest.NewRequest("GET", "/api/sessions/sess-1/commands", nil)
+		req = withChiContext(req, map[string]string{"sessionId": "sess-1"})
+		w := httptest.NewRecorder()
+
+		h.ListUserCommands(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var commands []UserCommand
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &commands))
+		assert.Empty(t, commands)
+	})
+
+	t.Run("returns empty list for empty commands directory", func(t *testing.T) {
+		h, s := setupTestHandlers(t)
+
+		createTestRepo(t, s, "ws-1", "/path/to/repo")
+		_, worktreePath := createTestSessionWithWorktree(t, s, "sess-1", "ws-1")
+
+		commandsDir := filepath.Join(worktreePath, ".claude", "commands")
+		require.NoError(t, os.MkdirAll(commandsDir, 0755))
+
+		req := httptest.NewRequest("GET", "/api/sessions/sess-1/commands", nil)
+		req = withChiContext(req, map[string]string{"sessionId": "sess-1"})
+		w := httptest.NewRecorder()
+
+		h.ListUserCommands(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var commands []UserCommand
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &commands))
+		assert.Empty(t, commands)
+	})
+}
+
+func TestExtractFirstLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{"heading", "# Deploy\nDetails here", "Deploy"},
+		{"plain text", "Run the deploy script", "Run the deploy script"},
+		{"with frontmatter", "---\nname: test\n---\n# Command\nBody", "Command"},
+		{"empty content", "", "Custom command"},
+		{"only whitespace", "   \n  \n  ", "Custom command"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractFirstLine(tt.content)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -692,19 +692,38 @@ func validatePath(basePath, requestedPath string) (string, error) {
 
 	fullPath := filepath.Join(basePath, cleanPath)
 
-	// Resolve to absolute and verify it's under basePath
-	absBase, err := filepath.Abs(basePath)
-	if err != nil {
-		return "", err
-	}
-	absPath, err := filepath.Abs(fullPath)
-	if err != nil {
-		return "", err
+	// Resolve symlinks to prevent symlink-based path traversal.
+	// If the path doesn't exist yet, fall back to Abs-based check
+	// (can't follow a symlink that doesn't exist).
+	resolvedBase, errBase := filepath.EvalSymlinks(basePath)
+	resolvedPath, errPath := filepath.EvalSymlinks(fullPath)
+
+	if errBase != nil && !os.IsNotExist(errBase) {
+		// Base directory exists but can't be resolved (e.g. permission error)
+		return "", fmt.Errorf("failed to resolve base directory: %w", errBase)
 	}
 
-	// Ensure path is under base (add trailing slash to prevent prefix attacks)
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) && absPath != absBase {
-		return "", fmt.Errorf("path escapes base directory")
+	if errBase == nil && errPath == nil {
+		// Both paths exist — verify resolved path is under resolved base
+		if !strings.HasPrefix(resolvedPath, resolvedBase+string(filepath.Separator)) && resolvedPath != resolvedBase {
+			return "", fmt.Errorf("path escapes base directory")
+		}
+	} else if errBase == nil && errPath != nil && !os.IsNotExist(errPath) {
+		// Path resolution failed for a reason other than "not found"
+		return "", fmt.Errorf("failed to resolve path: %w", errPath)
+	} else {
+		// Fallback: use Abs-based check (path or base doesn't exist yet)
+		absBase, err := filepath.Abs(basePath)
+		if err != nil {
+			return "", err
+		}
+		absPath, err := filepath.Abs(fullPath)
+		if err != nil {
+			return "", err
+		}
+		if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) && absPath != absBase {
+			return "", fmt.Errorf("path escapes base directory")
+		}
 	}
 
 	return cleanPath, nil

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -957,6 +957,56 @@ func TestValidatePath(t *testing.T) {
 	}
 }
 
+func TestValidatePath_SymlinkProtection(t *testing.T) {
+	// Use real directories so EvalSymlinks can resolve paths
+	baseDir := t.TempDir()
+
+	// Create a file inside the base
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, "subdir"), 0755))
+	writeFile(t, filepath.Join(baseDir, "subdir"), "real.txt", "safe content")
+
+	t.Run("allows normal file within base", func(t *testing.T) {
+		result, err := validatePath(baseDir, "subdir/real.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "subdir/real.txt", result)
+	})
+
+	t.Run("rejects symlink pointing outside base", func(t *testing.T) {
+		// Create a file outside the base directory
+		outsideDir := t.TempDir()
+		writeFile(t, outsideDir, "secret.txt", "secret data")
+
+		// Create a symlink inside the base that points outside
+		require.NoError(t, os.Symlink(
+			filepath.Join(outsideDir, "secret.txt"),
+			filepath.Join(baseDir, "evil-link.txt"),
+		))
+
+		_, err := validatePath(baseDir, "evil-link.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path escapes base directory")
+	})
+
+	t.Run("rejects symlinked directory pointing outside base", func(t *testing.T) {
+		outsideDir := t.TempDir()
+		writeFile(t, outsideDir, "secret.txt", "secret data")
+
+		// Create a symlinked directory inside the base that points outside
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(baseDir, "evil-dir")))
+
+		_, err := validatePath(baseDir, "evil-dir/secret.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path escapes base directory")
+	})
+
+	t.Run("allows non-existent path with fallback validation", func(t *testing.T) {
+		// Non-existent file can't be a symlink, falls back to Abs check
+		result, err := validatePath(baseDir, "does-not-exist.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "does-not-exist.txt", result)
+	})
+}
+
 func TestListSessionFiles_Success(t *testing.T) {
 	h, s := setupTestHandlers(t)
 


### PR DESCRIPTION
## Summary
Prevents directory traversal attacks by adding symlink protection at two layers:
1. Skips symlinked command files in ListUserCommands to prevent reading files outside the worktree
2. Uses filepath.EvalSymlinks in validatePath to resolve and reject symlink-based path escapes

## Details
- Addresses CM-119: Symlink protection for user command file reads
- Includes fallback to Abs-based checks for non-existent paths (e.g., during tests)
- Comprehensive test coverage for symlink protection scenarios

## Testing
All existing tests pass, including new symlink-specific test cases covering:
- Symlinks pointing outside the base directory
- Symlinked directories with nested paths
- Non-existent paths with fallback validation