### PR TITLE
Add file size limit to user command file reads

### DIFF
--- a/backend/server/command_handlers.go
+++ b/backend/server/command_handlers.go
@@ -11,6 +11,10 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// maxCommandFileSize is the maximum allowed size for command files (50MB).
+// Exposed as a var for testing.
+var maxCommandFileSize int64 = 50 * 1024 * 1024
+
 // UserCommand represents a user-defined command from .claude/commands/*.md
 type UserCommand struct {
 	Name        string `json:"name"`
@@ -72,6 +76,17 @@ func (h *Handlers) ListUserCommands(w http.ResponseWriter, r *http.Request) {
 		// Skip symlinks to prevent reading files outside the worktree
 		if entry.Type()&os.ModeSymlink != 0 {
 			logger.Handlers.Warnf("Skipping symlink command file %s", fullPath)
+			continue
+		}
+
+		// Skip files that exceed the size limit
+		info, err := entry.Info()
+		if err != nil {
+			logger.Handlers.Warnf("Failed to stat command file %s: %v", fullPath, err)
+			continue
+		}
+		if info.Size() > maxCommandFileSize {
+			logger.Handlers.Warnf("Skipping oversized command file %s (%d bytes, limit %d)", fullPath, info.Size(), maxCommandFileSize)
 			continue
 		}
 

--- a/backend/server/command_handlers_test.go
+++ b/backend/server/command_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,6 +118,39 @@ func TestListUserCommands(t *testing.T) {
 		var commands []UserCommand
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &commands))
 		assert.Empty(t, commands)
+	})
+
+	t.Run("skips oversized command files", func(t *testing.T) {
+		h, s := setupTestHandlers(t)
+
+		createTestRepo(t, s, "ws-1", "/path/to/repo")
+		_, worktreePath := createTestSessionWithWorktree(t, s, "sess-1", "ws-1")
+
+		commandsDir := filepath.Join(worktreePath, ".claude", "commands")
+		require.NoError(t, os.MkdirAll(commandsDir, 0755))
+
+		// Temporarily lower the size limit for testing
+		origLimit := maxCommandFileSize
+		maxCommandFileSize = 100
+		t.Cleanup(func() { maxCommandFileSize = origLimit })
+
+		// Create a small file (under limit) and a large file (over limit)
+		writeFile(t, commandsDir, "small.md", "# Small command")
+		writeFile(t, commandsDir, "large.md", strings.Repeat("x", 200))
+
+		req := httptest.NewRequest("GET", "/api/sessions/sess-1/commands", nil)
+		req = withChiContext(req, map[string]string{"sessionId": "sess-1"})
+		w := httptest.NewRecorder()
+
+		h.ListUserCommands(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var commands []UserCommand
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &commands))
+		// Only the small command should be returned
+		assert.Len(t, commands, 1)
+		assert.Equal(t, "small", commands[0].Name)
 	})
 
 	t.Run("returns empty list for empty commands directory", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Implement a 50MB file size limit for command files in `ListUserCommands` to prevent excessive memory usage when reading large files. Files exceeding the limit are gracefully skipped with a warning log.

## Changes

- Added `maxCommandFileSize` constant (50MB) exposed as a var for testability
- Size check performed before reading file content to avoid loading huge files into memory
- Comprehensive test coverage for the size limit enforcement

## Testing

- All existing tests pass
- New test validates that oversized files are skipped while normal files are processed