### PR TITLE
fix: Detect merged PRs by reading GitHub's merged field

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -352,8 +352,11 @@ func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, bran
 		details, err := w.ghClient.GetPRDetails(w.ctx, owner, repo, entry.PRNumber)
 		if err == nil && details != nil {
 			if details.State == "closed" {
-				// Check if it was merged
-				if details.MergeableState == "merged" || w.isPRMerged(owner, repo, entry.PRNumber) {
+				// Check if it was merged using the `merged` boolean from the PR response,
+				// falling back to the dedicated /merge endpoint
+				if details.Merged {
+					newStatus = models.PRStatusMerged
+				} else if merged, mergeErr := w.ghClient.IsPRMerged(w.ctx, owner, repo, entry.PRNumber); mergeErr == nil && merged {
 					newStatus = models.PRStatusMerged
 				} else {
 					newStatus = models.PRStatusClosed
@@ -362,8 +365,12 @@ func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, bran
 				prUrl = details.HTMLURL
 			}
 		} else {
-			// Couldn't fetch details - assume closed
-			newStatus = models.PRStatusClosed
+			// Couldn't fetch details - check merge endpoint directly
+			if merged, mergeErr := w.ghClient.IsPRMerged(w.ctx, owner, repo, entry.PRNumber); mergeErr == nil && merged {
+				newStatus = models.PRStatusMerged
+			} else {
+				newStatus = models.PRStatusClosed
+			}
 			prNumber = entry.PRNumber
 			prUrl = entry.PRUrl
 		}
@@ -436,14 +443,6 @@ func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, bran
 	}
 }
 
-// isPRMerged checks if a PR was merged using the merge API endpoint
-func (w *PRWatcher) isPRMerged(owner, repo string, prNumber int) bool {
-	// The PR details API shows state="closed" for both closed and merged PRs
-	// We already have the details, so check if mergeable_state indicates merged
-	// This is a simplification - in practice, the mergeable_state check in checkSessionPR
-	// should be sufficient for most cases
-	return false
-}
 
 // boolPtrEqual compares two *bool values for equality
 func boolPtrEqual(a, b *bool) bool {

--- a/backend/github/pr_status.go
+++ b/backend/github/pr_status.go
@@ -36,6 +36,7 @@ type PRDetails struct {
 	State          string        `json:"state"`         // "open", "closed"
 	Title          string        `json:"title"`
 	HTMLURL        string        `json:"htmlUrl"`
+	Merged         bool          `json:"merged"`         // true if the PR has been merged
 	Mergeable      *bool         `json:"mergeable"`      // Can be null while GitHub computes it
 	MergeableState string        `json:"mergeableState"` // "clean", "dirty", "blocked", "unknown", "unstable"
 	CheckStatus    CheckStatus   `json:"checkStatus"`
@@ -48,6 +49,7 @@ type githubPR struct {
 	State          string `json:"state"`
 	Title          string `json:"title"`
 	HTMLURL        string `json:"html_url"`
+	Merged         bool   `json:"merged"`
 	Mergeable      *bool  `json:"mergeable"`
 	MergeableState string `json:"mergeable_state"`
 	Head           struct {
@@ -112,6 +114,7 @@ func (c *Client) GetPRDetails(ctx context.Context, owner, repo string, prNumber 
 		State:          pr.State,
 		Title:          pr.Title,
 		HTMLURL:        pr.HTMLURL,
+		Merged:         pr.Merged,
 		Mergeable:      pr.Mergeable,
 		MergeableState: pr.MergeableState,
 		CheckStatus:    CheckStatusNone,
@@ -517,4 +520,31 @@ func (c *Client) FindPRForBranch(ctx context.Context, owner, repo, branch string
 	}
 
 	return prs[0].Number, nil
+}
+
+// IsPRMerged checks if a PR was merged using the dedicated GitHub merge endpoint.
+// Returns true if the PR has been merged (HTTP 204), false otherwise (HTTP 404).
+func (c *Client) IsPRMerged(ctx context.Context, owner, repo string, prNumber int) (bool, error) {
+	token := c.GetToken()
+	if token == "" {
+		return false, fmt.Errorf("not authenticated")
+	}
+
+	mergeURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/merge", c.apiURL, owner, repo, prNumber)
+	req, err := http.NewRequestWithContext(ctx, "GET", mergeURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("creating merge check request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("checking merge status: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 204 = merged, 404 = not merged
+	return resp.StatusCode == http.StatusNoContent, nil
 }


### PR DESCRIPTION
## Summary
- **Fixed:** PR watcher could never detect merged PRs — sessions with merged PRs stayed stuck showing "Ready to merge"
- **Root cause:** `isPRMerged()` was a stub returning `false`, and the code checked `mergeableState == "merged"` which GitHub never returns (the actual merge status is a separate `merged` boolean)
- **Fix:** Added `Merged` field to `githubPR`/`PRDetails` structs, implemented `IsPRMerged()` using GitHub's dedicated `/pulls/{number}/merge` endpoint as fallback

## Test plan
- [ ] Merge a PR on GitHub and verify the session updates to "Merged" status within the next poll cycle (~2 min)
- [ ] Close a PR without merging and verify it shows "Closed" (not "Merged")
- [ ] `go test ./...` passes
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)