### PR TITLE
fix: Restore PRNumber in PR watcher on restart for merged PR detection

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -84,7 +84,7 @@ func NewPRWatcher(
 }
 
 // WatchSession starts watching a session for PR status changes
-func (w *PRWatcher) WatchSession(sessionID, workspaceID, branch, repoPath, currentPRStatus string) {
+func (w *PRWatcher) WatchSession(sessionID, workspaceID, branch, repoPath, currentPRStatus string, prNumber int, prUrl string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -99,10 +99,12 @@ func (w *PRWatcher) WatchSession(sessionID, workspaceID, branch, repoPath, curre
 		Branch:      branch,
 		RepoPath:    repoPath,
 		PRStatus:    currentPRStatus,
+		PRNumber:    prNumber,
+		PRUrl:       prUrl,
 		LastChecked: time.Time{}, // Force immediate check
 	}
 
-	logger.PRWatcher.Infof("Started watching session %s (branch: %s)", sessionID, branch)
+	logger.PRWatcher.Infof("Started watching session %s (branch: %s, pr: %d)", sessionID, branch, prNumber)
 }
 
 // UnwatchSession stops watching a session for PR status changes
@@ -193,6 +195,11 @@ func (w *PRWatcher) run() {
 		return
 	case <-time.After(5 * time.Second):
 	}
+
+	// Immediately check all sessions on startup so merged/closed PRs
+	// are detected without waiting for the 2-minute slow ticker.
+	w.checkSessionsWithPR()
+	w.checkSessionsWithoutPR()
 
 	for {
 		select {

--- a/backend/branch/pr_watcher_test.go
+++ b/backend/branch/pr_watcher_test.go
@@ -99,7 +99,7 @@ func TestPRWatcher_WatchSession_AddsEntry(t *testing.T) {
 	w := newTestPRWatcher(newMockStore(), &mockPRWatcherRepoManager{}, nil)
 	defer w.Close()
 
-	w.WatchSession("sess-1", "ws-1", "feature/foo", "/repo/path", "none")
+	w.WatchSession("sess-1", "ws-1", "feature/foo", "/repo/path", "none", 0, "")
 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
@@ -113,12 +113,28 @@ func TestPRWatcher_WatchSession_AddsEntry(t *testing.T) {
 	assert.Equal(t, "none", entry.PRStatus)
 }
 
+func TestPRWatcher_WatchSession_WithPRNumber(t *testing.T) {
+	w := newTestPRWatcher(newMockStore(), &mockPRWatcherRepoManager{}, nil)
+	defer w.Close()
+
+	w.WatchSession("sess-1", "ws-1", "feature/foo", "/repo/path", "open", 42, "https://github.com/org/repo/pull/42")
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	entry, ok := w.sessions["sess-1"]
+	require.True(t, ok, "session entry should exist")
+	assert.Equal(t, 42, entry.PRNumber)
+	assert.Equal(t, "https://github.com/org/repo/pull/42", entry.PRUrl)
+	assert.Equal(t, "open", entry.PRStatus)
+}
+
 func TestPRWatcher_WatchSession_Idempotent(t *testing.T) {
 	w := newTestPRWatcher(newMockStore(), &mockPRWatcherRepoManager{}, nil)
 	defer w.Close()
 
-	w.WatchSession("sess-1", "ws-1", "feature/foo", "/repo/path", "none")
-	w.WatchSession("sess-1", "ws-1", "feature/bar", "/other/path", "open")
+	w.WatchSession("sess-1", "ws-1", "feature/foo", "/repo/path", "none", 0, "")
+	w.WatchSession("sess-1", "ws-1", "feature/bar", "/other/path", "open", 1, "")
 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
@@ -140,7 +156,7 @@ func TestPRWatcher_UnwatchSession_RemovesEntry(t *testing.T) {
 	w := newTestPRWatcher(newMockStore(), &mockPRWatcherRepoManager{}, nil)
 	defer w.Close()
 
-	w.WatchSession("sess-1", "ws-1", "feature/foo", "/repo/path", "none")
+	w.WatchSession("sess-1", "ws-1", "feature/foo", "/repo/path", "none", 0, "")
 	w.UnwatchSession("sess-1")
 
 	w.mu.RLock()
@@ -169,7 +185,7 @@ func TestPRWatcher_UpdateSessionBranch_UpdatesEntry(t *testing.T) {
 	w := newTestPRWatcher(newMockStore(), repoMgr, nil)
 	defer w.Close()
 
-	w.WatchSession("sess-1", "ws-1", "feature/old", "/repo/path", "none")
+	w.WatchSession("sess-1", "ws-1", "feature/old", "/repo/path", "none", 0, "")
 
 	// Set LastChecked to a non-zero value so we can verify it gets reset.
 	w.mu.Lock()
@@ -193,7 +209,7 @@ func TestPRWatcher_UpdateSessionBranch_InvalidatesPRCache(t *testing.T) {
 	w := newTestPRWatcher(newMockStore(), repoMgr, prCache)
 	defer w.Close()
 
-	w.WatchSession("sess-1", "ws-1", "feature/old", "/repo/path", "none")
+	w.WatchSession("sess-1", "ws-1", "feature/old", "/repo/path", "none", 0, "")
 
 	// This should call prCache.Invalidate internally without panicking.
 	assert.NotPanics(t, func() {

--- a/backend/main.go
+++ b/backend/main.go
@@ -387,7 +387,7 @@ func main() {
 				}
 				for _, sess := range sessions {
 					if sess.WorktreePath != "" && sess.Branch != "" {
-						prWatcher.WatchSession(sess.ID, sess.WorkspaceID, sess.Branch, repo.Path, sess.PRStatus)
+						prWatcher.WatchSession(sess.ID, sess.WorkspaceID, sess.Branch, repo.Path, sess.PRStatus, sess.PRNumber, sess.PRUrl)
 					}
 				}
 			}

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -1863,7 +1863,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 
 	// Start watching for PR status changes
 	if h.prWatcher != nil {
-		h.prWatcher.WatchSession(sess.ID, workspaceID, branchName, repo.Path, models.PRStatusNone)
+		h.prWatcher.WatchSession(sess.ID, workspaceID, branchName, repo.Path, models.PRStatusNone, 0, "")
 	}
 
 	// Invalidate branch cache after new session/branch creation
@@ -4443,7 +4443,7 @@ func (h *Handlers) CreatePR(w http.ResponseWriter, r *http.Request) {
 	// Register with PR watcher for status tracking
 	if h.prWatcher != nil {
 		repoPath := session.WorkspacePath
-		h.prWatcher.WatchSession(sessionID, session.WorkspaceID, session.Branch, repoPath, models.PRStatusOpen)
+		h.prWatcher.WatchSession(sessionID, session.WorkspaceID, session.Branch, repoPath, models.PRStatusOpen, prResult.Number, prResult.HTMLURL)
 	}
 
 	// Broadcast WebSocket event


### PR DESCRIPTION
## Summary

- `WatchSession()` didn't accept `prNumber`/`prUrl` params, so on restart sessions with open PRs got `PRNumber=0` in the watcher entry. The merged detection requires `PRNumber > 0`, causing it to never fire — sessions stayed stuck showing "Ready to Merge" instead of transitioning to "Merged".
- Runs an immediate PR check after the 5s startup delay instead of waiting for the 2-minute slow ticker, so stale PR statuses are resolved within seconds of restart.

## Test plan

- [x] All existing Go tests pass (`go test ./...`)
- [x] New test `TestPRWatcher_WatchSession_WithPRNumber` verifies PRNumber/PRUrl are stored
- [ ] Manual: restart app with a session whose PR is already merged → verify it transitions to "Merged" within ~5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)