### PR TITLE
feat: Cancel HTTP requests for rapid skill fetches

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -217,17 +217,19 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
   // Sync installed skills into slash command store (re-fetch on session change)
   useEffect(() => {
+    const abortController = new AbortController();
     const syncSkills = async () => {
       try {
         const { listSkills } = await import('@/lib/api');
-        const skills = await listSkills();
+        const skills = await listSkills(undefined, abortController.signal);
         const installed = skills.filter((s) => s.installed);
         setInstalledSkills(installed);
       } catch {
-        // Skills are optional
+        // Skills are optional (also catches AbortError on cleanup)
       }
     };
     syncSkills();
+    return () => { abortController.abort(); };
   }, [setInstalledSkills, selectedSessionId]);
 
   const slashMenu = useSlashCommands({

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1898,13 +1898,13 @@ export interface SkillContentResponse {
 }
 
 // List all skills with optional filtering
-export async function listSkills(params?: SkillListParams): Promise<SkillDTO[]> {
+export async function listSkills(params?: SkillListParams, signal?: AbortSignal): Promise<SkillDTO[]> {
   const queryParams = new URLSearchParams();
   if (params?.category) queryParams.set('category', params.category);
   if (params?.search) queryParams.set('search', params.search);
   const qs = queryParams.toString();
   const url = `${getApiBase()}/api/skills${qs ? `?${qs}` : ''}`;
-  const res = await fetchWithAuth(url);
+  const res = await fetchWithAuth(url, { signal });
   return handleResponse<SkillDTO[]>(res);
 }
 


### PR DESCRIPTION
Addressed code review feedback by using AbortController to cancel in-flight listSkills HTTP requests on rapid session changes, preventing request pile-up during concurrent operations.