### PR TITLE
Fix: Invalidate PR cache on branch rename

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -117,15 +117,26 @@ func (w *PRWatcher) UnwatchSession(sessionID string) {
 }
 
 // UpdateSessionBranch updates the branch for a watched session (e.g., after branch rename)
+// and invalidates the PR cache for the affected repo so the next poll fetches fresh data.
 func (w *PRWatcher) UpdateSessionBranch(sessionID, newBranch string) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	var repoPath string
 
+	w.mu.Lock()
 	if entry, exists := w.sessions[sessionID]; exists {
 		entry.Branch = newBranch
 		// Reset last checked to trigger re-check
 		entry.LastChecked = time.Time{}
+		repoPath = entry.RepoPath
 		logger.PRWatcher.Infof("Updated branch for session %s: %s", sessionID, newBranch)
+	}
+	w.mu.Unlock()
+
+	// Invalidate PR cache so next tick fetches fresh data from GitHub
+	if repoPath != "" && w.prCache != nil {
+		owner, repo, err := w.repoManager.GetGitHubRemote(w.ctx, repoPath)
+		if err == nil {
+			w.prCache.Invalidate(owner, repo)
+		}
 	}
 }
 
@@ -232,12 +243,15 @@ func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry) 
 			return
 		}
 
-		// Try the shared cache first
+		// Try the shared cache — only use fresh entries (within freshTTL).
+		// Stale entries are skipped so the PRWatcher fetches from GitHub directly,
+		// ensuring eager detection of newly created PRs within ~30 seconds.
 		var openPRs []github.PRListItem
 		if w.prCache != nil {
-			cached, ok := w.prCache.Get(key.owner, key.repo)
-			if ok {
-				openPRs = cached
+			entry, freshness := w.prCache.GetWithStale(key.owner, key.repo)
+			if freshness == github.CacheFresh && entry != nil {
+				openPRs = make([]github.PRListItem, len(entry.PRs))
+				copy(openPRs, entry.PRs)
 			}
 		}
 

--- a/backend/branch/watcher.go
+++ b/backend/branch/watcher.go
@@ -34,9 +34,10 @@ type Watcher struct {
 	mu                sync.RWMutex
 	watcher           *fsnotify.Watcher
 	sessions          map[string]*WatchEntry // sessionID -> entry
-	onChange          func(BranchChangeEvent)
-	onStatsInvalidate func(sessionID string) // Called when worktree files change
-	ctx               context.Context
+	onChange              func(BranchChangeEvent)
+	onStatsInvalidate    func(sessionID string)              // Called when worktree files change
+	onBranchChangeNotify func(sessionID, newBranch string)   // Called when branch changes (e.g., to notify PRWatcher)
+	ctx                  context.Context
 	cancel            context.CancelFunc
 }
 
@@ -138,6 +139,14 @@ func (w *Watcher) SetStatsInvalidateCallback(cb func(sessionID string)) {
 	w.onStatsInvalidate = cb
 }
 
+// SetBranchChangeNotifyCallback sets a callback invoked on branch changes.
+// Used to notify other subsystems (e.g., PRWatcher) when a session's branch is renamed.
+func (w *Watcher) SetBranchChangeNotifyCallback(cb func(sessionID, newBranch string)) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.onBranchChangeNotify = cb
+}
+
 // Close stops the watcher
 func (w *Watcher) Close() error {
 	w.cancel()
@@ -190,7 +199,8 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	var statsInvalidateSessions []string
 
 	w.mu.Lock()
-	onStatsInvalidate := w.onStatsInvalidate // Capture callback while holding lock
+	onStatsInvalidate := w.onStatsInvalidate       // Capture callback while holding lock
+	onBranchChangeNotify := w.onBranchChangeNotify // Capture callback while holding lock
 
 	// Find which session(s) this file belongs to
 	for sessionID, entry := range w.sessions {
@@ -252,6 +262,13 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	if onStatsInvalidate != nil {
 		for _, sessionID := range statsInvalidateSessions {
 			onStatsInvalidate(sessionID)
+		}
+	}
+
+	// Notify subscribers of branch changes (e.g., PRWatcher)
+	if onBranchChangeNotify != nil {
+		for _, evt := range branchEvents {
+			onBranchChangeNotify(evt.SessionID, evt.NewBranch)
 		}
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -375,6 +375,14 @@ func main() {
 		}
 	}
 
+	// Notify PRWatcher when branches change so it can update its in-memory state
+	// and invalidate the PR cache for immediate re-detection
+	if branchWatcher != nil {
+		branchWatcher.SetBranchChangeNotifyCallback(func(sessionID, newBranch string) {
+			prWatcher.UpdateSessionBranch(sessionID, newBranch)
+		})
+	}
+
 	// Issue cache for GitHub Issues API
 	issueCache := github.NewIssueCache(2*time.Minute, 10*time.Minute)
 	defer issueCache.Close()


### PR DESCRIPTION
When a session's branch is renamed, notify the PR watcher to update its in-memory state and invalidate the cache, ensuring fresh PR data is fetched from GitHub within ~30 seconds.

This fixes the issue where renamed branches don't show their associated PRs in the UI until the cache expires (up to 10 minutes).

**Changes:**
- Add branch change notification callback to the filesystem watcher
- Wire callback to PR watcher's UpdateSessionBranch method
- Invalidate PR cache when branch is updated
- Use cache freshness checks to prefer fresh data over stale entries