### PR TITLE
Show directory paths in file mention suggestions

### DIFF
--- a/src/components/ui/inline-combobox.tsx
+++ b/src/components/ui/inline-combobox.tsx
@@ -328,7 +328,7 @@ const InlineComboboxContent: typeof ComboboxPopover = ({
     <Portal>
       <ComboboxPopover
         className={cn(
-          'z-500 max-h-[288px] w-[300px] overflow-y-auto rounded-md bg-popover shadow-md',
+          'z-500 max-h-[288px] w-[400px] overflow-y-auto rounded-md bg-popover shadow-md',
           className
         )}
         onKeyDownCapture={handleKeyDown}

--- a/src/components/ui/mention-node.tsx
+++ b/src/components/ui/mention-node.tsx
@@ -131,7 +131,14 @@ export function MentionInputElement(
                 className="gap-2"
               >
                 <FileIcon filename={item.text} />
-                <span className="truncate">{item.text}</span>
+                <span className="truncate">
+                  {item.text}
+                  {(item.data as { directory?: string } | undefined)?.directory ? (
+                    <span className="ml-1.5 text-muted-foreground font-normal">
+                      {(item.data as { directory: string }).directory}
+                    </span>
+                  ) : null}
+                </span>
               </InlineComboboxItem>
             ))}
           </InlineComboboxGroup>


### PR DESCRIPTION
Display directory path alongside filenames in the inline combobox to help users distinguish between files with the same name in different directories. Widened the popover to accommodate the additional information.