### PR TITLE
Upgrade Claude Agent SDK to v0.2.41 and fix session ID bugs

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chatml-agent-runner",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.39",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.41",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.39",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.39.tgz",
-      "integrity": "sha512-wR1TBH62X6E1YwRnWa+A2Eau7AfpTWtfpnwQXO3yRY31FtmzOjPkQb93hbF3AkT0WL7YF9mxBBwJKUa3ZEc5+A==",
+      "version": "0.2.41",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.41.tgz",
+      "integrity": "sha512-8qOHvRWWJSULlRnLdJRWYSivDDA0C1szWQx83kXDrFsxMYlPQX3udFzS53GNoJz98rPxUqfH7MjNAc/Vkt7QSQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.39",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.41",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -72,6 +72,9 @@ const cwd = getArg("--cwd") || process.cwd();
 const conversationId = getArg("--conversation-id") || "default";
 const resumeSessionId = getArg("--resume");
 const forkSession = hasFlag("--fork");
+// Custom session ID — when provided, the SDK uses this instead of auto-generating one.
+// Typically set to the conversation ID so session tracking aligns with our data model.
+const customSessionId = getArg("--session-id");
 
 const linearIssue = getArg("--linear-issue");
 const toolPreset = (getArg("--tool-preset") || "full") as "full" | "read-only" | "no-bash" | "safe-edit";
@@ -192,7 +195,7 @@ interface Attachment {
 
 // Input message types from Go backend
 interface InputMessage {
-  type: "message" | "stop" | "interrupt" | "set_model" | "set_permission_mode" | "set_max_thinking_tokens" | "get_supported_models" | "get_supported_commands" | "get_mcp_status" | "get_account_info" | "rewind_files" | "user_question_response" | "plan_approval_response";
+  type: "message" | "stop" | "interrupt" | "set_model" | "set_permission_mode" | "set_max_thinking_tokens" | "get_supported_models" | "get_supported_commands" | "get_mcp_status" | "get_account_info" | "rewind_files" | "user_question_response" | "plan_approval_response" | "reconnect_mcp_server" | "toggle_mcp_server";
   content?: string;
   model?: string;
   permissionMode?: string;
@@ -206,6 +209,9 @@ interface InputMessage {
   planApproved?: boolean;
   // Max thinking tokens override
   maxThinkingTokens?: number;
+  // MCP server management fields (SDK v0.2.21+)
+  serverName?: string;
+  serverEnabled?: boolean;
 }
 
 // Escape a string for use in XML attribute values
@@ -420,6 +426,34 @@ function setupInputQueue(): void {
           });
         } else {
           emit({ type: "command_error", command: "get_mcp_status", error: "No active query" });
+        }
+        return;
+      }
+
+      // MCP server management (SDK v0.2.21+)
+      if (input.type === "reconnect_mcp_server" && input.serverName) {
+        if (queryRef) {
+          void queryRef.reconnectMcpServer(input.serverName).then(() => {
+            emit({ type: "mcp_server_reconnected", serverName: input.serverName! });
+          }).catch((cmdErr: unknown) => {
+            emit({ type: "command_error", command: "reconnect_mcp_server", error: String(cmdErr) });
+          });
+        } else {
+          emit({ type: "command_error", command: "reconnect_mcp_server", error: "No active query" });
+        }
+        return;
+      }
+
+      if (input.type === "toggle_mcp_server" && input.serverName) {
+        if (queryRef) {
+          const enabled = input.serverEnabled !== false;
+          void queryRef.toggleMcpServer(input.serverName, enabled).then(() => {
+            emit({ type: "mcp_server_toggled", serverName: input.serverName!, enabled });
+          }).catch((cmdErr: unknown) => {
+            emit({ type: "command_error", command: "toggle_mcp_server", error: String(cmdErr) });
+          });
+        } else {
+          emit({ type: "command_error", command: "toggle_mcp_server", error: "No active query" });
         }
         return;
       }
@@ -1226,6 +1260,8 @@ async function main(): Promise<void> {
       // Pass effort level to SDK if specified (Opus 4.6+)
       ...(effort ? { extraArgs: { "--effort": effort } } : {}),
       fallbackModel,
+      // Custom session ID — aligns SDK session with our conversation ID (SDK v0.2.33+)
+      ...(customSessionId ? { sessionId: customSessionId } : {}),
       forkSession,
       // Debug options (SDK v0.2.30+)
       debug: sdkDebug || !!process.env.DEBUG_CLAUDE_AGENT_SDK,
@@ -1884,6 +1920,13 @@ async function cleanup(reason: string): Promise<void> {
   if (queryRef) {
     try {
       await queryRef.interrupt();
+    } catch {
+      // Ignore errors during shutdown
+    }
+    // Force-close the query to ensure the subprocess is terminated (SDK v0.2.15+).
+    // close() kills the process immediately — useful when interrupt() alone isn't enough.
+    try {
+      queryRef.close();
     } catch {
       // Ignore errors during shutdown
     }

--- a/agent-runner/src/mcp/server.ts
+++ b/agent-runner/src/mcp/server.ts
@@ -48,7 +48,8 @@ export function createChatMLMcpServer(options: McpServerOptions) {
               }, null, 2),
             }],
           };
-        }
+        },
+        { annotations: { readOnlyHint: true } }
       ),
 
       // Workspace diff tool
@@ -80,7 +81,8 @@ export function createChatMLMcpServer(options: McpServerOptions) {
               content: [{ type: "text", text: `Error getting diff: ${error}` }],
             };
           }
-        }
+        },
+        { annotations: { readOnlyHint: true } }
       ),
 
       // Recent activity tool
@@ -103,7 +105,8 @@ export function createChatMLMcpServer(options: McpServerOptions) {
               content: [{ type: "text", text: `Error getting logs: ${error}` }],
             };
           }
-        }
+        },
+        { annotations: { readOnlyHint: true } }
       ),
 
       // Linear integration tools

--- a/agent-runner/src/mcp/tools/comments.ts
+++ b/agent-runner/src/mcp/tools/comments.ts
@@ -64,7 +64,8 @@ export function createCommentTools(context: WorkspaceContext) {
             }],
           };
         }
-      }
+      },
+      { annotations: { readOnlyHint: false, openWorldHint: true } }
     ),
 
     // List review comments for the current session
@@ -132,7 +133,8 @@ export function createCommentTools(context: WorkspaceContext) {
             }],
           };
         }
-      }
+      },
+      { annotations: { readOnlyHint: true } }
     ),
 
     // Get comment statistics for the session
@@ -192,7 +194,8 @@ export function createCommentTools(context: WorkspaceContext) {
             }],
           };
         }
-      }
+      },
+      { annotations: { readOnlyHint: true } }
     ),
   ];
 }

--- a/agent-runner/src/mcp/tools/linear.ts
+++ b/agent-runner/src/mcp/tools/linear.ts
@@ -32,7 +32,8 @@ export function createLinearTools(context: WorkspaceContext) {
             }, null, 2),
           }],
         };
-      }
+      },
+      { annotations: { readOnlyHint: true } }
     ),
 
     // Start working on a Linear issue
@@ -88,7 +89,8 @@ export function createLinearTools(context: WorkspaceContext) {
             content: [{ type: "text", text: `Error starting issue: ${error}` }],
           };
         }
-      }
+      },
+      { annotations: { idempotentHint: true } }
     ),
 
     // Update Linear issue status
@@ -118,7 +120,8 @@ export function createLinearTools(context: WorkspaceContext) {
             text: `Updated local status for ${issue.identifier} to "${state}".\n\nNote: To update Linear, use: mcp__linear__update_issue`,
           }],
         };
-      }
+      },
+      { annotations: { idempotentHint: true } }
     ),
   ];
 }

--- a/agent-runner/src/mcp/tools/scripts.ts
+++ b/agent-runner/src/mcp/tools/scripts.ts
@@ -65,7 +65,8 @@ export function createScriptTools(context: WorkspaceContext) {
             }],
           };
         }
-      }
+      },
+      { annotations: { readOnlyHint: true } }
     ),
 
     tool(
@@ -99,7 +100,8 @@ export function createScriptTools(context: WorkspaceContext) {
             text: `Proposed .chatml/config.json:\n\n\`\`\`json\n${JSON.stringify(config, null, 2)}\n\`\`\`\n\nPresent this to the user and ask them to approve before writing it to .chatml/config.json using the Write tool.`,
           }],
         };
-      }
+      },
+      { annotations: { readOnlyHint: true, idempotentHint: true } }
     ),
   ];
 }

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -197,6 +197,7 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 		ID:                  convID,
 		Workdir:             session.WorktreePath,
 		ConversationID:      convID,
+		SdkSessionID:        uuid.New().String(), // Full UUID required by SDK
 		EnableCheckpointing: true,
 	}
 

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -35,6 +35,7 @@ type ProcessOptions struct {
 	ID                  string
 	Workdir             string
 	ConversationID      string
+	SdkSessionID        string // Full UUID for SDK session tracking (must be valid UUID)
 	ResumeSession       string // Session ID to resume
 	ForkSession         bool   // Whether to fork the session
 	LinearIssue         string // Linear issue identifier (e.g., "LIN-123")
@@ -94,6 +95,9 @@ type InputMessage struct {
 	PlanApproved          *bool  `json:"planApproved,omitempty"`
 	// Max thinking tokens override (for runtime adjustment)
 	MaxThinkingTokens int `json:"maxThinkingTokens,omitempty"`
+	// MCP server management fields (SDK v0.2.21+)
+	ServerName    string `json:"serverName,omitempty"`
+	ServerEnabled *bool  `json:"serverEnabled,omitempty"`
 }
 
 // findAgentRunner locates the agent-runner executable
@@ -146,6 +150,14 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 		agentRunnerPath,
 		"--cwd", opts.Workdir,
 		"--conversation-id", opts.ConversationID,
+	}
+
+	// Pass a custom session ID to align SDK session tracking with our data model
+	// (SDK v0.2.33+). The SDK requires a valid UUID and prohibits combining
+	// --session-id with --resume unless --fork-session is also set, so only
+	// pass it for new (non-resume) sessions.
+	if opts.SdkSessionID != "" && opts.ResumeSession == "" {
+		args = append(args, "--session-id", opts.SdkSessionID)
 	}
 
 	// Add session resume if specified
@@ -533,6 +545,23 @@ func (p *Process) SendPlanApprovalResponse(requestId string, approved bool) erro
 		Type:                  "plan_approval_response",
 		PlanApprovalRequestID: requestId,
 		PlanApproved:          &approved,
+	})
+}
+
+// ReconnectMcpServer requests the agent to reconnect a failed MCP server (SDK v0.2.21+)
+func (p *Process) ReconnectMcpServer(serverName string) error {
+	return p.sendInput(InputMessage{
+		Type:       "reconnect_mcp_server",
+		ServerName: serverName,
+	})
+}
+
+// ToggleMcpServer enables or disables an MCP server at runtime (SDK v0.2.21+)
+func (p *Process) ToggleMcpServer(serverName string, enabled bool) error {
+	return p.sendInput(InputMessage{
+		Type:          "toggle_mcp_server",
+		ServerName:    serverName,
+		ServerEnabled: &enabled,
 	})
 }
 


### PR DESCRIPTION
## Summary

Upgrades Claude Agent SDK from v0.2.39 to v0.2.41 and fixes two critical SDK integration bugs:

1. **Invalid UUID format for session ID**: ConversationID was a truncated 8-char UUID but SDK requires a valid full UUID. Added SdkSessionID field to carry proper UUIDs.
2. **SDK validation error on session resume**: SDK prohibits combining --session-id with --resume unless --fork-session is set. Now only pass --session-id for new sessions.

## New SDK Features Enabled

- Custom session ID support for better conversation tracking alignment
- MCP server reconnect/toggle capabilities for runtime control  
- MCP tool annotations (readOnlyHint, openWorldHint, idempotentHint)
- Improved process cleanup with explicit subprocess termination

🤖 Generated with [Claude Code](https://claude.com/claude-code)