### PR TITLE
feat: Add workspace-aware GitHub username branch prefixes

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1128,9 +1128,16 @@ func (m *Manager) tryAutoNameSession(ctx context.Context, sessionID, suggestedNa
 		return
 	}
 
-	// Rename the git branch
+	// Rename the git branch, preserving the prefix from the original branch name.
+	// e.g. "mcastilho/tokyo" -> prefix "mcastilho", "session/tokyo" -> prefix "session"
 	oldBranchName := sess.Branch
-	newBranchName := fmt.Sprintf("session/%s", formattedName)
+	var newBranchName string
+	if idx := strings.LastIndex(oldBranchName, "/"); idx != -1 {
+		prefix := oldBranchName[:idx]
+		newBranchName = fmt.Sprintf("%s/%s", prefix, formattedName)
+	} else {
+		newBranchName = formattedName
+	}
 
 	if err := m.worktreeManager.RenameBranch(ctx, sess.WorktreePath, oldBranchName, newBranchName); err != nil {
 		logger.Manager.Errorf("Failed to rename branch for session %s: %v", sessionID, err)

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -1503,8 +1503,9 @@ type CreateSessionRequest struct {
 }
 
 // resolveRepoBranchPrefix returns the branch prefix based on repo-level settings.
+// For the "github" case, it resolves to the authenticated GitHub user's login.
 // Returns "session" as the default fallback.
-func resolveRepoBranchPrefix(repo *models.Repo) string {
+func (h *Handlers) resolveRepoBranchPrefix(repo *models.Repo) string {
 	switch repo.BranchPrefix {
 	case "custom":
 		if repo.CustomPrefix != "" {
@@ -1512,8 +1513,12 @@ func resolveRepoBranchPrefix(repo *models.Repo) string {
 		}
 	case "none":
 		return ""
+	case "github":
+		if user := h.ghClient.GetStoredUser(); user != nil && user.Login != "" {
+			return user.Login
+		}
 	}
-	// "github", "", or anything else → "session" (backend default)
+	// "", or anything else → "session" (backend default)
 	return "session"
 }
 
@@ -1602,7 +1607,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 	// Resolve branch prefix once (used for auto-generated names)
 	branchPrefix := req.BranchPrefix
 	if branchPrefix == "" && req.Branch == "" {
-		branchPrefix = resolveRepoBranchPrefix(repo)
+		branchPrefix = h.resolveRepoBranchPrefix(repo)
 	}
 
 	// Generate or use provided session name with atomic directory + worktree creation

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -4786,31 +4786,45 @@ func TestGetRepoRemotes_NotFound(t *testing.T) {
 // ============================================================================
 
 func TestResolveRepoBranchPrefix_EmptyDefault(t *testing.T) {
+	h := &Handlers{ghClient: github.NewClient("", "")}
 	repo := &models.Repo{BranchPrefix: ""}
-	assert.Equal(t, "session", resolveRepoBranchPrefix(repo))
+	assert.Equal(t, "session", h.resolveRepoBranchPrefix(repo))
 }
 
 func TestResolveRepoBranchPrefix_None(t *testing.T) {
+	h := &Handlers{ghClient: github.NewClient("", "")}
 	repo := &models.Repo{BranchPrefix: "none"}
-	assert.Equal(t, "", resolveRepoBranchPrefix(repo))
+	assert.Equal(t, "", h.resolveRepoBranchPrefix(repo))
 }
 
 func TestResolveRepoBranchPrefix_CustomWithValue(t *testing.T) {
+	h := &Handlers{ghClient: github.NewClient("", "")}
 	repo := &models.Repo{BranchPrefix: "custom", CustomPrefix: "my-prefix"}
-	assert.Equal(t, "my-prefix", resolveRepoBranchPrefix(repo))
+	assert.Equal(t, "my-prefix", h.resolveRepoBranchPrefix(repo))
 }
 
 func TestResolveRepoBranchPrefix_CustomWithEmptyPrefix(t *testing.T) {
+	h := &Handlers{ghClient: github.NewClient("", "")}
 	repo := &models.Repo{BranchPrefix: "custom", CustomPrefix: ""}
-	assert.Equal(t, "session", resolveRepoBranchPrefix(repo))
+	assert.Equal(t, "session", h.resolveRepoBranchPrefix(repo))
 }
 
-func TestResolveRepoBranchPrefix_GitHub(t *testing.T) {
+func TestResolveRepoBranchPrefix_GitHubNoUser(t *testing.T) {
+	h := &Handlers{ghClient: github.NewClient("", "")}
 	repo := &models.Repo{BranchPrefix: "github"}
-	assert.Equal(t, "session", resolveRepoBranchPrefix(repo))
+	assert.Equal(t, "session", h.resolveRepoBranchPrefix(repo))
+}
+
+func TestResolveRepoBranchPrefix_GitHubWithUser(t *testing.T) {
+	ghClient := github.NewClient("", "")
+	ghClient.SetUser(&github.User{Login: "mcastilho"})
+	h := &Handlers{ghClient: ghClient}
+	repo := &models.Repo{BranchPrefix: "github"}
+	assert.Equal(t, "mcastilho", h.resolveRepoBranchPrefix(repo))
 }
 
 func TestResolveRepoBranchPrefix_Unknown(t *testing.T) {
+	h := &Handlers{ghClient: github.NewClient("", "")}
 	repo := &models.Repo{BranchPrefix: "something-unknown"}
-	assert.Equal(t, "session", resolveRepoBranchPrefix(repo))
+	assert.Equal(t, "session", h.resolveRepoBranchPrefix(repo))
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -822,7 +822,9 @@ export default function Home() {
       useAppStore.getState().addWorkspace(workspace);
 
       // Auto-create first session for the new workspace (backend generates city-based name)
-      const prefix = getBranchPrefix();
+      const prefix = workspace.branchPrefix
+        ? getWorkspaceBranchPrefix(workspace)
+        : getBranchPrefix();
       const session = await createSession(workspace.id, {
         ...(prefix !== undefined && { branchPrefix: prefix }),
       });

--- a/src/components/dialogs/AddWorkspaceModal.tsx
+++ b/src/components/dialogs/AddWorkspaceModal.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useShallow } from 'zustand/react/shallow';
-import { useSettingsStore, getBranchPrefix } from '@/stores/settingsStore';
+import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix } from '@/stores/settingsStore';
 import { navigate } from '@/lib/navigation';
 import { addRepo, createSession as createSessionApi, listConversations as listConversationsApi, mapSessionDTO } from '@/lib/api';
 import type { SetupInfo } from '@/lib/types';
@@ -68,7 +68,9 @@ export function AddWorkspaceModal({ isOpen, onClose }: AddWorkspaceModalProps) {
       addWorkspace(workspace);
 
       // Auto-create first session for the new workspace (backend generates city-based name)
-      const branchPrefix = getBranchPrefix();
+      const branchPrefix = workspace.branchPrefix
+        ? getWorkspaceBranchPrefix(workspace)
+        : getBranchPrefix();
       const session = await createSessionApi(workspace.id, {
         ...(branchPrefix !== undefined && { branchPrefix }),
       });

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -19,7 +19,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { useAppStore } from '@/stores/appStore';
 import { navigate, navigateOrOpenTab } from '@/lib/navigation';
-import { useSettingsStore, getBranchPrefix, type ContentView, type SidebarSortBy } from '@/stores/settingsStore';
+import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix, type ContentView, type SidebarSortBy } from '@/stores/settingsStore';
 import { useSidebarSessions, isSidebarGroupExpanded, type SidebarGroup } from '@/hooks/useSidebarSessions';
 import { createSession as createSessionApi, listConversations as listConversationsApi, updateSession as updateSessionApi, deleteRepo as deleteRepoApi, addRepo as addRepoApi, mapSessionDTO } from '@/lib/api';
 import { registerSession, getSessionDirName } from '@/lib/tauri';
@@ -285,7 +285,10 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
 
     try {
       // Create session via backend API (generates city-based name, branch, and worktree path)
-      const branchPrefix = getBranchPrefix();
+      const workspace = workspaces.find(w => w.id === workspaceId);
+      const branchPrefix = workspace?.branchPrefix
+        ? getWorkspaceBranchPrefix(workspace)
+        : getBranchPrefix();
       const session = await createSessionApi(workspaceId, {
         ...(branchPrefix !== undefined && { branchPrefix }),
       });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { Workspace } from '@/lib/types';
+import { useAuthStore } from '@/stores/authStore';
 
 // Bottom panel tab IDs that can be toggled (Tasks is always visible)
 export type BottomPanelTab = 'plans' | 'history' | 'budget' | 'mcp' | 'file-history' | 'scripts';
@@ -427,10 +428,10 @@ export function getBranchPrefix(): string | undefined {
     case 'none':
       return '';
     case 'github':
-    default:
-      // 'github' uses the default backend behavior (session/ prefix)
-      // TODO: Pass GitHub username when available
-      return undefined;
+    default: {
+      const login = useAuthStore.getState().user?.login;
+      return login || undefined;
+    }
   }
 }
 
@@ -449,7 +450,9 @@ export function getWorkspaceBranchPrefix(workspace: Workspace): string | undefin
     case 'none':
       return '';
     case 'github':
-    default:
-      return undefined;
+    default: {
+      const login = useAuthStore.getState().user?.login;
+      return login || undefined;
+    }
   }
 }


### PR DESCRIPTION
Implement GitHub username resolution for branch prefixes across the stack.

**Backend Changes:**
- Preserve original branch prefixes when auto-renaming sessions (e.g., mcastilho/ prefix is retained)
- Resolve "github" prefix type to authenticated GitHub user's login

**Frontend Changes:**
- Support workspace-level branch prefix settings
- Resolve GitHub login in settings store functions when prefix type is "github"

Users can now use their GitHub username as a branch prefix and have it preserved during session renames.