### PR TITLE
fix: Sandbox Go backend tests from production workspaces directory

### DIFF
--- a/backend/git/worktree_test.go
+++ b/backend/git/worktree_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -15,8 +16,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	tmpHome, err := os.MkdirTemp("", "chatml-test-home-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp home: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HOME", tmpHome)
 	appdir.Init()
-	os.Exit(m.Run())
+
+	code := m.Run()
+	os.RemoveAll(tmpHome)
+	os.Exit(code)
 }
 
 func TestNewWorktreeManager(t *testing.T) {

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -1205,12 +1205,6 @@ func TestCreateSession_DuplicateUserProvidedName(t *testing.T) {
 	repoPath := createTestGitRepo(t)
 	repo := createTestRepo(t, s, "ws-1", repoPath)
 
-	// Clean up test session directory after test
-	t.Cleanup(func() {
-		workspacesDir, _ := git.WorkspacesBaseDir()
-		os.RemoveAll(filepath.Join(workspacesDir, "my-session"))
-	})
-
 	// Create first session with explicit name
 	body, _ := json.Marshal(CreateSessionRequest{Name: "my-session"})
 	req := httptest.NewRequest("POST", "/api/repos/ws-1/sessions", bytes.NewReader(body))
@@ -1985,7 +1979,10 @@ func TestGetSessionBranchCommits_CommitFilesHaveStats(t *testing.T) {
 // ============================================================================
 
 func TestGetWorkspacesBaseDir_Default(t *testing.T) {
-	h, _ := setupTestHandlers(t)
+	h, s := setupTestHandlers(t)
+
+	// Clear the workspaces-base-dir setting so the handler falls back to the default path
+	require.NoError(t, s.DeleteSetting(context.Background(), "workspaces-base-dir"))
 
 	req := httptest.NewRequest("GET", "/api/settings/workspaces-base-dir", nil)
 	w := httptest.NewRecorder()
@@ -4178,17 +4175,6 @@ func TestCreateSession_CheckoutExisting_Success(t *testing.T) {
 	runGit(t, cloneDir, "commit", "-m", "Add feature")
 	runGit(t, cloneDir, "push", "origin", "feature/existing-pr")
 
-	// Clean up test session directory after test
-	t.Cleanup(func() {
-		workspacesDir, _ := git.WorkspacesBaseDir()
-		entries, _ := os.ReadDir(workspacesDir)
-		for _, entry := range entries {
-			if entry.IsDir() {
-				os.RemoveAll(filepath.Join(workspacesDir, entry.Name()))
-			}
-		}
-	})
-
 	body, _ := json.Marshal(CreateSessionRequest{
 		Name:             "test-checkout-session",
 		Branch:           "feature/existing-pr",
@@ -4219,17 +4205,6 @@ func TestCreateSession_CheckoutExisting_BranchNotFound(t *testing.T) {
 
 	repoPath := createTestGitRepo(t)
 	repo := createTestRepo(t, s, "ws-1", repoPath)
-
-	// Clean up
-	t.Cleanup(func() {
-		workspacesDir, _ := git.WorkspacesBaseDir()
-		entries, _ := os.ReadDir(workspacesDir)
-		for _, entry := range entries {
-			if entry.IsDir() {
-				os.RemoveAll(filepath.Join(workspacesDir, entry.Name()))
-			}
-		}
-	})
 
 	body, _ := json.Marshal(CreateSessionRequest{
 		Name:             "test-nonexistent",
@@ -4269,16 +4244,6 @@ func TestCreateSession_CheckoutExisting_SystemMessageStored(t *testing.T) {
 	runGit(t, cloneDir, "add", ".")
 	runGit(t, cloneDir, "commit", "-m", "Test commit")
 	runGit(t, cloneDir, "push", "origin", "feature/sys-msg-test")
-
-	t.Cleanup(func() {
-		workspacesDir, _ := git.WorkspacesBaseDir()
-		entries, _ := os.ReadDir(workspacesDir)
-		for _, entry := range entries {
-			if entry.IsDir() {
-				os.RemoveAll(filepath.Join(workspacesDir, entry.Name()))
-			}
-		}
-	})
 
 	systemMsg := "## PR #42: Add auth\n**Branch:** feature/sys-msg-test → main\n**Changes:** +200 -50 across 8 files"
 
@@ -4379,12 +4344,6 @@ func TestCreateSession_WithBranchPrefix(t *testing.T) {
 
 	// Use timestamp-based session name to avoid conflicts
 	sessionName := fmt.Sprintf("test-session-%d", time.Now().UnixNano())
-
-	// Clean up test session directory after test
-	t.Cleanup(func() {
-		workspacesDir, _ := git.WorkspacesBaseDir()
-		os.RemoveAll(filepath.Join(workspacesDir, sessionName))
-	})
 
 	// Create session with BranchPrefix
 	reqBody := CreateSessionRequest{

--- a/backend/server/testhelpers_test.go
+++ b/backend/server/testhelpers_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -21,8 +22,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	tmpHome, err := os.MkdirTemp("", "chatml-test-home-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp home: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HOME", tmpHome)
 	appdir.Init()
-	os.Exit(m.Run())
+
+	code := m.Run()
+	os.RemoveAll(tmpHome)
+	os.Exit(code)
 }
 
 // setupTestHandlers creates handlers for testing
@@ -31,6 +41,10 @@ func setupTestHandlers(t *testing.T) (*Handlers, *store.SQLiteStore) {
 	t.Helper()
 
 	sqliteStore, err := store.NewSQLiteStoreInMemory()
+	require.NoError(t, err)
+
+	tmpWorkspaces := t.TempDir()
+	err = sqliteStore.SetSetting(context.Background(), "workspaces-base-dir", tmpWorkspaces)
 	require.NoError(t, err)
 
 	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
@@ -51,6 +65,10 @@ func setupTestHandlersWithAgentManager(t *testing.T) (*Handlers, *store.SQLiteSt
 	t.Helper()
 
 	sqliteStore, err := store.NewSQLiteStoreInMemory()
+	require.NoError(t, err)
+
+	tmpWorkspaces := t.TempDir()
+	err = sqliteStore.SetSetting(context.Background(), "workspaces-base-dir", tmpWorkspaces)
 	require.NoError(t, err)
 
 	worktreeManager := git.NewWorktreeManager()
@@ -191,6 +209,10 @@ func setupTestHandlersWithAIClient(t *testing.T, aiServerURL string) (*Handlers,
 	t.Helper()
 
 	sqliteStore, err := store.NewSQLiteStoreInMemory()
+	require.NoError(t, err)
+
+	tmpWorkspaces := t.TempDir()
+	err = sqliteStore.SetSetting(context.Background(), "workspaces-base-dir", tmpWorkspaces)
 	require.NoError(t, err)
 
 	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)


### PR DESCRIPTION
## Summary

- **TestMain** in both `server` and `git` packages now overrides `HOME` to a temp dir before `appdir.Init()`, so the global fallback path never touches production directories
- **All 3 setup helpers** (`setupTestHandlers`, `setupTestHandlersWithAgentManager`, `setupTestHandlersWithAIClient`) now set `"workspaces-base-dir"` in the in-memory store to `t.TempDir()`, giving each test its own isolated workspace
- **Removed 5 dangerous `t.Cleanup` blocks** in `handlers_test.go` that called `os.RemoveAll` on production workspace paths — no longer needed since sessions now go into auto-cleaning temp dirs

Zero production code changes. The existing `getWorkspacesBaseDir()` already checks the store for a `"workspaces-base-dir"` setting before falling back to the production path — tests just weren't using it.

## Test plan

- [x] `go test ./server/... -count=1` — all pass
- [x] `go test ./git/... -count=1` — all pass
- [x] `go test ./... -count=1` — full backend suite passes
- [x] `go build ./...` — builds clean
- [ ] Verify `~/Library/Application Support/ChatML/workspaces/` is untouched after test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)