### PR TITLE
style: Make archive session styling consistently destructive

### DIFF
--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -431,7 +431,7 @@ export function SessionToolbarContent() {
                   <RefreshCw /> Sync with Main
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onSelect={handleArchive}>
+                <DropdownMenuItem variant="destructive" onSelect={handleArchive}>
                   <Archive /> Archive Session
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1636,7 +1636,7 @@ function SessionRow({
               {/* Actions - positioned absolutely to avoid layout shift */}
               <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                 <button
-                  className="p-0.5 rounded hover:bg-surface-1 text-muted-foreground hover:text-foreground"
+                  className="p-0.5 rounded hover:bg-destructive/10 text-destructive/70 hover:text-destructive"
                   onClick={(e) => {
                     e.stopPropagation();
                     onArchiveSession(session.id);

--- a/src/components/session-manager/SessionsDataTable.tsx
+++ b/src/components/session-manager/SessionsDataTable.tsx
@@ -250,6 +250,7 @@ export function SessionsDataTable({
           label: 'Archive',
           icon: <Archive className="h-4 w-4" />,
           onClick: () => onArchiveSession(row.session.id),
+          variant: 'destructive',
         });
       }
 

--- a/src/components/session-manager/cells/ActionsCell.tsx
+++ b/src/components/session-manager/cells/ActionsCell.tsx
@@ -31,7 +31,7 @@ export function ActionsCell({
             <Button
               variant="ghost"
               size="icon"
-              className="h-7 w-7 text-text-warning/70 hover:text-text-warning hover:bg-text-warning/10"
+              className="h-7 w-7 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
               onClick={(e) => {
                 e.stopPropagation();
                 onArchive();


### PR DESCRIPTION
Apply red/destructive styling to all archive session UI elements for consistent visual feedback that the action is irreversible.

Updates:
- Toolbar dropdown menu item
- Session manager table context menu
- Session manager icon button
- Sidebar hover button

All archive actions now use the red/destructive color variant throughout the application.