### PR TITLE
fix: Use rune-based truncation in extractFirstLine for UTF-8

### DIFF
--- a/backend/server/command_handlers.go
+++ b/backend/server/command_handlers.go
@@ -123,9 +123,10 @@ func extractFirstLine(content string) string {
 		line = strings.TrimSpace(line)
 
 		if line != "" {
-			// Truncate long descriptions
-			if len(line) > 120 {
-				return line[:117] + "..."
+			// Truncate long descriptions (rune-based to avoid splitting multi-byte UTF-8)
+			runes := []rune(line)
+			if len(runes) > 120 {
+				return string(runes[:117]) + "..."
 			}
 			return line
 		}

--- a/backend/server/command_handlers_test.go
+++ b/backend/server/command_handlers_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,4 +163,17 @@ func TestExtractFirstLine(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+
+	t.Run("truncates multi-byte UTF-8 at rune boundary", func(t *testing.T) {
+		// 125 CJK characters (each 3 bytes in UTF-8) — exceeds 120 rune limit
+		input := strings.Repeat("漢", 125)
+		result := extractFirstLine(input)
+
+		assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+
+		runes := []rune(result)
+		// 117 runes + "..." (3 runes) = 120 runes total
+		assert.Equal(t, 120, len(runes))
+		assert.Equal(t, strings.Repeat("漢", 117)+"...", result)
+	})
 }


### PR DESCRIPTION
The previous byte-based truncation could split multi-byte UTF-8 characters, producing invalid output. This fix uses rune-based slicing to ensure truncation happens at character boundaries.

Includes comprehensive test coverage for multi-byte UTF-8 characters.