### PR TITLE
fix: Make Info Panel content responsive to overflow

### DIFF
--- a/src/components/shared/SessionInfoParts.tsx
+++ b/src/components/shared/SessionInfoParts.tsx
@@ -76,12 +76,12 @@ export function InfoRow({
       </div>
       <div
         className={cn(
-          'flex items-center text-right truncate min-w-0',
+          'flex items-center text-right min-w-0 overflow-hidden',
           mono && 'font-mono text-xs',
           className,
         )}
       >
-        <span className="truncate">{value}</span>
+        <span className="truncate min-w-0">{value}</span>
         {copyValue && <CopyButton text={copyValue} />}
       </div>
     </div>

--- a/src/components/shared/TargetBranchSelector.tsx
+++ b/src/components/shared/TargetBranchSelector.tsx
@@ -234,7 +234,7 @@ export function TargetBranchSelector({
       <PopoverTrigger asChild>
         <button
           className={cn(
-            'flex items-center gap-2 w-full text-left px-2 py-1 rounded-md',
+            'flex items-center gap-2 w-full text-left px-2 py-1 rounded-md min-w-0 overflow-hidden',
             'hover:bg-muted/50 transition-colors text-sm',
             disabled && 'opacity-50 pointer-events-none',
           )}
@@ -242,7 +242,7 @@ export function TargetBranchSelector({
         >
           <GitBranch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
           <span className="text-muted-foreground text-xs shrink-0">Target</span>
-          <span className="font-mono text-xs truncate">{displayTarget}</span>
+          <span className="font-mono text-xs truncate min-w-0">{displayTarget}</span>
           {isDefault && (
             <span className="text-2xs text-muted-foreground/60 shrink-0">(default)</span>
           )}


### PR DESCRIPTION
## Summary
Add missing overflow constraints to InfoRow value container and TargetBranchSelector panel variant. Long content (branch names, workspace names) now truncates with ellipsis instead of pushing items outside the panel boundary.

## Changes
- **SessionInfoParts.tsx**: Add `overflow-hidden` to value container div and `min-w-0` to inner span for proper flex shrinking
- **TargetBranchSelector.tsx**: Add `min-w-0 overflow-hidden` to button and `min-w-0` to branch name span

## Testing
- Lint: ✓ No errors
- Build: ✓ Passes TypeScript checks
- Manual: Verified truncation with long branch names at minimum sidebar width

Generated with [Claude Code](https://claude.com/claude-code)