### PR TITLE
Add smart input suggestions powered by Claude Haiku

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -700,6 +700,11 @@ outer:
 				m.onConversationEvent(convID, event)
 			}
 
+			// Generate input suggestion after turn completes (async, fire-and-forget)
+			if event.Type == EventTypeResult {
+				go m.generateInputSuggestion(convID)
+			}
+
 			// Also support legacy output handler (for backwards compatibility)
 			if m.onOutput != nil {
 				legacy := ParseStreamLine(line)
@@ -1318,6 +1323,49 @@ func (m *Manager) generateAndApplySessionTitle(sessionID, convID, userMessage st
 
 	// Also try to auto-name the session
 	m.tryAutoNameSession(ctx, sessionID, title)
+}
+
+// generateInputSuggestion uses the AI client to generate a suggested next prompt
+// from recent conversation messages, then broadcasts it via WebSocket.
+func (m *Manager) generateInputSuggestion(convID string) {
+	client := m.newAIClient()
+	if client == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(m.ctx, 10*time.Second)
+	defer cancel()
+
+	// Fetch last 4 messages from the conversation
+	page, err := m.store.GetConversationMessages(ctx, convID, nil, 4)
+	if err != nil || len(page.Messages) == 0 {
+		return
+	}
+
+	// Convert to SummaryMessage format
+	var msgs []ai.SummaryMessage
+	for _, msg := range page.Messages {
+		msgs = append(msgs, ai.SummaryMessage{Role: msg.Role, Content: msg.Content})
+	}
+
+	suggestion, err := client.GenerateInputSuggestion(ctx, ai.SuggestionRequest{Messages: msgs})
+	if err != nil {
+		logger.Manager.Debugf("Failed to generate input suggestion for conv %s: %v", convID, err)
+		return
+	}
+
+	// Only broadcast if there's something to suggest
+	if suggestion.GhostText == "" && len(suggestion.Pills) == 0 {
+		return
+	}
+
+	if m.onConversationEvent != nil {
+		m.onConversationEvent(convID, &AgentEvent{
+			Type:      EventTypeInputSuggestion,
+			GhostText: suggestion.GhostText,
+			Pills:     suggestion.Pills,
+		})
+	}
 }
 
 // tryAutoNameSession attempts to auto-name a session based on the first conversation's name suggestion.

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/chatml/chatml-backend/ai"
 )
 
 // AgentEvent represents a parsed event from the agent-runner stdout
@@ -130,6 +132,10 @@ type AgentEvent struct {
 
 	// Plan approval fields (ExitPlanMode tool)
 	PlanContent string `json:"planContent,omitempty"`
+
+	// Input suggestion fields (Haiku-generated prompt suggestions)
+	GhostText string              `json:"ghostText,omitempty"`
+	Pills     []ai.SuggestionPill `json:"pills,omitempty"`
 }
 
 // McpServerStatus represents MCP server connection status
@@ -251,6 +257,9 @@ const (
 
 	// CLI crash recovery (agent-runner auto-retrying)
 	EventTypeSessionRecovering = "session_recovering"
+
+	// Input suggestion events (Haiku-generated prompt suggestions)
+	EventTypeInputSuggestion = "input_suggestion"
 )
 
 // TodoItem represents a single todo item from the agent's TodoWrite tool

--- a/backend/ai/generate.go
+++ b/backend/ai/generate.go
@@ -591,3 +591,120 @@ func (c *Client) GenerateSessionSummary(ctx context.Context, req GenerateSession
 
 	return strings.TrimSpace(apiResp.Content[0].Text), nil
 }
+
+// SuggestionPill represents a clickable suggestion option.
+type SuggestionPill struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+}
+
+// SuggestionRequest contains the recent conversation messages for generating input suggestions.
+type SuggestionRequest struct {
+	Messages []SummaryMessage `json:"messages"`
+}
+
+// SuggestionResponse contains the AI-generated input suggestion.
+type SuggestionResponse struct {
+	GhostText string           `json:"ghost_text"`
+	Pills     []SuggestionPill `json:"pills"`
+}
+
+const suggestionSystemPrompt = `You analyze AI coding assistant conversations and suggest what the user should say next.
+
+Rules:
+- If the assistant just completed a task successfully, suggest a follow-up action (e.g., "Run the test suite", "Review the changes", "Let's commit and make a PR")
+- If the assistant is asking the user a question, provide 2-3 short pill answers the user can click, plus a ghost_text with the most likely answer
+- If no suggestion is appropriate (e.g., the assistant is mid-task, or the context is unclear), return empty ghost_text and empty pills array
+- ghost_text should be 5-15 words, natural language, imperative mood
+- pill labels should be 2-4 words; pill values should be complete sentences the user would type
+- Output valid JSON only, no markdown fences, no extra text
+
+Output format:
+{"ghost_text": "...", "pills": [{"label": "...", "value": "..."}]}`
+
+const suggestionMaxTokens = 200
+const suggestionMaxInputChars = 2000
+
+// GenerateInputSuggestion calls the Anthropic API to generate a suggested next prompt
+// based on recent conversation messages. Returns an empty suggestion on error.
+func (c *Client) GenerateInputSuggestion(ctx context.Context, req SuggestionRequest) (*SuggestionResponse, error) {
+	if c == nil {
+		return nil, fmt.Errorf("AI client not configured")
+	}
+
+	// Build user message from recent messages, capping total chars
+	var userMsg strings.Builder
+	totalChars := 0
+	for _, m := range req.Messages {
+		content := m.Content
+		remaining := suggestionMaxInputChars - totalChars
+		if remaining <= 0 {
+			break
+		}
+		if len(content) > remaining {
+			content = content[:remaining]
+		}
+		role := strings.ToUpper(m.Role[:1]) + m.Role[1:]
+		userMsg.WriteString(fmt.Sprintf("--- %s ---\n%s\n\n", role, content))
+		totalChars += len(content)
+	}
+
+	apiReq := anthropicRequest{
+		Model:     haikuModel,
+		MaxTokens: suggestionMaxTokens,
+		System:    suggestionSystemPrompt,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: userMsg.String()},
+		},
+	}
+
+	body, err := json.Marshal(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.apiURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set(c.authHeader, c.authValue)
+	httpReq.Header.Set("anthropic-version", apiVersion)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("calling Anthropic API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Anthropic API returned %d: %s", resp.StatusCode, respBody)
+	}
+
+	var apiResp anthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if len(apiResp.Content) == 0 {
+		return &SuggestionResponse{}, nil
+	}
+
+	// Parse JSON response
+	var suggestion SuggestionResponse
+	text := strings.TrimSpace(apiResp.Content[0].Text)
+	if err := json.Unmarshal([]byte(text), &suggestion); err != nil {
+		// Haiku may wrap in markdown fences — try stripping them
+		text = strings.TrimPrefix(text, "```json")
+		text = strings.TrimPrefix(text, "```")
+		text = strings.TrimSuffix(text, "```")
+		text = strings.TrimSpace(text)
+		if err := json.Unmarshal([]byte(text), &suggestion); err != nil {
+			return nil, fmt.Errorf("parsing suggestion JSON: %w", err)
+		}
+	}
+
+	return &suggestion, nil
+}

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -36,7 +36,7 @@ import { ContextMeter } from './ContextMeter';
 import { useToast } from '@/components/ui/toast';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { listenForFileDrop, listenForDragEnter, listenForDragLeave, openFileDialog, copyToClipboard } from '@/lib/tauri';
-import type { Attachment } from '@/lib/types';
+import type { Attachment, SuggestionPill } from '@/lib/types';
 import { AttachmentGrid } from './AttachmentGrid';
 import { processDroppedFiles, validateAttachments, SUPPORTED_EXTENSIONS, loadAllAttachmentContents, generateAttachmentId } from '@/lib/attachments';
 import { UserQuestionPrompt } from './UserQuestionPrompt';
@@ -106,6 +106,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const [planModeEnabled, setPlanModeEnabled] = useState(defaultPlanMode);
   const sendWithEnter = useSettingsStore((s) => s.sendWithEnter);
   const autoConvertLongText = useSettingsStore((s) => s.autoConvertLongText);
+  const suggestionsEnabled = useSettingsStore((s) => s.suggestionsEnabled);
+  const autoSubmitPill = useSettingsStore((s) => s.autoSubmitPillSuggestion);
   const [isDragOver, setIsDragOver] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
@@ -131,9 +133,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     setApprovedPlanContent,
     clearActiveTools,
     setPlanModeActive,
+    clearInputSuggestion,
   } = useAppStore();
   const hasQueuedMessage = useAppStore(
     (s) => selectedConversationId ? s.queuedMessage[selectedConversationId] != null : false
+  );
+  const inputSuggestion = useAppStore(
+    (s) => selectedConversationId ? s.inputSuggestions[selectedConversationId] : undefined
   );
   const { error: showError, info: showInfo } = useToast();
 
@@ -293,6 +299,18 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const planModeActive = selectedConversationId
     ? streamingState[selectedConversationId]?.planModeActive ?? false
     : false;
+
+  // Check if conversation has messages (for ghost text vs placeholder)
+  const conversationHasMessages = useAppStore(
+    (s) => selectedConversationId ? s.messages.some(m => m.conversationId === selectedConversationId) : false
+  );
+
+  // Ghost text visibility: show after first message when editor is empty and not streaming
+  const showGhostText = suggestionsEnabled
+    && !isStreaming
+    && !message.trim()
+    && !!inputSuggestion?.ghostText
+    && conversationHasMessages;
 
   // Check if there's a pending plan approval request
   const pendingPlanApproval = selectedConversationId
@@ -557,6 +575,20 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       showError('Failed to create new conversation for hand off');
     }
   }, [selectedWorkspaceId, selectedSessionId, selectedConversationId, pendingPlanApproval, selectedModel.id, addConversation, addMessage, selectConversation, setStreaming, clearPendingPlanApproval, showError]);
+
+  // Handle pill suggestion click
+  const handlePillClick = useCallback((pill: SuggestionPill) => {
+    if (selectedConversationId) {
+      clearInputSuggestion(selectedConversationId);
+    }
+    if (autoSubmitPill) {
+      sendMessage(pill.value);
+    } else {
+      plateInputRef.current?.setText(pill.value);
+      setMessage(pill.value);
+      plateInputRef.current?.focus();
+    }
+  }, [selectedConversationId, autoSubmitPill, sendMessage, clearInputSuggestion]);
 
   // Clamp thinking level when switching models (e.g. 'off' → 'low' for Opus)
   useEffect(() => {
@@ -823,6 +855,15 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       return;
     }
 
+    // Tab to accept ghost text suggestion
+    if (e.key === 'Tab' && !e.shiftKey && showGhostText && inputSuggestion?.ghostText && selectedConversationId) {
+      e.preventDefault();
+      plateInputRef.current?.setText(inputSuggestion.ghostText);
+      setMessage(inputSuggestion.ghostText);
+      clearInputSuggestion(selectedConversationId);
+      return;
+    }
+
     // ⌘⇧↵ to approve plan
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && e.shiftKey && pendingPlanApproval) {
       e.preventDefault();
@@ -848,6 +889,26 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
   return (
     <div className="pt-1 px-3 pb-3">
+      {/* Pill Suggestions */}
+      {suggestionsEnabled && inputSuggestion?.pills && inputSuggestion.pills.length > 0 && !isStreaming && !pendingPlanApproval && (
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-xs text-muted-foreground shrink-0">Suggested:</span>
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {inputSuggestion.pills.map((pill, i) => (
+              <Button
+                key={i}
+                variant="secondary"
+                size="sm"
+                className="h-7 text-xs rounded-full px-3"
+                onClick={() => handlePillClick(pill)}
+              >
+                {pill.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Plan Approval Bar */}
       {pendingPlanApproval && (
         <div className="space-y-1.5 mb-2">
@@ -984,7 +1045,10 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         <div className="relative px-3 py-2">
           <PlateInput
             ref={plateInputRef}
-            placeholder="Describe your task, @ to reference files, / for skills and commands"
+            placeholder={conversationHasMessages && suggestionsEnabled
+              ? undefined
+              : "Describe your task, @ to reference files, / for skills and commands"
+            }
             className="bg-transparent dark:bg-transparent relative z-10"
             mentionItems={mentionItems}
             mentionItemsLoading={mentionItemsLoading}
@@ -992,12 +1056,25 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             onSlashCommandExecute={handleSlashCommandExecute}
             onInput={(text) => {
               setMessage(text);
+              // Clear suggestion when user starts typing
+              if (text.trim() && selectedConversationId) {
+                clearInputSuggestion(selectedConversationId);
+              }
             }}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
           />
+          {/* Ghost text suggestion */}
+          {showGhostText && (
+            <div className="absolute inset-0 px-0 py-1 pointer-events-none z-0 flex items-start">
+              <span className="text-muted-foreground/40 text-base leading-relaxed">
+                {inputSuggestion!.ghostText}
+                <span className="text-muted-foreground/25 text-xs ml-2">Tab</span>
+              </span>
+            </div>
+          )}
           {/* Cmd+L hint - hidden when focused */}
           {!isFocused && (
             <div className="absolute top-3 right-3 text-xs text-muted-foreground/50 pointer-events-none z-20">

--- a/src/components/settings/sections/GeneralSettings.tsx
+++ b/src/components/settings/sections/GeneralSettings.tsx
@@ -33,6 +33,10 @@ export function GeneralSettings() {
   const setSendWithEnter = useSettingsStore((s) => s.setSendWithEnter);
   const autoConvertLongText = useSettingsStore((s) => s.autoConvertLongText);
   const setAutoConvertLongText = useSettingsStore((s) => s.setAutoConvertLongText);
+  const suggestionsEnabled = useSettingsStore((s) => s.suggestionsEnabled);
+  const setSuggestionsEnabled = useSettingsStore((s) => s.setSuggestionsEnabled);
+  const autoSubmitPillSuggestion = useSettingsStore((s) => s.autoSubmitPillSuggestion);
+  const setAutoSubmitPillSuggestion = useSettingsStore((s) => s.setAutoSubmitPillSuggestion);
   const defaultOpenApp = useSettingsStore((s) => s.defaultOpenApp);
   const setDefaultOpenApp = useSettingsStore((s) => s.setDefaultOpenApp);
   const { installedApps } = useInstalledApps();
@@ -65,6 +69,20 @@ export function GeneralSettings() {
             <SelectItem value="cmd-enter">Cmd+Enter</SelectItem>
           </SelectContent>
         </Select>
+      </SettingsRow>
+
+      <SettingsRow
+        title="Input suggestions"
+        description="Show AI-suggested prompts after each assistant turn"
+      >
+        <Switch checked={suggestionsEnabled} onCheckedChange={setSuggestionsEnabled} />
+      </SettingsRow>
+
+      <SettingsRow
+        title="Auto-submit pill suggestions"
+        description="Automatically send the message when clicking a suggestion pill"
+      >
+        <Switch checked={autoSubmitPillSuggestion} onCheckedChange={setAutoSubmitPillSuggestion} />
       </SettingsRow>
 
       <SettingsRow title="Default editor" description="App used by the toolbar Open button">

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -228,6 +228,8 @@ export function useWebSocket(enabled: boolean = true) {
         if (event?.content) {
           store.clearThinking(conversationId);
           store.appendStreamingText(conversationId, event.content);
+          // Clear input suggestions when new turn starts streaming
+          store.clearInputSuggestion(conversationId);
         }
         break;
 
@@ -324,6 +326,18 @@ export function useWebSocket(enabled: boolean = true) {
           store.updateConversation(conversationId, { name: event.name });
         }
         break;
+
+      case 'input_suggestion': {
+        // AI-generated input suggestion (ghost text + optional pills)
+        const currentStreaming = getStore().streamingState[conversationId];
+        if (!currentStreaming?.isStreaming && useSettingsStore.getState().suggestionsEnabled) {
+          store.setInputSuggestion(conversationId, {
+            ghostText: event?.ghostText || '',
+            pills: event?.pills || [],
+          });
+        }
+        break;
+      }
 
       case 'result': {
         // Result event signals the end of a turn - finalize streaming atomically

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -184,6 +184,18 @@ export interface Attachment {
   preview?: string;          // Text preview (first N chars)
 }
 
+// SuggestionPill = A clickable suggestion option
+export interface SuggestionPill {
+  label: string;
+  value: string;
+}
+
+// InputSuggestion = AI-generated input suggestion (ghost text + optional pills)
+export interface InputSuggestion {
+  ghostText: string;
+  pills: SuggestionPill[];
+}
+
 // Message = Individual message in a conversation
 export interface Message {
   id: string;
@@ -348,6 +360,10 @@ export interface AgentEvent {
 
   // Plan approval fields (ExitPlanMode tool)
   planContent?: string;
+
+  // Input suggestion fields
+  ghostText?: string;
+  pills?: SuggestionPill[];
 
   // CLI crash recovery fields
   attempt?: number;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -29,6 +29,7 @@ import type {
   ScriptRun,
   SetupProgress,
   TimelineEntry,
+  InputSuggestion,
 } from '@/lib/types';
 
 // Maximum number of file tabs before LRU eviction kicks in
@@ -212,6 +213,9 @@ interface AppState {
   // Pending user questions from AskUserQuestion tool (keyed by conversationId)
   pendingUserQuestion: { [conversationId: string]: PendingUserQuestion | null };
 
+  // Input suggestions from Haiku (keyed by conversationId)
+  inputSuggestions: { [conversationId: string]: InputSuggestion };
+
   // Conversation summaries (keyed by conversationId)
   summaries: { [conversationId: string]: Summary };
 
@@ -262,6 +266,10 @@ interface AppState {
   // Summary actions
   setSummary: (conversationId: string, summary: Summary) => void;
   updateSummary: (conversationId: string, updates: Partial<Summary>) => void;
+
+  // Input suggestion actions
+  setInputSuggestion: (conversationId: string, suggestion: InputSuggestion) => void;
+  clearInputSuggestion: (conversationId: string) => void;
 
   // Message actions
   setMessages: (messages: Message[]) => void;
@@ -469,6 +477,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   branchSyncDismissed: {},
   branchSyncCompletedAt: {},
   pendingUserQuestion: {},
+  inputSuggestions: {},
   summaries: {},
   lastFileChange: null,
   messagePagination: {},
@@ -828,6 +837,15 @@ export const useAppStore = create<AppState>((set, get) => ({
     return {
       summaries: { ...state.summaries, [conversationId]: { ...existing, ...updates } },
     };
+  }),
+
+  // Input suggestion actions
+  setInputSuggestion: (conversationId, suggestion) => set((state) => ({
+    inputSuggestions: { ...state.inputSuggestions, [conversationId]: suggestion },
+  })),
+  clearInputSuggestion: (conversationId) => set((state) => {
+    const { [conversationId]: _, ...rest } = state.inputSuggestions;
+    return { inputSuggestions: rest };
   }),
 
   // Message actions

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -73,6 +73,8 @@ interface SettingsState {
   soundEffects: boolean;
   soundEffectType: string;
   sendWithEnter: boolean;
+  suggestionsEnabled: boolean;
+  autoSubmitPillSuggestion: boolean;
   reviewModel: string;
   defaultPlanMode: boolean;
   autoConvertLongText: boolean;
@@ -146,6 +148,8 @@ interface SettingsState {
   setSoundEffects: (value: boolean) => void;
   setSoundEffectType: (value: string) => void;
   setSendWithEnter: (value: boolean) => void;
+  setSuggestionsEnabled: (value: boolean) => void;
+  setAutoSubmitPillSuggestion: (value: boolean) => void;
   setReviewModel: (value: string) => void;
   setDefaultPlanMode: (value: boolean) => void;
   setAutoConvertLongText: (value: boolean) => void;
@@ -206,6 +210,8 @@ export const useSettingsStore = create<SettingsState>()(
       soundEffects: false,
       soundEffectType: 'chime',
       sendWithEnter: true,
+      suggestionsEnabled: true,
+      autoSubmitPillSuggestion: false,
       reviewModel: 'claude-opus-4-6',
       defaultPlanMode: false,
       autoConvertLongText: true,
@@ -257,6 +263,8 @@ export const useSettingsStore = create<SettingsState>()(
       setSoundEffects: (value) => set({ soundEffects: value }),
       setSoundEffectType: (value) => set({ soundEffectType: value }),
       setSendWithEnter: (value) => set({ sendWithEnter: value }),
+      setSuggestionsEnabled: (value) => set({ suggestionsEnabled: value }),
+      setAutoSubmitPillSuggestion: (value) => set({ autoSubmitPillSuggestion: value }),
       setReviewModel: (value) => set({ reviewModel: value }),
       setDefaultPlanMode: (value) => set({ defaultPlanMode: value }),
       setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),


### PR DESCRIPTION
## Summary

Adds AI-powered input suggestions that appear after each assistant turn completes. The system uses Claude Haiku to generate contextual suggestions in two forms: ghost text (accepted with Tab) and clickable suggestion pills.

## Changes

- Backend: New suggestion generation pipeline using Haiku model, triggered on turn completion
- Frontend: Ghost text overlay in input field, clickable suggestion pills above input
- Settings: Two new toggles to enable/disable suggestions and control auto-submission behavior
- Bug fix: Prevents duplicate API calls by triggering only on EventTypeResult event

## Test Plan

- [x] Backend compiles without errors
- [ ] Enable "Input suggestions" in settings
- [ ] Have a conversation and verify suggestions appear after each turn
- [ ] Test Tab key to accept ghost text
- [ ] Click a suggestion pill and verify it populates or submits (based on auto-submit setting)
- [ ] Disable suggestions in settings and verify they stop appearing

🤖 Generated with Claude Code