### PR TITLE
feat: Sidebar new session workspace picker

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -256,6 +256,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
   };
 
   const handleCreateSession = async (workspaceId: string) => {
+    /* eslint-disable react-hooks/purity -- only called from event handlers, not during render */
     // Generate a temporary ID for the optimistic placeholder
     const tempId = `temp-${Date.now()}`;
     const now = new Date().toISOString();
@@ -349,6 +350,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
       removeFromStore(tempId);
       showError('Failed to create session');
     }
+    /* eslint-enable react-hooks/purity */
   };
 
   const handleArchiveSession = (sessionId: string) => {


### PR DESCRIPTION
## Summary
- When multiple workspaces are open, the sidebar **+** button now shows a dropdown picker to choose which workspace to create a new session in, with numbered keyboard shortcuts (1, 2, 3...)
- The right-click context menu's "New Session" item becomes a submenu with the same workspace picker when multiple workspaces exist
- Removes unused "Mark as read/unread" menu items from session dropdown menus
- Simplifies the section header to always display "Sessions"

## Test plan
- [ ] Open the app with a single workspace — verify the + button creates a session directly (no dropdown)
- [ ] Open the app with multiple workspaces — verify the + button shows a workspace picker dropdown
- [ ] Verify numbered keyboard shortcuts (1, 2, etc.) work in the workspace picker
- [ ] Right-click in sidebar — verify "New Session" shows submenu with workspace choices when multiple workspaces exist
- [ ] Verify session item dropdown no longer shows "Mark as read/unread"

🤖 Generated with [Claude Code](https://claude.com/claude-code)