### PR TITLE
Set Files tab as default first tab in secondary sidebar

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -663,7 +663,7 @@ const TOP_TABS_CONFIG: Record<AllTopPanelTab, { label: string; alwaysVisible?: b
   changes: { label: 'Changes', alwaysVisible: true },
   review: { label: 'Review' },
   checks: { label: 'Checks' },
-  files: { label: 'Files' },
+  files: { label: 'Files', alwaysVisible: true },
 };
 
 // Bottom panel tabs configuration

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -20,7 +20,7 @@ export type TopPanelTab = 'review' | 'checks' | 'files';
 export type AllTopPanelTab = 'changes' | TopPanelTab;
 
 // Default top tab order
-export const DEFAULT_TOP_TAB_ORDER: AllTopPanelTab[] = ['changes', 'review', 'checks', 'files'];
+export const DEFAULT_TOP_TAB_ORDER: AllTopPanelTab[] = ['files', 'changes', 'checks', 'review'];
 
 // Theme options
 export type ThemeOption = 'system' | 'light' | 'dark';


### PR DESCRIPTION
## Summary
- Reorders default sidebar tabs to: Files, Changes, Checks, Review
- Files tab now first in tab bar (matching initial selected tab state)
- Files tab marked as always visible (prevents accidental hiding)
- Existing users preserve custom tab order via Zustand persist merge logic

## Test Plan
- [x] All 889 tests pass
- [x] Build succeeds with no errors
- [x] Manual verification: clear localStorage to simulate fresh install and verify tab order