### PR TITLE
feat: Persist approved plans and improve ExitPlanMode UX labels

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -312,6 +312,7 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	// Buffer tools that arrive before their sub-agent registers (race recovery)
 	pendingSubAgentTools := make(map[string][]ActiveToolEntry)
 	var currentThinking string
+	var pendingPlanContent string
 	var isThinking bool
 	var snapshotDirty bool
 
@@ -597,6 +598,9 @@ outer:
 					markSnapshotDirty()
 				}
 
+			case EventTypePlanApprovalRequest:
+				pendingPlanContent = event.PlanContent
+
 			case EventTypeTurnComplete, EventTypeComplete, EventTypeResult:
 				// Turn or session completed — store accumulated message and reset
 				// streaming state. turn_complete means the process stays alive;
@@ -645,12 +649,24 @@ outer:
 
 					durationMs := int(time.Since(turnStartTime).Milliseconds())
 
+					// Only persist plan content if ExitPlanMode succeeded this turn
+					var planContent string
+					if pendingPlanContent != "" {
+						for _, tool := range completedTools {
+							if tool.Tool == "ExitPlanMode" && tool.Success != nil && *tool.Success {
+								planContent = pendingPlanContent
+								break
+							}
+						}
+					}
+
 					if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
 						ID:              uuid.New().String()[:8],
 						Role:            "assistant",
 						Content:         currentAssistantMessage,
 						ToolUsage:       completedTools,
 						ThinkingContent: currentThinking,
+						PlanContent:     planContent,
 						DurationMs:      durationMs,
 						Timeline:        timeline,
 						Timestamp:       time.Now(),
@@ -661,6 +677,7 @@ outer:
 				}
 				// Reset per-turn accumulation state
 				currentThinking = ""
+				pendingPlanContent = ""
 				isThinking = false
 				activeToolsMap = make(map[string]ActiveToolEntry)
 				activeSubAgents = make(map[string]*SubAgentEntry)
@@ -751,12 +768,24 @@ outer:
 
 		durationMs := int(time.Since(turnStartTime).Milliseconds())
 
+		// Only persist plan content if ExitPlanMode succeeded this turn
+		var finalPlanContent string
+		if pendingPlanContent != "" {
+			for _, tool := range completedTools {
+				if tool.Tool == "ExitPlanMode" && tool.Success != nil && *tool.Success {
+					finalPlanContent = pendingPlanContent
+					break
+				}
+			}
+		}
+
 		if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
 			ID:              uuid.New().String()[:8],
 			Role:            "assistant",
 			Content:         currentAssistantMessage,
 			ToolUsage:       completedTools,
 			ThinkingContent: currentThinking,
+			PlanContent:     finalPlanContent,
 			DurationMs:      durationMs,
 			Timeline:        timeline,
 			Timestamp:       time.Now(),

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -183,6 +183,7 @@ type Message struct {
 	ThinkingContent string             `json:"thinkingContent,omitempty"` // Extended thinking/reasoning content
 	DurationMs      int                `json:"durationMs,omitempty"`      // Turn duration in milliseconds
 	Timeline        []TimelineEntry    `json:"timeline,omitempty"`        // Interleaved text/tool ordering
+	PlanContent     string             `json:"planContent,omitempty"`     // Approved plan content
 	Timestamp       time.Time          `json:"timestamp"`
 }
 

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -681,6 +681,19 @@ func (s *SQLiteStore) runMigrations() error {
 		logger.SQLite.Infof("Migration: Added timeline column to messages")
 	}
 
+	// Migration: Add plan_content column to messages (approved plan content from ExitPlanMode)
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('messages') WHERE name = 'plan_content'`).Scan(&count)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		_, err = s.db.Exec(`ALTER TABLE messages ADD COLUMN plan_content TEXT DEFAULT NULL`)
+		if err != nil {
+			return err
+		}
+		logger.SQLite.Infof("Migration: Added plan_content column to messages")
+	}
+
 	return nil
 }
 
@@ -1782,7 +1795,7 @@ func (s *SQLiteStore) GetConversationMessages(ctx context.Context, convID string
 		rows, err = s.db.QueryContext(ctx, `
 			SELECT id, role, content, setup_info, run_summary,
 				tool_usage, thinking_content, duration_ms, timeline,
-				timestamp, position
+				plan_content, timestamp, position
 			FROM messages
 			WHERE conversation_id = ? AND position < ?
 			ORDER BY position DESC
@@ -1791,7 +1804,7 @@ func (s *SQLiteStore) GetConversationMessages(ctx context.Context, convID string
 		rows, err = s.db.QueryContext(ctx, `
 			SELECT id, role, content, setup_info, run_summary,
 				tool_usage, thinking_content, duration_ms, timeline,
-				timestamp, position
+				plan_content, timestamp, position
 			FROM messages
 			WHERE conversation_id = ?
 			ORDER BY position DESC
@@ -1812,11 +1825,12 @@ func (s *SQLiteStore) GetConversationMessages(ctx context.Context, convID string
 		var msg models.Message
 		var setupInfoJSON, runSummaryJSON sql.NullString
 		var toolUsageJSON, thinkingContentNull, timelineJSON sql.NullString
+		var planContentNull sql.NullString
 		var durationMsNull sql.NullInt64
 		var position int
 		if err := rows.Scan(&msg.ID, &msg.Role, &msg.Content, &setupInfoJSON, &runSummaryJSON,
 			&toolUsageJSON, &thinkingContentNull, &durationMsNull, &timelineJSON,
-			&msg.Timestamp, &position); err != nil {
+			&planContentNull, &msg.Timestamp, &position); err != nil {
 			return nil, fmt.Errorf("GetConversationMessages scan: %w", err)
 		}
 		if setupInfoJSON.Valid {
@@ -1848,6 +1862,9 @@ func (s *SQLiteStore) GetConversationMessages(ctx context.Context, convID string
 			if json.Unmarshal([]byte(timelineJSON.String), &timeline) == nil {
 				msg.Timeline = timeline
 			}
+		}
+		if planContentNull.Valid {
+			msg.PlanContent = planContentNull.String
 		}
 		items = append(items, messageWithPos{msg: msg, position: position})
 	}
@@ -2082,6 +2099,7 @@ func (s *SQLiteStore) AddMessageToConversation(ctx context.Context, convID strin
 
 	// Nullable scalar fields
 	thinkingContent := nullString(msg.ThinkingContent)
+	planContent := nullString(msg.PlanContent)
 	var durationMs sql.NullInt64
 	if msg.DurationMs > 0 {
 		durationMs = sql.NullInt64{Int64: int64(msg.DurationMs), Valid: true}
@@ -2108,11 +2126,11 @@ func (s *SQLiteStore) AddMessageToConversation(ctx context.Context, convID strin
 		_, err = tx.ExecContext(ctx, `
 			INSERT INTO messages (id, conversation_id, role, content, setup_info, run_summary,
 				tool_usage, thinking_content, duration_ms, timeline,
-				timestamp, position)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				plan_content, timestamp, position)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			msg.ID, convID, msg.Role, msg.Content, setupInfoJSON, runSummaryJSON,
 			toolUsageJSON, thinkingContent, durationMs, timelineJSON,
-			msg.Timestamp, nextPos)
+			planContent, msg.Timestamp, nextPos)
 		if err != nil {
 			tx.Rollback()
 			return err

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -150,6 +150,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     setQueuedMessage,
     commitQueuedMessage,
     clearPendingPlanApproval,
+    setApprovedPlanContent,
     clearActiveTools,
     setPlanModeActive,
   } = useAppStore();
@@ -475,7 +476,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const handleApprovePlan = useCallback(async () => {
     if (!selectedConversationId || !pendingPlanApproval) return;
 
-    const { requestId } = pendingPlanApproval;
+    const { requestId, planContent } = pendingPlanApproval;
+
+    // Save approved plan content for message persistence before clearing
+    if (planContent) {
+      setApprovedPlanContent(selectedConversationId, planContent);
+    }
 
     // Clear UI immediately — don't wait for the HTTP round-trip
     clearPendingPlanApproval(selectedConversationId);
@@ -489,7 +495,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       console.error('Failed to approve plan:', error);
       showError(error instanceof Error ? error.message : 'Failed to approve plan');
     }
-  }, [selectedConversationId, pendingPlanApproval, clearPendingPlanApproval, showError]);
+  }, [selectedConversationId, pendingPlanApproval, clearPendingPlanApproval, setApprovedPlanContent, showError]);
 
   // Handle reject - sends denial to the agent so it stays in plan mode
   const handleRejectPlan = useCallback(async () => {

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -8,7 +8,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
-import { Copy, Check, FileText, Brain, ChevronDown, ChevronRight } from 'lucide-react';
+import { Copy, Check, FileText, Brain, ClipboardCheck, ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Message } from '@/lib/types';
 import { COPY_FEEDBACK_DURATION_MS, PROSE_CLASSES } from '@/lib/constants';
@@ -49,6 +49,7 @@ export const MessageBlock = memo(function MessageBlock({
 }: MessageBlockProps) {
   const [copied, setCopied] = useState(false);
   const [isThinkingExpanded, setIsThinkingExpanded] = useState(false);
+  const [isPlanExpanded, setIsPlanExpanded] = useState(false);
   const showThinkingBlocks = useSettingsStore((s) => s.showThinkingBlocks);
 
   const copyContent = useCallback(async () => {
@@ -120,6 +121,29 @@ export const MessageBlock = memo(function MessageBlock({
             {isThinkingExpanded && (
               <div className="ml-5 text-xs px-2 py-1.5 rounded bg-ai-thinking/10 text-muted-foreground font-mono border border-ai-thinking/20 whitespace-pre-wrap max-h-[300px] overflow-y-auto">
                 {message.thinkingContent}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Approved Plan Content */}
+        {message.planContent && (
+          <div className="flex flex-col gap-1">
+            <button
+              onClick={() => setIsPlanExpanded(!isPlanExpanded)}
+              className="flex items-center gap-2 text-xs text-primary hover:text-primary/80 transition-colors"
+            >
+              <ClipboardCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+              <span className="font-medium">Approved Plan</span>
+              {isPlanExpanded ? (
+                <ChevronDown className="w-3 h-3" />
+              ) : (
+                <ChevronRight className="w-3 h-3" />
+              )}
+            </button>
+            {isPlanExpanded && (
+              <div className={cn(PROSE_CLASSES, 'ml-5 border-l-2 border-primary/20 pl-3')}>
+                <CachedMarkdown cacheKey={`plan:${message.id}`} content={message.planContent} />
               </div>
             )}
           </div>
@@ -276,6 +300,7 @@ export const MessageBlock = memo(function MessageBlock({
     prev.timestamp !== next.timestamp ||
     prev.role !== next.role ||
     prev.thinkingContent !== next.thinkingContent ||
+    prev.planContent !== next.planContent ||
     prevProps.isFirst !== nextProps.isFirst ||
     prevProps.worktreePath !== nextProps.worktreePath ||
     prevProps.searchQuery !== nextProps.searchQuery) {

--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -20,6 +20,7 @@ import {
   Search,
   Globe,
   FolderOpen,
+  ClipboardCheck,
   Circle,
   type LucideIcon,
 } from 'lucide-react';
@@ -112,6 +113,8 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
         return Globe;
       case 'list_dir':
         return FolderOpen;
+      case 'ExitPlanMode':
+        return ClipboardCheck;
       default:
         return Terminal;
     }
@@ -143,6 +146,8 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
         return 'Search web';
       case 'list_dir':
         return 'List';
+      case 'ExitPlanMode':
+        return isActive ? 'Propose Plan' : 'Exiting Plan mode';
       default:
         return tool;
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -930,6 +930,7 @@ export interface MessageDTO {
   thinkingContent?: string;
   durationMs?: number;
   timeline?: TimelineEntryDTO[];
+  planContent?: string;
   timestamp: string;
 }
 
@@ -976,6 +977,7 @@ export function toStoreMessage(dto: MessageDTO, conversationId: string): import(
     thinkingContent: dto.thinkingContent,
     durationMs: dto.durationMs,
     timeline: dto.timeline as import('@/lib/types').TimelineEntry[] | undefined,
+    planContent: dto.planContent,
     timestamp: dto.timestamp,
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -206,6 +206,8 @@ export interface Message {
   thinkingContent?: string;
   // Ordered timeline preserving interleaved text and tool structure from streaming
   timeline?: TimelineEntry[];
+  // Approved plan content from ExitPlanMode
+  planContent?: string;
 }
 
 // Run statistics from agent

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -143,6 +143,7 @@ interface StreamingState {
   startTime?: number; // When streaming started (for elapsed time)
   planModeActive: boolean; // Whether plan mode is active for this conversation
   pendingPlanApproval: { requestId: string; planContent?: string } | null; // Pending ExitPlanMode approval request
+  approvedPlanContent?: string; // Plan content to persist after approval
 }
 
 // ActiveTool is imported from @/lib/types
@@ -320,6 +321,7 @@ interface AppState {
   setPlanModeActive: (conversationId: string, active: boolean) => void;
   setPendingPlanApproval: (conversationId: string, requestId: string, planContent?: string) => void;
   clearPendingPlanApproval: (conversationId: string) => void;
+  setApprovedPlanContent: (conversationId: string, content: string) => void;
   addActiveTool: (conversationId: string, tool: ActiveTool, opts?: { skipTimeout?: boolean }) => void;
   completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string) => void;
   updateToolProgress: (conversationId: string, toolId: string, progress: { elapsedTimeSeconds?: number; toolName?: string }) => void;
@@ -1218,6 +1220,11 @@ updateFileTabContent: (id, content) => set((state) => ({
       pendingPlanApproval: null,
     }),
   })),
+  setApprovedPlanContent: (conversationId, content) => set((state) => ({
+    streamingState: updateStreamingConv(state.streamingState, conversationId, {
+      approvedPlanContent: content,
+    }),
+  })),
   addActiveTool: (conversationId, tool, opts) => {
     // Set up timeout to force-complete orphaned tools (skip for synthetic entries that will be completed immediately)
     if (!opts?.skipTimeout) {
@@ -1452,6 +1459,7 @@ updateFileTabContent: (id, content) => set((state) => ({
         startTime: hasQueuedMessage ? Date.now() : undefined,
         planModeActive: streaming?.planModeActive || false,
         pendingPlanApproval: null,
+        approvedPlanContent: undefined,
       };
 
       // If no streaming text, just clear the state
@@ -1502,6 +1510,7 @@ updateFileTabContent: (id, content) => set((state) => ({
         runSummary: metadata.runSummary,
         ...(streaming.thinking ? { thinkingContent: streaming.thinking } : {}),
         ...(timeline ? { timeline } : {}),
+        ...(streaming.approvedPlanContent ? { planContent: streaming.approvedPlanContent } : {}),
       };
 
       // Atomically: add message AND clear streaming state


### PR DESCRIPTION
## Summary

- Approved plan content is now persisted in the message (SQLite `plan_content` column) so it survives app restarts
- On reload, a collapsible "Approved Plan" section renders the persisted markdown in the message block
- Rejected plans are never stored — backend validates ExitPlanMode success, frontend only captures on explicit approval
- ExitPlanMode tool shows "Propose Plan" while active, "Exiting Plan mode" after completion, with ClipboardCheck icon

## Test plan

- [ ] Enter plan mode, agent proposes plan → ExitPlanMode tool shows "Propose Plan" label with clipboard icon
- [ ] Approve plan → tool label changes to "Exiting Plan mode"
- [ ] Agent completes turn → message saved with plan content
- [ ] Restart app → reload conversation → plan content visible in collapsible "Approved Plan" section
- [ ] Reject a plan → no plan content persisted in message
- [ ] `cd backend && go test ./...` passes
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)