### PR TITLE
Add effort parameter for reasoning depth control

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -101,6 +101,16 @@ const maxBudgetUsd = getNumericArg("--max-budget-usd");
 const maxTurns = getNumericArg("--max-turns");
 const maxThinkingTokens = getNumericArg("--max-thinking-tokens");
 
+// Reasoning effort level (Opus 4.6+)
+const validEffortLevels = ["low", "medium", "high", "max"] as const;
+type EffortLevel = typeof validEffortLevels[number];
+const effortArg = getArg("--effort");
+const effort: EffortLevel | undefined = effortArg
+  ? (validEffortLevels as readonly string[]).includes(effortArg)
+    ? (effortArg as EffortLevel)
+    : (() => { console.error(`Invalid --effort value: "${effortArg}". Ignoring.`); return undefined; })()
+  : undefined;
+
 // Permission mode (e.g., "plan" for plan mode at startup)
 const validPermissionModes = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk"] as const;
 type PermissionMode = typeof validPermissionModes[number];
@@ -1183,6 +1193,8 @@ async function main(): Promise<void> {
         settingSources,
         betas,
         model,
+        // Pass effort level to SDK if specified (Opus 4.6+)
+        ...(effort ? { extraArgs: { "--effort": effort } } : {}),
         fallbackModel,
         abortController: sessionAbortController,
         // Resume a previous session if requested (first turn loads its state)

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -89,6 +89,7 @@ func (m *Manager) SetSessionEventHandler(handler SessionEventHandler) {
 // StartConversationOptions contains optional parameters for starting a conversation
 type StartConversationOptions struct {
 	MaxThinkingTokens int                 // Enable extended thinking with this token budget
+	Effort            string              // Reasoning effort: low, medium, high, max
 	Attachments       []models.Attachment // File attachments for the initial message
 	PlanMode          bool                // Start agent in plan mode
 	Instructions      string              // Additional instructions (e.g., from conversation summaries)
@@ -206,6 +207,7 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 	// Apply optional parameters
 	if opts != nil {
 		procOpts.MaxThinkingTokens = opts.MaxThinkingTokens
+		procOpts.Effort = opts.Effort
 		procOpts.PlanMode = opts.PlanMode
 		procOpts.Instructions = opts.Instructions
 		procOpts.Model = opts.Model

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -43,6 +43,7 @@ type ProcessOptions struct {
 	MaxBudgetUsd        float64
 	MaxTurns            int
 	MaxThinkingTokens   int
+	Effort              string // Reasoning effort: low, medium, high, max
 	PlanMode            bool   // Start agent in plan mode
 	Instructions        string // Additional instructions for the agent (e.g., conversation summaries)
 	StructuredOutput    string
@@ -179,6 +180,9 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	}
 	if opts.MaxThinkingTokens > 0 {
 		args = append(args, "--max-thinking-tokens", strconv.Itoa(opts.MaxThinkingTokens))
+	}
+	if opts.Effort != "" {
+		args = append(args, "--effort", opts.Effort)
 	}
 	if opts.PlanMode {
 		args = append(args, "--permission-mode", "plan")

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -3150,6 +3150,7 @@ type CreateConversationRequest struct {
 	Model             string              `json:"model"`             // Model name override (optional)
 	PlanMode          bool                `json:"planMode"`          // Start in plan mode (optional)
 	MaxThinkingTokens int                 `json:"maxThinkingTokens"` // Enable extended thinking (optional)
+	Effort            string              `json:"effort"`            // Reasoning effort: low, medium, high, max (optional)
 	Attachments       []models.Attachment `json:"attachments"`       // File attachments (optional)
 	SummaryIDs        []string            `json:"summaryIds"`        // Summaries to attach as context (optional)
 }
@@ -3215,9 +3216,10 @@ func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
 
 	// Build options for starting the conversation
 	var opts *agent.StartConversationOptions
-	if req.MaxThinkingTokens > 0 || len(req.Attachments) > 0 || req.PlanMode || instructions != "" || req.Model != "" {
+	if req.MaxThinkingTokens > 0 || len(req.Attachments) > 0 || req.PlanMode || instructions != "" || req.Model != "" || req.Effort != "" {
 		opts = &agent.StartConversationOptions{
 			MaxThinkingTokens: req.MaxThinkingTokens,
+			Effort:            req.Effort,
 			Attachments:       req.Attachments,
 			PlanMode:          req.PlanMode,
 			Instructions:      instructions,

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -37,7 +37,7 @@ import { AttachmentGrid } from './AttachmentGrid';
 import { processDroppedFiles, validateAttachments, SUPPORTED_EXTENSIONS, loadAllAttachmentContents, generateAttachmentId } from '@/lib/attachments';
 import { UserQuestionPrompt } from './UserQuestionPrompt';
 import { usePendingUserQuestion } from '@/stores/selectors';
-import { useSettingsStore } from '@/stores/settingsStore';
+import { useSettingsStore, type EffortLevel } from '@/stores/settingsStore';
 import { useSlashCommandStore, type UnifiedSlashCommand } from '@/stores/slashCommandStore';
 import { SummaryPicker } from './SummaryPicker';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
@@ -71,9 +71,17 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
 }
 
 const MODELS = [
-  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', icon: Snowflake, supportsThinking: true, badge: 'NEW' as const },
-  { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5', icon: Snowflake, supportsThinking: true },
-  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', icon: Snowflake, supportsThinking: true },
+  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', icon: Snowflake, supportsThinking: true, supportsEffort: true, badge: 'NEW' as const },
+  { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5', icon: Snowflake, supportsThinking: true, supportsEffort: false },
+  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', icon: Snowflake, supportsThinking: true, supportsEffort: false },
+];
+
+// Effort levels for models that support the effort parameter (Opus 4.6+)
+const EFFORT_LEVELS: { id: EffortLevel; label: string }[] = [
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'max', label: 'Max' },
 ];
 
 // Models that support extended thinking mode (derived from MODELS)
@@ -102,6 +110,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const [thinkingEnabled, setThinkingEnabled] = useState(defaultThinking);
   const maxThinkingTokens = useSettingsStore((s) => s.maxThinkingTokens);
   const thinkingSupported = THINKING_SUPPORTED_MODELS.has(selectedModel.id);
+  const defaultEffort = useSettingsStore((s) => s.defaultEffort);
+  const [effortLevel, setEffortLevel] = useState<EffortLevel>(defaultEffort);
+  const effortSupported = selectedModel.supportsEffort;
   const defaultPlanMode = useSettingsStore((s) => s.defaultPlanMode);
   const [planModeEnabled, setPlanModeEnabled] = useState(defaultPlanMode);
   const sendWithEnter = useSettingsStore((s) => s.sendWithEnter);
@@ -465,6 +476,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     }
   }, [thinkingSupported, thinkingEnabled]);
 
+  // Auto-reset effort to default when switching to an unsupported model
+  useEffect(() => {
+    if (!effortSupported && effortLevel !== 'high') {
+      setEffortLevel('high');
+    }
+  }, [effortSupported, effortLevel]);
+
   // Global keyboard shortcuts
 
   useEffect(() => {
@@ -474,10 +492,18 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         e.preventDefault();
         plateInputRef.current?.focus();
       }
-      // Alt+T to toggle thinking mode (only if model supports it)
+      // Alt+T to toggle thinking mode or cycle effort levels
       if (e.code === 'KeyT' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
-        if (THINKING_SUPPORTED_MODELS.has(selectedModel.id)) {
+        const model = MODELS.find(m => m.id === selectedModel.id);
+        if (model?.supportsEffort) {
+          // Opus 4.6: cycle effort levels
+          setEffortLevel(prev => {
+            const ids = EFFORT_LEVELS.map(l => l.id);
+            const idx = ids.indexOf(prev);
+            return ids[(idx + 1) % ids.length];
+          });
+        } else if (THINKING_SUPPORTED_MODELS.has(selectedModel.id)) {
           setThinkingEnabled(prev => !prev);
         }
       }
@@ -497,7 +523,14 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     // Handle menu events from native Tauri menu
     const handleFocusInput = () => plateInputRef.current?.focus();
     const handleToggleThinking = () => {
-      if (THINKING_SUPPORTED_MODELS.has(selectedModel.id)) {
+      const model = MODELS.find(m => m.id === selectedModel.id);
+      if (model?.supportsEffort) {
+        setEffortLevel(prev => {
+          const ids = EFFORT_LEVELS.map(l => l.id);
+          const idx = ids.indexOf(prev);
+          return ids[(idx + 1) % ids.length];
+        });
+      } else if (THINKING_SUPPORTED_MODELS.has(selectedModel.id)) {
         setThinkingEnabled(prev => !prev);
       }
     };
@@ -568,8 +601,10 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           model: selectedModel.id,
           // Pass plan mode so agent starts in plan mode if toggled on before first message
           planMode: planModeEnabled ? true : undefined,
-          // Pass thinking tokens when thinking mode is enabled
-          maxThinkingTokens: thinkingEnabled ? maxThinkingTokens : undefined,
+          // Pass thinking tokens when thinking mode is enabled (non-Opus-4.6 models)
+          maxThinkingTokens: !effortSupported && thinkingEnabled ? maxThinkingTokens : undefined,
+          // Pass effort level for Opus 4.6 (only when non-default)
+          effort: effortSupported && effortLevel !== 'high' ? effortLevel : undefined,
           // Pass attachments with loaded content
           attachments: loadedAttachments.length > 0 ? loadedAttachments : undefined,
           // Pass conversation summary context
@@ -897,28 +932,64 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* Extended Thinking Toggle */}
-          <Button
-            variant="ghost"
-            size={thinkingEnabled ? 'sm' : 'icon'}
-            className={cn(
-              thinkingEnabled ? 'h-7 gap-1.5 px-2' : 'h-7 w-7',
-              thinkingEnabled && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20',
-              !thinkingSupported && 'opacity-50 cursor-not-allowed'
-            )}
-            onClick={() => setThinkingEnabled(!thinkingEnabled)}
-            disabled={!thinkingSupported}
-            title={
-              !thinkingSupported
-                ? `Extended thinking not available for ${selectedModel.name}`
-                : `Extended thinking ${thinkingEnabled ? 'on' : 'off'} (⌥T)`
-            }
-            aria-label={`Extended thinking ${thinkingEnabled ? 'on' : 'off'}`}
-            aria-pressed={thinkingEnabled}
-          >
-            <Brain className="h-4 w-4" />
-            {thinkingEnabled && <span className="text-xs font-medium">Thinking</span>}
-          </Button>
+          {/* Thinking / Effort Control — adapts based on model */}
+          {effortSupported ? (
+            // Opus 4.6: Effort level dropdown (thinking is implicit via adaptive thinking)
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'h-7 gap-1.5 px-2 text-xs',
+                    effortLevel !== 'high' && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20'
+                  )}
+                  title={`Reasoning effort: ${effortLevel} (⌥T to cycle)`}
+                  aria-label={`Reasoning effort: ${effortLevel}`}
+                >
+                  <Brain className="h-4 w-4" />
+                  <span className="font-medium capitalize">{effortLevel}</span>
+                  <ChevronDown className="h-3 w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                {EFFORT_LEVELS.map((level) => (
+                  <DropdownMenuItem
+                    key={level.id}
+                    onClick={() => setEffortLevel(level.id)}
+                  >
+                    {level.label}
+                    {level.id === 'high' && (
+                      <span className="ml-1.5 text-xs text-muted-foreground">(default)</span>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            // Non-Opus-4.6 models: Regular thinking toggle
+            <Button
+              variant="ghost"
+              size={thinkingEnabled ? 'sm' : 'icon'}
+              className={cn(
+                thinkingEnabled ? 'h-7 gap-1.5 px-2' : 'h-7 w-7',
+                thinkingEnabled && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20',
+                !thinkingSupported && 'opacity-50 cursor-not-allowed'
+              )}
+              onClick={() => setThinkingEnabled(!thinkingEnabled)}
+              disabled={!thinkingSupported}
+              title={
+                !thinkingSupported
+                  ? `Extended thinking not available for ${selectedModel.name}`
+                  : `Extended thinking ${thinkingEnabled ? 'on' : 'off'} (⌥T)`
+              }
+              aria-label={`Extended thinking ${thinkingEnabled ? 'on' : 'off'}`}
+              aria-pressed={thinkingEnabled}
+            >
+              <Brain className="h-4 w-4" />
+              {thinkingEnabled && <span className="text-xs font-medium">Thinking</span>}
+            </Button>
+          )}
 
           {/* Plan Mode Toggle */}
           <Button

--- a/src/components/settings/sections/AIModelSettings.tsx
+++ b/src/components/settings/sections/AIModelSettings.tsx
@@ -11,7 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Eye, EyeOff } from 'lucide-react';
-import { useSettingsStore } from '@/stores/settingsStore';
+import { useSettingsStore, type EffortLevel } from '@/stores/settingsStore';
 import { getAnthropicApiKey, setAnthropicApiKey } from '@/lib/api';
 import { useToast } from '@/components/ui/toast';
 import { SettingsRow } from '../shared/SettingsRow';
@@ -23,6 +23,8 @@ export function AIModelSettings() {
   const setDefaultThinking = useSettingsStore((s) => s.setDefaultThinking);
   const reviewModel = useSettingsStore((s) => s.reviewModel);
   const setReviewModel = useSettingsStore((s) => s.setReviewModel);
+  const defaultEffort = useSettingsStore((s) => s.defaultEffort);
+  const setDefaultEffort = useSettingsStore((s) => s.setDefaultEffort);
   const defaultPlanMode = useSettingsStore((s) => s.defaultPlanMode);
   const setDefaultPlanMode = useSettingsStore((s) => s.setDefaultPlanMode);
   const maxThinkingTokens = useSettingsStore((s) => s.maxThinkingTokens);
@@ -74,6 +76,23 @@ export function AIModelSettings() {
             <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
             <SelectItem value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</SelectItem>
             <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
+          </SelectContent>
+        </Select>
+      </SettingsRow>
+
+      <SettingsRow
+        title="Default reasoning effort"
+        description="Controls reasoning depth for Opus 4.6 conversations"
+      >
+        <Select value={defaultEffort} onValueChange={(v) => setDefaultEffort(v as EffortLevel)}>
+          <SelectTrigger className="w-36">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="low">Low</SelectItem>
+            <SelectItem value="medium">Medium</SelectItem>
+            <SelectItem value="high">High (default)</SelectItem>
+            <SelectItem value="max">Max (Opus 4.6)</SelectItem>
           </SelectContent>
         </Select>
       </SettingsRow>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -999,6 +999,7 @@ export async function createConversation(
     model?: string;
     planMode?: boolean;
     maxThinkingTokens?: number;
+    effort?: string;
     attachments?: AttachmentDTO[];
     summaryIds?: string[];
   }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -27,6 +27,9 @@ export type ThemeOption = 'system' | 'light' | 'dark';
 // Font size options
 export type FontSize = 'small' | 'medium' | 'large';
 
+// Effort level options for reasoning depth control (Opus 4.6+)
+export type EffortLevel = 'low' | 'medium' | 'high' | 'max';
+
 // Branch prefix options
 export type BranchPrefixType = 'github' | 'custom' | 'none';
 
@@ -72,6 +75,7 @@ interface SettingsState {
   soundEffectType: string;
   sendWithEnter: boolean;
   reviewModel: string;
+  defaultEffort: EffortLevel;
   defaultPlanMode: boolean;
   autoConvertLongText: boolean;
   showChatCost: boolean;
@@ -142,6 +146,7 @@ interface SettingsState {
   setSoundEffectType: (value: string) => void;
   setSendWithEnter: (value: boolean) => void;
   setReviewModel: (value: string) => void;
+  setDefaultEffort: (value: EffortLevel) => void;
   setDefaultPlanMode: (value: boolean) => void;
   setAutoConvertLongText: (value: boolean) => void;
   setShowChatCost: (value: boolean) => void;
@@ -201,6 +206,7 @@ export const useSettingsStore = create<SettingsState>()(
       soundEffectType: 'chime',
       sendWithEnter: true,
       reviewModel: 'claude-opus-4-6',
+      defaultEffort: 'high',
       defaultPlanMode: false,
       autoConvertLongText: true,
       showChatCost: true,
@@ -251,6 +257,7 @@ export const useSettingsStore = create<SettingsState>()(
       setSoundEffectType: (value) => set({ soundEffectType: value }),
       setSendWithEnter: (value) => set({ sendWithEnter: value }),
       setReviewModel: (value) => set({ reviewModel: value }),
+      setDefaultEffort: (value) => set({ defaultEffort: value }),
       setDefaultPlanMode: (value) => set({ defaultPlanMode: value }),
       setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),
       setShowChatCost: (value) => set({ showChatCost: value }),


### PR DESCRIPTION
## Summary

Add support for the `effort` parameter to control reasoning depth in Claude Opus 4.6. Users can select from four effort levels (low/medium/high/max) via a UI dropdown, with keyboard shortcut support. Non-Opus models continue using the existing thinking toggle. Includes new settings preference for default reasoning effort.

## Implementation

- **Backend**: Go REST API and agent-runner process argument handling
- **Frontend**: React UI component with effort selector, Zustand state management, and keyboard shortcuts
- **Full stack**: Properly threads effort parameter through the entire architecture

## Testing

Manual testing recommended for:
- Effort level selector in ChatInput for Opus 4.6 models
- Settings default preference persistence
- Keyboard shortcut Alt+T behavior on Opus vs non-Opus models
- Fallback to thinking toggle when switching to unsupported models

🤖 Generated with Claude Code