### PR TITLE
Display relative file paths in conversation UI

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -533,14 +533,14 @@ export function ConversationArea({ children }: ConversationAreaProps) {
           section="StreamingMessage"
           fallback={<InlineErrorFallback message="Error displaying streaming message" />}
         >
-          <StreamingMessage conversationId={selectedConversationId} />
+          <StreamingMessage conversationId={selectedConversationId} worktreePath={currentSession?.worktreePath} />
         </ErrorBoundary>
         {queuedMessage && (
           <QueuedMessageBubble message={queuedMessage} />
         )}
       </div>
     );
-  }, [selectedConversationId, queuedMessage]);
+  }, [selectedConversationId, queuedMessage, currentSession?.worktreePath]);
 
   // Reset scroll on conversation change
   useEffect(() => {
@@ -1081,6 +1081,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
             <VirtualizedMessageList
               ref={messageListRef}
               messages={conversationMessages}
+              worktreePath={currentSession?.worktreePath}
               searchQuery={searchQuery}
               currentMatchIndex={clampedMatchIndex}
               searchMatches={searchMatches}

--- a/src/components/conversation/FileChangesBlock.tsx
+++ b/src/components/conversation/FileChangesBlock.tsx
@@ -8,12 +8,14 @@ import {
 } from '@/components/ui/collapsible';
 import { ChevronRight, ChevronDown, FileCode } from 'lucide-react';
 import type { FileChange } from '@/lib/types';
+import { toRelativePath } from '@/lib/utils';
 
 interface FileChangesBlockProps {
   changes: FileChange[];
+  worktreePath?: string;
 }
 
-export const FileChangesBlock = memo(function FileChangesBlock({ changes }: FileChangesBlockProps) {
+export const FileChangesBlock = memo(function FileChangesBlock({ changes, worktreePath }: FileChangesBlockProps) {
   const [isOpen, setIsOpen] = useState(false);
   const totalAdditions = changes.reduce((sum, c) => sum + c.additions, 0);
   const totalDeletions = changes.reduce((sum, c) => sum + c.deletions, 0);
@@ -39,7 +41,7 @@ export const FileChangesBlock = memo(function FileChangesBlock({ changes }: File
               className="flex items-center gap-2 px-3 py-1.5 text-xs font-mono hover:bg-surface-2 cursor-pointer"
             >
               <FileCode className="w-3 h-3 text-muted-foreground shrink-0" />
-              <span className="flex-1 truncate">{change.path}</span>
+              <span className="flex-1 truncate">{toRelativePath(change.path, worktreePath)}</span>
               <span className="text-text-success">+{change.additions}</span>
               <span className="text-text-error">-{change.deletions}</span>
             </div>

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -29,6 +29,7 @@ import { useSettingsStore } from '@/stores/settingsStore';
 export interface MessageBlockProps {
   message: Message;
   isFirst: boolean;
+  worktreePath?: string;
   searchQuery?: string;
   currentMatchIndex?: number;
   matchOffset?: number;
@@ -38,6 +39,7 @@ export interface MessageBlockProps {
 export const MessageBlock = memo(function MessageBlock({
   message,
   isFirst,
+  worktreePath,
   searchQuery = '',
   currentMatchIndex = 0,
   matchOffset = 0,
@@ -128,7 +130,7 @@ export const MessageBlock = memo(function MessageBlock({
             section="ToolUsage"
             fallback={<InlineErrorFallback message="Unable to display tool usage" />}
           >
-            <ToolUsageHistory tools={message.toolUsage} />
+            <ToolUsageHistory tools={message.toolUsage} worktreePath={worktreePath} />
           </ErrorBoundary>
         )}
 
@@ -186,7 +188,7 @@ export const MessageBlock = memo(function MessageBlock({
 
         {/* File Changes */}
         {message.fileChanges && message.fileChanges.length > 0 && (
-          <FileChangesBlock changes={message.fileChanges} />
+          <FileChangesBlock changes={message.fileChanges} worktreePath={worktreePath} />
         )}
 
         {/* Run Summary */}
@@ -207,6 +209,7 @@ export const MessageBlock = memo(function MessageBlock({
     prev.role !== next.role ||
     prev.thinkingContent !== next.thinkingContent ||
     prevProps.isFirst !== nextProps.isFirst ||
+    prevProps.worktreePath !== nextProps.worktreePath ||
     prevProps.searchQuery !== nextProps.searchQuery) {
     return false;
   }

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -17,6 +17,7 @@ type TimelineItem =
 
 interface StreamingMessageProps {
   conversationId: string;
+  worktreePath?: string;
 }
 
 // Enhanced error display component
@@ -93,7 +94,7 @@ function ErrorDisplay({ error, onDismiss }: { error: string; onDismiss: () => vo
   );
 }
 
-export function StreamingMessage({ conversationId }: StreamingMessageProps) {
+export function StreamingMessage({ conversationId, worktreePath }: StreamingMessageProps) {
   // Use scoped selectors for this conversation only - prevents re-renders from other conversations
   const streaming = useStreamingState(conversationId);
   const tools = useActiveTools(conversationId);
@@ -284,6 +285,7 @@ export function StreamingMessage({ conversationId }: StreamingMessageProps) {
                   id={item.id}
                   tool={item.tool}
                   params={item.params}
+                  worktreePath={worktreePath}
                   isActive={!item.endTime}
                   success={item.success}
                   summary={item.summary}
@@ -299,7 +301,7 @@ export function StreamingMessage({ conversationId }: StreamingMessageProps) {
 
           {/* Sub-agent group display */}
           {subAgents.length > 0 && (
-            <SubAgentGroup subAgents={subAgents} />
+            <SubAgentGroup subAgents={subAgents} worktreePath={worktreePath} />
           )}
 
           {/* Enhanced error display */}

--- a/src/components/conversation/SubAgentGroup.tsx
+++ b/src/components/conversation/SubAgentGroup.tsx
@@ -55,9 +55,10 @@ function AgentElapsedTime({ startTime }: { startTime: number }) {
 
 interface SubAgentRowProps {
   agent: SubAgent;
+  worktreePath?: string;
 }
 
-const SubAgentRow = memo(function SubAgentRow({ agent }: SubAgentRowProps) {
+const SubAgentRow = memo(function SubAgentRow({ agent, worktreePath }: SubAgentRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const hasTools = agent.tools.length > 0;
 
@@ -130,6 +131,7 @@ const SubAgentRow = memo(function SubAgentRow({ agent }: SubAgentRowProps) {
                 id={tool.id}
                 tool={tool.tool}
                 params={tool.params}
+                worktreePath={worktreePath}
                 isActive={!tool.endTime}
                 success={tool.success}
                 summary={tool.summary}
@@ -148,15 +150,16 @@ const SubAgentRow = memo(function SubAgentRow({ agent }: SubAgentRowProps) {
 
 interface SubAgentGroupProps {
   subAgents: readonly SubAgent[];
+  worktreePath?: string;
 }
 
-export const SubAgentGroup = memo(function SubAgentGroup({ subAgents }: SubAgentGroupProps) {
+export const SubAgentGroup = memo(function SubAgentGroup({ subAgents, worktreePath }: SubAgentGroupProps) {
   if (subAgents.length === 0) return null;
 
   return (
     <div className="space-y-0.5">
       {subAgents.map((agent) => (
-        <SubAgentRow key={agent.agentId} agent={agent} />
+        <SubAgentRow key={agent.agentId} agent={agent} worktreePath={worktreePath} />
       ))}
     </div>
   );

--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -23,7 +23,7 @@ import {
   Circle,
   type LucideIcon,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn, toRelativePath } from '@/lib/utils';
 import { useAppStore } from '@/stores/appStore';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 
@@ -31,6 +31,7 @@ interface ToolUsageBlockProps {
   id: string;
   tool: string;
   params?: Record<string, unknown>;
+  worktreePath?: string;
   isActive?: boolean;
   success?: boolean;
   summary?: string;
@@ -76,6 +77,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   id,
   tool,
   params,
+  worktreePath,
   isActive = false,
   success,
   summary,
@@ -162,20 +164,27 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   const getTarget = () => {
     if (!params) return null;
 
-    // Common param names for file paths/commands
-    const path =
-      params.path ||
+    // Check file-path params first (these get worktree-relative conversion)
+    const filePath =
       params.file_path ||
+      params.path ||
       params.filepath ||
       params.filename ||
-      params.file ||
+      params.file;
+
+    if (typeof filePath === 'string') {
+      return toRelativePath(filePath, worktreePath);
+    }
+
+    // Non-file params (commands, URLs, patterns, queries) — no path conversion
+    const other =
       params.command ||
       params.url ||
       params.pattern ||
       params.query;
 
-    if (typeof path === 'string') {
-      return path;
+    if (typeof other === 'string') {
+      return other;
     }
 
     return null;

--- a/src/components/conversation/ToolUsageHistory.tsx
+++ b/src/components/conversation/ToolUsageHistory.tsx
@@ -24,7 +24,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
+import { cn, toRelativePath } from '@/lib/utils';
 import type { ToolUsage } from '@/lib/types';
 
 // Truncation limits (increased from original)
@@ -33,6 +33,7 @@ const PATH_TRUNCATE_LENGTH = 50;
 
 interface ToolUsageHistoryProps {
   tools: ToolUsage[];
+  worktreePath?: string;
 }
 
 const toolIcons: Record<string, React.ElementType> = {
@@ -57,7 +58,7 @@ interface ToolTargetInfo {
   isTruncated: boolean;
 }
 
-function formatToolTarget(tool: string, params?: Record<string, unknown>): ToolTargetInfo {
+function formatToolTarget(tool: string, params?: Record<string, unknown>, worktreePath?: string): ToolTargetInfo {
   const empty = { display: '', full: '', isTruncated: false };
   if (!params) return empty;
 
@@ -68,7 +69,8 @@ function formatToolTarget(tool: string, params?: Record<string, unknown>): ToolT
     case 'Read':
     case 'Write':
     case 'Edit': {
-      const filePath = params.file_path ? String(params.file_path) : '';
+      const rawPath = params.file_path ? String(params.file_path) : '';
+      const filePath = toRelativePath(rawPath, worktreePath);
       full = filePath;
       // Show more of the path now - last 2 directories + filename
       const parts = filePath.split('/').filter(Boolean);
@@ -135,7 +137,7 @@ function formatToolTarget(tool: string, params?: Record<string, unknown>): ToolT
   };
 }
 
-export const ToolUsageHistory = memo(function ToolUsageHistory({ tools }: ToolUsageHistoryProps) {
+export const ToolUsageHistory = memo(function ToolUsageHistory({ tools, worktreePath }: ToolUsageHistoryProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   if (tools.length === 0) return null;
@@ -164,7 +166,7 @@ export const ToolUsageHistory = memo(function ToolUsageHistory({ tools }: ToolUs
         <div className="mt-1.5 space-y-0.5">
           {tools.map((tool) => {
             const Icon = getToolIcon(tool.tool);
-            const targetInfo = formatToolTarget(tool.tool, tool.params);
+            const targetInfo = formatToolTarget(tool.tool, tool.params, worktreePath);
 
             return (
               <div

--- a/src/components/conversation/VirtualizedMessageList.tsx
+++ b/src/components/conversation/VirtualizedMessageList.tsx
@@ -17,6 +17,7 @@ export interface VirtualizedMessageListHandle {
 
 interface VirtualizedMessageListProps {
   messages: readonly Message[];
+  worktreePath?: string;
   searchQuery: string;
   currentMatchIndex: number;
   searchMatches: { total: number; messageOffsets: number[] };
@@ -33,6 +34,7 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
   function VirtualizedMessageList(
     {
       messages,
+      worktreePath,
       searchQuery,
       currentMatchIndex,
       searchMatches,
@@ -75,6 +77,7 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
             <MessageBlock
               message={message}
               isFirst={index === 0}
+              worktreePath={worktreePath}
               searchQuery={searchQuery}
               currentMatchIndex={currentMatchIndex}
               matchOffset={searchMatches.messageOffsets[index] ?? 0}
@@ -83,7 +86,7 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
           </ErrorBoundary>
         </div>
       ),
-      [searchQuery, currentMatchIndex, searchMatches.messageOffsets, messageHasMatches]
+      [worktreePath, searchQuery, currentMatchIndex, searchMatches.messageOffsets, messageHasMatches]
     );
 
     // Determine follow output behavior: auto-scroll when at bottom

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,25 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Convert an absolute file path to a path relative to the worktree root.
+ * Returns the original path if it's not under the worktree or if worktreePath is not provided.
+ */
+export function toRelativePath(absolutePath: string, worktreePath: string | undefined | null): string {
+  if (!worktreePath || !absolutePath) return absolutePath;
+
+  // Normalize: ensure worktreePath ends with / for prefix matching
+  const prefix = worktreePath.endsWith('/') ? worktreePath : worktreePath + '/';
+
+  if (absolutePath.startsWith(prefix)) {
+    return absolutePath.slice(prefix.length);
+  }
+
+  // Exact match (path IS the worktree root)
+  if (absolutePath === worktreePath) {
+    return '.';
+  }
+
+  return absolutePath;
+}


### PR DESCRIPTION
## Summary

Add toRelativePath() utility to convert absolute file paths to worktree-relative paths. Thread worktreePath prop through conversation components to display cleaner, more readable file paths in tool usage blocks, history, and file changes.

## Changes

- New utility: `toRelativePath()` in src/lib/utils.ts
- Props threaded through 9 components in conversation UI
- Path conversion applied to file path parameters only

## Impact

Users now see `src/lib/utils.ts` instead of `/Users/mcastilho/conductor/workspaces/chatml/new-york-v3/src/lib/utils.ts` in all conversation displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)