### PR TITLE
feat: Add conversation-scoped checkpoint filtering

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -190,9 +190,10 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 
 	// Build process options
 	procOpts := ProcessOptions{
-		ID:             convID,
-		Workdir:        session.WorktreePath,
-		ConversationID: convID,
+		ID:                  convID,
+		Workdir:             session.WorktreePath,
+		ConversationID:      convID,
+		EnableCheckpointing: true,
 	}
 
 	// Always pass the effective target branch to the agent-runner so it doesn't
@@ -702,6 +703,7 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 			// No previous process options (first start via this path) — use minimal config
 			restartOpts.ID = convID
 			restartOpts.ConversationID = convID
+			restartOpts.EnableCheckpointing = true
 		}
 		restartOpts.Workdir = session.WorktreePath
 		// Restore model from conversation record if not already set

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import type { WSEvent, AgentEvent, AgentTodoItem, CheckpointInfo, BudgetStatus, UserQuestion, ReviewComment, TokenUsage, ModelUsageInfo, McpServerStatus } from '@/lib/types';
+import type { WSEvent, AgentEvent, AgentTodoItem, BudgetStatus, UserQuestion, ReviewComment, TokenUsage, ModelUsageInfo, McpServerStatus } from '@/lib/types';
 
 import {
   WEBSOCKET_RECONNECT_BASE_DELAY_MS,
@@ -577,20 +577,27 @@ export function useWebSocket(enabled: boolean = true) {
             uuid: event.checkpointUuid as string,
             timestamp: new Date().toISOString(),
             messageIndex: event.messageIndex ?? 0,
+            isResult: event.isResult as boolean | undefined,
+            conversationId,
           });
         }
         break;
 
-      case 'files_rewound':
+      case 'files_rewound': {
+        const success = event?.success !== false;
+        const errorMsg = event?.error as string | undefined;
         window.dispatchEvent(new CustomEvent('agent-notification', {
           detail: {
-            title: 'Files rewound',
-            message: 'Files restored to checkpoint',
-            type: 'info',
+            title: success ? 'Files rewound' : 'Rewind failed',
+            message: success
+              ? 'Files restored to checkpoint'
+              : `Failed to rewind: ${errorMsg || 'Unknown error'}`,
+            type: success ? 'info' : 'error',
             conversationId,
           }
         }));
         break;
+      }
 
       // ====================================================================
       // Group E: Model Changed
@@ -832,26 +839,6 @@ export function useWebSocket(enabled: boolean = true) {
           if (payload?.mcpServers && Array.isArray(payload.mcpServers)) {
             getStore().setMcpServers(payload.mcpServers);
           }
-          return;
-        }
-
-        // Handle checkpoint events
-        if (data.type === 'checkpoint_created') {
-          const eventData = data as WSEvent & Record<string, unknown>;
-          const checkpoint: CheckpointInfo = {
-            uuid: eventData.checkpointUuid as string,
-            timestamp: new Date().toISOString(),
-            messageIndex: (eventData.messageIndex as number) || 0,
-            isResult: eventData.isResult as boolean | undefined,
-          };
-          getStore().addCheckpoint(checkpoint);
-          return;
-        }
-
-        // Handle files rewound event
-        if (data.type === 'files_rewound') {
-          const eventData = data as WSEvent & Record<string, unknown>;
-          console.log('Files rewound to checkpoint:', eventData.checkpointUuid);
           return;
         }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -475,6 +475,7 @@ export interface CheckpointInfo {
   timestamp: string;
   messageIndex: number;
   isResult?: boolean;
+  conversationId?: string;
 }
 
 // Budget and limits status

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -769,6 +769,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const sessionId = conversation?.sessionId || state.selectedSessionId;
     set({
       selectedConversationId: id,
+      checkpoints: [],
       ...(sessionId && id ? {
         lastActiveConversationPerSession: {
           ...state.lastActiveConversationPerSession,

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -286,7 +286,11 @@ export const useBudgetStatus = () => useAppStore((s) => s.budgetStatus);
  * Checkpoints.
  * Use in: CheckpointTimeline
  */
-export const useCheckpoints = () => useAppStore((s) => s.checkpoints);
+export const useCheckpoints = () => useAppStore((s) => {
+  const convId = s.selectedConversationId;
+  if (!convId) return [];
+  return s.checkpoints.filter(c => !c.conversationId || c.conversationId === convId);
+});
 
 /**
  * MCP servers.


### PR DESCRIPTION
## Summary
- Enable checkpointing in backend for all new conversations
- Associate checkpoints with their conversations for proper filtering
- Clear checkpoints when switching conversations to prevent stale data
- Improve error handling for file rewind operations with success/failure notifications
- Fix: Restore missing `isResult` field in checkpoint creation to fix label display ("After response" vs "Before message")

## Test Plan
- [x] Frontend builds successfully
- [x] Backend builds successfully
- [x] Checkpoints now correctly associated with conversations
- [x] Checkpoint timeline shows accurate labels based on isResult field