### PR TITLE
Use ai.ReadClaudeCodeOAuthToken for auth status endpoint

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
-	"regexp"
 	"path/filepath"
-	"runtime"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -5295,8 +5293,9 @@ func (h *Handlers) GetClaudeAuthStatus(w http.ResponseWriter, r *http.Request) {
 	// Check 2: ANTHROPIC_API_KEY environment variable
 	hasEnvKey := os.Getenv("ANTHROPIC_API_KEY") != ""
 
-	// Check 3: Claude Code CLI credentials
-	hasCliCredentials := checkClaudeCliCredentials()
+	// Check 3: Claude Code CLI credentials (validates token contents + expiration)
+	_, cliErr := ai.ReadClaudeCodeOAuthToken()
+	hasCliCredentials := cliErr == nil
 
 	configured := hasStoredKey || hasEnvKey || hasCliCredentials
 
@@ -5308,25 +5307,6 @@ func (h *Handlers) GetClaudeAuthStatus(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// checkClaudeCliCredentials checks if Claude Code CLI credentials are available.
-// On macOS, checks the Keychain. On other platforms, checks ~/.claude/.credentials.json.
-func checkClaudeCliCredentials() bool {
-	if runtime.GOOS == "darwin" {
-		cmd := exec.Command("security", "find-generic-password", "-s", "Claude Code-credentials")
-		if err := cmd.Run(); err == nil {
-			return true
-		}
-	}
-
-	// Fallback: check for credentials file (Linux/Windows)
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return false
-	}
-	credFile := filepath.Join(home, ".claude", ".credentials.json")
-	info, err := os.Stat(credFile)
-	return err == nil && info.Size() > 0
-}
 
 // settingKeyMcpServers returns the settings key for MCP servers in a workspace
 func settingKeyMcpServers(workspaceID string) string {


### PR DESCRIPTION
## Summary

- Replace the shallow `checkClaudeCliCredentials()` function in `GetClaudeAuthStatus` handler with `ai.ReadClaudeCodeOAuthToken()` from the `ai` package (introduced in #402)
- The old check only verified the keychain entry **existed** — the new call validates token contents and expiration
- Removes 20 lines of duplicated keychain/credentials logic and the now-unused `os/exec` and `runtime` imports

## Implementation Details

The `checkClaudeCliCredentials()` function used `security find-generic-password` without the `-g` flag, meaning it only checked if an entry existed in the keychain but never read or validated the token. This could report `hasCliCredentials: true` even with an expired or malformed token.

`ai.ReadClaudeCodeOAuthToken()` (from #402) properly:
- Reads the password from keychain (`-g` flag)
- Parses the JSON credential structure
- Validates `accessToken` is non-empty
- Checks token expiration via `expiresAt`
- Uses Go build tags for platform separation (`keychain_darwin.go` / `keychain_other.go`)

## Test Plan

- [x] `cd backend && go build ./...` compiles
- [x] `cd backend && go test ./server/...` passes
- [ ] Manual: fresh user without credentials → `configured: false`
- [ ] Manual: user with Claude Code CLI OAuth → `configured: true` with valid token, `false` with expired token