### PR TITLE
fix: Ensure worktree cleanup on repo/session deletion

### DIFF
--- a/backend/cleanup/orphans.go
+++ b/backend/cleanup/orphans.go
@@ -32,7 +32,10 @@ type WorktreeManager interface {
 // An orphaned worktree is one that exists on disk (in ~/.chatml/workspaces/) but has
 // no corresponding session record in the database.
 func CleanOrphanedWorktrees(ctx context.Context, store Store, wm WorktreeManager) error {
-	configured, _, _ := store.GetSetting(ctx, "workspaces-base-dir")
+	configured, _, err := store.GetSetting(ctx, "workspaces-base-dir")
+	if err != nil {
+		logger.Cleanup.Debugf("Failed to read workspaces-base-dir setting, using default: %v", err)
+	}
 	workspacesDir, err := git.WorkspacesBaseDirWithOverride(configured)
 	if err != nil {
 		return fmt.Errorf("failed to get workspaces directory: %w", err)
@@ -136,11 +139,14 @@ func findOrphansForRepo(ctx context.Context, store Store, wm WorktreeManager, re
 		}
 
 		if !trackedPaths[worktreePath] {
-			// Orphaned worktree - we don't know the session ID since it's not in the DB.
+			// Orphaned worktree — no DB record exists, so we don't know the branch name.
+			// RemoveAtPath will remove the worktree directory but the associated branch
+			// will remain in the repo. This is a known limitation: stale branches are
+			// harmless and can be pruned manually with `git branch -D`.
 			// Stale metadata cleanup happens separately via CleanupStaleMetadata.
 			orphans = append(orphans, orphanInfo{
 				path:      worktreePath,
-				branch:    "", // git worktree remove handles branch deletion
+				branch:    "", // Unknown — branch won't be deleted (see comment above)
 				sessionID: "", // Unknown for orphaned worktrees
 			})
 		}

--- a/backend/git/worktree.go
+++ b/backend/git/worktree.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/chatml/chatml-backend/logger"
 )
 
 // ErrDirectoryExists indicates a name collision during atomic directory creation
@@ -198,6 +200,8 @@ func (wm *WorktreeManager) RemoveByPath(ctx context.Context, repoPath, worktreeI
 // RemoveAtPath removes a worktree at an absolute path and deletes its branch.
 // If branchName is empty, only the worktree is removed (branch deletion is skipped).
 func (wm *WorktreeManager) RemoveAtPath(ctx context.Context, repoPath, worktreePath, branchName string) error {
+	logger.Cleanup.Infof("Removing worktree: path=%s branch=%s repo=%s", worktreePath, branchName, repoPath)
+
 	// Remove the worktree
 	cmd, cancel := gitCmdWithContext(ctx, repoPath, "worktree", "remove", worktreePath, "--force")
 	out, err := cmd.CombinedOutput()

--- a/backend/main.go
+++ b/backend/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/chatml/chatml-backend/agent"
 	"github.com/chatml/chatml-backend/ai"
 	"github.com/chatml/chatml-backend/branch"
+	"github.com/chatml/chatml-backend/cleanup"
 	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/github"
 	"github.com/chatml/chatml-backend/logger"
@@ -93,6 +94,11 @@ func main() {
 
 	hub := server.NewHub()
 	wm := git.NewWorktreeManager()
+
+	// Clean up orphaned worktrees from previous crashes or failed deletions
+	if err := cleanup.CleanOrphanedWorktrees(ctx, s, wm); err != nil {
+		logger.Main.Warnf("Failed to clean orphaned worktrees: %v", err)
+	}
 
 	agentMgr := agent.NewManager(ctx, s, wm)
 

--- a/backend/server/errors.go
+++ b/backend/server/errors.go
@@ -90,6 +90,7 @@ func writePayloadTooLarge(w http.ResponseWriter, msg string) {
 // writeWorktreeNotFound writes a 410 Gone response for worktree paths that no longer exist on disk.
 // The frontend uses the WORKTREE_NOT_FOUND code to stop polling and show a specific message.
 func writeWorktreeNotFound(w http.ResponseWriter, path string) {
+	logger.Cleanup.Warnf("Worktree not found on disk: path=%s", path)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusGone)
 	if err := json.NewEncoder(w).Encode(struct {

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -987,6 +987,33 @@ func (h *Handlers) GetRepoDetails(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) DeleteRepo(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id := chi.URLParam(r, "id")
+
+	// Clean up all session worktrees BEFORE cascade-deleting from DB.
+	// The sessions table has ON DELETE CASCADE from repos, so the DB delete
+	// removes all session records — but we must remove worktree directories first.
+	// This is the opposite order from DeleteSession (which does DB-first) because
+	// cascade deletion would destroy the session records we need for cleanup.
+	// If worktree removal partially fails here, the startup orphan cleanup will catch it.
+	sessions, err := h.store.ListSessions(ctx, id, true) // include archived
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	repo, err := h.store.GetRepo(ctx, id)
+	if err != nil {
+		logger.Cleanup.Warnf("Failed to get repo %s for worktree cleanup: %v", id, err)
+	}
+	if repo != nil {
+		for _, sess := range sessions {
+			if sess.WorktreePath != "" {
+				session.DeleteMetadata(sess.ID)
+				if rmErr := h.worktreeManager.RemoveAtPath(ctx, repo.Path, sess.WorktreePath, sess.Branch); rmErr != nil {
+					logger.Cleanup.Warnf("Failed to remove worktree %s during repo delete: %v", sess.WorktreePath, rmErr)
+				}
+			}
+		}
+	}
+
 	if err := h.store.DeleteRepo(ctx, id); err != nil {
 		writeDBError(w, err)
 		return
@@ -1285,9 +1312,10 @@ func (h *Handlers) ListBranches(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, response)
 }
 
-// getSessionBranchMap builds a mapping from branch name to session info for a workspace
+// getSessionBranchMap builds a mapping from branch name to session info for a workspace.
+// Includes archived sessions so their branches are protected during branch cleanup.
 func (h *Handlers) getSessionBranchMap(ctx context.Context, workspaceID string) (map[string]*git.SessionInfo, error) {
-	sessions, err := h.store.ListSessions(ctx, workspaceID, false)
+	sessions, err := h.store.ListSessions(ctx, workspaceID, true)
 	if err != nil {
 		return nil, err
 	}
@@ -2131,7 +2159,8 @@ func (h *Handlers) DeleteSession(w http.ResponseWriter, r *http.Request) {
 		defer h.sessionLocks.Unlock(worktreePath)
 	}
 
-	// Clean up worktree if session exists
+	// Capture cleanup info BEFORE deleting from DB
+	var repoPath, branch, sessionName string
 	if sess != nil {
 		// Stop watching for branch changes
 		if h.branchWatcher != nil {
@@ -2148,26 +2177,35 @@ func (h *Handlers) DeleteSession(w http.ResponseWriter, r *http.Request) {
 			writeDBError(w, err)
 			return
 		}
-		if repo != nil && sess.WorktreePath != "" {
-			// Delete session metadata file (if exists)
-			session.DeleteMetadata(sessionID)
-
-			// Remove the git worktree using absolute path
-			h.worktreeManager.RemoveAtPath(ctx, repo.Path, sess.WorktreePath, sess.Branch)
-
-			// Remove from session name cache
-			h.sessionNameCache.Remove(sess.Name)
-
-			// Invalidate branch cache after branch/worktree removal
-			h.branchCache.InvalidateRepo(repo.Path)
+		if repo != nil {
+			repoPath = repo.Path
+			branch = sess.Branch
+			sessionName = sess.Name
 		}
 	}
 
-	// Delete from DB while still holding the lock (if acquired)
+	// DELETE DB RECORD FIRST — this is the authoritative action.
+	// If this fails, no disk cleanup happens and the session remains intact.
+	// Previously, worktree was removed first and DB delete could fail (no retry),
+	// leaving a ghost session with no worktree on disk.
 	if err := h.store.DeleteSession(ctx, sessionID); err != nil {
 		writeDBError(w, err)
 		return
 	}
+
+	// THEN clean up disk resources (best-effort).
+	// If worktree removal fails, orphan cleanup at startup will catch it.
+	if worktreePath != "" && repoPath != "" {
+		session.DeleteMetadata(sessionID)
+
+		if err := h.worktreeManager.RemoveAtPath(ctx, repoPath, worktreePath, branch); err != nil {
+			logger.Cleanup.Warnf("Failed to remove worktree for deleted session %s at %s: %v", sessionID, worktreePath, err)
+		}
+
+		h.sessionNameCache.Remove(sessionName)
+		h.branchCache.InvalidateRepo(repoPath)
+	}
+
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -1122,11 +1122,10 @@ func (s *SQLiteStore) getSessionNoLock(ctx context.Context, id string) (*models.
 }
 
 func (s *SQLiteStore) DeleteSession(ctx context.Context, id string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE id = ?`, id)
-	if err != nil {
-		return fmt.Errorf("DeleteSession: %w", err)
-	}
-	return nil
+	return RetryDBExec(ctx, "DeleteSession", DefaultRetryConfig(), func(ctx context.Context) error {
+		_, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE id = ?`, id)
+		return err
+	})
 }
 
 // SessionExistsByName checks whether a session with the given name exists


### PR DESCRIPTION
Adds robustness to worktree lifecycle management by reordering operations to prevent orphaned directories and ghost database records.

**Key changes:** DeleteSession now deletes DB first (with retry for transient SQLite errors), then cleans up disk best-effort. DeleteRepo cleans worktrees before cascade deletion. Startup orphan cleanup detects and removes any leftover worktrees. Also improves error handling with logging for diagnosability.

Addresses code review feedback on error handling and documentation.