### PR TITLE
Reduce letter spacing on ChatML logo

### DIFF
--- a/src/components/layout/SidebarToolbar.tsx
+++ b/src/components/layout/SidebarToolbar.tsx
@@ -45,7 +45,7 @@ export function SidebarToolbar() {
       )}
     >
       <span
-        className="text-[20px] font-extrabold select-none truncate min-w-0"
+        className="text-[20px] font-extrabold select-none truncate min-w-0 tracking-tight"
         style={{
           fontFamily:
             'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',


### PR DESCRIPTION
Add tracking-tight class to the logo span for a more compact appearance.