### PR TITLE
feat: Add Claude auth status check to onboarding and session view

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -359,7 +359,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"regexp"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -5271,6 +5273,59 @@ func maskAPIKey(key string) string {
 
 	suffix := key[len(key)-4:]
 	return key[:prefixEnd] + "..." + suffix
+}
+
+// GetClaudeAuthStatus checks all possible sources of Claude/Anthropic credentials
+// and returns which ones are available. Sources checked:
+//   - Settings-stored encrypted API key
+//   - ANTHROPIC_API_KEY environment variable
+//   - Claude Code CLI credentials (macOS Keychain or ~/.claude/.credentials.json)
+func (h *Handlers) GetClaudeAuthStatus(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Check 1: Settings-stored API key
+	hasStoredKey := false
+	encrypted, found, err := h.store.GetSetting(ctx, settingKeyAnthropicAPIKey)
+	if err == nil && found && encrypted != "" {
+		if _, decErr := crypto.Decrypt(encrypted); decErr == nil {
+			hasStoredKey = true
+		}
+	}
+
+	// Check 2: ANTHROPIC_API_KEY environment variable
+	hasEnvKey := os.Getenv("ANTHROPIC_API_KEY") != ""
+
+	// Check 3: Claude Code CLI credentials
+	hasCliCredentials := checkClaudeCliCredentials()
+
+	configured := hasStoredKey || hasEnvKey || hasCliCredentials
+
+	writeJSON(w, map[string]interface{}{
+		"configured":       configured,
+		"hasStoredKey":     hasStoredKey,
+		"hasEnvKey":        hasEnvKey,
+		"hasCliCredentials": hasCliCredentials,
+	})
+}
+
+// checkClaudeCliCredentials checks if Claude Code CLI credentials are available.
+// On macOS, checks the Keychain. On other platforms, checks ~/.claude/.credentials.json.
+func checkClaudeCliCredentials() bool {
+	if runtime.GOOS == "darwin" {
+		cmd := exec.Command("security", "find-generic-password", "-s", "Claude Code-credentials")
+		if err := cmd.Run(); err == nil {
+			return true
+		}
+	}
+
+	// Fallback: check for credentials file (Linux/Windows)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	credFile := filepath.Join(home, ".claude", ".credentials.json")
+	info, err := os.Stat(credFile)
+	return err == nil && info.Size() > 0
 }
 
 // settingKeyMcpServers returns the settings key for MCP servers in a workspace

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -196,6 +196,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	r.Put("/api/settings/pr-template", h.SetGlobalPRTemplate)
 	r.Get("/api/settings/anthropic-api-key", h.GetAnthropicApiKey)
 	r.Put("/api/settings/anthropic-api-key", h.SetAnthropicApiKey)
+	r.Get("/api/settings/claude-auth-status", h.GetClaudeAuthStatus)
 
 	// Attachment endpoints
 	r.Get("/api/attachments/{attachmentId}/data", h.GetAttachmentData)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ import { OnboardingScreen } from '@/components/shared/OnboardingScreen';
 import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard';
 import { GuidedTour } from '@/components/onboarding/GuidedTour';
 import { useOnboarding } from '@/hooks/useOnboarding';
+import { refreshClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
 import { initAuth, listenForOAuthCallback, validateStoredToken, OAUTH_TIMEOUT_MS } from '@/lib/auth';
 import { getLinearAuthStatus } from '@/lib/linearAuth';
 import { useLinearAuthStore } from '@/stores/linearAuthStore';
@@ -164,6 +165,7 @@ export default function Home() {
   const [showCreateFromPR, setShowCreateFromPR] = useState(false);
   const [showWorkspaceSettings, setShowWorkspaceSettings] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
+  const [settingsInitialCategory, setSettingsInitialCategory] = useState<string | undefined>(undefined);
 
   // Listen for open-settings events from other components (e.g. auth error display)
   useEffect(() => {
@@ -1156,8 +1158,12 @@ export default function Home() {
 
   // Handle CommandPalette custom events
   useEffect(() => {
-    const handleOpenSettings = () => setShowSettings(true);
-    const handleCloseSettings = () => setShowSettings(false);
+    const handleOpenSettings = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.category) setSettingsInitialCategory(detail.category);
+      setShowSettings(true);
+    };
+    const handleCloseSettings = () => { setShowSettings(false); setSettingsInitialCategory(undefined); refreshClaudeAuthStatus(); };
     const handleSpawnAgent = () => handleNewSession();
     const handleNewConv = () => handleNewConversation();
     const handleAddWorkspace = () => setShowAddWorkspace(true);
@@ -1476,7 +1482,11 @@ export default function Home() {
 
         {/* Onboarding Wizard Overlay */}
         {showWizard && (
-          <OnboardingWizard onComplete={completeWizard} onSkip={skipAll} />
+          <OnboardingWizard
+            onComplete={completeWizard}
+            onSkip={skipAll}
+            onOpenSettings={() => { skipAll(); setSettingsInitialCategory('ai-models'); setShowSettings(true); }}
+          />
         )}
 
         {/* Guided Tour Overlay */}
@@ -1487,7 +1497,7 @@ export default function Home() {
         {/* Settings Overlay - full screen */}
         {showSettings && (
           <div className="absolute inset-0 z-20 bg-content-background">
-            <SettingsPage onBack={() => setShowSettings(false)} />
+            <SettingsPage initialCategory={settingsInitialCategory as 'general' | 'ai-models' | undefined} onBack={() => { setShowSettings(false); setSettingsInitialCategory(undefined); refreshClaudeAuthStatus(); }} />
           </div>
         )}
 

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -28,6 +28,7 @@ import {
   ScrollText,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
 import { ContextMeter } from './ContextMeter';
 import { useToast } from '@/components/ui/toast';
 import { listenForFileDrop, listenForDragEnter, listenForDragLeave, openFileDialog } from '@/lib/tauri';
@@ -85,6 +86,8 @@ interface ChatInputProps {
 }
 
 export function ChatInput({ onMessageSubmit }: ChatInputProps) {
+  const claudeAuthConfigured = useClaudeAuthStatus();
+  const authDisabled = claudeAuthConfigured === false;
   const [message, setMessage] = useState('');
   // Read store defaults once at mount time — these initialize per-conversation
   // state and intentionally don't sync if the user changes settings mid-session.
@@ -974,7 +977,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                 (!message.trim() || isSending) && 'opacity-50'
               )}
               onClick={handleSubmit}
-              disabled={!message.trim() || !selectedSessionId || isSending}
+              disabled={!message.trim() || !selectedSessionId || isSending || authDisabled}
               aria-label={sendWithEnter ? 'Send message (Enter)' : 'Send message (⌘Enter)'}
               title={sendWithEnter ? 'Send (Enter)' : 'Send (⌘Enter)'}
             >

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -49,6 +49,8 @@ import { BlockErrorFallback, InlineErrorFallback } from '@/components/shared/Err
 import { BranchSyncBanner } from '@/components/BranchSyncBanner';
 import { BranchSyncConflictDialog } from '@/components/BranchSyncConflictDialog';
 import { useBranchSync } from '@/hooks/useBranchSync';
+import { useClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
+import { KeyRound, Settings2 } from 'lucide-react';
 
 interface ConversationAreaProps {
   children?: React.ReactNode;
@@ -84,6 +86,8 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const streamingState = useAppStore((s) => s.streamingState);
   const addMessage = useAppStore((s) => s.addMessage);
+
+  const claudeAuthConfigured = useClaudeAuthStatus();
 
   // Use messages selector scoped to the selected conversation
   const conversationMessages = useMessages(selectedConversationId);
@@ -876,6 +880,25 @@ export function ConversationArea({ children }: ConversationAreaProps) {
           onMerge={handleBranchMerge}
           onDismiss={handleBranchDismiss}
         />
+      )}
+
+      {/* Claude auth banner - shows when no API key / credentials configured */}
+      {claudeAuthConfigured === false && (
+        <div className="bg-amber-500/10 border-b border-amber-500/20 px-3 py-2">
+          <div className="flex items-center gap-2">
+            <KeyRound className="h-4 w-4 text-amber-500 shrink-0" />
+            <span className="text-xs text-amber-200/90">
+              No Anthropic API key configured. Agents cannot run without credentials.
+            </span>
+            <button
+              className="ml-auto flex items-center gap-1 text-xs text-amber-300 hover:text-amber-100 transition-colors shrink-0"
+              onClick={() => window.dispatchEvent(new CustomEvent('open-settings', { detail: { category: 'ai-models' } }))}
+            >
+              <Settings2 className="h-3 w-3" />
+              Open Settings
+            </button>
+          </div>
+        </div>
       )}
 
       {/* Branch sync conflict dialog */}

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -1,27 +1,46 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { getClaudeAuthStatus } from '@/lib/api';
 import { WelcomeStep } from './steps/WelcomeStep';
 import { WorkspacesStep } from './steps/WorkspacesStep';
 import { SessionsStep } from './steps/SessionsStep';
 import { ConversationsStep } from './steps/ConversationsStep';
 import { ShortcutsStep } from './steps/ShortcutsStep';
+import { ApiKeyStep } from './steps/ApiKeyStep';
 
 interface OnboardingWizardProps {
   onComplete: () => void;
   onSkip: () => void;
+  onOpenSettings?: () => void;
 }
 
-const STEPS = [WelcomeStep, WorkspacesStep, SessionsStep, ConversationsStep, ShortcutsStep];
-const TOTAL_STEPS = STEPS.length;
+const CONCEPT_STEPS = [WelcomeStep, WorkspacesStep, SessionsStep, ConversationsStep, ShortcutsStep];
 
-export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) {
+export function OnboardingWizard({ onComplete, onSkip, onOpenSettings }: OnboardingWizardProps) {
   const [currentStep, setCurrentStep] = useState(0);
   const keyboardReady = useRef(false);
+  const [needsApiKey, setNeedsApiKey] = useState<boolean | null>(null);
 
-  const isLastStep = currentStep === TOTAL_STEPS - 1;
+  // Check auth status once when component mounts
+  useEffect(() => {
+    getClaudeAuthStatus()
+      .then((result) => setNeedsApiKey(!result.configured))
+      .catch(() => setNeedsApiKey(true));
+  }, []);
+
+  const steps = useMemo(() => {
+    if (needsApiKey) {
+      return [...CONCEPT_STEPS, ApiKeyStep];
+    }
+    return CONCEPT_STEPS;
+  }, [needsApiKey]);
+
+  const totalSteps = steps.length;
+  const isLastStep = currentStep === totalSteps - 1;
+  const isApiKeyStep = needsApiKey && currentStep === totalSteps - 1;
 
   const handleNext = useCallback(() => {
     if (isLastStep) {
@@ -66,7 +85,22 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [handleNext, handlePrev, onSkip]);
 
-  const StepComponent = STEPS[currentStep];
+  const StepComponent = steps[currentStep];
+
+  const getButtonLabel = () => {
+    if (currentStep === 0) return 'Get Started';
+    if (isApiKeyStep) return 'Open Settings';
+    if (isLastStep) return 'Start Using ChatML';
+    return 'Next';
+  };
+
+  const handleButtonClick = () => {
+    if (isApiKeyStep && onOpenSettings) {
+      onOpenSettings();
+    } else {
+      handleNext();
+    }
+  };
 
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-background overflow-hidden">
@@ -78,7 +112,7 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
         onClick={onSkip}
         className="absolute top-14 right-6 text-sm text-muted-foreground/70 hover:text-foreground transition-colors z-40"
       >
-        Skip Onboarding
+        {isApiKeyStep ? 'Skip for now' : 'Skip Onboarding'}
       </button>
 
       {/* Step content — full-size opaque layer prevents GPU cache artifacts from previous step */}
@@ -93,15 +127,15 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
         {/* Action button */}
         <Button
           size="lg"
-          onClick={handleNext}
+          onClick={handleButtonClick}
           className="h-12 px-8 text-lg bg-foreground text-background hover:bg-foreground/90 font-medium rounded-xl transition-colors"
         >
-          {currentStep === 0 ? 'Get Started' : isLastStep ? 'Start Using ChatML' : 'Next'}
+          {getButtonLabel()}
         </Button>
 
         {/* Dot indicators */}
         <div className="flex items-center gap-2">
-          {STEPS.map((_, index) => (
+          {steps.map((_, index) => (
             <button
               key={index}
               onClick={() => setCurrentStep(index)}

--- a/src/components/onboarding/steps/ApiKeyStep.tsx
+++ b/src/components/onboarding/steps/ApiKeyStep.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { KeyRound, ExternalLink } from 'lucide-react';
+import { OnboardingWizardStep } from '../OnboardingWizardStep';
+
+export function ApiKeyStep() {
+  return (
+    <OnboardingWizardStep
+      icon={<KeyRound className="w-8 h-8 text-primary" />}
+      title="Connect your API key"
+    >
+      <p>
+        To run AI agents, ChatML needs an <strong className="text-white">Anthropic API key</strong>. You can create one from the Anthropic Console.
+      </p>
+      <a
+        href="https://console.anthropic.com/settings/keys"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+      >
+        Get an API key
+        <ExternalLink className="w-3.5 h-3.5" />
+      </a>
+    </OnboardingWizardStep>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -26,6 +26,7 @@ import { AboutSettings } from './sections/AboutSettings';
 
 interface SettingsPageProps {
   onBack: () => void;
+  initialCategory?: SettingsCategory;
 }
 
 type SettingsCategory =
@@ -58,8 +59,8 @@ const moreNavItems: NavItem[] = [
   { id: 'about', label: 'About', icon: <Info className="w-3.5 h-3.5" /> },
 ];
 
-export function SettingsPage({ onBack }: SettingsPageProps) {
-  const [selectedCategory, setSelectedCategory] = useState<SettingsCategory>('general');
+export function SettingsPage({ onBack, initialCategory = 'general' }: SettingsPageProps) {
+  const [selectedCategory, setSelectedCategory] = useState<SettingsCategory>(initialCategory);
 
   return (
     <div className="flex h-full bg-content-background">

--- a/src/hooks/useClaudeAuthStatus.ts
+++ b/src/hooks/useClaudeAuthStatus.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import { getClaudeAuthStatus } from '@/lib/api';
+
+let cachedStatus: boolean | null = null;
+const listeners = new Set<(v: boolean) => void>();
+
+function notify(value: boolean) {
+  cachedStatus = value;
+  listeners.forEach((fn) => fn(value));
+}
+
+export function refreshClaudeAuthStatus() {
+  getClaudeAuthStatus()
+    .then((result) => notify(result.configured))
+    .catch(() => notify(false));
+}
+
+export function useClaudeAuthStatus() {
+  const [configured, setConfigured] = useState<boolean | null>(cachedStatus);
+
+  useEffect(() => {
+    listeners.add(setConfigured);
+    // Fetch on first subscriber
+    if (cachedStatus === null) {
+      refreshClaudeAuthStatus();
+    }
+    return () => { listeners.delete(setConfigured); };
+  }, []);
+
+  return configured;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1434,6 +1434,16 @@ export async function getAnthropicApiKey(): Promise<{ configured: boolean; maske
   return handleResponse<{ configured: boolean; maskedKey: string }>(res);
 }
 
+export async function getClaudeAuthStatus(): Promise<{
+  configured: boolean;
+  hasStoredKey: boolean;
+  hasEnvKey: boolean;
+  hasCliCredentials: boolean;
+}> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/claude-auth-status`);
+  return handleResponse(res);
+}
+
 export async function setAnthropicApiKey(apiKey: string): Promise<{ configured: boolean; maskedKey: string }> {
   const res = await fetchWithAuth(
     `${getApiBase()}/api/settings/anthropic-api-key`,


### PR DESCRIPTION
## Summary
- Add backend endpoint (`GET /api/settings/claude-auth-status`) that checks all credential sources: stored API key in Settings, `ANTHROPIC_API_KEY` env var, and Claude Code CLI keychain on macOS (with `~/.claude/.credentials.json` fallback on Linux)
- Add conditional API key setup step to the onboarding wizard when no credentials are detected
- Show an amber warning banner in the conversation area and disable the chat send button when no credentials are configured
- Add `initialCategory` prop to SettingsPage so it can open directly to "AI & Models" tab

## Implementation Details
- **`backend/server/handlers.go`** — New `GetClaudeAuthStatus` handler checks three credential sources and returns `{ configured, hasStoredKey, hasEnvKey, hasCliCredentials }`
- **`src/components/onboarding/OnboardingWizard.tsx`** — Calls `getClaudeAuthStatus()` on mount; conditionally appends `ApiKeyStep` after the concept slides when no credentials found. "Open Settings" button on the API key step dismisses the wizard and opens Settings to AI & Models
- **`src/hooks/useClaudeAuthStatus.ts`** — Shared hook with module-level cache so ConversationArea and ChatInput share a single fetch. Exposes `refreshClaudeAuthStatus()` to re-check after settings closes
- **`src/components/conversation/ConversationArea.tsx`** — Amber banner with "Open Settings" link when auth is not configured
- **`src/components/conversation/ChatInput.tsx`** — Send button disabled when auth is not configured
- **`src/components/settings/SettingsPage.tsx`** — New `initialCategory` prop to open directly to a specific tab

## Test Plan
- [ ] Fresh user (no credentials anywhere): wizard shows API key step after shortcuts, "Open Settings" opens to AI & Models tab, wizard is dismissed
- [ ] User with Claude Code CLI: wizard skips API key step entirely
- [ ] User with `ANTHROPIC_API_KEY` env var: wizard skips API key step
- [ ] Session without credentials: amber banner visible, send button disabled
- [ ] After saving API key in settings: banner disappears, send button enabled
- [ ] "Replay Welcome Tour" in settings still works correctly

## Notes
- The keychain check uses `security find-generic-password -s "Claude Code-credentials"` on macOS
- On Linux/Windows, falls back to checking `~/.claude/.credentials.json`