### PR TITLE
Replace binary uiMode with adaptive panel system

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useLayoutEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useLayoutEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useTheme } from 'next-themes';
 import { Loader2 } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
@@ -12,6 +12,7 @@ import {
   useMessages,
 } from '@/stores/selectors';
 import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix } from '@/stores/settingsStore';
+import { useDisclosureStore } from '@/stores/disclosureStore';
 import { navigate } from '@/lib/navigation';
 import { ENABLE_BROWSER_TABS } from '@/lib/constants';
 import { useTabStore } from '@/stores/tabStore';
@@ -32,10 +33,11 @@ import { useExternalLinkGuard } from '@/hooks/useExternalLinkGuard';
 import { useDesktopNotifications } from '@/hooks/useDesktopNotifications';
 import { useFontSize } from '@/hooks/useFontSize';
 import { useReviewTrigger } from '@/hooks/useReviewTrigger';
+import { useAutoExpandPanels } from '@/hooks/useAutoExpandPanels';
 import { useShortcut } from '@/hooks/useShortcut';
 import { getDashboardData, listConversations, createSession, createConversation, deleteConversation, addRepo, mapSessionDTO, getConversationMessages, toStoreMessage, type RepoDTO, type SessionDTO, type ConversationDTO, type MessageDTO } from '@/lib/api';
 import type { SetupInfo } from '@/lib/types';
-import { WorkspaceSidebar } from '@/components/navigation/WorkspaceSidebar';
+import { StreamlinedSidebar } from '@/components/navigation/StreamlinedSidebar';
 import { WorkspaceSettings } from '@/components/settings/WorkspaceSettings';
 import { SettingsPage } from '@/components/settings/SettingsPage';
 import { SessionToolbarContent } from '@/components/navigation/SessionToolbarContent';
@@ -167,7 +169,8 @@ export default function Home() {
     return () => window.removeEventListener('open-settings', handler);
   }, []);
   const [leftSidebarCollapsed, setLeftSidebarCollapsed] = useState(false);
-  const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState(false);
+  const fullModeEnabled = useDisclosureStore((s) => s.fullModeEnabled);
+  const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState(!fullModeEnabled);
   const sidebarWidthRef = useRef(250); // Tracked via ref — no re-renders on resize
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const [pendingCloseConvId, setPendingCloseConvId] = useState<string | null>(null);
@@ -183,6 +186,16 @@ export default function Home() {
   const rightSidebarPanelRef = useRef<PanelImperativeHandle>(null);
   const bottomTerminalPanelRef = useRef<PanelImperativeHandle>(null);
   const leftSidebarDomRef = useRef<HTMLDivElement>(null);
+
+  // Callback ref for right sidebar: explicitly collapse() on mount so the
+  // library's internal state matches the 0% size from effectiveLayoutInner.
+  // Without this, isCollapsed() returns false and expand() has no target size.
+  const setRightSidebarPanel = useCallback((handle: PanelImperativeHandle | null) => {
+    rightSidebarPanelRef.current = handle;
+    if (handle && !useDisclosureStore.getState().fullModeEnabled) {
+      queueMicrotask(() => handle.collapse());
+    }
+  }, []);
 
   // Pre-zen mode state for restoration
   const preZenStateRef = useRef({ left: false, right: false });
@@ -225,6 +238,49 @@ export default function Home() {
   // Determine if we're in a Full Content view (not conversation)
   // Also treat as full content view when no session is selected (to show welcome screen)
   const isFullContentView = contentView.type !== 'conversation';
+
+  // Effective vertical layout: when bottom terminal is hidden, ensure it starts at 0%
+  // to prevent a flash of the uncollapsed terminal panel on first mount.
+  // The persisted layoutVertical may have a stale non-zero terminal size if the
+  // panel group unmounted before onLayoutChange could persist the collapsed state.
+  const effectiveLayoutVertical = useMemo(() => {
+    if (!showBottomTerminal && layoutVertical) {
+      const termSize = layoutVertical['bottom-terminal'];
+      if (termSize && termSize > 0) {
+        const convSize = layoutVertical['conversation'] ?? 70;
+        return {
+          ...layoutVertical,
+          'conversation': convSize + termSize,
+          'bottom-terminal': 0,
+        };
+      }
+    }
+    return layoutVertical;
+  }, [showBottomTerminal, layoutVertical]);
+
+  // Effective inner layout: when right sidebar should start collapsed, ensure it's at 0%
+  // to prevent a flash of the expanded panel on first mount.
+  // Handles fresh install (layoutInner undefined) by creating an explicit collapsed layout.
+  const effectiveLayoutInner = useMemo(() => {
+    if (!rightSidebarCollapsed) return layoutInner;
+
+    // Sidebar should be collapsed — ensure layout reflects that
+    const base = layoutInner || {};
+    const sidebarSize = base['right-sidebar'] ?? 0;
+    if (sidebarSize > 0) {
+      // Transfer sidebar space to content
+      return {
+        ...base,
+        'inner-content': (base['inner-content'] ?? 72) + sidebarSize,
+        'right-sidebar': 0,
+      };
+    }
+    // Already at 0 or no layout — return explicit collapsed layout
+    return {
+      'inner-content': base['inner-content'] ?? 100,
+      'right-sidebar': 0,
+    };
+  }, [rightSidebarCollapsed, layoutInner]);
 
   const {
     isLoading: authLoading,
@@ -420,6 +476,16 @@ export default function Home() {
 
   // Listen for /review, /deep-review, /security slash commands
   useReviewTrigger();
+
+  // Auto-expand panels based on session activity and disclosure mode.
+  // panelReady gates the effect so it doesn't fire while the skeleton is shown
+  // (inner panel group not yet mounted → ref is null → expand() would silently fail).
+  const panelReady = !isLoadingData && !isFullContentView && !!selectedSessionId;
+  useAutoExpandPanels({
+    rightSidebarPanelRef,
+    bottomTerminalPanelRef,
+    panelReady,
+  });
 
   // Persist file tabs to backend
   useTabPersistence();
@@ -1213,7 +1279,7 @@ export default function Home() {
               <SidebarToolbar />
               <div className="flex-1 min-h-0">
               <ErrorBoundary section="Sidebar">
-                <WorkspaceSidebar
+                <StreamlinedSidebar
                   onOpenProject={handleOpenProject}
                   onCloneFromUrl={() => setShowCloneFromUrl(true)}
                   onQuickStart={() => setShowQuickStart(true)}
@@ -1322,7 +1388,7 @@ export default function Home() {
               <ResizablePanelGroup
                 direction="horizontal"
                 className="h-full"
-                defaultLayout={layoutInner}
+                defaultLayout={effectiveLayoutInner}
                 onLayoutChange={setLayoutInner}
               >
                 {/* Inner Content - Contains vertical split */}
@@ -1331,7 +1397,7 @@ export default function Home() {
                   <ResizablePanelGroup
                     direction="vertical"
                     className="h-full"
-                    defaultLayout={layoutVertical}
+                    defaultLayout={effectiveLayoutVertical}
                     onLayoutChange={setLayoutVertical}
                   >
                     {/* Conversation Area */}
@@ -1348,7 +1414,7 @@ export default function Home() {
                       ) : null}
                     </ResizablePanel>
 
-                    {/* Bottom Terminal - always mounted to preserve PTY session */}
+                    {/* Bottom Terminal - always mounted to preserve PTY session, hidden in streamlined mode */}
                     {selectedSession && (
                       <>
                         <ResizableHandle
@@ -1358,7 +1424,7 @@ export default function Home() {
                         <ResizablePanel
                           ref={bottomTerminalPanelRef}
                           id="bottom-terminal"
-                          defaultSize="180px"
+                          defaultSize={showBottomTerminal ? "180px" : 0}
                           minSize="100px"
                           maxSize="400px"
                           collapsible={true}
@@ -1379,6 +1445,7 @@ export default function Home() {
                   </ResizablePanelGroup>
                 </ResizablePanel>
 
+                {/* Right sidebar handle + panel — always mounted, starts collapsed */}
                 <ResizableHandle
                   direction="horizontal"
                   className={cn(
@@ -1388,7 +1455,7 @@ export default function Home() {
 
                 {/* Right Sidebar - Nested inside main content, collapsible */}
                 <ResizablePanel
-                  ref={rightSidebarPanelRef}
+                  ref={setRightSidebarPanel}
                   id="right-sidebar"
                   defaultSize="280px"
                   minSize="250px"
@@ -1396,9 +1463,9 @@ export default function Home() {
                   collapsible={true}
                   collapsedSize={0}
                   onResize={(size) => {
-              const collapsed = size.asPercentage === 0;
-              setRightSidebarCollapsed((prev) => prev === collapsed ? prev : collapsed);
-            }}
+                    const collapsed = size.asPercentage === 0;
+                    setRightSidebarCollapsed((prev) => prev === collapsed ? prev : collapsed);
+                  }}
                   className={cn(
                     "overflow-hidden",
                     (zenMode || !selectedSessionId) && "hidden"

--- a/src/components/layout/MainToolbar.tsx
+++ b/src/components/layout/MainToolbar.tsx
@@ -6,12 +6,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { PanelLeft, PanelRight, PanelBottom, Plus } from 'lucide-react';
+import { PanelLeft, PanelRight, PanelBottom, Plus, Layers } from 'lucide-react';
 import { type ReactNode, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { useUIStore, type ToolbarSlots } from '@/stores/uiStore';
 import { useTabStore } from '@/stores/tabStore';
 import { useConnectionStore } from '@/stores/connectionStore';
+import { useDisclosureStore } from '@/stores/disclosureStore';
 import { BrowserTabStrip, createAndSwitchToNewTab } from '@/components/navigation/BrowserTabBar';
 import { ENABLE_BROWSER_TABS } from '@/lib/constants';
 import { AppSettingsMenu } from '@/components/settings/AppSettingsMenu';
@@ -107,6 +108,8 @@ export function MainToolbar({
   const activeTabId = useTabStore((s) => s.activeTabId);
   const tabCount = useTabStore((s) => s.tabOrder.length);
   const hasMultipleTabs = ENABLE_BROWSER_TABS && tabCount > 1;
+  const fullModeEnabled = useDisclosureStore((s) => s.fullModeEnabled);
+  const setFullModeEnabled = useDisclosureStore((s) => s.setFullModeEnabled);
 
   // Cache the active tab's rich toolbar title whenever it changes
   const toolbarTitle = toolbarConfig?.title;
@@ -219,6 +222,23 @@ export function MainToolbar({
                     Toggle Sidebar <span className="ml-2 px-1.5 py-0.5 bg-background/20 rounded text-sm">⌘⌥ B</span>
                   </TooltipContent>
                 </Tooltip>
+
+                {/* Show All Panels Toggle */}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className={cn('h-6 w-6', fullModeEnabled && 'bg-surface-2')}
+                      onClick={() => setFullModeEnabled(!fullModeEnabled)}
+                    >
+                      <Layers className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {fullModeEnabled ? 'Progressive mode' : 'Show all panels'}
+                  </TooltipContent>
+                </Tooltip>
               </div>
 
               {/* Spacer between toggles and settings */}
@@ -269,6 +289,7 @@ export function ConnectionIndicator() {
 /** Context-aware action bar rendered at the top of the main content area */
 export function ContentActionBar() {
   const bottom = useUIStore((s) => s.toolbarConfig?.bottom);
+
   if (!bottom) return null;
 
   return (

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -203,24 +203,26 @@ export function SessionToolbarContent() {
   const toolbarConfig = useMemo(() => {
     if (!selectedWorkspace || !selectedSession) return {};
 
+    const title = (
+      <span className="flex items-center gap-1.5 min-w-0">
+        <span className="flex items-center gap-1.5 min-w-0 shrink overflow-hidden">
+          <div
+            className="w-3 h-3 rounded-full shrink-0"
+            style={{ backgroundColor: getWorkspaceColor(selectedWorkspace.id) }}
+          />
+          <span className="text-base font-semibold truncate">{selectedWorkspace.name}</span>
+          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+        </span>
+        <span className="flex items-center gap-1.5 shrink-0">
+          <GitBranch className="h-4 w-4 text-purple-400" />
+          <span className="text-base font-semibold truncate">{selectedSession.branch || selectedSession.name}</span>
+        </span>
+      </span>
+    );
+
     return {
       titlePosition: 'center' as const,
-      title: (
-        <span className="flex items-center gap-1.5 min-w-0">
-          <span className="flex items-center gap-1.5 min-w-0 shrink overflow-hidden">
-            <div
-              className="w-3 h-3 rounded-full shrink-0"
-              style={{ backgroundColor: getWorkspaceColor(selectedWorkspace.id) }}
-            />
-            <span className="text-base font-semibold truncate">{selectedWorkspace.name}</span>
-            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
-          </span>
-          <span className="flex items-center gap-1.5 shrink-0">
-            <GitBranch className="h-4 w-4 text-purple-400" />
-            <span className="text-base font-semibold truncate">{selectedSession.branch || selectedSession.name}</span>
-          </span>
-        </span>
-      ),
+      title,
       bottom: {
         titlePosition: 'left' as const,
         title: (

--- a/src/components/navigation/StreamlinedSidebar.tsx
+++ b/src/components/navigation/StreamlinedSidebar.tsx
@@ -1,0 +1,491 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import {
+  MessageSquare,
+  Zap,
+  Eye,
+  CheckCircle2,
+  Archive,
+  Plus,
+  Search,
+  X,
+  LayoutList,
+  List,
+} from 'lucide-react';
+import { useWorkspaceSelection } from '@/stores/selectors';
+import { useSettingsStore, type SidebarFilter } from '@/stores/settingsStore';
+import { navigate } from '@/lib/navigation';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { WorktreeSession } from '@/lib/types';
+
+// ─── Nav Filter Items ────────────────────────────────────────────────────────
+
+interface NavItem {
+  id: SidebarFilter;
+  label: string;
+  icon: React.ElementType;
+}
+
+const NAV_FILTERS: NavItem[] = [
+  { id: 'all', label: 'All Sessions', icon: MessageSquare },
+  { id: 'active', label: 'Active', icon: Zap },
+  { id: 'needs-review', label: 'Needs Review', icon: Eye },
+  { id: 'done', label: 'Done', icon: CheckCircle2 },
+  { id: 'archived', label: 'Archived', icon: Archive },
+];
+
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatTimeAgo(date: string): string {
+  const now = new Date();
+  const then = new Date(date);
+  const diffMs = now.getTime() - then.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 1) return 'now';
+  if (diffMins < 60) return `${diffMins}m`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d`;
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks < 5) return `${diffWeeks}w`;
+  const diffMonths = Math.floor(diffDays / 30);
+  return `${diffMonths}mo`;
+}
+
+function matchesFilter(session: WorktreeSession, filter: SidebarFilter): boolean {
+  switch (filter) {
+    case 'all':
+      return !session.archived;
+    case 'active':
+      return !session.archived && (session.status === 'active' || session.taskStatus === 'in_progress');
+    case 'needs-review':
+      return !session.archived && session.taskStatus === 'in_review';
+    case 'done':
+      return !session.archived && session.taskStatus === 'done';
+    case 'archived':
+      return !!session.archived;
+    default:
+      return !session.archived;
+  }
+}
+
+function getStatusColor(session: WorktreeSession): string {
+  if (session.status === 'active') return 'bg-green-500';
+  if (session.taskStatus === 'in_review') return 'bg-amber-500';
+  if (session.taskStatus === 'done') return 'bg-purple-500';
+  if (session.taskStatus === 'in_progress') return 'bg-blue-500';
+  return 'bg-muted-foreground/30';
+}
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+interface StreamlinedSidebarProps {
+  onOpenProject: () => void;
+  onCloneFromUrl: () => void;
+  onQuickStart: () => void;
+  onOpenWorkspaceSettings?: (workspaceId: string) => void;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function StreamlinedSidebar({
+  onOpenProject,
+  onCloneFromUrl,
+}: StreamlinedSidebarProps) {
+  const { workspaces, sessions, selectedSessionId, selectedWorkspaceId } = useWorkspaceSelection();
+  const sidebarFilter = useSettingsStore((s) => s.sidebarFilter);
+  const setSidebarFilter = useSettingsStore((s) => s.setSidebarFilter);
+  const sessionListGrouped = useSettingsStore((s) => s.sessionListGrouped);
+  const setSessionListGrouped = useSettingsStore((s) => s.setSessionListGrouped);
+  const contentView = useSettingsStore((s) => s.contentView);
+  const setContentView = useSettingsStore((s) => s.setContentView);
+
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Build workspace lookup
+  const workspaceMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const w of workspaces) {
+      map.set(w.id, w.name);
+    }
+    return map;
+  }, [workspaces]);
+
+  // Filter and sort sessions
+  const filteredSessions = useMemo(() => {
+    let result = sessions.filter((s) => matchesFilter(s, sidebarFilter));
+
+    // Apply search
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (s) =>
+          s.name.toLowerCase().includes(q) ||
+          s.branch.toLowerCase().includes(q) ||
+          (s.task && s.task.toLowerCase().includes(q))
+      );
+    }
+
+    // Sort: pinned first, then by updatedAt desc
+    result.sort((a, b) => {
+      if (a.pinned && !b.pinned) return -1;
+      if (!a.pinned && b.pinned) return 1;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+
+    return result;
+  }, [sessions, sidebarFilter, searchQuery]);
+
+  // Count sessions per filter (for badges)
+  const filterCounts = useMemo(() => {
+    const counts: Record<SidebarFilter, number> = {
+      all: 0,
+      active: 0,
+      'needs-review': 0,
+      done: 0,
+      archived: 0,
+    };
+    for (const s of sessions) {
+      if (matchesFilter(s, 'all')) counts.all++;
+      if (matchesFilter(s, 'active')) counts.active++;
+      if (matchesFilter(s, 'needs-review')) counts['needs-review']++;
+      if (matchesFilter(s, 'done')) counts.done++;
+      if (matchesFilter(s, 'archived')) counts.archived++;
+    }
+    return counts;
+  }, [sessions]);
+
+  // Group sessions by workspace if toggled
+  const groupedSessions = useMemo(() => {
+    if (!sessionListGrouped) return null;
+    const groups = new Map<string, WorktreeSession[]>();
+    for (const s of filteredSessions) {
+      const list = groups.get(s.workspaceId) || [];
+      list.push(s);
+      groups.set(s.workspaceId, list);
+    }
+    return groups;
+  }, [filteredSessions, sessionListGrouped]);
+
+  const handleSelectSession = useCallback(
+    (session: WorktreeSession) => {
+      navigate({
+        workspaceId: session.workspaceId,
+        sessionId: session.id,
+        contentView: { type: 'conversation' },
+      });
+    },
+    []
+  );
+
+  // Resolve workspace name for the "new session" CTA
+  const activeWorkspaceName = useMemo(() => {
+    if (selectedWorkspaceId) return workspaceMap.get(selectedWorkspaceId);
+    if (workspaces.length === 1) return workspaces[0].name;
+    return undefined;
+  }, [selectedWorkspaceId, workspaces, workspaceMap]);
+
+  const handleNewSession = useCallback(() => {
+    window.dispatchEvent(new CustomEvent('spawn-agent'));
+  }, []);
+
+  return (
+    <div className="flex flex-col h-full bg-sidebar">
+      {/* ── Navigation Filters ── */}
+      <nav className="flex flex-col pt-2 px-2 gap-0.5">
+        {NAV_FILTERS.map((item) => {
+          const Icon = item.icon;
+          const isActive = sidebarFilter === item.id;
+          const count = filterCounts[item.id];
+
+          return (
+            <button
+              key={item.id}
+              onClick={() => {
+                setSidebarFilter(item.id);
+                if (contentView.type !== 'conversation') {
+                  setContentView({ type: 'conversation' });
+                }
+              }}
+              className={cn(
+                'flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm transition-colors w-full text-left',
+                isActive
+                  ? 'bg-sidebar-accent text-foreground font-medium'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-sidebar-accent/50'
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              <span className="flex-1 truncate">{item.label}</span>
+              {count !== undefined && count > 0 && (
+                <span
+                  className={cn(
+                    'text-xs tabular-nums',
+                    isActive
+                      ? 'text-foreground/60'
+                      : 'text-muted-foreground/60'
+                  )}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+
+      </nav>
+
+      <div className="h-px bg-border/50 my-2 mx-4" />
+
+      {/* ── Session List Header ── */}
+      <div className="flex items-center justify-between px-4 py-1">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Sessions
+        </span>
+        <div className="flex items-center gap-0.5">
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                onClick={() => setSessionListGrouped(!sessionListGrouped)}
+              >
+                {sessionListGrouped ? (
+                  <LayoutList className="h-3.5 w-3.5" />
+                ) : (
+                  <List className="h-3.5 w-3.5" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="text-xs">
+              {sessionListGrouped ? 'Flat list' : 'Group by project'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* ── Session List ── */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-2">
+        {workspaces.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-32 gap-3">
+            <p className="text-sm text-muted-foreground">Add a project to get started</p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2 text-xs"
+              onClick={onOpenProject}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Open Project
+            </Button>
+          </div>
+        ) : (
+          <>
+            {filteredSessions.length === 0 ? (
+              <NewSessionButton
+                workspaceName={activeWorkspaceName}
+                onClick={handleNewSession}
+              />
+            ) : sessionListGrouped && groupedSessions ? (
+              // Grouped view
+              Array.from(groupedSessions.entries()).map(
+                ([workspaceId, wSessions]) => (
+                  <div key={workspaceId} className="mb-2">
+                    <div className="px-2 py-1 text-xs font-medium text-muted-foreground/70 uppercase tracking-wide truncate">
+                      {workspaceMap.get(workspaceId) || 'Unknown'}
+                    </div>
+                    {wSessions.map((session) => (
+                      <SessionItem
+                        key={session.id}
+                        session={session}
+                        workspaceName={workspaceMap.get(session.workspaceId)}
+                        isSelected={
+                          contentView.type === 'conversation' &&
+                          selectedSessionId === session.id
+                        }
+                        showWorkspace={false}
+                        onSelect={handleSelectSession}
+                      />
+                    ))}
+                  </div>
+                )
+              )
+            ) : (
+              // Flat view
+              filteredSessions.map((session) => (
+                <SessionItem
+                  key={session.id}
+                  session={session}
+                  workspaceName={workspaceMap.get(session.workspaceId)}
+                  isSelected={
+                    contentView.type === 'conversation' &&
+                    selectedSessionId === session.id
+                  }
+                  showWorkspace={true}
+                  onSelect={handleSelectSession}
+                />
+              ))
+            )}
+
+            {/* New session button below existing sessions */}
+            {filteredSessions.length > 0 && (
+              <NewSessionButton
+                workspaceName={activeWorkspaceName}
+                onClick={handleNewSession}
+              />
+            )}
+          </>
+        )}
+      </div>
+
+      {/* ── Footer ── */}
+      <div className="flex flex-col gap-2 p-2 border-t border-border/50">
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/50" />
+          <input
+            type="text"
+            placeholder="Search sessions..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full h-8 pl-8 pr-8 text-sm bg-sidebar-accent/50 border border-border/50 rounded-md placeholder:text-muted-foreground/40 focus:outline-none focus:ring-1 focus:ring-ring/30"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+
+        {/* New button */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              className="w-full h-8 text-sm text-muted-foreground hover:text-foreground justify-start gap-2"
+            >
+              <Plus className="h-4 w-4" />
+              New...
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-48">
+            <DropdownMenuItem onClick={handleNewSession}>
+              New Session
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onOpenProject}>
+              Open Project
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onCloneFromUrl}>
+              Clone from URL
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}
+
+// ─── New Session Button (styled like a session entry) ────────────────────────
+
+function NewSessionButton({
+  workspaceName,
+  onClick,
+}: {
+  workspaceName?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-start gap-2.5 w-full px-3 py-2.5 rounded-md text-left transition-colors group text-muted-foreground/60 hover:text-foreground hover:bg-sidebar-accent/50 border border-dashed border-border/50 hover:border-border mt-1"
+    >
+      <div className="mt-1 shrink-0">
+        <Plus className="h-3.5 w-3.5" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm">
+          New session{workspaceName ? ` in ${workspaceName}` : ''}
+        </div>
+        <div className="text-xs text-muted-foreground/40 mt-0.5">
+          ⌘N
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ─── Session Item ────────────────────────────────────────────────────────────
+
+interface SessionItemProps {
+  session: WorktreeSession;
+  workspaceName?: string;
+  isSelected: boolean;
+  showWorkspace: boolean;
+  onSelect: (session: WorktreeSession) => void;
+}
+
+function SessionItem({
+  session,
+  workspaceName,
+  isSelected,
+  showWorkspace,
+  onSelect,
+}: SessionItemProps) {
+  const displayName = session.name || session.branch;
+
+  return (
+    <button
+      onClick={() => onSelect(session)}
+      className={cn(
+        'flex items-start gap-2.5 w-full px-3 py-2.5 rounded-md text-left transition-colors group',
+        isSelected
+          ? 'bg-sidebar-accent text-foreground'
+          : 'text-foreground/80 hover:bg-sidebar-accent/50'
+      )}
+    >
+      {/* Status dot */}
+      <div className="mt-1.5 shrink-0">
+        <div
+          className={cn(
+            'h-2 w-2 rounded-full transition-colors',
+            getStatusColor(session),
+            session.status === 'active' && 'animate-pulse'
+          )}
+        />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm font-medium truncate">{displayName}</span>
+          <span className="text-xs text-muted-foreground/50 shrink-0 tabular-nums">
+            {formatTimeAgo(session.updatedAt)}
+          </span>
+        </div>
+        {showWorkspace && workspaceName && (
+          <div className="text-xs text-muted-foreground/60 truncate mt-0.5">
+            {workspaceName}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -107,7 +107,7 @@ export function ChangesPanel() {
   const updateSession = useAppStore((s) => s.updateSession);
   const layoutChanges = useSettingsStore((s) => s.layoutChanges);
   const setLayoutChanges = useSettingsStore((s) => s.setLayoutChanges);
-  const [selectedTab, setSelectedTab] = useState('files');
+  const [selectedTab, setSelectedTab] = useState('changes');
   const [bottomTab, setBottomTab] = useState('todos');
   const [files, setFiles] = useState<FileNode[]>([]);
   const [filesLoading, setFilesLoading] = useState(false);

--- a/src/components/panels/StreamlinedDetailsPanel.tsx
+++ b/src/components/panels/StreamlinedDetailsPanel.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState, useMemo, type ReactNode } from 'react';
+import { ChevronDown, ChevronRight, MoreHorizontal } from 'lucide-react';
+import { useSelectedIds } from '@/stores/selectors';
+import { useAppStore } from '@/stores/appStore';
+import { TodoPanel } from '@/components/panels/TodoPanel';
+import { PlansPanel } from '@/components/panels/PlansPanel';
+import { ReviewPanel } from '@/components/panels/ReviewPanel';
+import { ChecksPanel } from '@/components/panels/ChecksPanel';
+import { CheckpointTimeline } from '@/components/panels/CheckpointTimeline';
+import { BudgetStatusPanel } from '@/components/panels/BudgetStatusPanel';
+import { McpServersPanel } from '@/components/panels/McpServersPanel';
+import { FileHistoryPanel } from '@/components/panels/FileHistoryPanel';
+import { ScriptsPanel } from '@/components/panels/ScriptsPanel';
+import { SessionInfoPanel } from '@/components/panels/SessionInfoPanel';
+import { Button } from '@/components/ui/button';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface SectionConfig {
+  id: string;
+  label: string;
+  render: () => ReactNode;
+  tier: 'default' | 'contextual' | 'advanced';
+  isRelevant?: () => boolean;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function StreamlinedDetailsPanel() {
+  const { selectedSessionId, selectedWorkspaceId } = useSelectedIds();
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(
+    new Set(['tasks', 'plans'])
+  );
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // Check for contextual relevance
+  const hasReview = useAppStore(
+    (s) => {
+      if (!selectedSessionId) return false;
+      return s.conversations.some((c) => c.sessionId === selectedSessionId && c.type === 'review');
+    }
+  );
+  const hasChecks = useAppStore(
+    (s) => {
+      if (!selectedSessionId) return false;
+      const session = s.sessions.find((ss) => ss.id === selectedSessionId);
+      return !!(session?.hasCheckFailures);
+    }
+  );
+
+  const sections: SectionConfig[] = useMemo(
+    () => [
+      { id: 'tasks', label: 'Tasks', render: () => <TodoPanel />, tier: 'default' },
+      { id: 'plans', label: 'Plans', render: () => <PlansPanel />, tier: 'default' },
+      {
+        id: 'review', label: 'Review', tier: 'contextual', isRelevant: () => hasReview,
+        render: () => <ReviewPanel workspaceId={selectedWorkspaceId} sessionId={selectedSessionId} />,
+      },
+      {
+        id: 'checks', label: 'Checks', tier: 'contextual', isRelevant: () => hasChecks,
+        render: () => <ChecksPanel />,
+      },
+      { id: 'checkpoints', label: 'Checkpoints', render: () => <CheckpointTimeline />, tier: 'advanced' },
+      { id: 'file-history', label: 'File History', render: () => <FileHistoryPanel />, tier: 'advanced' },
+      { id: 'budget', label: 'Budget', render: () => <BudgetStatusPanel />, tier: 'advanced' },
+      { id: 'mcp', label: 'MCP Servers', render: () => <McpServersPanel />, tier: 'advanced' },
+      { id: 'scripts', label: 'Scripts', render: () => <ScriptsPanel />, tier: 'advanced' },
+      { id: 'info', label: 'Session Info', render: () => <SessionInfoPanel />, tier: 'advanced' },
+    ],
+    [hasReview, hasChecks, selectedWorkspaceId, selectedSessionId]
+  );
+
+  const visibleSections = useMemo(() => {
+    return sections.filter((s) => {
+      if (s.tier === 'default') return true;
+      if (s.tier === 'contextual') return s.isRelevant?.() ?? false;
+      if (s.tier === 'advanced') return showAdvanced;
+      return false;
+    });
+  }, [sections, showAdvanced]);
+
+  const toggleSection = (id: string) => {
+    setExpandedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  if (!selectedSessionId) return null;
+
+  return (
+    <div className="flex flex-col h-full bg-content-background">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border/50">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Details
+        </span>
+      </div>
+
+      {/* Sections */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {visibleSections.map((section) => {
+          const isExpanded = expandedSections.has(section.id);
+
+          return (
+            <div key={section.id} className="border-b border-border/30">
+              <button
+                onClick={() => toggleSection(section.id)}
+                className="flex items-center gap-1.5 w-full px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {isExpanded ? (
+                  <ChevronDown className="h-3 w-3 shrink-0" />
+                ) : (
+                  <ChevronRight className="h-3 w-3 shrink-0" />
+                )}
+                {section.label}
+              </button>
+              {isExpanded && (
+                <div className="pb-2">
+                  <ErrorBoundary section={section.label}>
+                    {section.render()}
+                  </ErrorBoundary>
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Show More / Less toggle */}
+        <div className="px-3 py-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full h-7 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => setShowAdvanced(!showAdvanced)}
+          >
+            <MoreHorizontal className="h-3.5 w-3.5 mr-1.5" />
+            {showAdvanced ? 'Show Less' : 'Show More'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAutoExpandPanels.ts
+++ b/src/hooks/useAutoExpandPanels.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react';
+import { useAppStore } from '@/stores/appStore';
+import { useDisclosureStore } from '@/stores/disclosureStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import type { PanelImperativeHandle } from '@/components/ui/resizable';
+
+interface UseAutoExpandPanelsOptions {
+  rightSidebarPanelRef: React.RefObject<PanelImperativeHandle | null>;
+  bottomTerminalPanelRef: React.RefObject<PanelImperativeHandle | null>;
+  /** Set to true only when the inner panel group is mounted (not loading, session selected, conversation view). */
+  panelReady: boolean;
+}
+
+/**
+ * Watches session stats and fullModeEnabled to auto-expand/collapse panels.
+ *
+ * The right sidebar starts collapsed (via effectiveLayoutInner in page.tsx).
+ * This hook only EXPANDS it when:
+ * - Session stats arrive with non-zero changes (first time per session)
+ * - fullModeEnabled is toggled on
+ */
+export function useAutoExpandPanels({
+  rightSidebarPanelRef,
+  bottomTerminalPanelRef,
+  panelReady,
+}: UseAutoExpandPanelsOptions) {
+  const selectedSessionId = useAppStore((s) => s.selectedSessionId);
+
+  // Derive a stable boolean — avoids re-renders from new stats object references.
+  const sessionHasChanges = useAppStore((s) => {
+    if (!s.selectedSessionId) return false;
+    const session = s.sessions.find((sess) => sess.id === s.selectedSessionId);
+    if (!session?.stats) return false;
+    return session.stats.additions > 0 || session.stats.deletions > 0;
+  });
+
+  const fullModeEnabled = useDisclosureStore((s) => s.fullModeEnabled);
+  const setShowBottomTerminal = useSettingsStore((s) => s.setShowBottomTerminal);
+
+  const prevFullModeRef = useRef(fullModeEnabled);
+
+  // Track which sessions we've auto-expanded for (local ref, no store writes)
+  const expandedSessionsRef = useRef(new Set<string>());
+
+  // Auto-expand right sidebar when session first gets file changes.
+  // panelReady ensures we don't fire before the inner panel group mounts
+  // (e.g. during initial data loading when the skeleton is shown).
+  useEffect(() => {
+    if (!panelReady) return;
+    if (!selectedSessionId || !sessionHasChanges || fullModeEnabled) return;
+    if (expandedSessionsRef.current.has(selectedSessionId)) return;
+
+    expandedSessionsRef.current.add(selectedSessionId);
+    rightSidebarPanelRef.current?.expand();
+  }, [panelReady, selectedSessionId, sessionHasChanges, fullModeEnabled, rightSidebarPanelRef]);
+
+  // Handle fullModeEnabled toggle transitions
+  useEffect(() => {
+    const wasFullMode = prevFullModeRef.current;
+    prevFullModeRef.current = fullModeEnabled;
+
+    if (fullModeEnabled && !wasFullMode) {
+      rightSidebarPanelRef.current?.expand();
+      setShowBottomTerminal(true);
+    } else if (!fullModeEnabled && wasFullMode) {
+      rightSidebarPanelRef.current?.collapse();
+      setShowBottomTerminal(false);
+    }
+  }, [fullModeEnabled, rightSidebarPanelRef, bottomTerminalPanelRef, setShowBottomTerminal]);
+}

--- a/src/stores/disclosureStore.ts
+++ b/src/stores/disclosureStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface DisclosureState {
+  // Persisted: replaces the old uiMode toggle
+  fullModeEnabled: boolean;
+  setFullModeEnabled: (value: boolean) => void;
+}
+
+export const useDisclosureStore = create<DisclosureState>()(
+  persist(
+    (set) => ({
+      fullModeEnabled: false,
+      setFullModeEnabled: (value) => set({ fullModeEnabled: value }),
+    }),
+    {
+      name: 'chatml-disclosure',
+    }
+  )
+);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -29,6 +29,9 @@ export type FontSize = 'small' | 'medium' | 'large';
 // Branch prefix options
 export type BranchPrefixType = 'github' | 'custom' | 'none';
 
+// Sidebar filter categories for streamlined mode
+export type SidebarFilter = 'all' | 'active' | 'needs-review' | 'done' | 'archived';
+
 // Content view types for Full Content Area pattern
 export type ContentView =
   | { type: 'conversation' }
@@ -87,6 +90,8 @@ interface SettingsState {
   parallelAgents: boolean;
   // Advanced settings
   developerMode: boolean;
+  sessionListGrouped: boolean;
+  sidebarFilter: SidebarFilter;
   // UI state
   collapsedWorkspaces: string[]; // Workspace IDs that are collapsed (all others are expanded)
   unreadWorkspaces: string[]; // Workspace IDs marked as unread
@@ -142,6 +147,8 @@ interface SettingsState {
   setStrictPrivacy: (value: boolean) => void;
   setParallelAgents: (value: boolean) => void;
   setDeveloperMode: (value: boolean) => void;
+  setSessionListGrouped: (value: boolean) => void;
+  setSidebarFilter: (value: SidebarFilter) => void;
   setShowBottomTerminal: (value: boolean) => void;
   setZenMode: (value: boolean) => void;
   toggleWorkspaceCollapsed: (workspaceId: string) => void;
@@ -196,6 +203,8 @@ export const useSettingsStore = create<SettingsState>()(
       strictPrivacy: false,
       parallelAgents: false,
       developerMode: false,
+      sessionListGrouped: false,
+      sidebarFilter: 'all' as SidebarFilter,
       collapsedWorkspaces: [], // Workspace IDs that are collapsed (all others expanded by default)
       unreadWorkspaces: [], // Workspace IDs marked as unread
       showBottomTerminal: false,
@@ -242,6 +251,8 @@ export const useSettingsStore = create<SettingsState>()(
       setStrictPrivacy: (value) => set({ strictPrivacy: value }),
       setParallelAgents: (value) => set({ parallelAgents: value }),
       setDeveloperMode: (value) => set({ developerMode: value }),
+      setSessionListGrouped: (value) => set({ sessionListGrouped: value }),
+      setSidebarFilter: (value) => set({ sidebarFilter: value }),
       setShowBottomTerminal: (value) => set({ showBottomTerminal: value }),
       setZenMode: (value) => set({ zenMode: value }),
       toggleWorkspaceCollapsed: (workspaceId) =>
@@ -323,10 +334,10 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: 'chatml-settings',
-      // Exclude contentView from persistence - always start in conversation view
+      // Exclude transient state from persistence
       partialize: (state) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { contentView, ...rest } = state;
+        const { contentView, sidebarFilter, ...rest } = state;
         return rest;
       },
       // Merge persisted state with defaults to handle new tabs added after initial save


### PR DESCRIPTION
## Summary
- Replace the binary streamlined/classic mode toggle with a progressive disclosure system where panels start collapsed and auto-expand based on session activity
- Right sidebar auto-expands when the agent makes file changes (detected via session stats)
- New "Show All" toggle replaces the old mode switch, backed by a persisted `disclosureStore`
- Always render `StreamlinedSidebar` as the only sidebar; remove `WorkspaceSidebar` usage

## Implementation Details
- **`disclosureStore.ts`** — New Zustand store with persisted `fullModeEnabled` toggle
- **`useAutoExpandPanels.ts`** — Hook that watches session stats and expands the right sidebar on first non-zero changes per session. Uses `panelReady` gate to avoid firing before the inner panel group mounts
- **`page.tsx`** — Callback ref on right sidebar panel calls `collapse()` on mount to sync the panel library's internal collapsed state with the 0% layout size. `effectiveLayoutInner` handles both fresh installs and persisted layouts
- **`MainToolbar.tsx`** — Replaced uiMode toggle with "Show All" (Layers icon) backed by disclosureStore
- **`SessionToolbarContent.tsx`** / **`ChatInput.tsx`** — Removed `isStreamlined` conditionals; always show full title, action bar, thinking/plan buttons
- **`ChangesPanel.tsx`** — Default tab changed from Files to Changes
- **`StreamlinedSidebar.tsx`** — New sidebar with session filtering, empty states, and "New session" button

## Test Plan
- [ ] App starts → right sidebar collapsed, terminal collapsed
- [ ] Agent makes file changes → right sidebar auto-expands showing Changes tab
- [ ] Manually collapse right sidebar → stays collapsed (no re-expand)
- [ ] Toggle right sidebar via button or ⌘⌥B → works correctly
- [ ] Cmd+J → terminal opens regardless of disclosure state
- [ ] "Show All" toggle → all panels expand; toggle off → panels collapse
- [ ] Session switch → panels reset, auto-expand re-evaluates
- [ ] Fresh install (clear localStorage) → correct collapsed initial state
- [ ] ChatInput shows full model names, thinking/plan buttons always visible
- [ ] Action bar shows commit/push/review/PR buttons