### PR TITLE
fix: Resolve Plan Mode approval loop

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -113,7 +113,7 @@ const effort: EffortLevel | undefined = effortArg
   : undefined;
 
 // Permission mode (e.g., "plan" for plan mode at startup)
-const validPermissionModes = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk"] as const;
+const validPermissionModes = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk", "delegate"] as const;
 type PermissionMode = typeof validPermissionModes[number];
 let initialPermissionMode: PermissionMode = "bypassPermissions";
 // Tracks the current permission mode and the mode before plan mode was activated.


### PR DESCRIPTION
## Summary

- Fix Plan Mode approval button looping instead of properly exiting plan mode
- After ExitPlanMode completes via the PreToolUse hook, the agent-runner now emits `permission_mode_changed` to sync the Go backend and frontend out of plan mode
- Propagate `permissionMode` from SDK status messages (previously ignored)
- Explicitly call `setPermissionMode()` as a safety net for SDK bug [#15755](https://github.com/anthropics/claude-code/issues/15755)
- Track `prePlanPermissionMode` to correctly restore the mode that was active before plan mode was entered

## Root Cause

When the user clicked "Approve Plan", the PreToolUse hook returned `permissionDecision: "allow"` and the SDK executed ExitPlanMode internally. However, the agent-runner never emitted a `permission_mode_changed` event for this internal mode transition — it only emitted one when the user explicitly set the mode via stdin. This left the Go backend and frontend stuck with `planModeActive: true`.

## Test plan

- [ ] `npm run lint` — passes (0 errors)
- [ ] `npm run build` — passes
- [ ] `go test ./...` — passes
- [ ] `make dev` → start conversation in Plan Mode → verify approve button works and exits plan mode
- [ ] Verify active conversations still show live elapsed time for sub-agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)