### PR TITLE
fix: Keep agent status visible above gradient overlay

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -528,7 +528,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   const messageListFooter = useMemo(() => {
     if (!selectedConversationId) return undefined;
     return (
-      <div className="pl-5 pr-12 pb-10">
+      <div className="pl-5 pr-12 pb-16">
         <ErrorBoundary
           section="StreamingMessage"
           fallback={<InlineErrorFallback message="Error displaying streaming message" />}


### PR DESCRIPTION
## Summary
Increased the message list footer's bottom padding from `pb-10` (40px) to `pb-16` (64px) so the "Agent is working" status indicator remains fully visible above the gradient overlay that separates the conversation area from the composer.

The gradient overlay is 48px tall, so 40px of padding wasn't enough to clear it. With 64px, there's 16px of comfortable breathing room.

## Verification
- TypeScript compiles successfully
- No scroll behavior changed (Virtuoso's `alignToBottom` continues working as expected)
- Footer content is now fully visible when scrolled to bottom