### PR TITLE
fix: Widen betas type from hardcoded literal to string[]

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -124,7 +124,7 @@ const settingSources = settingSourcesArg
 
 // Task 7: Beta Features Flag
 const betasArg = getArg("--betas");
-const betas = betasArg ? betasArg.split(',').map(s => s.trim()) as ("context-1m-2025-08-07")[] : undefined;
+const betas = betasArg ? betasArg.split(',').map(s => s.trim()) : undefined;
 
 // Task 8: Model Configuration
 const model = getArg("--model");


### PR DESCRIPTION
## Summary
- Removes the narrow type assertion `("context-1m-2025-08-07")[]` on the `--betas` CLI flag, replacing it with `string[]` so any beta header can be passed through to the SDK
- Discovered during a full agent-runner vs Claude Agent SDK gap analysis that identified this as the only code fix needed immediately (other gaps tracked as new Linear tickets)

## Context
New SDK beta headers like `compact-2026-01-12`, `fast-mode-2026-02-01`, `computer-use-2025-11-24`, and `mcp-client-2025-11-20` could not be passed because the type was hardcoded to a single literal. This one-line fix unblocks all of them.

## Related Linear Tickets Created
- **CM-136** — Add effort parameter for reasoning depth control (High)
- **CM-137** — Add fast mode (speed) support for Opus 4.6 (High)
- **CM-138** — Add metadata.user_id passthrough for abuse detection (Medium)
- **CM-139** — Add token counting pre-flight for budget estimation (Medium)

## Existing Tickets Enriched
- **CM-129** — Added effort parameter relationship context
- **CM-121** — Added compaction custom instructions details
- **CM-135** — Added V2 send/stream architectural comparison

## Test plan
- [ ] Verify `--betas compact-2026-01-12,fast-mode-2026-02-01` passes through without type errors
- [ ] Verify existing `--betas context-1m-2025-08-07` still works
- [ ] No runtime behavior change — only type narrowing removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)