### PR TITLE
fix: Defer agent spawning for new conversations without initial message

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -135,12 +135,20 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 	}
 
 	now := time.Now()
+
+	// Set status based on whether there's an initial message.
+	// Without a message the agent has nothing to do, so start idle.
+	status := models.ConversationStatusIdle
+	if initialMessage != "" {
+		status = models.ConversationStatusActive
+	}
+
 	conv := &models.Conversation{
 		ID:          convID,
 		SessionID:   sessionID,
 		Type:        conversationType,
 		Name:        name,
-		Status:      models.ConversationStatusActive,
+		Status:      status,
 		Messages:    []models.Message{},
 		ToolSummary: []models.ToolAction{},
 		CreatedAt:   now,
@@ -152,6 +160,32 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 
 	if err := m.store.AddConversation(ctx, conv); err != nil {
 		return nil, fmt.Errorf("failed to add conversation: %w", err)
+	}
+
+	// When there's no initial message, add a setupInfo system message so the
+	// frontend can render the session card, then return without spawning an
+	// agent process. SendConversationMessage will auto-start the process when
+	// the user sends their first message.
+	if initialMessage == "" {
+		originBranch := sessionWithWs.WorkspaceBranch
+		if originBranch == "" {
+			originBranch = "main"
+		}
+		setupMsg := models.Message{
+			ID:   uuid.New().String()[:8],
+			Role: "system",
+			SetupInfo: &models.SetupInfo{
+				SessionName:  session.Name,
+				BranchName:   session.Branch,
+				OriginBranch: originBranch,
+			},
+			Timestamp: now,
+		}
+		if err := m.store.AddMessageToConversation(ctx, convID, setupMsg); err != nil {
+			return nil, fmt.Errorf("failed to add setup message to conversation %s: %w", convID, err)
+		}
+		conv.Messages = append(conv.Messages, setupMsg)
+		return conv, nil
 	}
 
 	// Build process options
@@ -691,7 +725,11 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 			restartOpts.ResumeSession = conv.AgentSessionID
 		}
 
-		logger.Manager.Warnf("Unexpected: auto-restarting process for conversation %s (previous exit error: %v). Multi-turn processes should stay alive between turns.", convID, prevExitErr)
+		if ok && proc != nil {
+			logger.Manager.Warnf("Unexpected: auto-restarting process for conversation %s (previous exit error: %v). Multi-turn processes should stay alive between turns.", convID, prevExitErr)
+		} else {
+			logger.Manager.Infof("Starting process for idle conversation %s", convID)
+		}
 
 		// Cancel any pending user questions from the old process so the frontend
 		// doesn't show a stale question UI pointing at the dead process.

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -1045,7 +1045,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
               firstItemIndex={firstItemIndex}
               isLoadingOlder={pagination?.isLoadingMore}
               emptyState={
-                !selectedConversationId ? (
+                (!selectedConversationId || conversationMessages.length === 0) ? (
                   <ConversationEmptyState sessionName={currentSession?.name} />
                 ) : undefined
               }


### PR DESCRIPTION
## Summary
- When a conversation is created without an initial message, start it in idle status and inject a setupInfo system message so the frontend can render the session card without a spinner
- The agent process spawns lazily when the user sends their first message via SendConversationMessage
- Distinguishes first-start vs restart logging and properly propagates setup message write errors

## Test plan
- [ ] Create a new tab/conversation without typing a message — verify no spinner appears
- [ ] Type a first message in the idle conversation — verify the agent starts and responds
- [ ] Verify the empty state renders correctly for conversations with no messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)