### PR TITLE
fix: Persist plan markdown after approval and fix console errors

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chatml-agent-runner",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.41",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.42",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.41",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.41.tgz",
-      "integrity": "sha512-8qOHvRWWJSULlRnLdJRWYSivDDA0C1szWQx83kXDrFsxMYlPQX3udFzS53GNoJz98rPxUqfH7MjNAc/Vkt7QSQ==",
+      "version": "0.2.42",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.42.tgz",
+      "integrity": "sha512-/CugP7AjP57Dqtl2sbsDtxdbpQoPKIhjyF5WrTViGu4NHQdM+UikrRs4MhZ2jeotiC5R7iK9ZUN9SiBgcZ8oLw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.41",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.42",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -421,8 +421,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     let unlistenEnter: (() => void) | undefined;
     let unlistenLeave: (() => void) | undefined;
 
-    const safeUnlisten = (fn?: () => void) => {
+    const safeUnlisten = (fn?: () => void): undefined => {
       try { fn?.(); } catch { /* listener already removed */ }
+      return undefined;
     };
 
     const setupListeners = async () => {
@@ -451,9 +452,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         unlistenLeave = leave;
       } catch (error) {
         console.error('Failed to setup drag-drop listeners:', error);
-        safeUnlisten(unlistenDrop);
-        safeUnlisten(unlistenEnter);
-        safeUnlisten(unlistenLeave);
+        unlistenDrop = safeUnlisten(unlistenDrop);
+        unlistenEnter = safeUnlisten(unlistenEnter);
+        unlistenLeave = safeUnlisten(unlistenLeave);
       }
     };
 
@@ -461,9 +462,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
     return () => {
       isCancelled = true;
-      safeUnlisten(unlistenDrop);
-      safeUnlisten(unlistenEnter);
-      safeUnlisten(unlistenLeave);
+      unlistenDrop = safeUnlisten(unlistenDrop);
+      unlistenEnter = safeUnlisten(unlistenEnter);
+      unlistenLeave = safeUnlisten(unlistenLeave);
     };
   }, []);
 

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useMemo, memo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useStreamingState, useActiveTools, useSubAgents } from '@/stores/selectors';
-import { AlertCircle, Brain, ChevronDown, ChevronRight, Clock } from 'lucide-react';
+import { AlertCircle, Brain, ChevronDown, ChevronRight, ClipboardCheck, Clock } from 'lucide-react';
 import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
 import { ThinkingNode } from '@/components/conversation/ThinkingNode';
 import { SubAgentRow, SubAgentGroupedRow } from '@/components/conversation/SubAgentGroup';
@@ -170,6 +170,8 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
   // Check if extended thinking is enabled for this conversation
   const isExtendedThinkingEnabled = budgetStatus?.maxThinkingTokens !== undefined && budgetStatus.maxThinkingTokens > 0;
 
+  const [isApprovedPlanExpanded, setIsApprovedPlanExpanded] = useState(true);
+
   // Build interleaved timeline from segments, tools, and thinking
   const timeline = useMemo((): TimelineItem[] => {
     const items: TimelineItem[] = [];
@@ -264,7 +266,7 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
   }, [streaming, tools, subAgents]);
 
   // Don't render if no streaming content, no active tools, no sub-agents, no thinking, no error, and no pending plan
-  if (timeline.length === 0 && !streaming?.error && !streaming?.isThinking && !streaming?.isStreaming && !streaming?.pendingPlanApproval?.planContent) {
+  if (timeline.length === 0 && !streaming?.error && !streaming?.isThinking && !streaming?.isStreaming && !streaming?.pendingPlanApproval?.planContent && !streaming?.approvedPlanContent) {
     return null;
   }
 
@@ -354,6 +356,32 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
                 cacheKey={`plan:${streaming.pendingPlanApproval.requestId}`}
                 content={streaming.pendingPlanApproval.planContent}
               />
+            </div>
+          )}
+
+          {/* Approved plan content - persists after plan approval during continued streaming */}
+          {!streaming?.pendingPlanApproval?.planContent && streaming?.approvedPlanContent && (
+            <div className="flex flex-col gap-1">
+              <button
+                onClick={() => setIsApprovedPlanExpanded(!isApprovedPlanExpanded)}
+                className="flex items-center gap-2 text-xs text-primary hover:text-primary/80 transition-colors"
+              >
+                <ClipboardCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                <span className="font-medium">Approved Plan</span>
+                {isApprovedPlanExpanded ? (
+                  <ChevronDown className="w-3 h-3" />
+                ) : (
+                  <ChevronRight className="w-3 h-3" />
+                )}
+              </button>
+              {isApprovedPlanExpanded && (
+                <div className={cn(PROSE_CLASSES, 'ml-5 border-l-2 border-primary/20 pl-3')}>
+                  <CachedMarkdown
+                    cacheKey={`approved-plan:${conversationId}`}
+                    content={streaming.approvedPlanContent}
+                  />
+                </div>
+              )}
             </div>
           )}
 

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -46,7 +46,7 @@ export const useUpdateStore = create<UpdateState>()((set, get) => ({
         set({ status: 'idle', version: null });
       }
     } catch (err) {
-      console.error('Update check failed:', err);
+      console.debug('Update check failed:', err);
       // Silently return to idle on check failure — not actionable for users
       set({ status: 'idle' });
     }


### PR DESCRIPTION
## Summary
- **Plan markdown persistence**: After approving a plan, the markdown content now stays visible in the conversation as a collapsible "Approved Plan" section during continued streaming, instead of disappearing until message finalization
- **SDK version mismatch fix**: Updated Claude Agent SDK from 0.2.41 to 0.2.42 to match CLI 2.1.42, fixing ZodError (`invalid_union`) on tool permission requests after plan approval
- **Tauri listener cleanup**: Prevent double-unlisten TypeError by nullifying listener references after cleanup, avoiding stale reference errors in React strict mode
- **Update check noise**: Downgraded update check failure log from `console.error` to `console.debug` since the missing release JSON is expected during development

## Test plan
- [ ] Enter plan mode, have agent create a plan, approve it — verify plan markdown stays visible as collapsible "Approved Plan" during agent execution
- [ ] After message finalization, verify plan appears in MessageBlock with same collapsible style
- [ ] Verify no ZodError on tool permissions after approving a plan
- [ ] Check console for absence of Tauri listener TypeError and update check error
- [ ] Run `npm run build` and `npm run lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)