### PR TITLE
Fix AskUserQuestion SDK retries and state issues

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -240,6 +240,12 @@ interface PendingQuestionRequest {
 const pendingQuestionRequests = new Map<string, PendingQuestionRequest>();
 let questionRequestCounter = 0;
 
+// Retry dedup for AskUserQuestion — similar to ExitPlanMode's cooldown for SDK bug #15755.
+// After the user answers, cache answers so SDK retries get auto-approved without re-prompting.
+let lastQuestionAnswers: Record<string, string> | null = null;
+let lastQuestionAnswerTime = 0;
+const ASK_USER_QUESTION_COOLDOWN_MS = 30_000; // 30 seconds
+
 // Pending plan approval requests (for ExitPlanMode tool)
 const PLAN_APPROVAL_HOOK_TIMEOUT_S = 86400; // 24 hours — lets users take as long as they need
 
@@ -1021,7 +1027,30 @@ interface AskUserQuestionInput {
 const askUserQuestionHook: HookCallback = async (input) => {
   const hookInput = input as PreToolUseHookInput;
   const toolInput = hookInput.tool_input as unknown as AskUserQuestionInput;
+
+  // SDK retry guard: if we recently answered a question, auto-return the cached
+  // answers instead of prompting the user again. Mirrors the ExitPlanMode
+  // cooldown workaround for SDK bug #15755.
+  if (lastQuestionAnswers && Date.now() - lastQuestionAnswerTime < ASK_USER_QUESTION_COOLDOWN_MS) {
+    debug("Auto-returning cached answers for AskUserQuestion retry (cooldown active)");
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse" as const,
+        permissionDecision: "allow" as const,
+        updatedInput: {
+          ...(hookInput.tool_input as Record<string, unknown>),
+          answers: lastQuestionAnswers,
+        },
+      },
+    };
+  }
+
   const requestId = `question-${++questionRequestCounter}-${Date.now()}`;
+
+  // Flush any buffered text so it appears BEFORE the question UI.
+  // The PreToolUse hook fires before the SDK yields the assistant message
+  // through the iterator, so flushBlockBuffer() in handleMessage hasn't run yet.
+  flushBlockBuffer();
 
   // Emit the question request to the Go backend
   emit({
@@ -1044,6 +1073,10 @@ const askUserQuestionHook: HookCallback = async (input) => {
       }, ASK_USER_QUESTION_HOOK_TIMEOUT_S * 1000);
     });
 
+    // Cache answers for retry dedup
+    lastQuestionAnswers = answers;
+    lastQuestionAnswerTime = Date.now();
+
     // Allow tool execution with answers populated
     return {
       hookSpecificOutput: {
@@ -1056,6 +1089,10 @@ const askUserQuestionHook: HookCallback = async (input) => {
       },
     };
   } catch (error) {
+    // Clear cached answers on cancellation/timeout
+    lastQuestionAnswers = null;
+    lastQuestionAnswerTime = 0;
+
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       hookSpecificOutput: {
@@ -1093,6 +1130,9 @@ const exitPlanModeHook: HookCallback = async (_input) => {
   }
 
   const requestId = `plan-approval-${++planApprovalRequestCounter}-${Date.now()}`;
+
+  // Flush any buffered text so plan content appears before the approval UI
+  flushBlockBuffer();
 
   // Read plan file content if tracked during plan mode
   let planContent: string | undefined;
@@ -1168,9 +1208,18 @@ const PLAN_MODE_DENIED_TOOLS = new Set([
 // In plan mode the SDK should enforce restrictions natively, but we double-check here.
 const canUseTool = async (
   toolName: string,
-  _toolInput: Record<string, unknown>,
+  toolInput: Record<string, unknown>,
   _options: { signal: AbortSignal; toolUseID: string }
 ): Promise<{ behavior: "allow"; updatedInput?: Record<string, unknown> } | { behavior: "deny"; message: string }> => {
+  // Defense-in-depth: if AskUserQuestion reaches canUseTool with cached answers,
+  // provide them via updatedInput. In bypassPermissions mode (the default), the SDK
+  // auto-allows before reaching this callback — this covers non-bypass modes.
+  if (toolName === "AskUserQuestion" && lastQuestionAnswers &&
+      Date.now() - lastQuestionAnswerTime < ASK_USER_QUESTION_COOLDOWN_MS) {
+    const answers = lastQuestionAnswers;
+    lastQuestionAnswers = null; // Consume once
+    return { behavior: "allow", updatedInput: { ...toolInput, answers } };
+  }
   if (currentPermissionMode === "plan" && PLAN_MODE_DENIED_TOOLS.has(toolName)) {
     return { behavior: "deny", message: "This tool is not available in plan mode. Present your plan using ExitPlanMode first." };
   }
@@ -1621,6 +1670,10 @@ function handleMessage(message: SDKMessage): void {
         if (contentBlock?.type === "thinking") {
           emit({ type: "thinking_start" });
         }
+      } else if (event.type === "content_block_stop") {
+        // Text block finished — flush any remaining buffered content so text
+        // is fully emitted before subsequent tool events.
+        flushBlockBuffer();
       } else if (event.type === "error") {
         // Surface API-level errors (e.g., overloaded_error) during streaming
         const errorEvent = event as { error?: { type?: string; message?: string } };

--- a/src/components/conversation/UserQuestionPrompt.tsx
+++ b/src/components/conversation/UserQuestionPrompt.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { usePendingUserQuestion, useUserQuestionActions } from '@/stores/selectors';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -18,6 +18,7 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
   const { updateUserQuestionAnswer, nextUserQuestion, prevUserQuestion, clearPendingUserQuestion } = useUserQuestionActions();
   const { error: showError } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [freeTextValue, setFreeTextValue] = useState('');
 
   const currentQuestion: UserQuestion | undefined = pending?.questions[pending.currentIndex];
   const totalQuestions = pending?.questions.length ?? 0;
@@ -51,7 +52,7 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
   }, [conversationId, currentQuestion, selectedValues, updateUserQuestionAnswer]);
 
   const handleDismiss = useCallback(async () => {
-    if (!pending) return;
+    if (!pending || isSubmitting) return;
     // Send cancellation to the agent so it doesn't wait for timeout
     try {
       await answerConversationQuestion(conversationId, pending.requestId, { __cancelled: 'true' });
@@ -59,7 +60,7 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
       // Ignore errors - the question may have already timed out
     }
     clearPendingUserQuestion(conversationId);
-  }, [conversationId, pending, clearPendingUserQuestion]);
+  }, [conversationId, pending, isSubmitting, clearPendingUserQuestion]);
 
   const handlePrev = useCallback(() => {
     prevUserQuestion(conversationId);
@@ -92,6 +93,15 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
     });
   }, [pending]);
 
+  // Sync free-text state when the current question changes
+  const currentHeader = currentQuestion?.header;
+  const hasFreeText = currentQuestion && currentQuestion.options.length === 0;
+  useEffect(() => {
+    if (hasFreeText && currentHeader && pending) {
+      setFreeTextValue(pending.answers[currentHeader] || '');
+    }
+  }, [currentHeader, hasFreeText, pending]);
+
   if (!pending || !currentQuestion) return null;
 
   return (
@@ -105,46 +115,70 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
             size="icon"
             className="h-6 w-6 -mt-1 -mr-1 text-muted-foreground hover:text-foreground"
             onClick={handleDismiss}
+            disabled={isSubmitting}
             data-testid="dismiss-question"
           >
             <X className="h-4 w-4" />
           </Button>
         </div>
 
-        {/* Options List */}
+        {/* Options List or Free-text Input */}
         <div className="px-2 pb-2">
-          {currentQuestion.options.map((option, index) => {
-            const isSelected = selectedValues.has(option.label);
-            return (
-              <button
-                key={option.label}
-                type="button"
-                onClick={() => handleOptionToggle(option.label)}
-                className={cn(
-                  'w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-left transition-colors',
-                  isSelected
-                    ? 'bg-primary/10 text-foreground'
-                    : 'text-muted-foreground hover:bg-surface-1/60 hover:text-foreground'
-                )}
-              >
-                <span className="text-xs font-mono text-muted-foreground/70 w-4">{index + 1}</span>
-                <div className="flex-1 min-w-0">
-                  <span className="text-sm block">{option.label}</span>
-                  {option.description && (
-                    <span className="text-xs text-muted-foreground/70 block truncate">{option.description}</span>
+          {currentQuestion.options.length > 0 ? (
+            currentQuestion.options.map((option, index) => {
+              const isSelected = selectedValues.has(option.label);
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  onClick={() => handleOptionToggle(option.label)}
+                  className={cn(
+                    'w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-left transition-colors',
+                    isSelected
+                      ? 'bg-primary/10 text-foreground'
+                      : 'text-muted-foreground hover:bg-surface-1/60 hover:text-foreground'
                   )}
-                </div>
-                <div className={cn(
-                  'w-5 h-5 rounded border-2 flex items-center justify-center transition-colors flex-shrink-0',
-                  isSelected
-                    ? 'border-primary bg-primary text-primary-foreground'
-                    : 'border-muted-foreground/40'
-                )}>
-                  {isSelected && <Check className="h-3 w-3" />}
-                </div>
-              </button>
-            );
-          })}
+                >
+                  <span className="text-xs font-mono text-muted-foreground/70 w-4">{index + 1}</span>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm block">{option.label}</span>
+                    {option.description && (
+                      <span className="text-xs text-muted-foreground/70 block truncate">{option.description}</span>
+                    )}
+                  </div>
+                  <div className={cn(
+                    'w-5 h-5 rounded border-2 flex items-center justify-center transition-colors flex-shrink-0',
+                    isSelected
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-muted-foreground/40'
+                  )}>
+                    {isSelected && <Check className="h-3 w-3" />}
+                  </div>
+                </button>
+              );
+            })
+          ) : (
+            <div className="px-2 py-1">
+              <input
+                type="text"
+                className="w-full px-3 py-2 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                placeholder="Type your answer..."
+                value={freeTextValue}
+                onChange={(e) => {
+                  setFreeTextValue(e.target.value);
+                  updateUserQuestionAnswer(conversationId, currentQuestion.header, e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && canSubmit && !isSubmitting) {
+                    e.preventDefault();
+                    handleSubmit();
+                  }
+                }}
+                autoFocus
+                data-testid="free-text-input"
+              />
+            </div>
+          )}
         </div>
 
         {/* Footer with pagination and submit */}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -450,6 +450,8 @@ export function useWebSocket(enabled: boolean = true) {
         freshStore.updateConversation(conversationId, { status: 'completed' });
         // Clear agent todos — tasks are no longer relevant after turn ends
         freshStore.clearAgentTodos(conversationId);
+        // Clear any stale pending question — the turn is over
+        freshStore.clearPendingUserQuestion(conversationId);
         // Desktop notification for task completion.
         // success defaults to true when the field is absent (only explicitly false means failure).
         notifyDesktop(
@@ -507,6 +509,7 @@ export function useWebSocket(enabled: boolean = true) {
         store.clearActiveTools(conversationId);
         store.clearSubAgents(conversationId);
         store.clearAgentTodos(conversationId);
+        store.clearPendingUserQuestion(conversationId);
         // Update conversation status to idle (ready for new input)
         store.updateConversation(conversationId, { status: 'idle' });
         break;
@@ -781,10 +784,12 @@ export function useWebSocket(enabled: boolean = true) {
         store.clearActiveTools(conversationId);
         store.clearThinking(conversationId);
         store.clearSubAgents(conversationId);
+        store.clearPendingUserQuestion(conversationId);
         store.updateConversation(conversationId, { status: 'idle' });
         break;
 
       case 'user_question_timeout':
+      case 'user_question_cancelled':
         store.clearPendingUserQuestion(conversationId);
         break;
 


### PR DESCRIPTION
## Summary

Fixes multiple issues with the AskUserQuestion feature:
- Implements 30-second cooldown cache to prevent duplicate prompts from SDK bug #15755 retries
- Adds text buffer flushing before question UI to ensure proper display order
- Adds free-text input support for questions without predefined options
- Clears stale pending questions on turn completion, errors, and cancellations

## Changes

- **agent-runner/src/index.ts**: Retry dedup cache, buffer flushing, defense-in-depth in canUseTool
- **src/components/conversation/UserQuestionPrompt.tsx**: Free-text input mode and state management
- **src/hooks/useWebSocket.ts**: Stale question cleanup on various completion scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)