### PR TITLE
Fix tab spinner state synchronization

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -423,7 +423,9 @@ export function ConversationArea({ children }: ConversationAreaProps) {
       }
       switch (conv.status) {
         case 'active':
-          return <Loader2 className="w-2.5 h-2.5 animate-spin text-primary" />;
+          // Process alive but not streaming — show idle, not spinner.
+          // The spinner is driven by isStreaming (checked above).
+          return <Circle className="w-2.5 h-2.5 text-muted-foreground/50" />;
         case 'completed':
           return <CheckCircle2 className="w-2.5 h-2.5 text-text-success" />;
         case 'idle':

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -133,6 +133,14 @@ export function useWebSocket(enabled: boolean = true) {
     if (data.type === 'conversation_status') {
       if (typeof data.payload === 'string' && isValidConversationStatus(data.payload)) {
         store.updateConversation(conversationId, { status: data.payload });
+        // Safety net: when backend says idle, clear any stale streaming state.
+        // This catches cases where result/complete events were dropped or missed.
+        if (data.payload === 'idle' && store.streamingState[conversationId]?.isStreaming) {
+          store.clearStreamingText(conversationId);
+          store.clearActiveTools(conversationId);
+          store.clearThinking(conversationId);
+          store.clearSubAgents(conversationId);
+        }
       } else {
         console.warn('Invalid conversation status payload:', data.payload);
       }
@@ -665,6 +673,10 @@ export function useWebSocket(enabled: boolean = true) {
       // Group I: Diagnostic Events
       // ====================================================================
       case 'agent_stop':
+        store.clearStreamingText(conversationId);
+        store.clearActiveTools(conversationId);
+        store.clearThinking(conversationId);
+        store.clearSubAgents(conversationId);
         store.updateConversation(conversationId, { status: 'idle' });
         break;
 


### PR DESCRIPTION
Fix the tab spinner to only show when the agent is actually streaming output, not when the conversation is just active. Add safety-net cleanup of stale streaming state when conversations become idle or agents stop to prevent UI inconsistencies.