### PR TITLE
fix: Sync workspace color dots across all views

### DIFF
--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -33,7 +33,7 @@ import { BranchCleanupDialog } from '@/components/dialogs/branch-cleanup/BranchC
 import { copyToClipboard } from '@/lib/tauri';
 import { useToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
-import { getWorkspaceColor } from '@/lib/workspace-colors';
+import { resolveWorkspaceColor } from '@/lib/workspace-colors';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 
@@ -233,7 +233,7 @@ export function BranchesDashboard({
   const hasFetchedRef = useRef(false);
 
   const workspaces = useAppStore((s) => s.workspaces);
-  const { setLastRepoDashboardWorkspaceId } = useSettingsStore();
+  const { setLastRepoDashboardWorkspaceId, workspaceColors } = useSettingsStore();
 
   // Get workspace name for the title
   const workspace = workspaces.find((w) => w.id === workspaceId);
@@ -254,7 +254,7 @@ export function BranchesDashboard({
               <button className="flex items-center gap-1.5 min-w-0 shrink overflow-hidden hover:bg-surface-1 px-1.5 py-0.5 rounded-md transition-colors">
                 <div
                   className="w-3 h-3 rounded-full shrink-0"
-                  style={{ backgroundColor: getWorkspaceColor(workspaceId) }}
+                  style={{ backgroundColor: resolveWorkspaceColor(workspaceId, workspaceColors) }}
                 />
                 <span className="text-base font-semibold truncate">{workspace.name}</span>
                 <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
@@ -269,7 +269,7 @@ export function BranchesDashboard({
                 >
                   <div
                     className="w-2.5 h-2.5 rounded-full shrink-0"
-                    style={{ backgroundColor: getWorkspaceColor(w.id) }}
+                    style={{ backgroundColor: resolveWorkspaceColor(w.id, workspaceColors) }}
                   />
                   <span className="truncate font-medium">{w.name}</span>
                 </DropdownMenuItem>
@@ -280,7 +280,7 @@ export function BranchesDashboard({
           <span className="flex items-center gap-1.5 min-w-0 shrink overflow-hidden">
             <div
               className="w-3 h-3 rounded-full shrink-0"
-              style={{ backgroundColor: getWorkspaceColor(workspaceId) }}
+              style={{ backgroundColor: resolveWorkspaceColor(workspaceId, workspaceColors) }}
             />
             <span className="text-base font-semibold truncate">{workspace.name}</span>
           </span>
@@ -323,7 +323,7 @@ export function BranchesDashboard({
         </>
       ),
     },
-  }), [workspace, workspaces, workspaceId, branchData, refreshing, handleWorkspaceChange]);
+  }), [workspace, workspaces, workspaceId, branchData, refreshing, handleWorkspaceChange, workspaceColors]);
   useMainToolbarContent(toolbarConfig);
 
   const fetchBranches = useCallback(async (isRefresh = false) => {

--- a/src/components/dashboards/PRDashboard.tsx
+++ b/src/components/dashboards/PRDashboard.tsx
@@ -44,7 +44,7 @@ import {
   ChevronDown,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getWorkspaceColor } from '@/lib/workspace-colors';
+import { resolveWorkspaceColor } from '@/lib/workspace-colors';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 
@@ -336,7 +336,7 @@ export function PRDashboard({
   const [searchTerm, setSearchTerm] = useState('');
 
   const workspaces = useAppStore((s) => s.workspaces);
-  const { setLastRepoDashboardWorkspaceId } = useSettingsStore();
+  const { setLastRepoDashboardWorkspaceId, workspaceColors } = useSettingsStore();
 
   // Get workspace name for the title
   const workspace = workspaces.find((w) => w.id === initialWorkspaceId);
@@ -679,7 +679,7 @@ export function PRDashboard({
               <button className="flex items-center gap-1.5 min-w-0 shrink overflow-hidden hover:bg-surface-1 px-1.5 py-0.5 rounded-md transition-colors">
                 <div
                   className="w-3 h-3 rounded-full shrink-0"
-                  style={{ backgroundColor: getWorkspaceColor(initialWorkspaceId ?? '') }}
+                  style={{ backgroundColor: resolveWorkspaceColor(initialWorkspaceId ?? '', workspaceColors) }}
                 />
                 <span className="text-base font-semibold truncate">{workspace.name}</span>
                 <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
@@ -694,7 +694,7 @@ export function PRDashboard({
                 >
                   <div
                     className="w-2.5 h-2.5 rounded-full shrink-0"
-                    style={{ backgroundColor: getWorkspaceColor(w.id) }}
+                    style={{ backgroundColor: resolveWorkspaceColor(w.id, workspaceColors) }}
                   />
                   <span className="truncate font-medium">{w.name}</span>
                 </DropdownMenuItem>
@@ -705,7 +705,7 @@ export function PRDashboard({
           <span className="flex items-center gap-1.5 min-w-0 shrink overflow-hidden">
             <div
               className="w-3 h-3 rounded-full shrink-0"
-              style={{ backgroundColor: getWorkspaceColor(initialWorkspaceId ?? '') }}
+              style={{ backgroundColor: resolveWorkspaceColor(initialWorkspaceId ?? '', workspaceColors) }}
             />
             <span className="text-base font-semibold truncate">{workspace.name}</span>
           </span>
@@ -740,7 +740,7 @@ export function PRDashboard({
         </Button>
       ),
     },
-  }), [workspace, workspaces, initialWorkspaceId, stats, refreshing, handleWorkspaceChange]);
+  }), [workspace, workspaces, initialWorkspaceId, stats, refreshing, handleWorkspaceChange, workspaceColors]);
   useMainToolbarContent(toolbarConfig);
 
   return (

--- a/src/components/dashboards/RepositoriesDashboard.tsx
+++ b/src/components/dashboards/RepositoriesDashboard.tsx
@@ -19,7 +19,8 @@ import {
   GitBranch,
 } from 'lucide-react';
 import type { Workspace } from '@/lib/types';
-import { getWorkspaceColor } from '@/lib/workspace-colors';
+import { resolveWorkspaceColor } from '@/lib/workspace-colors';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { showInFinder, openInTerminal, copyToClipboard } from '@/lib/tauri';
 import { useToast } from '@/components/ui/toast';
 
@@ -52,11 +53,12 @@ function formatTimeAgo(dateStr: string): string {
 
 // Icon cell component
 function IconCell({ workspace }: { workspace: Workspace }) {
+  const workspaceColors = useSettingsStore((s) => s.workspaceColors);
   return (
     <div className="flex items-center justify-center">
       <div
         className="w-3 h-3 rounded-full"
-        style={{ backgroundColor: getWorkspaceColor(workspace.id) }}
+        style={{ backgroundColor: resolveWorkspaceColor(workspace.id, workspaceColors) }}
       />
     </div>
   );

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -39,7 +39,7 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getWorkspaceColor } from '@/lib/workspace-colors';
+import { resolveWorkspaceColor } from '@/lib/workspace-colors';
 import { updateSession as apiUpdateSession } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import {
@@ -100,6 +100,7 @@ export function SessionToolbarContent() {
   const [openAppPopoverOpen, setOpenAppPopoverOpen] = useState(false);
   const { installedApps } = useInstalledApps();
   const defaultOpenApp = useSettingsStore((s) => s.defaultOpenApp);
+  const workspaceColors = useSettingsStore((s) => s.workspaceColors);
   const { requestArchive, dialogProps: archiveDialogProps } = useArchiveSession({
     onSuccess: () => showSuccess('Session archived'),
     onError: () => showError('Failed to archive session'),
@@ -194,7 +195,7 @@ export function SessionToolbarContent() {
           <span className="flex items-center gap-1.5 min-w-0 shrink overflow-hidden">
             <div
               className="w-3 h-3 rounded-full shrink-0"
-              style={{ backgroundColor: getWorkspaceColor(selectedWorkspace.id) }}
+              style={{ backgroundColor: resolveWorkspaceColor(selectedWorkspace.id, workspaceColors) }}
             />
             <span className="text-base font-semibold truncate">{selectedWorkspace.name}</span>
             <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
@@ -437,7 +438,7 @@ export function SessionToolbarContent() {
         ),
       },
     };
-  }, [selectedWorkspace, selectedSession, selectedWorkspaceId, handleGitActionMessage, handleFixIssues, handleNewConversation, handleCopyBranch, handleArchive, requestArchive, handleTaskStatusChange, reviewPopoverOpen, openAppPopoverOpen, defaultOpenApp, installedApps]);
+  }, [selectedWorkspace, selectedSession, selectedWorkspaceId, handleGitActionMessage, handleFixIssues, handleNewConversation, handleCopyBranch, handleArchive, requestArchive, handleTaskStatusChange, reviewPopoverOpen, openAppPopoverOpen, defaultOpenApp, installedApps, workspaceColors]);
 
   useMainToolbarContent(toolbarConfig);
 

--- a/src/components/session-manager/cells/WorkspaceCell.tsx
+++ b/src/components/session-manager/cells/WorkspaceCell.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import { getWorkspaceColor } from '@/lib/workspace-colors';
+import { resolveWorkspaceColor } from '@/lib/workspace-colors';
+import { useSettingsStore } from '@/stores/settingsStore';
 
 interface WorkspaceCellProps {
   workspaceId: string;
@@ -10,6 +11,7 @@ interface WorkspaceCellProps {
 }
 
 export function WorkspaceCell({ workspaceId, workspaceName, archived }: WorkspaceCellProps) {
+  const workspaceColors = useSettingsStore((s) => s.workspaceColors);
   return (
     <div className={cn(
       'flex items-center gap-2 min-w-0',
@@ -17,7 +19,7 @@ export function WorkspaceCell({ workspaceId, workspaceName, archived }: Workspac
     )}>
       <div
         className="w-2.5 h-2.5 rounded-full shrink-0"
-        style={{ backgroundColor: getWorkspaceColor(workspaceId) }}
+        style={{ backgroundColor: resolveWorkspaceColor(workspaceId, workspaceColors) }}
       />
       <span className="text-sm text-muted-foreground truncate">
         {workspaceName}

--- a/src/lib/workspace-colors.ts
+++ b/src/lib/workspace-colors.ts
@@ -4,6 +4,13 @@ export const WORKSPACE_COLORS = [
   '#eab308', '#22c55e', '#14b8a6', '#06b6d4', '#3b82f6',
 ];
 
+export function resolveWorkspaceColor(
+  workspaceId: string,
+  workspaceColors: Record<string, string>
+): string {
+  return workspaceColors[workspaceId] || getWorkspaceColor(workspaceId);
+}
+
 export function getWorkspaceColor(workspaceId: string): string {
   let hash = 0;
   for (let i = 0; i < workspaceId.length; i++) {


### PR DESCRIPTION
## Summary

Fixed workspace color dot synchronization across all views. When a user customizes a workspace color in the sidebar color picker, the change now properly reflects in PR Dashboard, Branches Dashboard, Session Toolbar, Repositories Dashboard, and WorkspaceCell.

## Changes

- Added `resolveWorkspaceColor()` helper function that checks custom colors first, falling back to hash-based defaults
- Updated 5 components to read `workspaceColors` from `useSettingsStore` and use the new helper
- Updated `useMemo` dependencies to ensure re-renders when colors change

## Testing

- TypeScript compilation: ✓ No type errors in changed files
- Manual test: Change workspace color in sidebar → verify sync to PR, Branches, and other views

🤖 Generated with [Claude Code](https://claude.com/claude-code)