### PR TITLE
Add PreCompact hook for context compaction control

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -20,6 +20,7 @@ import {
   type SubagentStopHookInput,
   type PostToolUseFailureHookInput,
   type StopHookInput,
+  type PreCompactHookInput,
   type McpServerConfig,
 } from "@anthropic-ai/claude-agent-sdk";
 import * as readline from "readline";
@@ -807,6 +808,17 @@ const stopHook: HookCallback = async (input) => {
   return {};
 };
 
+const preCompactHook: HookCallback = async (input) => {
+  const hookInput = input as PreCompactHookInput;
+  emit({
+    type: "pre_compact",
+    trigger: hookInput.trigger,
+    customInstructions: hookInput.custom_instructions,
+    sessionId: hookInput.session_id,
+  });
+  return {};
+};
+
 const subagentStartHook: HookCallback = async (input) => {
   const hookInput = input as SubagentStartHookInput;
   // Register session → agentId mapping for correlating sub-agent tool events
@@ -998,6 +1010,7 @@ const hooks = {
   SessionStart: [{ hooks: [sessionStartHook] }],
   SessionEnd: [{ hooks: [sessionEndHook] }],
   Stop: [{ hooks: [stopHook] }],
+  PreCompact: [{ hooks: [preCompactHook] }],
   SubagentStart: [{ hooks: [subagentStartHook] }],
   SubagentStop: [{ hooks: [subagentStopHook] }],
 };

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -71,8 +71,9 @@ type AgentEvent struct {
 	TranscriptPath string `json:"transcriptPath,omitempty"`
 
 	// Compact boundary fields
-	Trigger   string `json:"trigger,omitempty"`
-	PreTokens int    `json:"preTokens,omitempty"`
+	Trigger            string `json:"trigger,omitempty"`
+	PreTokens          int    `json:"preTokens,omitempty"`
+	CustomInstructions string `json:"customInstructions,omitempty"`
 
 	// Context usage fields
 	InputTokens              int `json:"inputTokens,omitempty"`
@@ -196,6 +197,7 @@ const (
 	EventTypeSubagentStarted   = "subagent_started"
 	EventTypeSubagentStopped   = "subagent_stopped"
 	EventTypeCompactBoundary   = "compact_boundary"
+	EventTypePreCompact        = "pre_compact"
 	EventTypeStatusUpdate      = "status_update"
 	EventTypeHookResponse      = "hook_response"
 	EventTypeToolProgress      = "tool_progress"

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -587,6 +587,11 @@ export function useWebSocket(enabled: boolean = true) {
         });
         break;
 
+      case 'pre_compact':
+        // Hook fires BEFORE context compaction occurs
+        // Future: Could show "Compacting context..." indicator
+        break;
+
       // ====================================================================
       // Group B: Tool Progress — elapsed time on long-running tools
       // The agent SDK emits tool_progress with `parentToolUseId` as the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -300,6 +300,7 @@ export interface AgentEvent {
   // Compact boundary fields
   trigger?: 'manual' | 'auto';
   preTokens?: number;
+  customInstructions?: string | null;
 
   // Status fields
   status?: string | null;
@@ -421,6 +422,7 @@ export const AgentEventTypes = {
 
   // System events
   COMPACT_BOUNDARY: 'compact_boundary',
+  PRE_COMPACT: 'pre_compact',
   STATUS_UPDATE: 'status_update',
   TOOL_PROGRESS: 'tool_progress',
   AUTH_STATUS: 'auth_status',


### PR DESCRIPTION
## Summary

Implement a PreCompact hook that fires before context compaction occurs, enabling visibility and custom handling of compaction events. The hook is called with the trigger type (manual or automatic) and any custom instructions associated with the compaction event.

## Changes

- **agent-runner**: New `preCompactHook` callback that emits `pre_compact` events
- **backend**: Added `EventTypePreCompact` constant and `CustomInstructions` field to `AgentEvent`
- **frontend**: Added WebSocket handler for `pre_compact` events with placeholder for future UI indicator

This provides a foundation for future features like displaying a "Compacting context..." indicator during compaction events.