### PR TITLE
feat: Add checkpoint tracking infrastructure

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -601,6 +601,25 @@ outer:
 			case EventTypePlanApprovalRequest:
 				pendingPlanContent = event.PlanContent
 
+			case EventTypeCheckpointCreated:
+				if event.CheckpointUuid != "" {
+					conv, _ := m.store.GetConversationMeta(ctx, convID)
+					if conv != nil {
+						cp := &models.Checkpoint{
+							ID:             uuid.New().String(),
+							ConversationID: convID,
+							SessionID:      conv.SessionID,
+							UUID:           event.CheckpointUuid,
+							MessageIndex:   event.MessageIndex,
+							IsResult:       event.IsResult,
+							Timestamp:      time.Now(),
+						}
+						if err := m.store.AddCheckpoint(ctx, cp); err != nil {
+							logger.Manager.Errorf("Failed to persist checkpoint for conv %s: %v", convID, err)
+						}
+					}
+				}
+
 			case EventTypeTurnComplete, EventTypeComplete, EventTypeResult:
 				// Turn or session completed — store accumulated message and reset
 				// streaming state. turn_complete means the process stays alive;

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -65,6 +65,11 @@ type AgentEvent struct {
 	IsInterrupt      bool        `json:"isInterrupt,omitempty"`
 	StopHookActive   bool        `json:"stopHookActive,omitempty"`
 
+	// Checkpoint fields
+	CheckpointUuid string `json:"checkpointUuid,omitempty"`
+	MessageIndex   int    `json:"messageIndex,omitempty"`
+	IsResult       bool   `json:"isResult,omitempty"`
+
 	// Subagent fields
 	AgentId            string `json:"agentId,omitempty"`
 	AgentType          string `json:"agentType,omitempty"`

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -438,3 +438,14 @@ type BranchSyncResult struct {
 	ConflictFiles []string `json:"conflictFiles,omitempty"`
 	ErrorMessage  string   `json:"errorMessage,omitempty"`
 }
+
+// Checkpoint represents a file state snapshot created by the Claude Agent SDK at message boundaries.
+type Checkpoint struct {
+	ID             string    `json:"id"`
+	ConversationID string    `json:"conversationId"`
+	SessionID      string    `json:"sessionId"`
+	UUID           string    `json:"uuid"`
+	MessageIndex   int       `json:"messageIndex"`
+	IsResult       bool      `json:"isResult"`
+	Timestamp      time.Time `json:"timestamp"`
+}

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -694,6 +694,27 @@ func (s *SQLiteStore) runMigrations() error {
 		logger.SQLite.Infof("Migration: Added plan_content column to messages")
 	}
 
+	// Migration: Create checkpoints table (file state snapshots from Agent SDK)
+	_, err = s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS checkpoints (
+			id TEXT PRIMARY KEY,
+			conversation_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			uuid TEXT NOT NULL,
+			message_index INTEGER NOT NULL DEFAULT 0,
+			is_result INTEGER NOT NULL DEFAULT 0,
+			timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+			FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+		)`)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_checkpoints_conversation ON checkpoints(conversation_id)`)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -2654,6 +2675,55 @@ func (s *SQLiteStore) DeleteReviewCommentsForSession(ctx context.Context, sessio
 	_, err := s.db.ExecContext(ctx, `DELETE FROM review_comments WHERE session_id = ?`, sessionID)
 	if err != nil {
 		return fmt.Errorf("DeleteReviewCommentsForSession: %w", err)
+	}
+	return nil
+}
+
+// ============================================================================
+// Checkpoint methods
+// ============================================================================
+
+func (s *SQLiteStore) AddCheckpoint(ctx context.Context, cp *models.Checkpoint) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO checkpoints (id, conversation_id, session_id, uuid, message_index, is_result, timestamp)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		cp.ID, cp.ConversationID, cp.SessionID, cp.UUID, cp.MessageIndex, boolToInt(cp.IsResult), cp.Timestamp)
+	if err != nil {
+		return fmt.Errorf("AddCheckpoint: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) ListCheckpointsByConversation(ctx context.Context, conversationID string) ([]*models.Checkpoint, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, conversation_id, session_id, uuid, message_index, is_result, timestamp
+		FROM checkpoints WHERE conversation_id = ?
+		ORDER BY timestamp ASC`, conversationID)
+	if err != nil {
+		return nil, fmt.Errorf("ListCheckpointsByConversation: %w", err)
+	}
+	defer rows.Close()
+
+	checkpoints := []*models.Checkpoint{}
+	for rows.Next() {
+		var cp models.Checkpoint
+		var isResult int
+		if err := rows.Scan(&cp.ID, &cp.ConversationID, &cp.SessionID, &cp.UUID, &cp.MessageIndex, &isResult, &cp.Timestamp); err != nil {
+			return nil, fmt.Errorf("ListCheckpointsByConversation scan: %w", err)
+		}
+		cp.IsResult = intToBool(isResult)
+		checkpoints = append(checkpoints, &cp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ListCheckpointsByConversation rows: %w", err)
+	}
+	return checkpoints, nil
+}
+
+func (s *SQLiteStore) DeleteCheckpointsForConversation(ctx context.Context, conversationID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM checkpoints WHERE conversation_id = ?`, conversationID)
+	if err != nil {
+		return fmt.Errorf("DeleteCheckpointsForConversation: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Implement backend support for tracking file state snapshots at message boundaries. 

Adds Checkpoint model, parser events, event handler, and SQLite persistence with CRUD operations. Includes fix for missing rows.Err() check in checkpoint list method to match patterns used by all other list methods in the codebase.