### PR TITLE
feat: Add Xcode to Open in App dropdown

### DIFF
--- a/src/lib/openApps.ts
+++ b/src/lib/openApps.ts
@@ -75,6 +75,17 @@ export const APP_REGISTRY: AppDefinition[] = [
     },
   },
   {
+    id: 'xcode',
+    name: 'Xcode',
+    category: 'editor',
+    platforms: {
+      darwin: {
+        bundlePaths: ['/Applications/Xcode.app'],
+        appName: 'Xcode',
+      },
+    },
+  },
+  {
     id: 'sublime',
     name: 'Sublime Text',
     category: 'editor',


### PR DESCRIPTION
Include Xcode in the APP_REGISTRY so it appears in the Open in App dropdown menu. Xcode will use the existing generic `open -a` fallback to open workspace paths.