### PR TITLE
feat: Add PRNumberBadge component with status-based styling

### DIFF
--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -20,6 +20,7 @@ import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog'
 import { CreatePRDialog } from '@/components/dialogs/CreatePRDialog';
 import { openUrlInBrowser } from '@/lib/tauri';
 import { useArchiveSession } from '@/hooks/useArchiveSession';
+import { PRNumberBadge } from '@/components/shared/PRNumberBadge';
 import {
   ChevronRight,
   ChevronDown,
@@ -237,6 +238,14 @@ export function SessionToolbarContent() {
               onChange={handleTaskStatusChange}
               size="sm"
             />
+            {selectedSession.prStatus && selectedSession.prStatus !== 'none' && selectedSession.prNumber && (
+              <PRNumberBadge
+                prNumber={selectedSession.prNumber}
+                prStatus={selectedSession.prStatus as 'open' | 'merged' | 'closed'}
+                prUrl={selectedSession.prUrl}
+                size="sm"
+              />
+            )}
             <GitBranch className="h-3.5 w-3.5 text-purple-400" />
             <span className="text-sm font-medium">
               {selectedSession.branch || selectedSession.name}

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -106,6 +106,7 @@ import type { Workspace, WorktreeSession, SessionTaskStatus } from '@/lib/types'
 import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog';
 import { useArchiveSession } from '@/hooks/useArchiveSession';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { PRNumberBadge } from '@/components/shared/PRNumberBadge';
 import { CardErrorFallback } from '@/components/shared/ErrorFallbacks';
 
 interface WorkspaceSidebarProps {
@@ -1603,15 +1604,23 @@ function SessionRow({
               {showProjectIndicator && workspaceName && (
                 <span className="shrink-0 text-muted-foreground/70">{workspaceName}</span>
               )}
-              {/* PR icon if applicable */}
-              {hasPR && (
+              {/* PR badge if applicable */}
+              {hasPR && session.prNumber && (
+                <>
+                  {showProjectIndicator && workspaceName && <span className="text-muted-foreground/50">·</span>}
+                  <PRNumberBadge
+                    prNumber={session.prNumber}
+                    prStatus={session.prStatus as 'open' | 'merged' | 'closed'}
+                    prUrl={session.prUrl}
+                    size="sm"
+                  />
+                </>
+              )}
+              {hasPR && !session.prNumber && (
                 <>
                   {showProjectIndicator && workspaceName && <span className="text-muted-foreground/50">·</span>}
                   <GitPullRequest className="h-3 w-3 shrink-0 text-nav-icon-prs" />
                 </>
-              )}
-              {hasPR && session.prNumber && (
-                <span className="shrink-0">PR #{session.prNumber}</span>
               )}
               {prStatusInfo && (
                 <>

--- a/src/components/shared/PRNumberBadge.tsx
+++ b/src/components/shared/PRNumberBadge.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { GitPullRequest } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { openUrlInBrowser } from '@/lib/tauri';
+
+interface PRNumberBadgeProps {
+  prNumber: number;
+  prStatus: 'open' | 'merged' | 'closed';
+  prUrl?: string;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+const STATUS_STYLES = {
+  open: {
+    text: 'text-text-success',
+    bg: 'bg-emerald-500/10 hover:bg-emerald-500/15',
+    border: 'border-emerald-500/20',
+  },
+  merged: {
+    text: 'text-nav-icon-prs',
+    bg: 'bg-purple-500/10 hover:bg-purple-500/15',
+    border: 'border-purple-500/20',
+  },
+  closed: {
+    text: 'text-text-error',
+    bg: 'bg-red-500/10 hover:bg-red-500/15',
+    border: 'border-red-500/20',
+  },
+};
+
+export function PRNumberBadge({
+  prNumber,
+  prStatus,
+  prUrl,
+  size = 'sm',
+  className,
+}: PRNumberBadgeProps) {
+  const styles = STATUS_STYLES[prStatus];
+  const iconSize = size === 'sm' ? 'h-3 w-3' : 'h-3.5 w-3.5';
+  const badgeSize = size === 'sm' ? 'h-5 text-xs' : 'h-6 text-sm';
+
+  const content = (
+    <>
+      <GitPullRequest className={cn(iconSize, styles.text, 'shrink-0')} />
+      <span className={cn('font-medium', styles.text)}>#{prNumber}</span>
+    </>
+  );
+
+  const sharedClasses = cn(
+    'inline-flex items-center gap-1 px-1.5 rounded-full border transition-colors',
+    badgeSize,
+    styles.bg,
+    styles.border,
+    prUrl && 'cursor-pointer',
+    className,
+  );
+
+  if (prUrl) {
+    return (
+      <button
+        className={sharedClasses}
+        onClick={(e) => {
+          e.stopPropagation();
+          openUrlInBrowser(prUrl);
+        }}
+        title={`Open PR #${prNumber}`}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return <span className={sharedClasses}>{content}</span>;
+}

--- a/src/components/shared/SessionInfoParts.tsx
+++ b/src/components/shared/SessionInfoParts.tsx
@@ -119,7 +119,7 @@ export function PrStatusBadge({
 }) {
   const colorMap: Record<string, string> = {
     open: 'text-text-success',
-    merged: 'text-purple-400',
+    merged: 'text-nav-icon-prs',
     closed: 'text-text-error',
     none: 'text-muted-foreground',
   };


### PR DESCRIPTION
Adds a new reusable PRNumberBadge component for displaying PR numbers with status-based color coding. Integrates the badge into the session toolbar and workspace sidebar, replacing plain text PR displays.

**Changes:**
- Create PRNumberBadge component with support for three statuses (open, merged, closed)
- Integrate badge into SessionToolbarContent and WorkspaceSidebar
- Update color tokens for consistency

**Features:**
- Color-coded status styling (green for open, purple for merged, red for closed)
- Clickable links to external PRs
- Responsive size variants (sm, md)