### PR TITLE
fix: Make context meter reliable by filtering sub-agents and using result usage

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1325,16 +1325,20 @@ function handleMessage(message: SDKMessage): void {
         }
       }
 
-      // Extract per-message usage for context meter
-      const msgUsage = (message.message as { usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } }).usage;
-      if (msgUsage) {
-        emit({
-          type: "context_usage",
-          inputTokens: msgUsage.input_tokens ?? 0,
-          outputTokens: msgUsage.output_tokens ?? 0,
-          cacheReadInputTokens: msgUsage.cache_read_input_tokens ?? 0,
-          cacheCreationInputTokens: msgUsage.cache_creation_input_tokens ?? 0,
-        });
+      // Extract per-message usage for context meter — skip sub-agent messages
+      // to avoid overwriting the parent conversation's context usage.
+      if (!isSubAgentMessage) {
+        const msgUsage = (message.message as { usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } }).usage;
+        debug(`[context_usage] assistant message usage: ${JSON.stringify(msgUsage)}, isSubAgent=${isSubAgentMessage}, sessionId=${msgSessionId}`);
+        if (msgUsage) {
+          emit({
+            type: "context_usage",
+            inputTokens: msgUsage.input_tokens ?? 0,
+            outputTokens: msgUsage.output_tokens ?? 0,
+            cacheReadInputTokens: msgUsage.cache_read_input_tokens ?? 0,
+            cacheCreationInputTokens: msgUsage.cache_creation_input_tokens ?? 0,
+          });
+        }
       }
       break;
     }
@@ -1519,6 +1523,22 @@ function handleMessage(message: SDKMessage): void {
             message: "Authentication failed. Your OAuth token may have expired or your API key is invalid. Check your API key in Settings > Claude Code.",
           });
         }
+      }
+
+      // Emit reliable context_usage from the result's cumulative usage.
+      // The SDK's per-assistant-message usage may not be populated correctly
+      // during streaming, but the result's usage is always reliable.
+      const resultUsage = resultMsg.usage as { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } | undefined;
+      debug(`[context_usage] result usage: ${JSON.stringify(resultUsage)}`);
+      debug(`[context_usage] result modelUsage: ${JSON.stringify(resultMsg.modelUsage)}`);
+      if (resultUsage?.input_tokens) {
+        emit({
+          type: "context_usage",
+          inputTokens: resultUsage.input_tokens,
+          outputTokens: resultUsage.output_tokens ?? 0,
+          cacheReadInputTokens: resultUsage.cache_read_input_tokens ?? 0,
+          cacheCreationInputTokens: resultUsage.cache_creation_input_tokens ?? 0,
+        });
       }
 
       // Extract context window size from modelUsage for context meter

--- a/docs/agent-sdk.md
+++ b/docs/agent-sdk.md
@@ -1,0 +1,437 @@
+# Claude Agent SDK Integration
+
+## What the Agent Runner Is
+
+The agent runner is a Node.js TypeScript process located at `agent-runner/src/index.ts` (~1,754 lines). It serves as the bridge between the Go backend and the Anthropic Claude API, wrapping the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) to provide a multi-turn, streaming conversation experience.
+
+The Go backend spawns one agent-runner process per active conversation. Communication happens via **JSON lines over stdin/stdout** — the backend writes user messages and control commands to the process's stdin, and the agent runner emits streaming events on stdout. Stderr is captured for diagnostics.
+
+The agent runner has four core responsibilities:
+1. **Lifecycle management** — Initialize the SDK, maintain the session across turns, handle shutdown
+2. **Event translation** — Convert SDK events into JSON events the Go backend understands
+3. **Runtime control** — Handle model changes, permission mode switches, interrupts, and file rewinds mid-session
+4. **MCP orchestration** — Merge and manage MCP servers from multiple sources
+
+```mermaid
+graph LR
+    Backend[Go Backend] -->|stdin JSON| AR[Agent Runner]
+    AR -->|stdout JSON| Backend
+    AR <-->|SDK| Claude[Claude API]
+    AR <-->|stdio/SSE/HTTP| MCP[MCP Servers]
+```
+
+---
+
+## Persistent Multi-Turn Architecture
+
+The most important architectural decision in the agent runner is its use of a **streaming input generator** pattern. Rather than spawning a new process for each turn (which would require `--resume` to reload state), a single `query()` call persists for the entire session lifetime.
+
+An async generator function called `messageStream()` yields user messages to the SDK one at a time. Between yields, the generator blocks waiting for the next message from stdin. The SDK processes each message, generates a response (which the agent runner captures via a `for-await` loop), and then asks the generator for the next message.
+
+This design provides several critical benefits:
+- **No subprocess restarts** — The process stays alive across turns, avoiding startup overhead
+- **Natural state persistence** — Session state persists in memory without serialization
+- **MCP connections stay alive** — MCP servers don't need to reconnect between turns
+- **stdin stays open** — Hooks, `canUseTool` callbacks, and MCP servers continue to function
+
+```mermaid
+sequenceDiagram
+    participant B as Go Backend
+    participant AR as Agent Runner
+    participant SDK as Claude SDK
+    participant API as Claude API
+
+    B->>AR: spawn process
+    AR->>SDK: query(messageStream(), options)
+
+    Note over AR: Turn 1
+    B->>AR: {"type":"message","content":"..."}
+    AR->>SDK: yield SDKUserMessage
+    SDK->>API: Messages API call
+    API-->>SDK: streaming response
+    SDK-->>AR: for-await events
+    AR-->>B: assistant_text, tool_start, tool_end, result
+
+    Note over AR: Turn 2 (same process, same query())
+    B->>AR: {"type":"message","content":"..."}
+    AR->>SDK: yield SDKUserMessage
+    SDK->>API: Messages API call (with full history)
+    API-->>SDK: streaming response
+    SDK-->>AR: for-await events
+    AR-->>B: assistant_text, tool_start, tool_end, result
+
+    Note over AR: Session ends
+    B->>AR: {"type":"stop"}
+    AR->>AR: mainLoopRunning = false
+    AR->>AR: generator returns
+    AR-->>B: {"type":"complete"}
+```
+
+---
+
+## CLI Arguments
+
+The Go backend spawns the agent runner with these command-line arguments:
+
+| Argument | Type | Default | Purpose |
+|----------|------|---------|---------|
+| `--cwd` | string | `process.cwd()` | Working directory (worktree path) |
+| `--conversation-id` | string | `"default"` | Conversation identifier for tracking |
+| `--resume` | string | — | SDK session ID to resume from |
+| `--fork` | flag | false | Fork the resumed session |
+| `--linear-issue` | string | — | Linear issue identifier (e.g., "LIN-123") |
+| `--target-branch` | string | — | Base branch for PR operations |
+| `--tool-preset` | string | `"full"` | Tool restriction level |
+| `--enable-checkpointing` | flag | false | Enable file checkpoint support |
+| `--structured-output` | JSON | — | JSON schema for structured responses |
+| `--max-budget-usd` | number | — | Maximum cost limit in USD |
+| `--max-turns` | number | — | Maximum conversation turn count |
+| `--max-thinking-tokens` | number | — | Extended thinking token budget |
+| `--permission-mode` | string | `"bypassPermissions"` | Initial permission mode |
+| `--setting-sources` | CSV | — | Where to load settings (project, user, local) |
+| `--betas` | CSV | — | Beta feature flags |
+| `--model` | string | — | Model override |
+| `--fallback-model` | string | — | Fallback model if primary unavailable |
+| `--instructions-file` | string | — | Path to system prompt file |
+| `--mcp-servers-file` | string | — | Path to user-configured MCP servers JSON |
+| `--sdk-debug` | flag | false | Enable SDK debugging |
+| `--sdk-debug-file` | string | — | Write SDK debug output to file |
+
+---
+
+## Tool Presets
+
+Tool presets restrict which tools the agent can use. They are applied via `allowedTools` and `disallowedTools` in the SDK query options:
+
+| Preset | Allowed Tools | Use Case |
+|--------|---------------|----------|
+| `full` | All tools | Default — unrestricted access |
+| `read-only` | Read, Glob, Grep, WebFetch, WebSearch | Code exploration without modifications |
+| `no-bash` | All except Bash | Prevent shell command execution |
+| `safe-edit` | Read, Glob, Grep, Edit, WebFetch, WebSearch | File editing without Bash or Write |
+
+---
+
+## Event-Driven Input Queue
+
+Messages from the Go backend arrive as JSON lines on stdin. The agent runner parses each line and routes it based on the `type` field:
+
+```mermaid
+graph TD
+    stdin[stdin JSON line] --> parse[Parse JSON]
+    parse --> switch{type?}
+    switch -->|message| queue[Queue for next turn]
+    switch -->|stop| stop[Break main loop]
+    switch -->|interrupt| int[queryRef.interrupt]
+    switch -->|set_model| model[queryRef.setModel]
+    switch -->|set_permission_mode| perm[queryRef.setPermissionMode]
+    switch -->|get_supported_models| query1[Query SDK → emit response]
+    switch -->|get_supported_commands| query2[Query SDK → emit response]
+    switch -->|get_mcp_status| query3[Query SDK → emit response]
+    switch -->|get_account_info| query4[Query SDK → emit response]
+    switch -->|rewind_files| rewind[queryRef.rewindFiles]
+    switch -->|user_question_response| uq[Resolve pending question]
+    switch -->|plan_approval_response| pa[Resolve pending approval]
+```
+
+The `message` type is the only one that goes through the queue. A `messageQueue` array buffers messages, and a `messageWaiter` callback resolves a pending Promise when a message arrives. If someone is already waiting, the message is delivered immediately; otherwise, it's buffered.
+
+---
+
+## Message Stream Generator
+
+The heart of the multi-turn architecture is the async generator:
+
+```typescript
+async function* messageStream(): AsyncGenerator<SDKUserMessage> {
+  while (mainLoopRunning) {
+    const msg = await waitForNextMessage();  // Blocks until stdin has a message
+    if (!msg) break;                          // stdin closed or stop received
+
+    turnCount++;
+    currentTurnStartTime = Date.now();
+    blockBuffer = "";                         // Reset text buffer
+    resetRunStats();                          // Clear tool tracking
+
+    yield buildUserMessage(msg);              // Yield to SDK
+    // SDK processes, returns for next iteration
+  }
+}
+```
+
+The generator blocks on `waitForNextMessage()` until a user message arrives (or the stop signal is received). It then yields a single `SDKUserMessage` to the SDK. The SDK processes the message, streams back results through the `for-await` loop, and eventually returns control to the generator, which blocks again waiting for the next message.
+
+---
+
+## Query Initialization
+
+The SDK is initialized with a single `query()` call:
+
+```typescript
+const result = query({
+  prompt: messageStream(),                    // Streaming input generator
+  options: {
+    cwd,                                      // Worktree directory
+    permissionMode: initialPermissionMode,
+    allowDangerouslySkipPermissions: true,
+    canUseTool: async () => ({ behavior: "allow" }),
+    mcpServers: mergedMcpServers,             // Built-in + .mcp.json + user
+    includePartialMessages: true,             // Enable streaming
+    tools: { type: "preset", preset: "claude_code" },
+    systemPrompt: instructions
+      ? { type: "preset", preset: "claude_code", append: instructions }
+      : { type: "preset", preset: "claude_code" },
+    hooks,                                    // All hooks always enabled
+    allowedTools: presetConfig.allowedTools,
+    disallowedTools: presetConfig.disallowedTools,
+    enableFileCheckpointing: enableCheckpointing,
+    outputFormat,                             // Structured output schema
+    maxBudgetUsd, maxTurns, maxThinkingTokens,
+    model, fallbackModel,
+    abortController: sessionAbortController,
+    resume: resumeSessionId,
+    forkSession,
+  },
+});
+```
+
+Key options:
+- **`includePartialMessages: true`** enables streaming text events during generation
+- **`canUseTool`** always returns `allow` — actual permission logic lives in the PreToolUse hooks
+- **`allowDangerouslySkipPermissions: true`** is required because permission mode can change at runtime
+- The **system prompt** uses the `claude_code` preset (built into the SDK) with optional appended instructions from conversation summaries
+
+---
+
+## Hook System
+
+All hooks are always enabled. They provide real-time tracking of every agent activity:
+
+### PreToolUse Hooks
+
+**AskUserQuestion** (24-hour timeout): When Claude uses the `AskUserQuestion` tool, the hook intercepts it, emits a `user_question_request` event to the Go backend, and blocks on a Promise until the user responds. The 24-hour timeout gives users unlimited practical time to answer.
+
+**ExitPlanMode** (24-hour timeout): When Claude uses `ExitPlanMode`, the hook emits a `plan_approval_request` event and blocks until the user approves or rejects the plan.
+
+**Default** (all other tools): Emits a `hook_pre_tool` event for tracking. For sub-agent tools, also tracks the tool start with the agent ID.
+
+### PostToolUse Hook
+
+Tracks tool completion, calculates duration from start time, and emits a `hook_post_tool` event. For sub-agent tools, emits `tool_end` with the agent ID.
+
+### PostToolUseFailure Hook
+
+Tracks failed tools, emits failure events, and cleans up sub-agent tool tracking.
+
+### Other Hooks
+
+- **Notification** — Emits `agent_notification` events (title, message, type)
+- **SessionStart** — Updates `currentSessionId`, emits `session_started`
+- **SessionEnd** — Emits `session_ended` with reason
+- **Stop** — Emits `agent_stop` event
+- **SubagentStart** — Maps session ID to agent ID for correlation, finds parent Task tool
+- **SubagentStop** — Cleans up session-to-agent mapping, emits `subagent_stopped`
+
+---
+
+## Output Event Types
+
+All events are emitted as JSON lines on stdout via `console.log(JSON.stringify(event))`:
+
+### Lifecycle Events
+- `ready` — Process initialized and ready for messages
+- `init` — SDK configuration (model, tools, MCP servers, budget config)
+- `session_started` / `session_ended` — Session lifecycle
+- `session_id_update` — SDK session ID changed (for resume)
+- `turn_complete` — Turn finished, process stays alive for next message
+- `complete` — Session ended, process will exit
+
+### Content Events
+- `assistant_text` — Streamed text content (paragraph-buffered)
+- `thinking_start` / `thinking_delta` / `thinking` — Extended thinking blocks
+
+### Tool Events
+- `tool_start` — Tool invocation begins (with params)
+- `tool_end` — Tool completed (success/failure, summary, duration)
+- `tool_progress` — Elapsed time update for long-running tools
+
+### Sub-Agent Events
+- `subagent_started` — Child agent spawned (with agentId, agentType, parentToolUseId)
+- `subagent_stopped` — Child agent completed
+
+### Interactive Events
+- `user_question_request` — AskUserQuestion waiting for user input
+- `plan_approval_request` — ExitPlanMode waiting for approval
+- `todo_update` — TodoWrite tool updated the task list
+
+### Result Events
+- `result` — Turn summary with cost, usage, stats, success/error status
+- `context_usage` — Per-message token counts
+- `context_window_size` — Model context window info
+- `compact_boundary` — Context compaction occurred
+
+### Checkpoint Events
+- `checkpoint_created` — File snapshot created (with UUID)
+- `files_rewound` — Files restored to checkpoint
+
+### State Change Events
+- `model_changed` — Model switched via set_model
+- `permission_mode_changed` — Permission mode toggled
+
+### Error Events
+- `error` — Fatal error
+- `auth_error` — Authentication failure (user-friendly message)
+- `interrupted` — Execution interrupted by user
+- `shutdown` — Graceful exit with reason
+
+---
+
+## Text Streaming
+
+The agent runner uses block-level buffering to emit text in readable paragraphs rather than character-by-character:
+
+1. Text chunks from the SDK accumulate in a `blockBuffer` string
+2. The buffer is split on double newlines (`\n\n`) — paragraph breaks
+3. Complete paragraphs are emitted immediately as `assistant_text` events
+4. The last incomplete paragraph stays in the buffer
+5. If the buffer exceeds **4,096 characters**, a force-flush occurs at the nearest newline
+6. At turn boundaries, `flushBlockBuffer()` emits any remaining text
+
+This approach balances streaming responsiveness with readable output — the frontend receives complete paragraphs rather than individual words.
+
+---
+
+## Sub-Agent Tracking
+
+When Claude spawns child agents via the Task tool, the agent runner tracks them for proper event correlation:
+
+- **`sessionToAgentId` Map** — Maps sub-agent session IDs to agent IDs. Populated by `SubagentStartHook`, cleaned up by `SubagentStopHook`
+- **`subagentActiveTools` Map** — Tracks tools currently executing in sub-agent context, with agentId for UI attribution
+
+The SubagentStart hook also identifies the **parent Task tool** by iterating through active tools to find the one whose session matches. This `parentToolUseId` lets the frontend nest sub-agent activity under its parent tool call.
+
+Sub-agent text and thinking messages are **skipped** in the main `handleMessage()` function to prevent duplicate output — only the parent agent's content is emitted to the frontend.
+
+---
+
+## Statistics Tracking
+
+Per-turn statistics are tracked and emitted in the `result` event:
+
+| Stat | What It Counts |
+|------|---------------|
+| `toolCalls` | Total tool invocations |
+| `toolsByType` | Breakdown by tool name (e.g., `{"Read": 5, "Write": 2}`) |
+| `subAgents` | Number of Task tool invocations |
+| `filesRead` | Read, Glob, and Grep invocations |
+| `filesWritten` | Write and Edit invocations |
+| `bashCommands` | Bash tool invocations |
+| `webSearches` | WebSearch and WebFetch invocations |
+| `totalToolDurationMs` | Cumulative time spent in tools |
+
+Statistics are reset at the start of each turn and included in the `result` event at the end of the turn.
+
+---
+
+## MCP Integration
+
+The agent runner merges MCP servers from three sources:
+
+### 1. Built-in ChatML MCP Server
+
+The `chatml` MCP server is always available and provides workspace-aware tools:
+
+| Tool | Purpose |
+|------|---------|
+| `get_session_status` | Current branch, git state, Linear issue |
+| `get_workspace_diff` | Git diff summary or full diff |
+| `get_recent_activity` | Recent git log entries |
+| `add_review_comment` | Post a code review comment |
+| `list_review_comments` | List review comments (with optional file filter) |
+| `get_review_comment_stats` | Per-file comment counts |
+| `get_linear_context` | Current Linear issue details |
+| `start_linear_issue` | Create branch from Linear issue |
+| `update_linear_status` | Update Linear issue status (local only) |
+| `get_workspace_scripts_config` | Read `.chatml/config.json` |
+| `propose_scripts_config` | Generate a config proposal for user approval |
+
+These tools use a `WorkspaceContext` class that manages session state: the working directory, workspace ID, session ID, target branch, Linear issue, and git state (current branch, uncommitted changes, ahead/behind counts).
+
+### 2. Project-Level Servers (`.mcp.json`)
+
+If the repository contains a `.mcp.json` file, its servers are loaded and merged. This allows projects to define MCP servers that are always available when working on that codebase.
+
+### 3. Backend-Provided Servers
+
+The Go backend writes user-configured MCP servers to a temporary JSON file and passes its path via `--mcp-servers-file`. These are servers the user has configured through the settings UI. Supported transport types: `stdio`, `sse`, and `http`.
+
+---
+
+## Error Handling
+
+### Auth Error Detection
+
+The agent runner pattern-matches on common authentication error strings: `"authentication_error"`, `"oauth token has expired"`, `"invalid api key"`, `"401 unauthorized"`, and others. When detected, a user-friendly `auth_error` event is emitted instead of a generic error.
+
+### Cleanup Sequence
+
+Graceful shutdown follows a 9-step sequence:
+1. Set `mainLoopRunning = false` to break the generator loop
+2. Signal the `AbortController` to cancel pending operations
+3. Reject all pending user question and plan approval Promises
+4. Emit `tool_end` for any in-flight tools (prevents infinite spinners in the UI)
+5. Flush the text buffer
+6. Call `queryRef.interrupt()` to tear down MCP connections
+7. Unblock the message waiter (if blocked on `waitForNextMessage`)
+8. Close the readline interface
+9. Emit `shutdown` event
+
+### Signal Handlers
+
+- **SIGTERM** / **SIGINT** → cleanup() → `process.exit(0)`
+- **Unhandled rejection** → cleanup() → emit error → `process.exit(1)`
+- **Uncaught exception** → cleanup() → detect auth errors → emit error → `process.exit(1)`
+
+---
+
+## File Checkpointing
+
+When `--enable-checkpointing` is passed, the SDK creates file checkpoints at turn boundaries:
+
+- Each checkpoint has a UUID that's included in `checkpoint_created` events
+- The frontend can later call `rewind_files` with a checkpoint UUID to restore all files to that state
+- Checkpoints are created for both user messages (during processing) and result messages (at turn end)
+- This enables a "rewind" feature where users can undo unwanted changes within a session
+
+---
+
+## Permission Modes
+
+| Mode | Behavior |
+|------|----------|
+| `bypassPermissions` | Allow all tools without prompting (default in agent-runner) |
+| `default` | Show prompts for sensitive operations |
+| `acceptEdits` | Accept file edits automatically, prompt for others |
+| `plan` | Agent proposes plans that require user approval |
+| `dontAsk` | Never prompt (experimental) |
+
+Permission modes can be changed mid-session via the `set_permission_mode` input message.
+
+---
+
+## Attachment Handling
+
+User messages can include file and image attachments:
+
+- **Images**: Embedded as base64 content blocks with MIME type
+- **Files**: Wrapped in `<attached_file>` XML tags with path and line count metadata
+- Closing tags (`</attached_file>`) are escaped to prevent XML injection
+
+---
+
+## Cross-References
+
+- **Overview**: See [overview.md](./overview.md) for the application architecture
+- **Streaming Events**: See [claude-sdk-events.md](./claude-sdk-events.md) for the event catalog
+- **WebSocket Streaming**: See [websocket-streaming.md](./websocket-streaming.md) for the event pipeline
+- **Session Management**: See [session-management.md](./session-management.md) for process spawning

--- a/docs/git-worktrees.md
+++ b/docs/git-worktrees.md
@@ -1,0 +1,375 @@
+# Git Worktrees and Session Isolation
+
+## What Git Worktrees Are
+
+Git worktrees are a built-in git feature that allows multiple working directories to share a single repository's object database. Each worktree has its own HEAD reference, staging area (index), and working tree, but they all share the same commits, branches, tags, and object store. This means you can have multiple branches checked out simultaneously without cloning the entire repository.
+
+In a regular git repository, the `.git` entry is a directory containing the full object database. In a worktree, however, the `.git` entry is a **file** containing a single line that points back to the main repository:
+
+```
+gitdir: /path/to/main/repo/.git/worktrees/<worktree-name>
+```
+
+This pointer tells git where to find the shared object database. The main repository keeps track of all its worktrees in `.git/worktrees/`, with each worktree getting its own subdirectory containing its HEAD, index, and other per-worktree state.
+
+The key advantage of worktrees over clones is efficiency. Since all worktrees share the same object database, creating a new worktree is nearly instantaneous — git only needs to check out the files, not copy the entire history. This makes worktrees ideal for scenarios where you need multiple isolated working copies of the same repository.
+
+---
+
+## How ChatML Uses Worktrees
+
+ChatML's entire session model is built on git worktrees. When a user creates a new coding session, ChatML creates a git worktree in a dedicated directory. This gives each session a fully isolated working directory where the AI agent can read, modify, and create files without affecting the main repository or any other session.
+
+This design enables several important workflows:
+
+**Parallel Development** — A developer can have multiple sessions active simultaneously on the same repository. One session might be adding a new feature, another fixing a bug, and a third refactoring code. Each operates on its own branch in its own directory, so there are no conflicts.
+
+**Safe AI Experimentation** — Since each session is isolated, Claude can make aggressive changes, run build commands, and modify configuration files without risk. If the changes don't work out, the worktree can simply be deleted without affecting anything else.
+
+**Clean Pull Requests** — Each session creates a dedicated branch, making it straightforward to create a pull request when the work is complete. The branch contains only the changes from that specific session.
+
+**File Checkpointing** — Within a session, the Claude Agent SDK can create file checkpoints at turn boundaries, allowing users to rewind changes to any previous state.
+
+---
+
+## Directory Structure
+
+ChatML stores all session worktrees in a configurable base directory. The default location and structure:
+
+```
+<workspaces-base-dir>/
+├── orion/                       # Session worktree
+│   ├── .git                     # FILE pointing to main repo
+│   ├── src/                     # Full repository source tree
+│   ├── package.json
+│   └── ...
+├── cassiopeia/                  # Another session worktree
+│   ├── .git                     # FILE pointing to main repo
+│   └── ...
+├── lyra/                        # Third session
+│   ├── .git
+│   └── ...
+└── andromeda/                   # Fourth session
+    ├── .git
+    └── ...
+```
+
+Each session directory is a complete, independent working copy of the repository. The `.git` file in each directory is small — just a pointer to the main repository's `.git/worktrees/<session-name>/` directory where the per-worktree state lives.
+
+---
+
+## Session Creation Flow
+
+Creating a session involves a carefully orchestrated sequence of operations with rollback semantics to ensure consistency even when errors occur.
+
+```mermaid
+sequenceDiagram
+    participant U as User/Frontend
+    participant H as HTTP Handler
+    participant G as Git Operations
+    participant DB as SQLite Store
+    participant W as Branch Watcher
+    participant PR as PR Watcher
+
+    U->>H: POST /api/repos/{id}/sessions
+    H->>H: Validate input (branch format, protected branches)
+    H->>H: Generate session name (constellation pool)
+    H->>H: Atomic directory creation (os.Mkdir)
+    H->>G: Create worktree + branch
+    G-->>H: worktree path, branch name, base commit SHA
+    H->>DB: Insert session record
+    H->>DB: Create initial conversation + system message
+    H->>W: Start watching branch HEAD file
+    H->>PR: Start watching for PR creation
+    H-->>U: 201 Created (session object)
+```
+
+### Step 1: Input Validation
+
+The handler validates the request parameters:
+
+- **Target branch format**: Must match a strict regex pattern (`^[a-zA-Z0-9][a-zA-Z0-9_.\-/~^@{}]*$`) to prevent command injection
+- **Protected branch check**: Sessions cannot be created on `main`, `master`, or `develop` branches. This is enforced both at the HTTP handler level and in the git operations layer (defense-in-depth)
+- **Session source validation**: The request can specify a source type — `scratch` (new branch from target), `branch` (existing remote branch), or `pr` (from a pull request URL)
+
+### Step 2: Session Name Generation
+
+If the user doesn't provide a session name, one is auto-generated:
+
+- A random name is selected from a **pool of 88 constellation names**: Orion, Cassiopeia, Andromeda, Lyra, Draco, Perseus, Cygnus, Aquila, Gemini, Leo, Scorpius, Sagittarius, Pegasus, Ursa Major, Ursa Minor, Centaurus, and 72 more
+- A **case-insensitive uniqueness check** runs against all existing session names (loaded from an in-memory cache with 5-minute TTL)
+- If the name collides, the system **retries up to 10 times** with different random selections
+- As a last resort, if all 10 attempts collide, a **4-character random suffix** is appended (e.g., `orion-x7k2`)
+- If the user provides a name explicitly, only one attempt is made — a collision returns 409 Conflict
+
+The session gets an `auto_named` flag set to `true` for auto-generated names. This flag is important for the branch watcher: when an auto-named session's branch is changed externally (e.g., by the user in their IDE), the watcher can update the session name to match the new branch.
+
+### Step 3: Atomic Directory Creation
+
+The session directory is created using `os.Mkdir()` (not `os.MkdirAll()`). This is a deliberate choice for atomicity — `os.Mkdir()` fails if the directory already exists, which acts as a filesystem-level lock preventing two concurrent requests from creating the same session. This is a TOCTOU-safe approach (Time-of-Check-Time-of-Use).
+
+If directory creation fails because another session already claimed the name, the system either retries with a new name (for auto-generated names) or returns 409 Conflict (for user-provided names).
+
+### Step 4: Worktree Creation
+
+There are two paths depending on whether the session uses a new or existing branch:
+
+**New branch (from scratch)**:
+```bash
+git worktree add -b <branchName> <directory> <targetBranch>
+```
+This creates a new worktree at `<directory>`, creates a new branch `<branchName>` pointing at `<targetBranch>`, and checks out the new branch.
+
+**Existing remote branch**:
+```bash
+git fetch origin <branchName>
+git worktree add -b <branchName> --track <directory> origin/<branchName>
+```
+This fetches the latest state of the remote branch, creates a worktree tracking it, and checks it out. This path is used when creating sessions from existing branches or pull requests.
+
+If worktree creation fails (e.g., because the branch is already checked out in another worktree), a rollback function removes the directory using `context.Background()` to survive request cancellation.
+
+### Step 5: Base Commit Capture
+
+The base commit SHA is captured via `git rev-parse <targetBranch>`. This SHA is stored with the session and used later for computing file change statistics (additions/deletions via `git diff`) and for creating pull requests.
+
+### Step 6: Database Persistence
+
+A session record is inserted into SQLite with all metadata: ID, workspace ID, name, branch, worktree path, base commit SHA, target branch, status (idle), and timestamps.
+
+### Step 7: Initial Conversation
+
+A conversation of type `task` is automatically created for the session, along with a system message containing setup information (branch name, origin repository, base branch). This gives Claude context about the session's git state when the user starts chatting.
+
+### Step 8: Branch and PR Watchers
+
+The branch watcher begins monitoring the session's HEAD file for changes (see Branch Watching below). If the session was created from a PR, the PR watcher also starts polling for status updates.
+
+### Step 9: Setup Scripts
+
+If the workspace has a `.chatml/config.json` file with `autoSetup: true`, the configured setup scripts run sequentially in the new worktree directory. Each script has a 5-minute timeout. Output is streamed to the frontend via WebSocket. Setup script failure is non-fatal — the session is still created and usable.
+
+---
+
+## Branch Naming
+
+Branch names in ChatML follow a configurable prefix strategy. The prefix is resolved through a cascade:
+
+1. **Repository-level setting** (if set) takes priority
+2. **Workspace-level setting** falls back next
+3. **Global setting** is the default
+
+The available prefix types are:
+
+| Type | Example Branch | Description |
+|------|---------------|-------------|
+| `session` (default) | `session/orion` | Generic "session/" prefix |
+| `github` | `mcastilho/orion` | Uses the authenticated GitHub username |
+| `custom` | `feature/orion` | Uses a user-configured custom string |
+| `none` | `orion` | No prefix, just the session name |
+
+The full branch name is `{prefix}/{sessionName}` (or just `{sessionName}` with no prefix).
+
+When extracting a session name from a branch, the system strips known prefixes in order: `session/`, `feature/`, `fix/`, `bugfix/`, `hotfix/`, `chore/`, `refactor/`, `docs/`, `test/`, and any GitHub username prefix. For deeply nested branches like `user/feature/deep/nested`, the last segment (`nested`) is used as the session name.
+
+---
+
+## Protected Branches
+
+The branches `main`, `master`, and `develop` are protected. Sessions cannot be created on these branches because they are typically shared branches that should not be modified by isolated coding sessions.
+
+This protection is enforced at two levels:
+1. **HTTP handler**: Validates the target branch before any git operations
+2. **Git operations layer**: The worktree creation functions also check for protected branches
+
+This defense-in-depth approach ensures that even if a request bypasses the handler validation, the git layer will still reject the operation.
+
+---
+
+## Branch Watching
+
+ChatML uses filesystem watchers (via the `fsnotify` package in Go and the `notify` crate in Rust) to detect when a session's branch changes.
+
+### How It Works
+
+When a session is created, the branch watcher resolves the session's git directory by reading the `.git` file in the worktree:
+
+```
+.git file contains: gitdir: /path/to/main/repo/.git/worktrees/session-name
+```
+
+The watcher then monitors the **gitdir directory** (not the `.git` file itself, since fsnotify watches directories). It looks for changes to two files:
+
+- **HEAD**: When this file changes, a branch switch has occurred. The watcher reads the new HEAD to determine the current branch name and emits a `BranchChangeEvent` with the old and new branch names
+- **index**: When this file changes, files in the working directory have been modified. This triggers a session stats recomputation (additions/deletions count)
+
+### What Happens on Branch Change
+
+When a branch change is detected:
+
+1. The session's branch name is updated in the database
+2. If the session was auto-named, the session name is updated to match the new branch (stripping the prefix)
+3. A `session_name_update` WebSocket event is broadcast to all connected frontends
+4. The session stats cache is invalidated, triggering a recomputation of file change counts
+
+### Concurrency
+
+The watcher maintains a map of watched sessions protected by a lock. The lock is held only during map reads; events are emitted outside the lock to prevent deadlocks. Stats invalidation callbacks execute asynchronously.
+
+---
+
+## PR Watching
+
+Sessions can be associated with pull requests. The PR watcher monitors GitHub for status changes using a two-tier polling strategy:
+
+| Session State | Polling Interval | Rationale |
+|--------------|-----------------|-----------|
+| No PR associated | 30 seconds | Eager detection of newly created PRs |
+| Open PR | 2 minutes | Lower frequency for known PRs |
+
+### What Is Tracked
+
+For each session with a PR:
+
+- **PR state**: Open, merged, or closed
+- **Check status**: Pending, success, failure, or none (aggregated from individual check runs)
+- **Mergeability**: Whether the PR can be merged (may be null while GitHub computes)
+- **Individual check details**: Name, status, conclusion, and duration of each check run
+
+### Caching
+
+A shared PR cache prevents redundant GitHub API calls:
+- **Short cache**: 2-minute TTL for volatile data
+- **Long cache**: 10-minute backoff for PRs that return "not found" (prevents hammering the API)
+
+### Broadcasting
+
+When a PR status changes, two WebSocket events are broadcast:
+- `session_pr_update`: Targeted to the specific session (includes prStatus, prNumber, prUrl, checkStatus, mergeable)
+- `pr_dashboard_update`: A general invalidation signal for the PR dashboard view
+
+---
+
+## Session Deletion
+
+Session deletion follows a **database-first** strategy to prevent "ghost sessions" (database records with no corresponding disk data):
+
+```mermaid
+sequenceDiagram
+    participant H as HTTP Handler
+    participant DB as SQLite Store
+    participant W as Watchers
+    participant FS as Filesystem
+    participant C as Cache
+
+    H->>DB: Delete session record
+    H->>W: Stop branch watcher
+    H->>W: Stop PR watcher
+    H->>FS: Remove worktree directory
+    H->>C: Invalidate caches
+```
+
+1. **Database record deleted first** — This ensures that even if the filesystem cleanup fails, there's no orphaned database record
+2. **Watchers stopped** — Both the branch watcher and PR watcher for the session are unregistered
+3. **Worktree removal** — `git worktree remove <path> --force` followed by `git worktree prune` to clean up stale entries
+4. **Cache cleanup** — Session name cache, branch cache, and stats cache entries are invalidated
+
+The session directory on disk is treated as a permanent artifact — if the worktree removal command fails, the directory may remain but the session is no longer tracked by the application.
+
+---
+
+## Concurrency and Thread Safety
+
+### Session Lock Manager
+
+The `SessionLockManager` provides per-path mutexes with reference counting to prevent concurrent operations on the same session:
+
+```go
+type SessionLockManager struct {
+    mu    sync.Mutex
+    locks map[string]*lockEntry
+}
+
+type lockEntry struct {
+    mu       sync.Mutex
+    refCount int
+}
+```
+
+Each `Lock(path)` call increments the reference count. Each `Unlock(path)` decrements it. When the count reaches zero, the entry is removed from the map. This reference counting prevents memory leaks from accumulating temporary locks.
+
+### Rollback Semantics
+
+Session creation uses deferred rollback functions. If any step fails after the directory has been created, a cleanup function removes the directory. The cleanup uses `context.Background()` (not the request context) to ensure it runs even if the HTTP request is cancelled.
+
+### Atomic Directory Creation
+
+The use of `os.Mkdir()` (which fails if the directory exists) rather than `os.MkdirAll()` provides a filesystem-level mutex. Two concurrent requests trying to create the same session will see one succeed and one fail at the directory creation step, preventing race conditions.
+
+---
+
+## File Watcher Integration (Tauri)
+
+The Tauri desktop shell runs a separate file watcher that monitors the workspaces base directory for external changes:
+
+### Architecture
+
+- **Single recursive watcher** — One OS-level file watcher covers all session directories
+- **2-second debounce** — Rapid file changes are batched to avoid flooding the frontend
+- **Session-to-workspace mapping** — Each session directory is registered with its workspace ID so events can be routed correctly
+
+### Ignored Directories
+
+The watcher skips changes in directories that are typically auto-generated:
+- `.git`, `node_modules`, `target`, `.next`, `__pycache__`, `.cache`, `dist`, `build`, `.venv`, `venv`
+
+### Events
+
+- **`file-changed`**: Emitted when files change in a session directory. Includes the workspace ID, relative path, and a list of changed files
+- **`session-deleted-externally`**: Emitted when a registered session directory no longer exists on disk (detected when a file event references a non-existent path)
+
+### Thread Safety
+
+The session registration map uses a `RwLock`, allowing concurrent reads during event emission while requiring exclusive access only for registration changes.
+
+---
+
+## Setup Scripts
+
+When a workspace is configured with setup scripts (via `.chatml/config.json`), these scripts run automatically after worktree creation if `autoSetup` is `true`.
+
+### Configuration Format
+
+```json
+{
+  "setupScripts": [
+    { "name": "Install dependencies", "command": "npm install" },
+    { "name": "Generate types", "command": "npm run codegen" }
+  ],
+  "autoSetup": true
+}
+```
+
+### Execution
+
+- Scripts run **sequentially** in the worktree directory
+- Each script has a **5-minute timeout**
+- Output is **streamed to the frontend** via WebSocket (`script_output` events)
+- Failure is **non-fatal** — the session is fully created regardless of setup script results
+- Output is capped at **1,000 lines** per script to prevent memory issues
+
+### Auto-Detection
+
+If no `.chatml/config.json` exists, the backend can auto-detect likely setup scripts by inspecting the repository:
+- `package.json` → suggests `npm install`
+- `Makefile` → suggests `make`
+- `docker-compose.yml` → suggests `docker-compose up -d`
+
+---
+
+## Cross-References
+
+- **Overview**: See [overview.md](./overview.md) for the application architecture
+- **Session Management**: See [session-management.md](./session-management.md) for agent process lifecycle
+- **Backend API**: See [backend-api.md](./backend-api.md) for the REST endpoints
+- **Data Models**: See [data-models-persistence.md](./data-models-persistence.md) for the session schema

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,492 @@
+# ChatML Application Overview
+
+## What Is ChatML
+
+ChatML is a native desktop application for AI-assisted software development. It wraps Anthropic's Claude Agent SDK into a polished desktop experience, enabling developers to work on coding tasks with Claude as a full-featured coding partner. The application provides isolated coding sessions through git worktrees, real-time streaming of Claude's responses and tool execution, and deep integration with GitHub and Linear.
+
+ChatML is a **polyglot application** spanning four languages and runtimes:
+
+- **TypeScript/React** — The user interface, built with Next.js 16 and React 19
+- **Go** — The backend server, handling REST API, WebSocket, git operations, and process management
+- **Rust** — The Tauri 2 desktop shell, providing native window management, secure storage, and system integration
+- **Node.js/TypeScript** — The agent runner, wrapping the Claude Agent SDK for multi-turn AI conversations
+
+The application runs entirely on the developer's local machine. There is no cloud server or SaaS component beyond the Claude API itself. All data is stored locally in SQLite, all git operations happen on local repositories, and all communication happens over localhost.
+
+---
+
+## The Core Concept: Git Worktree Sessions
+
+The fundamental design principle of ChatML is **session isolation through git worktrees**. Every coding session gets its own git worktree — a fully isolated copy of the repository with its own branch, working directory, and index. This means:
+
+- **Parallel work**: A developer can have multiple AI coding sessions running simultaneously on the same repository without branch conflicts
+- **Safe experimentation**: Each session operates in isolation. If Claude makes unwanted changes, they don't affect the main repository or other sessions
+- **Clean branches**: Each session creates a dedicated branch, making it easy to create pull requests from completed work
+
+Sessions are stored at `~/.chatml/workspaces/<session-name>/` (or the configured workspaces base directory). The session names are auto-generated from a pool of constellation and city names, giving each workspace a memorable identifier. When a name collides with an existing session, the system retries with different names, and as a last resort appends a random suffix.
+
+```
+<workspaces-base-dir>/
+├── orion/                   # Session worktree
+│   ├── .git                 # File pointing to main repo's .git
+│   ├── src/                 # Full repository contents
+│   └── ...
+├── cassiopeia/              # Another session
+│   ├── .git
+│   └── ...
+└── lyra/                    # And another
+    ├── .git
+    └── ...
+```
+
+Each worktree's `.git` is a **file** (not a directory) that contains a pointer back to the main repository's `.git/worktrees/` directory. This is how git worktrees share the object database while maintaining separate working trees.
+
+---
+
+## Architecture Overview
+
+ChatML's architecture consists of four layers that communicate through well-defined interfaces:
+
+```mermaid
+graph TB
+    subgraph Desktop["Tauri Desktop Shell (Rust)"]
+        TW[Window Manager]
+        TS[System Tray]
+        TF[File Watcher]
+        TD[Deep Links]
+        TP[PTY Terminal]
+        TSS[Stronghold Storage]
+    end
+
+    subgraph Frontend["Frontend (Next.js / React 19)"]
+        UI[React Components]
+        ZS[Zustand Stores]
+        WS[WebSocket Hook]
+        API[HTTP Client]
+    end
+
+    subgraph Backend["Go Backend Server"]
+        RT[Chi Router]
+        WH[WebSocket Hub]
+        AM[Agent Manager]
+        GI[Git Operations]
+        DB[(SQLite)]
+        GH[GitHub Client]
+        LI[Linear Client]
+    end
+
+    subgraph Agent["Agent Runner (Node.js)"]
+        SDK[Claude Agent SDK]
+        MCP[MCP Servers]
+        HK[Hook System]
+    end
+
+    Desktop <-->|IPC Commands| Frontend
+    Frontend <-->|HTTP REST| Backend
+    Frontend <-->|WebSocket| Backend
+    Backend -->|Spawn Process| Agent
+    Agent -->|stdout JSON| Backend
+    Backend -->|stdin JSON| Agent
+    Agent <-->|API| Claude[Claude API]
+    Backend <-->|API| GH
+    Backend <-->|GraphQL| LI
+```
+
+### The Frontend Layer
+
+The frontend is a **Next.js 16 application** using the App Router, built with React 19, Tailwind CSS 4, and Zustand 5 for state management. It is exported as **static HTML** (no Node.js server at runtime) and served directly by Tauri's webview.
+
+Key technologies:
+- **Zustand 5** — Lightweight state management with 12+ stores for different concerns
+- **Monaco Editor** — Full VS Code editor experience for viewing and editing files
+- **xterm.js** — Terminal emulation with PTY support for interactive shell sessions
+- **Shiki** — Syntax highlighting for code blocks in conversations
+- **Radix UI / shadcn/ui** — Accessible component primitives with the New York style variant
+- **Plate.js** — Rich text editor capabilities
+- **react-virtuoso** — Virtual scrolling for large message lists
+
+The frontend communicates with the Go backend via HTTP REST for data operations and WebSocket for real-time streaming. It communicates with the Tauri shell via IPC commands for native capabilities like file dialogs, clipboard, and notifications.
+
+### The Go Backend Layer
+
+The backend is a **Go server** built with the chi/v5 HTTP router. It runs as a sidecar process spawned by Tauri and listens on localhost (port 9876, with fallback to 9877-9899 if the port is busy).
+
+Responsibilities:
+- **REST API** — Full CRUD for workspaces, sessions, conversations, messages, and settings
+- **WebSocket Hub** — Broadcasting real-time events to all connected frontend clients
+- **Agent Management** — Spawning, monitoring, and communicating with agent-runner processes
+- **Git Operations** — Worktree creation/deletion, branch management, diff computation
+- **GitHub Integration** — OAuth, PR creation, CI/CD status, issue tracking
+- **Linear Integration** — OAuth, issue tracking, branch creation from issues
+- **SQLite Persistence** — All data stored in a local SQLite database with WAL mode
+
+The backend uses gorilla/websocket for WebSocket connections and modernc.org/sqlite for the database (a pure-Go SQLite implementation that requires no CGo).
+
+### The Agent Runner Layer
+
+The agent runner is a **Node.js TypeScript process** that wraps the Anthropic Claude Agent SDK. The Go backend spawns one agent-runner process per active conversation. The two communicate via **JSON lines over stdin/stdout** — the backend sends user messages and control commands on stdin, and the agent runner emits streaming events on stdout.
+
+The agent runner uses a **persistent multi-turn architecture**: a single `query()` call to the SDK lasts for the entire session. An async generator yields user messages across turns, so there's no subprocess restart between messages. This means MCP connections stay alive, session state persists naturally, and there's no need for `--resume` between turns.
+
+### The Tauri Desktop Shell Layer
+
+Tauri 2 (Rust) provides the native desktop wrapper. It transforms the static Next.js output into a native macOS/Windows/Linux application with:
+
+- **Window management** — Native titlebar, traffic light positioning, window state persistence
+- **System tray** — Quick actions menu with Show/Hide, New Session, Quit
+- **File watcher** — Monitors the workspaces directory for external changes
+- **Deep links** — Handles `chatml://` protocol URLs for OAuth callbacks
+- **PTY terminal** — Pseudo-terminal support for xterm.js integration
+- **Stronghold** — Encrypted credential storage using Argon2id key derivation
+- **Auto-updater** — Checks GitHub releases for updates with signature verification
+- **Notifications** — Native OS notifications for task completion and agent questions
+- **Clipboard** — Read/write system clipboard
+- **Single instance** — Prevents multiple app instances
+
+---
+
+## Communication Patterns
+
+### Frontend to Backend (HTTP + WebSocket)
+
+The frontend communicates with the Go backend over **localhost** using two protocols:
+
+**HTTP REST** — Used for all data operations: fetching workspaces, creating sessions, loading messages, saving files, managing settings. Every request includes a Bearer token generated by Tauri at startup.
+
+**WebSocket** — Used for real-time streaming of agent events. The frontend opens a single WebSocket connection at `ws://localhost:{port}/ws?token={authToken}` and receives all events for all conversations. The WebSocket supports automatic reconnection with exponential backoff.
+
+### Backend to Agent Runner (stdin/stdout)
+
+The Go backend communicates with each agent-runner process via **JSON lines on stdio**:
+
+**stdin** (Backend → Agent): User messages, stop/interrupt signals, model changes, permission mode changes, user question responses, plan approvals, and file rewind requests.
+
+**stdout** (Agent → Backend): Streaming text, tool execution events, thinking blocks, session lifecycle events, budget tracking, checkpoint creation, and error notifications. Each line is a complete JSON object.
+
+**stderr** (Agent → Backend): Diagnostic output and SDK debug logs. The last 10 lines are captured in a ring buffer for crash diagnostics.
+
+### Agent Runner to Claude API
+
+The agent runner communicates with the Claude API through the Claude Agent SDK. The SDK manages the conversation history, tool registration, system prompts, and streaming. The agent runner configures the SDK with the `claude_code` tool preset, which provides Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, and other development tools.
+
+---
+
+## Key Features
+
+### Workspace Management
+
+Users add git repositories as **workspaces** through a folder picker dialog. Each workspace represents one git repository that can host multiple sessions. Workspace settings include:
+
+- **Branch prefix strategy** — How session branch names are prefixed (GitHub username, custom string, or none)
+- **Default branch** — The base branch for new sessions (main, master, or custom)
+- **MCP servers** — Per-workspace MCP server configurations
+- **PR template** — Custom pull request description template
+- **Setup scripts** — Commands to run when creating new sessions (e.g., `npm install`)
+
+### Session System
+
+Sessions are the primary unit of work. Each session creates:
+- A **git worktree** with its own branch
+- One or more **conversations** (AI chat threads)
+- **File tabs** scoped to the session
+- **Terminal instances** (1-5 per session)
+- Tracking for **PR status**, **CI checks**, and **file changes**
+
+Sessions have rich metadata: priority (Urgent/High/Medium/Low), task status (Backlog/In Progress/In Review/Done/Cancelled), pinning, and archiving with summaries. They can be created from scratch, from existing branches, or from pull request URLs.
+
+### Multi-Turn Conversations
+
+Each session can have multiple conversations of different types:
+- **Task** — The primary coding conversation with Claude
+- **Review** — Code review conversations
+- **Chat** — General discussion conversations
+
+Conversations support multi-turn interaction where Claude maintains context across messages. The SDK session ID is persisted so conversations can be resumed even after process restarts.
+
+### Real-Time Streaming
+
+Claude's responses stream in real-time through a multi-layer pipeline:
+
+1. The Claude API generates tokens
+2. The agent runner receives them via the SDK and buffers text at paragraph boundaries
+3. Events are emitted as JSON lines on stdout
+4. The Go backend parses events, builds streaming snapshots, and broadcasts via WebSocket
+5. The frontend receives events and renders them incrementally
+
+Text and tool executions are **interleaved in a timeline** — you see exactly when Claude read a file, made an edit, or ran a command relative to its text output.
+
+### Tool Execution Tracking
+
+Every tool Claude uses is tracked in real-time:
+- **tool_start** — Shows which tool is executing with its parameters
+- **tool_progress** — Displays elapsed time for long-running operations
+- **tool_end** — Shows the result (success/failure) with a summary
+
+Tools include file reads, writes, edits, bash commands, web searches, and glob/grep operations. Each tool execution is timed and recorded in the message's tool usage array.
+
+### Sub-Agent Support
+
+Claude can spawn child agents using the Task tool. These sub-agents are tracked hierarchically — each sub-agent has its own ID, and its tool executions are attributed to it rather than the parent agent. The frontend shows sub-agent activity nested under the parent Task tool call.
+
+### Extended Thinking
+
+When enabled, Claude's reasoning process is visible in collapsible thinking blocks. The thinking content streams in real-time alongside the regular response text.
+
+### Plan Mode
+
+Claude can propose plans before executing them. In plan mode:
+1. Claude analyzes the task and writes a plan
+2. The plan is presented to the user with Approve/Reject buttons
+3. Only after approval does Claude proceed with execution
+
+This is useful for complex tasks where you want to review the approach before changes are made.
+
+### File Browser and Editor
+
+The application includes a Monaco-based code editor with:
+- **File tabs** — Scoped to the current session, with dirty tracking
+- **Diff viewer** — Side-by-side diffs for changed files
+- **File tree** — Browse the session's worktree
+- **Auto-save** — Automatically saves changes after a delay
+
+### Terminal Integration
+
+Full terminal emulation via xterm.js with PTY support:
+- Interactive shell sessions in the session's worktree
+- Multiple terminal instances per session (up to 5)
+- Standard terminal features (search, fit-to-container, color support)
+
+### GitHub Integration
+
+- **OAuth authentication** — Login with GitHub for API access
+- **PR creation** — Create pull requests from sessions with AI-generated descriptions
+- **CI/CD monitoring** — View workflow runs, job logs, and check statuses
+- **Issue tracking** — Search and view GitHub issues
+- **PR status tracking** — Automatic polling detects PR merges, closes, and CI status changes
+
+### Linear Integration
+
+- **OAuth authentication** — Login with Linear for issue management
+- **Issue tracking** — Link sessions to Linear issues
+- **Branch creation** — Create branches named after Linear issues
+
+### Skills System
+
+A unified command system with 25+ built-in skills organized into categories:
+- **Development** — TDD workflow, unit testing, debugging, code review, API design, refactoring, performance optimization
+- **Security** — Security audit, dependency review
+- **Documentation** — Brainstorming, writing plans, architecture decision records, technical writing
+- **Version Control** — Git commit helper, PR creation, branch management, code migration
+
+Skills are activated via slash commands (e.g., `/tdd-workflow`) and inject specialized guidance into the conversation. Users can also create custom commands by placing `.md` files in `.claude/commands/`.
+
+### MCP Support
+
+Model Context Protocol (MCP) servers extend Claude's capabilities:
+- **Built-in ChatML server** — Provides workspace-aware tools (git status, diff, review comments, scripts)
+- **Project-level servers** — Configured via `.mcp.json` in the repository
+- **User-configured servers** — Managed through the settings UI
+- Supports **stdio**, **SSE**, and **HTTP** transport types
+
+### Budget Tracking
+
+Per-conversation budget tracking with three dimensions:
+- **Cost** — Total USD spent (from Claude API usage)
+- **Turns** — Number of conversation turns
+- **Thinking tokens** — Extended thinking token usage
+
+Each dimension can have a maximum limit. The Budget panel shows real-time usage with progress bars, and the system stops execution when limits are reached.
+
+### File Checkpointing
+
+The SDK creates file checkpoints at turn boundaries, allowing users to **rewind** file changes to any previous state within the session. This is valuable when Claude makes unwanted modifications — instead of manually reverting, you can restore files to a specific checkpoint.
+
+### Branch Sync
+
+The application monitors each session's git HEAD file via filesystem watchers. When a branch change is detected (from the user's IDE or terminal), the session automatically updates its display. The monitoring also detects index changes to trigger file stats recomputation.
+
+### PR Status Tracking
+
+Sessions with open pull requests are monitored with a two-tier polling strategy:
+- Sessions without PR: Checked every 30 seconds for new PR detection
+- Sessions with open PR: Checked every 2 minutes for status changes
+
+The system tracks PR state (open/merged/closed), CI check status (pending/success/failure), and mergeability. Status changes are broadcast via WebSocket and update the session display in real-time.
+
+---
+
+## The Multi-Tab Interface
+
+ChatML uses a browser-like multi-tab interface where each tab can display different content views:
+
+- **Conversation** — Chat with Claude in a specific session
+- **Global Dashboard** — Overview of all workspaces and sessions
+- **Workspace Dashboard** — Focused view of a single workspace's sessions
+- **PR Dashboard** — Pull request status across all workspaces
+- **Branches** — Branch management for a workspace
+- **Repositories** — Add and manage git repositories
+- **Session Manager** — Data table view of all sessions with filtering and sorting
+- **Skills Store** — Browse and install available skills
+
+Tabs persist across sessions and can be reordered via drag-and-drop.
+
+---
+
+## Settings System
+
+User preferences are persisted via Zustand middleware to localStorage:
+
+### Chat Settings
+- **Default model** — Which Claude model to use (default: claude-opus-4-6)
+- **Thinking mode** — Whether extended thinking is enabled by default
+- **Max thinking tokens** — Token budget for extended thinking (default: 10,000)
+- **Sound effects** — Audio feedback for events
+
+### Appearance Settings
+- **Theme** — System, Light, or Dark mode
+- **Editor theme** — Monaco editor color scheme
+- **Font size** — Editor font size
+- **Zen mode** — Distraction-free interface
+
+### Git Settings
+- **Branch prefix** — Strategy for branch naming (GitHub username, custom, none)
+- **Custom prefix** — Custom string for branch names
+- **Archive on merge** — Auto-archive sessions when PR is merged
+
+### Panel Layout
+- **Resizable panels** — Outer, inner, vertical, and changes panel sizes are persisted
+- **Panel visibility** — Left sidebar, right sidebar, terminal, thinking visibility
+- **Bottom panel tabs** — Which tabs are visible (todos, plans, scripts, history, budget, MCP)
+
+---
+
+## Security Model
+
+### Authentication
+- A 32-byte cryptographically random token is generated at app startup
+- Encoded as URL-safe base64 (43 characters)
+- Passed to the Go backend via the `CHATML_AUTH_TOKEN` environment variable
+- Every HTTP request includes this token as a Bearer token
+- WebSocket connections require the token as a query parameter
+
+### Content Security Policy
+The CSP restricts connections to localhost ports 9876-9899, preventing the webview from contacting external servers. Images allow data URIs and blobs for canvas-generated content.
+
+### Encrypted Storage
+Sensitive credentials are stored in Tauri's Stronghold plugin, which uses Argon2id key derivation (4MB memory, 1 iteration) with a fixed application-specific salt.
+
+### Process Isolation
+Each agent-runner process runs in its own worktree directory. Tool presets can restrict which tools are available (read-only, no-bash, safe-edit, or full access).
+
+### Path Protection
+File operations validate paths to prevent traversal attacks. Protected branches (main, master, develop) cannot be used for session branches. Git ref names are validated with a strict regex pattern.
+
+---
+
+## Data Model
+
+The application uses a hierarchical data model persisted in SQLite:
+
+```mermaid
+erDiagram
+    Workspace ||--o{ Session : contains
+    Session ||--o{ Conversation : contains
+    Conversation ||--o{ Message : contains
+    Conversation ||--o{ ToolAction : records
+    Session ||--o{ ReviewComment : has
+    Session ||--o{ ScriptRun : tracks
+
+    Workspace {
+        string id PK
+        string name
+        string path
+        string branch
+        string remote
+        string branch_prefix
+    }
+
+    Session {
+        string id PK
+        string workspace_id FK
+        string name
+        string branch
+        string worktree_path
+        string base_commit_sha
+        string status
+        string pr_status
+        int priority
+        string task_status
+        boolean pinned
+        boolean archived
+    }
+
+    Conversation {
+        string id PK
+        string session_id FK
+        string type
+        string name
+        string status
+        string model
+        string agent_session_id
+    }
+
+    Message {
+        string id PK
+        string conversation_id FK
+        string role
+        string content
+        json tool_usage
+        string thinking_content
+        json timeline
+        int duration_ms
+        int position
+    }
+```
+
+---
+
+## Development Workflow
+
+### Prerequisites
+- Node.js 20+
+- Go 1.25+
+- Rust 1.77+
+- Tauri CLI
+
+### Running in Development
+
+```bash
+make dev
+# Builds Go backend + agent-runner, then starts Tauri dev with Next.js on port 3100
+```
+
+### Building for Production
+
+```bash
+make build
+# Go build with release flags + agent-runner + Tauri native app bundle
+```
+
+### Testing
+
+```bash
+npm run test          # Watch mode
+npm run test:run      # Single run
+npm run test:coverage # Coverage report (20% minimum threshold)
+```
+
+---
+
+## Cross-References
+
+- **Git Worktrees & Sessions**: See [git-worktrees.md](./git-worktrees.md)
+- **Agent SDK Integration**: See [agent-sdk.md](./agent-sdk.md)
+- **Streaming Events**: See [claude-sdk-events.md](./claude-sdk-events.md)
+- **Skills & Commands**: See [skills-and-commands.md](./skills-and-commands.md)
+- **Tauri Desktop Shell**: See [tauri-desktop.md](./tauri-desktop.md)
+- **Backend API**: See [backend-api.md](./backend-api.md)
+- **WebSocket Streaming**: See [websocket-streaming.md](./websocket-streaming.md)
+- **Frontend Rendering**: See [frontend-rendering.md](./frontend-rendering.md)
+- **Data Models**: See [data-models-persistence.md](./data-models-persistence.md)
+- **Session Management**: See [session-management.md](./session-management.md)
+- **Conversation Architecture**: See [conversation-architecture.md](./conversation-architecture.md)

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -370,6 +370,29 @@ export function useWebSocket(enabled: boolean = true) {
           };
           freshStore.setBudgetStatus(budgetStatus);
         }
+        // Update context meter from reliable result data.
+        // This ensures the meter is always updated at the end of each turn, even if
+        // the per-message context_usage events were unreliable during streaming.
+        const resultModelUsage = event.modelUsage as Record<string, { contextWindow?: number }> | undefined;
+        if (resultModelUsage) {
+          for (const key of Object.keys(resultModelUsage)) {
+            if (resultModelUsage[key]?.contextWindow) {
+              freshStore.setContextUsage(conversationId, {
+                contextWindow: resultModelUsage[key].contextWindow!,
+              });
+              break;
+            }
+          }
+        }
+        const resultUsage = normalizeUsage(event.usage);
+        if (resultUsage && resultUsage.inputTokens > 0) {
+          freshStore.setContextUsage(conversationId, {
+            inputTokens: resultUsage.inputTokens,
+            outputTokens: resultUsage.outputTokens,
+            cacheReadInputTokens: resultUsage.cacheReadInputTokens ?? 0,
+            cacheCreationInputTokens: resultUsage.cacheCreationInputTokens ?? 0,
+          });
+        }
         // Update conversation status to completed
         freshStore.updateConversation(conversationId, { status: 'completed' });
         // Desktop notification for task completion.


### PR DESCRIPTION
## Summary

The context meter was unreliable because per-message usage events during streaming were often incomplete, and sub-agent messages would overwrite the parent conversation's metrics.

## Changes

- **agent-runner/src/index.ts**: Added guard to skip sub-agent messages in per-message context usage emission; added context_usage emission from result's cumulative usage (which is always reliable)
- **src/hooks/useWebSocket.ts**: Updated frontend to read context and usage data from result events as a fallback source
- **docs/**: Added comprehensive documentation for agent SDK integration, git worktrees, and application architecture

## Result

The context meter now displays accurate token counts at conversation end by using the result's cumulative usage as the source of truth.