### PR TITLE
feat: Add thinking events as first-class timeline items

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -324,7 +324,7 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	activeSubAgents := make(map[string]*SubAgentEntry)
 	// Buffer tools that arrive before their sub-agent registers (race recovery)
 	pendingSubAgentTools := make(map[string][]ActiveToolEntry)
-	var currentThinking string
+	var currentThinking string // Accumulated thinking for snapshot/backwards compat
 	var pendingPlanContent string
 	var isThinking bool
 	var snapshotDirty bool
@@ -336,7 +336,14 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 		content   string
 		timestamp time.Time
 	}
+	type thinkingBlock struct {
+		content   string
+		timestamp time.Time
+	}
 	var textSegments []textSegment
+	var thinkingBlocks []thinkingBlock
+	var currentThinkingText string
+	var thinkingBlockStart *time.Time
 	var currentSegmentText string
 	var currentSegmentStart *time.Time
 	turnStartTime := time.Now()
@@ -458,6 +465,14 @@ outer:
 			// Handle specific event types
 			switch event.Type {
 			case EventTypeAssistantText:
+				// Seal thinking block when text starts
+				if thinkingBlockStart != nil && currentThinkingText != "" {
+					thinkingBlocks = append(thinkingBlocks, thinkingBlock{content: currentThinkingText, timestamp: *thinkingBlockStart})
+					currentThinkingText = ""
+					thinkingBlockStart = nil
+				}
+				isThinking = false
+
 				currentAssistantMessage += event.Content
 				// Track text segments for timeline persistence
 				if currentSegmentStart == nil {
@@ -515,7 +530,23 @@ outer:
 				proc.SetPlanModeFromEvent(event.Mode == "plan")
 				markSnapshotDirty()
 
+			case EventTypeThinkingStart:
+				// Seal previous thinking block if any
+				if thinkingBlockStart != nil && currentThinkingText != "" {
+					thinkingBlocks = append(thinkingBlocks, thinkingBlock{content: currentThinkingText, timestamp: *thinkingBlockStart})
+				}
+				now := time.Now()
+				thinkingBlockStart = &now
+				currentThinkingText = ""
+				isThinking = true
+				markSnapshotDirty()
+
 			case EventTypeThinking, EventTypeThinkingDelta:
+				if thinkingBlockStart == nil {
+					now := time.Now()
+					thinkingBlockStart = &now
+				}
+				currentThinkingText += event.Content
 				currentThinking += event.Content
 				isThinking = true
 				markSnapshotDirty()
@@ -655,8 +686,14 @@ outer:
 							timestamp: *currentSegmentStart,
 						})
 					}
+					// Seal any in-progress thinking block
+					if thinkingBlockStart != nil && currentThinkingText != "" {
+						thinkingBlocks = append(thinkingBlocks, thinkingBlock{content: currentThinkingText, timestamp: *thinkingBlockStart})
+						currentThinkingText = ""
+						thinkingBlockStart = nil
+					}
 
-					// Build interleaved timeline from text segments and completed tools
+					// Build interleaved timeline from text segments, thinking blocks, and completed tools
 					type timelineItem struct {
 						timestamp time.Time
 						entry     models.TimelineEntry
@@ -666,6 +703,12 @@ outer:
 						items = append(items, timelineItem{
 							timestamp: seg.timestamp,
 							entry:     models.TimelineEntry{Type: "text", Content: seg.content},
+						})
+					}
+					for _, block := range thinkingBlocks {
+						items = append(items, timelineItem{
+							timestamp: block.timestamp,
+							entry:     models.TimelineEntry{Type: "thinking", Content: block.content},
 						})
 					}
 					for _, tool := range completedTools {
@@ -721,6 +764,9 @@ outer:
 				currentThinking = ""
 				pendingPlanContent = ""
 				isThinking = false
+				thinkingBlocks = nil
+				currentThinkingText = ""
+				thinkingBlockStart = nil
 				activeToolsMap = make(map[string]ActiveToolEntry)
 				activeSubAgents = make(map[string]*SubAgentEntry)
 				pendingSubAgentTools = make(map[string][]ActiveToolEntry)
@@ -787,10 +833,16 @@ outer:
 			currentSegmentText = ""
 			currentSegmentStart = nil
 		}
+		// Seal any in-progress thinking block
+		if thinkingBlockStart != nil && currentThinkingText != "" {
+			thinkingBlocks = append(thinkingBlocks, thinkingBlock{content: currentThinkingText, timestamp: *thinkingBlockStart})
+			currentThinkingText = ""
+			thinkingBlockStart = nil
+		}
 
-		// Build timeline from text segments + completed tools
+		// Build timeline from text segments, thinking blocks, and completed tools
 		var timeline []models.TimelineEntry
-		if len(textSegments) > 0 || len(completedTools) > 0 {
+		if len(textSegments) > 0 || len(completedTools) > 0 || len(thinkingBlocks) > 0 {
 			type timelineItem struct {
 				timestamp time.Time
 				entry     models.TimelineEntry
@@ -798,6 +850,9 @@ outer:
 			var items []timelineItem
 			for _, seg := range textSegments {
 				items = append(items, timelineItem{timestamp: seg.timestamp, entry: models.TimelineEntry{Type: "text", Content: seg.content}})
+			}
+			for _, block := range thinkingBlocks {
+				items = append(items, timelineItem{timestamp: block.timestamp, entry: models.TimelineEntry{Type: "thinking", Content: block.content}})
 			}
 			for _, tool := range completedTools {
 				ts := tool.StartTime

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -202,8 +202,8 @@ type ToolUsageRecord struct {
 
 // TimelineEntry represents an entry in the interleaved message timeline
 type TimelineEntry struct {
-	Type    string `json:"type"`              // "text" or "tool"
-	Content string `json:"content,omitempty"` // For text entries
+	Type    string `json:"type"`              // "text", "tool", or "thinking"
+	Content string `json:"content,omitempty"` // For text and thinking entries
 	ToolID  string `json:"toolId,omitempty"`  // For tool entries, references ToolUsageRecord.ID
 }
 

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -8,13 +8,14 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
-import { Copy, Check, FileText, Brain, ClipboardCheck, ChevronDown, ChevronRight } from 'lucide-react';
+import { Copy, Check, FileText, ClipboardCheck, ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Message } from '@/lib/types';
 import { COPY_FEEDBACK_DURATION_MS, PROSE_CLASSES } from '@/lib/constants';
 import { copyToClipboard } from '@/lib/tauri';
 import { ToolUsageHistory } from '@/components/conversation/ToolUsageHistory';
 import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
+import { ThinkingNode } from '@/components/conversation/ThinkingNode';
 import { VerificationBlock } from '@/components/conversation/VerificationBlock';
 import { FileChangesBlock } from '@/components/conversation/FileChangesBlock';
 import { RunSummaryBlock } from '@/components/conversation/RunSummaryBlock';
@@ -25,7 +26,6 @@ import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
 import { MentionText } from '@/components/conversation/MentionText';
-import { useSettingsStore } from '@/stores/settingsStore';
 
 export interface MessageBlockProps {
   message: Message;
@@ -48,9 +48,7 @@ export const MessageBlock = memo(function MessageBlock({
   // comparator below to skip re-renders for messages without search matches.
 }: MessageBlockProps) {
   const [copied, setCopied] = useState(false);
-  const [isThinkingExpanded, setIsThinkingExpanded] = useState(false);
   const [isPlanExpanded, setIsPlanExpanded] = useState(false);
-  const showThinkingBlocks = useSettingsStore((s) => s.showThinkingBlocks);
 
   const copyContent = useCallback(async () => {
     const success = await copyToClipboard(message.content);
@@ -103,29 +101,6 @@ export const MessageBlock = memo(function MessageBlock({
   return (
     <div className="py-2">
       <div className="space-y-1.5">
-        {/* Thinking/Reasoning Content */}
-        {message.role === 'assistant' && showThinkingBlocks && message.thinkingContent && (
-          <div className="flex flex-col gap-1">
-            <button
-              onClick={() => setIsThinkingExpanded(!isThinkingExpanded)}
-              className="flex items-center gap-2 text-xs text-ai-thinking hover:text-ai-thinking/80 transition-colors"
-            >
-              <Brain className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-              <span className="font-medium">Thinking</span>
-              {isThinkingExpanded ? (
-                <ChevronDown className="w-3 h-3" />
-              ) : (
-                <ChevronRight className="w-3 h-3" />
-              )}
-            </button>
-            {isThinkingExpanded && (
-              <div className="ml-5 text-xs px-2 py-1.5 rounded bg-ai-thinking/10 text-muted-foreground font-mono border border-ai-thinking/20 whitespace-pre-wrap max-h-[300px] overflow-y-auto">
-                {message.thinkingContent}
-              </div>
-            )}
-          </div>
-        )}
-
         {/* Approved Plan Content */}
         {message.planContent && (
           <div className="flex flex-col gap-1">
@@ -155,7 +130,14 @@ export const MessageBlock = memo(function MessageBlock({
             <ContextMenuTrigger asChild>
               <div className="group relative">
                 {message.timeline.map((entry, idx) => {
-                  if (entry.type === 'text') {
+                  if (entry.type === 'thinking') {
+                    return (
+                      <ThinkingNode
+                        key={`tl-thinking-${idx}`}
+                        content={entry.content}
+                      />
+                    );
+                  } else if (entry.type === 'text') {
                     return (
                       <div
                         key={`tl-text-${idx}`}
@@ -167,7 +149,7 @@ export const MessageBlock = memo(function MessageBlock({
                         />
                       </div>
                     );
-                  } else {
+                  } else if (entry.type === 'tool') {
                     const tool = message.toolUsage!.find(t => t.id === entry.toolId);
                     if (!tool) return null;
                     return (
@@ -186,6 +168,7 @@ export const MessageBlock = memo(function MessageBlock({
                       />
                     );
                   }
+                  return null;
                 })}
                 <Button
                   variant="ghost"
@@ -214,6 +197,11 @@ export const MessageBlock = memo(function MessageBlock({
           </ContextMenu>
         ) : (
           <>
+            {/* Legacy fallback: Thinking content for messages without timeline */}
+            {message.role === 'assistant' && message.thinkingContent && (
+              <ThinkingNode content={message.thinkingContent} />
+            )}
+
             {/* Legacy fallback: Tool Usage History (collapsed) + full content */}
             {message.toolUsage && message.toolUsage.length > 0 && (
               <ErrorBoundary

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -2,10 +2,10 @@
 
 import { useState, useEffect, useRef, useMemo, memo } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import { useSettingsStore } from '@/stores/settingsStore';
 import { useStreamingState, useActiveTools, useSubAgents } from '@/stores/selectors';
-import { Loader2, AlertCircle, Brain, Clock, ChevronDown, ChevronRight } from 'lucide-react';
+import { AlertCircle, Brain, ChevronDown, ChevronRight, Clock } from 'lucide-react';
 import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
+import { ThinkingNode } from '@/components/conversation/ThinkingNode';
 import { SubAgentRow, SubAgentGroupedRow } from '@/components/conversation/SubAgentGroup';
 import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
 import { StreamingMarkdown } from '@/components/shared/StreamingMarkdown';
@@ -16,6 +16,7 @@ import { PROSE_CLASSES } from '@/lib/constants';
 type TimelineItem =
   | { type: 'text'; id: string; text: string; timestamp: number }
   | { type: 'tool'; id: string; tool: string; params?: Record<string, unknown>; startTime: number; endTime?: number; success?: boolean; summary?: string; stdout?: string; stderr?: string; elapsedSeconds?: number }
+  | { type: 'thinking'; id: string; text: string; isActive: boolean; timestamp: number }
   | { type: 'subagent'; agent: import('@/lib/types').SubAgent }
   | { type: 'subagent_group'; agents: import('@/lib/types').SubAgent[] };
 
@@ -166,19 +167,23 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
   const clearStreamingText = useAppStore((s) => s.clearStreamingText);
   const budgetStatus = useAppStore((s) => s.budgetStatus);
 
-  const showThinkingBlocks = useSettingsStore((s) => s.showThinkingBlocks);
-
   // Check if extended thinking is enabled for this conversation
   const isExtendedThinkingEnabled = budgetStatus?.maxThinkingTokens !== undefined && budgetStatus.maxThinkingTokens > 0;
 
-  // Thinking expansion state (must be before early return to satisfy Rules of Hooks)
-  // Note: We don't need to reset this when thinking becomes null because the
-  // expansion UI only renders when there's thinking content to show
-  const [isThinkingExpanded, setIsThinkingExpanded] = useState(false);
-
-  // Build interleaved timeline from segments and tools
+  // Build interleaved timeline from segments, tools, and thinking
   const timeline = useMemo((): TimelineItem[] => {
     const items: TimelineItem[] = [];
+
+    // Add thinking as a timeline item
+    if (streaming?.thinking) {
+      items.push({
+        type: 'thinking',
+        id: 'thinking-current',
+        text: streaming.thinking,
+        isActive: !!streaming.isThinking,
+        timestamp: streaming.startTime || 0,
+      });
+    }
 
     // Add text segments
     const segments = streaming?.segments || [];
@@ -221,6 +226,7 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
     const getItemTime = (item: TimelineItem): number => {
       switch (item.type) {
         case 'text': return item.timestamp;
+        case 'thinking': return item.timestamp;
         case 'subagent': return item.agent.startTime;
         case 'subagent_group': return item.agents[0].startTime;
         default: return item.startTime;
@@ -255,85 +261,39 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
     }
 
     return grouped;
-  }, [streaming?.segments, tools, subAgents]);
+  }, [streaming, tools, subAgents]);
 
   // Don't render if no streaming content, no active tools, no sub-agents, no thinking, no error, and no pending plan
-  if (timeline.length === 0 && !streaming?.error && !streaming?.thinking && !streaming?.isThinking && !streaming?.isStreaming && !streaming?.pendingPlanApproval?.planContent) {
+  if (timeline.length === 0 && !streaming?.error && !streaming?.isThinking && !streaming?.isStreaming && !streaming?.pendingPlanApproval?.planContent) {
     return null;
   }
-
-  // Truncate thinking text for display (increased limit)
-  const THINKING_TRUNCATE_LENGTH = 120;
-  const truncateThinking = (text: string) => {
-    if (text.length <= THINKING_TRUNCATE_LENGTH) return text;
-    return text.slice(0, THINKING_TRUNCATE_LENGTH) + '...';
-  };
-
-  const thinkingNeedsTruncation = streaming?.thinking && streaming.thinking.length > THINKING_TRUNCATE_LENGTH;
 
   return (
     <div className="py-2" role="status" aria-live="polite" aria-atomic="false">
       <div className="space-y-1.5">
           {/* Extended thinking mode indicator - shows when thinking is enabled but no content yet */}
-          {isExtendedThinkingEnabled && streaming?.isStreaming && !streaming?.isThinking && !streaming?.thinking && (
+          {isExtendedThinkingEnabled && streaming?.isStreaming && !streaming?.isThinking && !streaming?.thinking && timeline.length === 0 && (
             <div className="flex items-center gap-2 animate-fade-in" aria-label="Extended thinking enabled">
               <Brain className="w-3.5 h-3.5 text-ai-thinking shrink-0 animate-thinking-pulse" aria-hidden="true" />
               <span className="text-xs text-ai-thinking">Extended thinking active</span>
             </div>
           )}
 
-          {/* Thinking indicator with expandable content */}
-          {(streaming?.isThinking || streaming?.thinking) && (
-            <div className="flex flex-col gap-1 animate-slide-up-fade" aria-label="Agent is thinking">
-              <div className="flex items-center gap-2">
-                <Brain className={cn(
-                  "w-3.5 h-3.5 shrink-0 text-ai-thinking",
-                  streaming.isThinking && "animate-thinking-pulse"
-                )} aria-hidden="true" />
-                <span className="text-xs font-medium text-ai-thinking">Thinking</span>
-                {streaming.isThinking && (
-                  <Loader2 className="w-3 h-3 animate-spin text-ai-thinking" aria-hidden="true" />
-                )}
-                {showThinkingBlocks && thinkingNeedsTruncation && (
-                  <button
-                    onClick={() => setIsThinkingExpanded(!isThinkingExpanded)}
-                    className="flex items-center gap-0.5 text-xs text-primary hover:text-primary/80 transition-colors"
-                  >
-                    {isThinkingExpanded ? (
-                      <>
-                        <ChevronDown className="w-3 h-3" />
-                        <span>collapse</span>
-                      </>
-                    ) : (
-                      <>
-                        <ChevronRight className="w-3 h-3" />
-                        <span>expand</span>
-                      </>
-                    )}
-                  </button>
-                )}
-              </div>
-              {showThinkingBlocks && streaming.thinking && (
-                <div
-                  className={cn(
-                    'ml-5 text-xs px-2 py-1.5 rounded bg-ai-thinking/10 text-muted-foreground font-mono',
-                    'border border-ai-thinking/20',
-                    isThinkingExpanded ? 'whitespace-pre-wrap max-h-[200px] overflow-y-auto' : 'truncate max-w-full'
-                  )}
-                >
-                  {isThinkingExpanded ? streaming.thinking : truncateThinking(streaming.thinking)}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Interleaved timeline of text and tools */}
+          {/* Interleaved timeline of thinking, text, and tools */}
           {(() => {
             // The last text segment is actively streaming — use block-level
             // memoized StreamingMarkdown for it; use CachedMarkdown for completed segments.
             const lastTextId = timeline.findLast((i) => i.type === 'text')?.id;
             return timeline.map((item) => {
-            if (item.type === 'text') {
+            if (item.type === 'thinking') {
+              return (
+                <ThinkingNode
+                  key={item.id}
+                  content={item.text}
+                  isStreaming={item.isActive}
+                />
+              );
+            } else if (item.type === 'text') {
               const isLastText = item.id === lastTextId;
               return (
                 <div

--- a/src/components/conversation/ThinkingNode.tsx
+++ b/src/components/conversation/ThinkingNode.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState, memo } from 'react';
+import { Brain, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+interface ThinkingNodeProps {
+  content: string;
+  isStreaming?: boolean;
+}
+
+export const ThinkingNode = memo(function ThinkingNode({
+  content,
+  isStreaming = false,
+}: ThinkingNodeProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const showThinkingBlocks = useSettingsStore((s) => s.showThinkingBlocks);
+
+  if (!showThinkingBlocks) return null;
+
+  return (
+    <div className="flex flex-col gap-1 animate-slide-up-fade" aria-label="Agent thinking">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center gap-2 text-xs text-ai-thinking hover:text-ai-thinking/80 transition-colors"
+      >
+        <Brain
+          className={cn(
+            'w-3.5 h-3.5 shrink-0',
+            isStreaming && 'animate-thinking-pulse'
+          )}
+          aria-hidden="true"
+        />
+        <span className="font-medium">Thinking</span>
+        {isStreaming && (
+          <Loader2 className="w-3 h-3 animate-spin text-ai-thinking" aria-hidden="true" />
+        )}
+        {isExpanded ? (
+          <ChevronDown className="w-3 h-3" />
+        ) : (
+          <ChevronRight className="w-3 h-3" />
+        )}
+      </button>
+      {isExpanded && (
+        <div className="ml-5 text-xs px-2 py-1.5 rounded bg-ai-thinking/10 text-muted-foreground font-mono border border-ai-thinking/20 whitespace-pre-wrap max-h-[300px] overflow-y-auto">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -253,9 +253,9 @@ export function useWebSocket(enabled: boolean = true) {
         break;
 
       case 'assistant_text':
-        // Append streaming text - clear thinking when regular text starts
+        // Append streaming text - mark thinking as done but preserve content
         if (event?.content) {
-          store.clearThinking(conversationId);
+          store.setThinking(conversationId, false);
           store.appendStreamingText(conversationId, event.content);
           // Clear input suggestions when new turn starts streaming
           store.clearInputSuggestion(conversationId);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -130,7 +130,8 @@ export interface ToolUsage {
 // Timeline entry preserving interleaved text/tool ordering in finalized messages
 export type TimelineEntry =
   | { type: 'text'; content: string }
-  | { type: 'tool'; toolId: string };
+  | { type: 'tool'; toolId: string }
+  | { type: 'thinking'; content: string };
 
 // Active tool during streaming (real-time tracking)
 export interface ActiveTool {


### PR DESCRIPTION
Introduces thinking blocks as discrete timeline entries alongside text and tool usage. The backend now tracks and emits separate thinking blocks with accurate timestamps, while the frontend renders them via a collapsible ThinkingNode component that respects the showThinkingBlocks setting. This enables chronological interleaving of agent reasoning with actions.

**Changes:**
- Backend: Track discrete thinking blocks with timestamps, seal them on text arrival, include in timeline
- Frontend: New ThinkingNode component for reusable thinking display, integrated into message and streaming timelines
- WebSocket: Preserve thinking content when text arrives (changed from clearThinking to setThinking)

This provides better UX visibility into agent reasoning flow.