### PR TITLE
fix: Prevent sidebar panels from overflowing horizontally

### DIFF
--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -18,7 +18,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&>div]:!block"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
## Summary

- Radix ScrollArea's internal viewport wrapper uses `display: table; min-width: 100%` which expands to fit content's intrinsic width, causing sidebar panels (Checks, Info, Git Status) to overflow horizontally despite previous `min-w-0`/`truncate` fixes
- Override to `display: block` via `[&>div]:!block` on the ScrollArea Viewport so content constrains to the viewport width instead of expanding beyond it
- Single-line fix in `scroll-area.tsx` that resolves the root cause for all panels

## Test plan

- [ ] Open a session with a long branch name — verify Checks panel text truncates with ellipsis and buttons remain visible
- [ ] Check Info panel — branch, worktree path, and target branch should truncate properly
- [ ] Resize the sidebar narrower — no content should push horizontally out of view
- [ ] Verify vertical scrolling still works in all sidebar panels
- [ ] Check Changes and Files panels are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)