### PR TITLE
fix: Resolve session not found race condition and display plan content

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -248,6 +248,10 @@ interface PendingPlanApprovalRequest {
 const pendingPlanApprovalRequests = new Map<string, PendingPlanApprovalRequest>();
 let planApprovalRequestCounter = 0;
 
+// Track the last file written during plan mode so we can include plan content
+// in the plan_approval_request event when ExitPlanMode fires.
+let lastPlanFilePath: string | null = null;
+
 // Module-level references for cleanup
 let abortControllerRef: AbortController | null = null;
 
@@ -771,6 +775,15 @@ const preToolUseHook: HookCallback = async (input, toolUseId) => {
     });
   }
 
+  // Track Write tool file paths during plan mode so exitPlanModeHook can
+  // read the plan content and include it in the plan_approval_request event.
+  if (currentPermissionMode === "plan" && hookInput.tool_name === "Write") {
+    const writeInput = hookInput.tool_input as { file_path?: string };
+    if (writeInput.file_path) {
+      lastPlanFilePath = writeInput.file_path;
+    }
+  }
+
   return {}; // Allow all tools (no blocking)
 };
 
@@ -1044,11 +1057,22 @@ const askUserQuestionHook: HookCallback = async (input) => {
 const exitPlanModeHook: HookCallback = async (_input) => {
   const requestId = `plan-approval-${++planApprovalRequestCounter}-${Date.now()}`;
 
-  // Emit the plan approval request to the Go backend
+  // Read plan file content if tracked during plan mode
+  let planContent: string | undefined;
+  if (lastPlanFilePath) {
+    try {
+      planContent = readFileSync(lastPlanFilePath, "utf-8");
+    } catch (err) {
+      debug(`Failed to read plan file ${lastPlanFilePath}: ${err}`);
+    }
+  }
+
+  // Emit the plan approval request to the Go backend (with plan content if available)
   emit({
     type: "plan_approval_request",
     requestId,
     sessionId: currentSessionId,
+    ...(planContent && { planContent }),
   });
 
   // Wait for user response with a safety timeout matching the hook timeout

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -127,6 +127,9 @@ type AgentEvent struct {
 	// User question fields (AskUserQuestion tool)
 	RequestID string         `json:"requestId,omitempty"`
 	Questions []UserQuestion `json:"questions,omitempty"`
+
+	// Plan approval fields (ExitPlanMode tool)
+	PlanContent string `json:"planContent,omitempty"`
 }
 
 // McpServerStatus represents MCP server connection status

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -226,8 +226,8 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
     return items;
   }, [streaming?.segments, tools, subAgents]);
 
-  // Don't render if no streaming content, no active tools, no sub-agents, no thinking, and no error
-  if (timeline.length === 0 && !streaming?.error && !streaming?.thinking && !streaming?.isThinking && !streaming?.isStreaming) {
+  // Don't render if no streaming content, no active tools, no sub-agents, no thinking, no error, and no pending plan
+  if (timeline.length === 0 && !streaming?.error && !streaming?.thinking && !streaming?.isThinking && !streaming?.isStreaming && !streaming?.pendingPlanApproval?.planContent) {
     return null;
   }
 
@@ -347,6 +347,16 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
             }
           });
           })()}
+
+          {/* Plan content display - shown when ExitPlanMode sends plan for approval */}
+          {streaming?.pendingPlanApproval?.planContent && (
+            <div className={PROSE_CLASSES}>
+              <CachedMarkdown
+                cacheKey={`plan:${streaming.pendingPlanApproval.requestId}`}
+                content={streaming.pendingPlanApproval.planContent}
+              />
+            </div>
+          )}
 
           {/* Enhanced error display */}
           {streaming?.error && (

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -263,7 +263,9 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
     const now = new Date().toISOString();
     const t0 = performance.now();
 
-    // Add placeholder session and navigate immediately — no waiting
+    // Add placeholder session to sidebar immediately (but don't navigate —
+    // that happens after the backend creates the real session, preventing
+    // effects from firing API calls with the temp ID).
     addSession({
       id: tempId,
       workspaceId,
@@ -277,11 +279,6 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
       updatedAt: now,
     });
     expandWorkspace(workspaceId);
-    navigate({
-      workspaceId,
-      sessionId: tempId,
-      contentView: { type: 'conversation' },
-    });
 
     try {
       // Create session via backend API (generates city-based name, branch, and worktree path)
@@ -294,16 +291,14 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onQuickStart, 
       });
       console.debug(`[CreateSession] API returned in ${(performance.now() - t0).toFixed(0)}ms`);
 
-      // Atomically swap the temp placeholder with the real session in a single
-      // setState call. This avoids any intermediate state where selectedSessionId
-      // is null (removeSession nullifies it when the removed session is selected,
-      // and navigate uses startTransition which defers the re-select).
+      // Swap the temp placeholder with the real session. The temp was never
+      // navigated to (selectedSessionId was not set to tempId), so we only
+      // need to replace it in the sessions list. Navigation happens below
+      // after conversations are fetched, which triggers effects only once.
       const t1 = performance.now();
       const realSession = mapSessionDTO(session);
       useAppStore.setState((state) => ({
         sessions: [realSession, ...state.sessions.filter((s) => s.id !== tempId)],
-        selectedSessionId: realSession.id,
-        selectedConversationId: null,
       }));
 
       // Register file watcher (non-blocking)

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -468,7 +468,11 @@ export function useWebSocket(enabled: boolean = true) {
       case 'plan_approval_request':
         // ExitPlanMode tool intercepted by PreToolUse hook - show approval UI
         if (event?.requestId) {
-          store.setPendingPlanApproval(conversationId, event.requestId as string);
+          store.setPendingPlanApproval(
+            conversationId,
+            event.requestId as string,
+            event.planContent as string | undefined,
+          );
           notifyDesktop(conversationId, 'Plan ready for approval', 'Review and approve the plan to continue');
         }
         break;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -344,6 +344,9 @@ export interface AgentEvent {
   requestId?: string;
   questions?: UserQuestion[];
 
+  // Plan approval fields (ExitPlanMode tool)
+  planContent?: string;
+
   // CLI crash recovery fields
   attempt?: number;
   maxAttempts?: number;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -142,7 +142,7 @@ interface StreamingState {
   isThinking: boolean;
   startTime?: number; // When streaming started (for elapsed time)
   planModeActive: boolean; // Whether plan mode is active for this conversation
-  pendingPlanApproval: { requestId: string } | null; // Pending ExitPlanMode approval request
+  pendingPlanApproval: { requestId: string; planContent?: string } | null; // Pending ExitPlanMode approval request
 }
 
 // ActiveTool is imported from @/lib/types
@@ -318,7 +318,7 @@ interface AppState {
   setThinking: (conversationId: string, isThinking: boolean) => void;
   clearThinking: (conversationId: string) => void;
   setPlanModeActive: (conversationId: string, active: boolean) => void;
-  setPendingPlanApproval: (conversationId: string, requestId: string) => void;
+  setPendingPlanApproval: (conversationId: string, requestId: string, planContent?: string) => void;
   clearPendingPlanApproval: (conversationId: string) => void;
   addActiveTool: (conversationId: string, tool: ActiveTool, opts?: { skipTimeout?: boolean }) => void;
   completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string) => void;
@@ -1208,9 +1208,9 @@ updateFileTabContent: (id, content) => set((state) => ({
       planModeActive: active,
     }),
   })),
-  setPendingPlanApproval: (conversationId, requestId) => set((state) => ({
+  setPendingPlanApproval: (conversationId, requestId, planContent) => set((state) => ({
     streamingState: updateStreamingConv(state.streamingState, conversationId, {
-      pendingPlanApproval: { requestId },
+      pendingPlanApproval: { requestId, ...(planContent && { planContent }) },
     }),
   })),
   clearPendingPlanApproval: (conversationId) => set((state) => ({


### PR DESCRIPTION
## Summary

- **Fix session creation race condition**: Removed premature `navigate()` to temp session ID during optimistic session creation. The placeholder still appears in the sidebar instantly, but navigation/selection only happens after the backend returns the real session — preventing API calls (`listReviewComments`, `getBranchSyncStatus`, `listSessionFiles`, etc.) from hitting `"session not found"`.
- **Display plan markdown in conversation**: When `ExitPlanMode` fires, the agent-runner now reads the plan file and includes its content in the `plan_approval_request` event. The frontend renders it as a markdown block in the streaming message area above the approval UI.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Agent Runner | `agent-runner/src/index.ts` | Track Write tool file paths during plan mode; read plan file in `exitPlanModeHook` and include `planContent` in event |
| Go Backend | `backend/agent/parser.go` | Add `PlanContent` field to `AgentEvent` struct |
| Frontend | `src/components/navigation/WorkspaceSidebar.tsx` | Remove early `navigate()` to temp session; simplify state swap |
| Frontend | `src/lib/types.ts` | Add `planContent` to `AgentEvent` interface |
| Frontend | `src/stores/appStore.ts` | Extend `pendingPlanApproval` type and setter to carry `planContent` |
| Frontend | `src/hooks/useWebSocket.ts` | Pass `planContent` from WebSocket event to store |
| Frontend | `src/components/conversation/StreamingMessage.tsx` | Render plan markdown via `CachedMarkdown` when pending approval has content |

## Test plan

- [ ] Create a new session from sidebar — verify no console errors ("session not found") and session loads cleanly after ~1s
- [ ] Verify the "Creating session..." placeholder appears in the sidebar immediately
- [ ] Enter plan mode in a conversation, let the agent write a plan and call ExitPlanMode — verify the plan markdown is rendered in the conversation area
- [ ] Approve/reject the plan and verify the content clears properly
- [ ] Verify `npm run build`, `go build ./...`, and `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)