### PR TITLE
Default markdown files to preview mode

### DIFF
--- a/src/components/files/CodeViewer.tsx
+++ b/src/components/files/CodeViewer.tsx
@@ -59,9 +59,18 @@ export function CodeViewer({
 }: CodeViewerProps) {
   const toast = useToast();
   const [copied, setCopied] = useState(false);
-  const [viewMode, setViewMode] = useState<'code' | 'rendered'>('code');
+  const [viewMode, setViewMode] = useState<'code' | 'rendered'>(
+    isMarkdownFile(filename) ? 'rendered' : 'code'
+  );
   const [diffViewMode, setDiffViewMode] = useState<'split' | 'unified'>('unified');
   const [wordWrap, setWordWrap] = useState(false);
+
+  // Reset view mode when switching files
+  const [prevFilename, setPrevFilename] = useState(filename);
+  if (prevFilename !== filename) {
+    setPrevFilename(filename);
+    setViewMode(isMarkdownFile(filename) ? 'rendered' : 'code');
+  }
 
   const isMarkdown = isMarkdownFile(filename);
   const isDiffMode = typeof oldContent === 'string';


### PR DESCRIPTION
## Summary

- When opening `.md` or `.mdx` files, they now display in rendered markdown preview mode by default
- Users can toggle between preview and raw code view with the Eye/Code button in the toolbar
- View mode resets appropriately when switching between different files

## Test Plan

- [x] All 889 existing tests pass
- [x] ESLint passes
- [x] TypeScript build completes successfully
- Manual verification: open `.md` file → should show preview by default; toggle Eye button → switches to code view

🤖 Generated with [Claude Code](https://claude.com/claude-code)