### PR TITLE
feat: Unified thinking level control

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, setConversationMaxThinkingTokens, approvePlan } from '@/lib/api';
+import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, approvePlan } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -39,7 +39,8 @@ import { AttachmentGrid } from './AttachmentGrid';
 import { processDroppedFiles, validateAttachments, SUPPORTED_EXTENSIONS, loadAllAttachmentContents, generateAttachmentId } from '@/lib/attachments';
 import { UserQuestionPrompt } from './UserQuestionPrompt';
 import { usePendingUserQuestion } from '@/stores/selectors';
-import { useSettingsStore, type EffortLevel } from '@/stores/settingsStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { THINKING_LEVELS, type ThinkingLevel, resolveThinkingParams, clampThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
 import { useSlashCommandStore, type UnifiedSlashCommand } from '@/stores/slashCommandStore';
 import { SummaryPicker } from './SummaryPicker';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
@@ -78,26 +79,6 @@ const MODELS = [
   { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', icon: Snowflake, supportsThinking: true, supportsEffort: false },
 ];
 
-// Effort levels for models that support the effort parameter (Opus 4.6+)
-const EFFORT_LEVELS: { id: EffortLevel; label: string }[] = [
-  { id: 'low', label: 'Low' },
-  { id: 'medium', label: 'Medium' },
-  { id: 'high', label: 'High' },
-  { id: 'max', label: 'Max' },
-];
-
-// Preset options for max thinking tokens
-const THINKING_TOKEN_PRESETS = [
-  { value: 8000, label: '8K' },
-  { value: 10000, label: '10K' },
-  { value: 16000, label: '16K' },
-  { value: 32000, label: '32K' },
-];
-
-// Models that support extended thinking mode (derived from MODELS)
-const THINKING_SUPPORTED_MODELS = new Set(
-  MODELS.filter((m) => m.supportsThinking).map((m) => m.id)
-);
 
 interface ChatInputProps {
   onMessageSubmit?: () => void;
@@ -110,20 +91,15 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   // Read store defaults once at mount time — these initialize per-conversation
   // state and intentionally don't sync if the user changes settings mid-session.
   const defaultModel = useSettingsStore((s) => s.defaultModel);
-  const defaultThinking = useSettingsStore((s) => s.defaultThinking);
+  const defaultThinkingLevel = useSettingsStore((s) => s.defaultThinkingLevel);
   const [selectedModel, setSelectedModel] = useState(
     () => MODELS.find((m) => m.id === defaultModel) ?? MODELS[0]
   );
   const [isSending, setIsSending] = useState(false);
   const [approvalError, setApprovalError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [thinkingEnabled, setThinkingEnabled] = useState(defaultThinking);
+  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(defaultThinkingLevel);
   const defaultMaxThinkingTokens = useSettingsStore((s) => s.maxThinkingTokens);
-  const [localMaxThinkingTokens, setLocalMaxThinkingTokens] = useState(defaultMaxThinkingTokens);
-  const thinkingSupported = THINKING_SUPPORTED_MODELS.has(selectedModel.id);
-  const defaultEffort = useSettingsStore((s) => s.defaultEffort);
-  const [effortLevel, setEffortLevel] = useState<EffortLevel>(defaultEffort);
-  const effortSupported = selectedModel.supportsEffort;
   const defaultPlanMode = useSettingsStore((s) => s.defaultPlanMode);
   const [planModeEnabled, setPlanModeEnabled] = useState(defaultPlanMode);
   const sendWithEnter = useSettingsStore((s) => s.sendWithEnter);
@@ -458,18 +434,6 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     }
   }, [planModeEnabled, selectedConversationId]);
 
-  // Handler for changing max thinking tokens - also notifies running conversation
-  const handleThinkingTokensChange = useCallback(async (tokens: number) => {
-    setLocalMaxThinkingTokens(tokens);
-    // Apply to running conversation if one exists
-    if (selectedConversationId) {
-      try {
-        await setConversationMaxThinkingTokens(selectedConversationId, tokens);
-      } catch {
-        // Silently ignore if process isn't running
-      }
-    }
-  }, [selectedConversationId]);
 
   // Handle plan approval — clear UI optimistically so the bar disappears instantly
   const handleApprovePlan = useCallback(async () => {
@@ -565,19 +529,10 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     }
   }, [selectedWorkspaceId, selectedSessionId, selectedConversationId, pendingPlanApproval, selectedModel.id, addConversation, addMessage, selectConversation, setStreaming, clearPendingPlanApproval, showError]);
 
-  // Auto-disable thinking when switching to an unsupported model
+  // Clamp thinking level when switching models (e.g. 'off' → 'low' for Opus)
   useEffect(() => {
-    if (thinkingEnabled && !thinkingSupported) {
-      setThinkingEnabled(false);
-    }
-  }, [thinkingSupported, thinkingEnabled]);
-
-  // Auto-reset effort to default when switching to an unsupported model
-  useEffect(() => {
-    if (!effortSupported && effortLevel !== 'high') {
-      setEffortLevel('high');
-    }
-  }, [effortSupported, effortLevel]);
+    setThinkingLevel(prev => clampThinkingLevel(prev, selectedModel));
+  }, [selectedModel]);
 
   // Global keyboard shortcuts
 
@@ -588,20 +543,16 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         e.preventDefault();
         plateInputRef.current?.focus();
       }
-      // Alt+T to toggle thinking mode or cycle effort levels
+      // Alt+T to cycle thinking levels
       if (e.code === 'KeyT' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
-        const model = MODELS.find(m => m.id === selectedModel.id);
-        if (model?.supportsEffort) {
-          // Opus 4.6: cycle effort levels
-          setEffortLevel(prev => {
-            const ids = EFFORT_LEVELS.map(l => l.id);
-            const idx = ids.indexOf(prev);
-            return ids[(idx + 1) % ids.length];
-          });
-        } else if (THINKING_SUPPORTED_MODELS.has(selectedModel.id)) {
-          setThinkingEnabled(prev => !prev);
-        }
+        setThinkingLevel(prev => {
+          const levels = THINKING_LEVELS.map(l => l.id);
+          const allowOff = canDisableThinking(selectedModel);
+          const available = allowOff ? levels : levels.filter(l => l !== 'off');
+          const idx = available.indexOf(prev);
+          return available[(idx + 1) % available.length];
+        });
       }
       // Shift+Tab to toggle plan mode
       if (e.code === 'Tab' && e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
@@ -619,16 +570,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     // Handle menu events from native Tauri menu
     const handleFocusInput = () => plateInputRef.current?.focus();
     const handleToggleThinking = () => {
-      const model = MODELS.find(m => m.id === selectedModel.id);
-      if (model?.supportsEffort) {
-        setEffortLevel(prev => {
-          const ids = EFFORT_LEVELS.map(l => l.id);
-          const idx = ids.indexOf(prev);
-          return ids[(idx + 1) % ids.length];
-        });
-      } else if (THINKING_SUPPORTED_MODELS.has(selectedModel.id)) {
-        setThinkingEnabled(prev => !prev);
-      }
+      setThinkingLevel(prev => {
+        const levels = THINKING_LEVELS.map(l => l.id);
+        const allowOff = canDisableThinking(selectedModel);
+        const available = allowOff ? levels : levels.filter(l => l !== 'off');
+        const idx = available.indexOf(prev);
+        return available[(idx + 1) % available.length];
+      });
     };
     const handleTogglePlanMode = () => handlePlanModeToggle();
 
@@ -642,7 +590,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       window.removeEventListener('toggle-thinking', handleToggleThinking);
       window.removeEventListener('toggle-plan-mode', handleTogglePlanMode);
     };
-  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel.id]);
+  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel]);
 
   const handleSubmit = async () => {
     const { text: content, mentionedFiles } = plateInputRef.current?.getContent() ?? { text: '', mentionedFiles: [] };
@@ -693,20 +641,20 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
         // Create new conversation with initial message via API
         const convType = currentConversation?.type || 'task';
+        // Resolve thinking level into backend params based on model
+        const thinkingParams = resolveThinkingParams(
+          thinkingLevel,
+          selectedModel,
+          defaultMaxThinkingTokens,
+        );
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
           type: convType,
           message: trimmedContent,
-          // Pass selected model so agent uses the correct model
           model: selectedModel.id,
-          // Pass plan mode so agent starts in plan mode if toggled on before first message
           planMode: planModeEnabled ? true : undefined,
-          // Pass thinking tokens when thinking mode is enabled (non-Opus-4.6 models)
-          maxThinkingTokens: !effortSupported && thinkingEnabled ? localMaxThinkingTokens : undefined,
-          // Pass effort level for Opus 4.6 (only when non-default)
-          effort: effortSupported && effortLevel !== 'high' ? effortLevel : undefined,
-          // Pass attachments with loaded content
+          maxThinkingTokens: thinkingParams.maxThinkingTokens,
+          effort: thinkingParams.effort,
           attachments: loadedAttachments.length > 0 ? loadedAttachments : undefined,
-          // Pass conversation summary context
           summaryIds: selectedSummaryIds.length > 0 ? selectedSummaryIds : undefined,
         });
 
@@ -1050,88 +998,43 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* Thinking / Effort Control — adapts based on model */}
-          {effortSupported ? (
-            // Opus 4.6: Effort level dropdown (thinking is implicit via adaptive thinking)
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    'h-7 gap-1.5 px-2 text-xs',
-                    effortLevel !== 'high' && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20'
-                  )}
-                  title={`Reasoning effort: ${effortLevel} (⌥T to cycle)`}
-                  aria-label={`Reasoning effort: ${effortLevel}`}
+          {/* Unified Thinking Level Dropdown */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  'h-7 gap-1.5 px-2 text-xs',
+                  thinkingLevel !== 'high' && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20'
+                )}
+                title={`Thinking: ${thinkingLevel} (⌥T to cycle)`}
+                aria-label={`Thinking: ${thinkingLevel}`}
+              >
+                <Brain className="h-4 w-4" />
+                <span className="font-medium capitalize">{thinkingLevel}</span>
+                <ChevronDown className="h-3 w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              {THINKING_LEVELS.map((level) => (
+                <DropdownMenuItem
+                  key={level.id}
+                  disabled={level.id === 'off' && !canDisableThinking(selectedModel)}
+                  onClick={() => setThinkingLevel(level.id)}
                 >
-                  <Brain className="h-4 w-4" />
-                  <span className="font-medium capitalize">{effortLevel}</span>
-                  <ChevronDown className="h-3 w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                {EFFORT_LEVELS.map((level) => (
-                  <DropdownMenuItem
-                    key={level.id}
-                    onClick={() => setEffortLevel(level.id)}
-                  >
-                    {level.label}
-                    {level.id === 'high' && (
-                      <span className="ml-1.5 text-xs text-muted-foreground">(default)</span>
-                    )}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            // Non-Opus-4.6 models: Regular thinking toggle
-            <Button
-              variant="ghost"
-              size={thinkingEnabled ? 'sm' : 'icon'}
-              className={cn(
-                thinkingEnabled ? 'h-7 gap-1.5 px-2' : 'h-7 w-7',
-                thinkingEnabled && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20',
-                !thinkingSupported && 'opacity-50 cursor-not-allowed'
-              )}
-              onClick={() => setThinkingEnabled(!thinkingEnabled)}
-              disabled={!thinkingSupported}
-              title={
-                !thinkingSupported
-                  ? `Extended thinking not available for ${selectedModel.name}`
-                  : `Extended thinking ${thinkingEnabled ? 'on' : 'off'} (⌥T)`
-              }
-              aria-label={`Extended thinking ${thinkingEnabled ? 'on' : 'off'}`}
-              aria-pressed={thinkingEnabled}
-            >
-              <Brain className="h-4 w-4" />
-              {thinkingEnabled && <span className="text-xs font-medium">Thinking</span>}
-            </Button>
-          )}
-
-          {/* Thinking Tokens Selector — visible when thinking is active */}
-          {((effortSupported) || (!effortSupported && thinkingEnabled && thinkingSupported)) && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="h-7 gap-1 px-1.5 text-xs text-muted-foreground">
-                  {THINKING_TOKEN_PRESETS.find(p => p.value === localMaxThinkingTokens)?.label
-                    ?? `${Math.round(localMaxThinkingTokens / 1000)}K`}
-                  <ChevronDown className="h-3 w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                {THINKING_TOKEN_PRESETS.map((preset) => (
-                  <DropdownMenuItem
-                    key={preset.value}
-                    onClick={() => handleThinkingTokensChange(preset.value)}
-                  >
-                    {preset.label} tokens
-                    {preset.value === localMaxThinkingTokens && <Check className="ml-auto h-3.5 w-3.5" />}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+                  {level.label}
+                  {level.id === 'high' && (
+                    <span className="ml-1.5 text-xs text-muted-foreground">(default)</span>
+                  )}
+                  {level.id === 'off' && !canDisableThinking(selectedModel) && (
+                    <span className="ml-1.5 text-xs text-muted-foreground">(Opus always thinks)</span>
+                  )}
+                  {level.id === thinkingLevel && <Check className="ml-auto h-3.5 w-3.5" />}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
 
           {/* Plan Mode Toggle */}
           <Button

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -211,13 +211,15 @@ const COMMANDS: Command[] = [
   {
     id: 'toggle-thinking-mode',
     category: 'Actions',
-    label: 'Toggle Thinking Mode',
+    label: 'Cycle Thinking Level',
     icon: Brain,
     shortcutId: 'toggleThinking',
-    keywords: ['extended', 'reasoning', 'deep'],
+    keywords: ['extended', 'reasoning', 'deep', 'effort', 'thinking'],
     action: () => {
       const store = useSettingsStore.getState();
-      store.setDefaultThinking(!store.defaultThinking);
+      const levels = ['off', 'low', 'medium', 'high', 'max'] as const;
+      const idx = levels.indexOf(store.defaultThinkingLevel);
+      store.setDefaultThinkingLevel(levels[(idx + 1) % levels.length]);
     },
   },
   {

--- a/src/components/settings/sections/AIModelSettings.tsx
+++ b/src/components/settings/sections/AIModelSettings.tsx
@@ -11,7 +11,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Eye, EyeOff } from 'lucide-react';
-import { useSettingsStore, type EffortLevel } from '@/stores/settingsStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import type { ThinkingLevel } from '@/lib/thinkingLevels';
 import { getAnthropicApiKey, setAnthropicApiKey } from '@/lib/api';
 import { useToast } from '@/components/ui/toast';
 import { SettingsRow } from '../shared/SettingsRow';
@@ -19,12 +20,10 @@ import { SettingsRow } from '../shared/SettingsRow';
 export function AIModelSettings() {
   const defaultModel = useSettingsStore((s) => s.defaultModel);
   const setDefaultModel = useSettingsStore((s) => s.setDefaultModel);
-  const defaultThinking = useSettingsStore((s) => s.defaultThinking);
-  const setDefaultThinking = useSettingsStore((s) => s.setDefaultThinking);
+  const defaultThinkingLevel = useSettingsStore((s) => s.defaultThinkingLevel);
+  const setDefaultThinkingLevel = useSettingsStore((s) => s.setDefaultThinkingLevel);
   const reviewModel = useSettingsStore((s) => s.reviewModel);
   const setReviewModel = useSettingsStore((s) => s.setReviewModel);
-  const defaultEffort = useSettingsStore((s) => s.defaultEffort);
-  const setDefaultEffort = useSettingsStore((s) => s.setDefaultEffort);
   const defaultPlanMode = useSettingsStore((s) => s.defaultPlanMode);
   const setDefaultPlanMode = useSettingsStore((s) => s.setDefaultPlanMode);
   const maxThinkingTokens = useSettingsStore((s) => s.maxThinkingTokens);
@@ -41,30 +40,16 @@ export function AIModelSettings() {
       <h2 className="text-xl font-semibold mb-5">AI & Models</h2>
 
       <SettingsRow title="Default model" description="Model for new conversations">
-        <div className="flex gap-2">
-          <Select value={defaultModel} onValueChange={setDefaultModel}>
-            <SelectTrigger className="w-52">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
-              <SelectItem value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</SelectItem>
-              <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select
-            value={defaultThinking ? 'thinking-on' : 'thinking-off'}
-            onValueChange={(v) => setDefaultThinking(v === 'thinking-on')}
-          >
-            <SelectTrigger className="w-32">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="thinking-on">Thinking on</SelectItem>
-              <SelectItem value="thinking-off">Thinking off</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        <Select value={defaultModel} onValueChange={setDefaultModel}>
+          <SelectTrigger className="w-52">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
+            <SelectItem value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</SelectItem>
+            <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
+          </SelectContent>
+        </Select>
       </SettingsRow>
 
       <SettingsRow title="Review model" description="Model for code reviews">
@@ -81,18 +66,19 @@ export function AIModelSettings() {
       </SettingsRow>
 
       <SettingsRow
-        title="Default reasoning effort"
-        description="Controls reasoning depth for Opus 4.6 conversations"
+        title="Default thinking"
+        description="Controls reasoning depth for new conversations"
       >
-        <Select value={defaultEffort} onValueChange={(v) => setDefaultEffort(v as EffortLevel)}>
+        <Select value={defaultThinkingLevel} onValueChange={(v) => setDefaultThinkingLevel(v as ThinkingLevel)}>
           <SelectTrigger className="w-36">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="off">Off</SelectItem>
             <SelectItem value="low">Low</SelectItem>
             <SelectItem value="medium">Medium</SelectItem>
             <SelectItem value="high">High (default)</SelectItem>
-            <SelectItem value="max">Max (Opus 4.6)</SelectItem>
+            <SelectItem value="max">Max</SelectItem>
           </SelectContent>
         </Select>
       </SettingsRow>
@@ -104,28 +90,30 @@ export function AIModelSettings() {
         <Switch checked={defaultPlanMode} onCheckedChange={setDefaultPlanMode} />
       </SettingsRow>
 
-      <SettingsRow
-        title="Max thinking tokens"
-        description="Maximum tokens for extended thinking"
-      >
-        <Select
-          value={maxThinkingTokens.toString()}
-          onValueChange={(value) => {
-            const n = parseInt(value, 10);
-            if (!isNaN(n) && n > 0) setMaxThinkingTokens(n);
-          }}
+      {defaultThinkingLevel !== 'off' && (
+        <SettingsRow
+          title="Max thinking budget"
+          description="Token budget cap for Sonnet & Haiku (Opus uses adaptive thinking)"
         >
-          <SelectTrigger className="w-32">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="8000">8,000</SelectItem>
-            <SelectItem value="10000">10,000</SelectItem>
-            <SelectItem value="16000">16,000</SelectItem>
-            <SelectItem value="32000">32,000</SelectItem>
-          </SelectContent>
-        </Select>
-      </SettingsRow>
+          <Select
+            value={maxThinkingTokens.toString()}
+            onValueChange={(value) => {
+              const n = parseInt(value, 10);
+              if (!isNaN(n) && n > 0) setMaxThinkingTokens(n);
+            }}
+          >
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="8000">8,000</SelectItem>
+              <SelectItem value="10000">10,000</SelectItem>
+              <SelectItem value="16000">16,000</SelectItem>
+              <SelectItem value="32000">32,000</SelectItem>
+            </SelectContent>
+          </Select>
+        </SettingsRow>
+      )}
 
       <SettingsRow
         title="Show token usage"

--- a/src/lib/thinkingLevels.ts
+++ b/src/lib/thinkingLevels.ts
@@ -1,0 +1,95 @@
+/**
+ * Unified thinking level configuration.
+ *
+ * Replaces the previous 3-control approach (thinking on/off, effort level,
+ * max thinking tokens) with a single ThinkingLevel that maps to the correct
+ * backend params per model.
+ */
+
+export type ThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'max';
+
+export const THINKING_LEVELS: { id: ThinkingLevel; label: string }[] = [
+  { id: 'off', label: 'Off' },
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'max', label: 'Max' },
+];
+
+/** Default thinking token budgets for non-effort models (Sonnet/Haiku). */
+const THINKING_TOKEN_MAP: Record<ThinkingLevel, number | undefined> = {
+  off: undefined,
+  low: 8000,
+  medium: 10000,
+  high: 16000,
+  max: 32000,
+};
+
+export interface ModelThinkingCapabilities {
+  /** Whether the model supports the effort parameter (Opus 4.6+). */
+  supportsEffort: boolean;
+  /** Whether the model supports extended thinking at all. */
+  supportsThinking: boolean;
+}
+
+export interface ThinkingParams {
+  effort?: string;
+  maxThinkingTokens?: number;
+}
+
+/**
+ * Translate a unified ThinkingLevel into backend API params based on model.
+ *
+ * - Opus 4.6 (supportsEffort): uses adaptive thinking + effort param.
+ *   maxThinkingTokens is omitted — the model handles it dynamically.
+ * - Sonnet/Haiku: uses manual thinking with budget_tokens.
+ *   effort is omitted — not supported.
+ *   The thinking level selects a token budget from THINKING_TOKEN_MAP,
+ *   capped by maxThinkingTokensCap (the user's settings override).
+ */
+export function resolveThinkingParams(
+  level: ThinkingLevel,
+  model: ModelThinkingCapabilities,
+  maxThinkingTokensCap?: number,
+): ThinkingParams {
+  if (model.supportsEffort) {
+    // Opus 4.6: adaptive thinking — only send effort, no maxThinkingTokens
+    const effectiveLevel = level === 'off' ? 'low' : level;
+    return {
+      effort: effectiveLevel !== 'high' ? effectiveLevel : undefined,
+    };
+  }
+
+  if (!model.supportsThinking || level === 'off') {
+    return {};
+  }
+
+  // Sonnet/Haiku: level picks the budget, settings value caps it
+  const levelTokens = THINKING_TOKEN_MAP[level];
+  const tokens = maxThinkingTokensCap != null && levelTokens != null
+    ? Math.min(levelTokens, maxThinkingTokensCap)
+    : levelTokens;
+  return {
+    maxThinkingTokens: tokens,
+  };
+}
+
+/**
+ * Clamp a ThinkingLevel for a given model.
+ * Opus 4.6 can't disable thinking — 'off' becomes 'low'.
+ */
+export function clampThinkingLevel(
+  level: ThinkingLevel,
+  model: ModelThinkingCapabilities,
+): ThinkingLevel {
+  if (model.supportsEffort && level === 'off') return 'low';
+  return level;
+}
+
+/**
+ * Whether "Off" is allowed for this model.
+ * Opus 4.6 always has implicit thinking — can't disable it.
+ */
+export function canDisableThinking(model: ModelThinkingCapabilities): boolean {
+  return !model.supportsEffort;
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { Workspace } from '@/lib/types';
 import { useAuthStore } from '@/stores/authStore';
+import type { ThinkingLevel } from '@/lib/thinkingLevels';
 
 // Bottom panel tab IDs that can be toggled (Tasks is always visible)
 export type BottomPanelTab = 'plans' | 'history' | 'budget' | 'mcp' | 'file-history' | 'scripts';
@@ -27,8 +28,8 @@ export type ThemeOption = 'system' | 'light' | 'dark';
 // Font size options
 export type FontSize = 'small' | 'medium' | 'large';
 
-// Effort level options for reasoning depth control (Opus 4.6+)
-export type EffortLevel = 'low' | 'medium' | 'high' | 'max';
+// Re-export ThinkingLevel for convenience
+export type { ThinkingLevel } from '@/lib/thinkingLevels';
 
 // Branch prefix options
 export type BranchPrefixType = 'github' | 'custom' | 'none';
@@ -64,8 +65,8 @@ interface SettingsState {
   confirmCloseActiveTab: boolean;
   confirmArchiveDirtySession: boolean;
   defaultModel: string;
-  defaultThinking: boolean;
-  maxThinkingTokens: number;
+  defaultThinkingLevel: ThinkingLevel;
+  maxThinkingTokens: number; // Secondary setting for Sonnet/Haiku token budget
   showThinkingBlocks: boolean; // Whether to show thinking/reasoning content in messages
   showTokenUsage: boolean; // Whether to show token counts and cost breakdown in run summaries
   desktopNotifications: boolean;
@@ -73,7 +74,6 @@ interface SettingsState {
   soundEffectType: string;
   sendWithEnter: boolean;
   reviewModel: string;
-  defaultEffort: EffortLevel;
   defaultPlanMode: boolean;
   autoConvertLongText: boolean;
   showChatCost: boolean;
@@ -137,7 +137,7 @@ interface SettingsState {
   setConfirmCloseActiveTab: (value: boolean) => void;
   setConfirmArchiveDirtySession: (value: boolean) => void;
   setDefaultModel: (value: string) => void;
-  setDefaultThinking: (value: boolean) => void;
+  setDefaultThinkingLevel: (value: ThinkingLevel) => void;
   setMaxThinkingTokens: (value: number) => void;
   setShowThinkingBlocks: (value: boolean) => void;
   toggleShowThinkingBlocks: () => void;
@@ -147,7 +147,6 @@ interface SettingsState {
   setSoundEffectType: (value: string) => void;
   setSendWithEnter: (value: boolean) => void;
   setReviewModel: (value: string) => void;
-  setDefaultEffort: (value: EffortLevel) => void;
   setDefaultPlanMode: (value: boolean) => void;
   setAutoConvertLongText: (value: boolean) => void;
   setShowChatCost: (value: boolean) => void;
@@ -199,8 +198,8 @@ export const useSettingsStore = create<SettingsState>()(
       confirmCloseActiveTab: true,
       confirmArchiveDirtySession: true,
       defaultModel: 'claude-opus-4-6',
-      defaultThinking: true,
-      maxThinkingTokens: 10000,
+      defaultThinkingLevel: 'high' as ThinkingLevel,
+      maxThinkingTokens: 16000,
       showThinkingBlocks: true,
       showTokenUsage: true,
       desktopNotifications: true,
@@ -208,7 +207,6 @@ export const useSettingsStore = create<SettingsState>()(
       soundEffectType: 'chime',
       sendWithEnter: true,
       reviewModel: 'claude-opus-4-6',
-      defaultEffort: 'high',
       defaultPlanMode: false,
       autoConvertLongText: true,
       showChatCost: true,
@@ -250,7 +248,7 @@ export const useSettingsStore = create<SettingsState>()(
       setConfirmCloseActiveTab: (value) => set({ confirmCloseActiveTab: value }),
       setConfirmArchiveDirtySession: (value) => set({ confirmArchiveDirtySession: value }),
       setDefaultModel: (value) => set({ defaultModel: value }),
-      setDefaultThinking: (value) => set({ defaultThinking: value }),
+      setDefaultThinkingLevel: (value) => set({ defaultThinkingLevel: value }),
       setMaxThinkingTokens: (value) => set({ maxThinkingTokens: value }),
       setShowThinkingBlocks: (value) => set({ showThinkingBlocks: value }),
       toggleShowThinkingBlocks: () => set((state) => ({ showThinkingBlocks: !state.showThinkingBlocks })),
@@ -260,7 +258,6 @@ export const useSettingsStore = create<SettingsState>()(
       setSoundEffectType: (value) => set({ soundEffectType: value }),
       setSendWithEnter: (value) => set({ sendWithEnter: value }),
       setReviewModel: (value) => set({ reviewModel: value }),
-      setDefaultEffort: (value) => set({ defaultEffort: value }),
       setDefaultPlanMode: (value) => set({ defaultPlanMode: value }),
       setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),
       setShowChatCost: (value) => set({ showChatCost: value }),
@@ -381,6 +378,14 @@ export const useSettingsStore = create<SettingsState>()(
       merge: (persistedState, currentState) => {
         const persisted = persistedState as Partial<SettingsState>;
         const merged = { ...currentState, ...persisted };
+
+        // Migrate old thinking settings → unified ThinkingLevel
+        const oldState = persistedState as Record<string, unknown>;
+        if ('defaultThinking' in oldState && !('defaultThinkingLevel' in oldState)) {
+          const wasOn = oldState.defaultThinking as boolean;
+          const oldEffort = (oldState.defaultEffort as string) || 'high';
+          merged.defaultThinkingLevel = (wasOn ? oldEffort : 'off') as ThinkingLevel;
+        }
 
         // Ensure bottomTabOrder includes all tabs from DEFAULT_BOTTOM_TAB_ORDER
         // and remove any tabs that no longer exist in the defaults


### PR DESCRIPTION
Consolidate three separate controls (thinking on/off, effort level, max tokens) into a single "Thinking Level" dropdown that maps to backend params per model.

**Changes:**
- New `src/lib/thinkingLevels.ts` with unified type and translation logic
- ChatInput: single dropdown replacing three separate controls
- Settings: single "Default thinking" setting (from "Default reasoning effort")
- Store: migrate old thinking/effort settings to new `defaultThinkingLevel`
- **Fix:** thinking level now affects Sonnet/Haiku token budgets (level picks budget, settings value caps it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)