### PR TITLE
fix: Sync plan toggle when agent enters plan mode

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -289,10 +289,23 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     return hasText ? 'queue' : 'stop';
   })();
 
+  // Check if plan mode is active (agent-driven state from backend events)
+  const planModeActive = selectedConversationId
+    ? streamingState[selectedConversationId]?.planModeActive ?? false
+    : false;
+
   // Check if there's a pending plan approval request
   const pendingPlanApproval = selectedConversationId
     ? streamingState[selectedConversationId]?.pendingPlanApproval
     : null;
+
+  // Sync toggle ON when agent enters plan mode (e.g. EnterPlanMode tool).
+  // Only syncs activation — deactivation is handled by handleApprovePlan.
+  useEffect(() => {
+    if (planModeActive && !planModeEnabled) {
+      setPlanModeEnabled(true);
+    }
+  }, [planModeActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Check if there's a pending user question
   const pendingQuestion = usePendingUserQuestion(selectedConversationId);


### PR DESCRIPTION
## Summary

- When the agent enters plan mode itself (via `EnterPlanMode` tool), the compose area plan toggle now syncs to the enabled (amber) state
- Previously the "Plan Mode Active" banner showed at the top but the compose toggle remained off — they were inconsistent
- The sync only activates the toggle (on) — deactivation is still handled exclusively by `handleApprovePlan`, avoiding stale SDK status issues

## Test plan

- [ ] Agent enters plan mode via `EnterPlanMode` tool → banner shows AND toggle turns amber
- [ ] User manually toggles plan mode → works as before
- [ ] Approve plan → toggle turns off, banner hides
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)