### PR TITLE
feat: Add keyboard navigation for tabs

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -78,6 +78,17 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         )
         .separator()
         .item(
+            &MenuItemBuilder::with_id("next_tab", "Next Tab")
+                .accelerator("CmdOrCtrl+Alt+]")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("previous_tab", "Previous Tab")
+                .accelerator("CmdOrCtrl+Alt+[")
+                .build(app)?,
+        )
+        .separator()
+        .item(
             &MenuItemBuilder::with_id("toggle_thinking", "Toggle Thinking Mode")
                 .accelerator("Alt+T")
                 .build(app)?,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1129,6 +1129,12 @@ export default function Home() {
           // Emit event for ChatInput to handle
           window.dispatchEvent(new CustomEvent('focus-input'));
           break;
+        case 'next_tab':
+          selectNextTab();
+          break;
+        case 'previous_tab':
+          selectPreviousTab();
+          break;
         default:
           // Unhandled menu event
       }
@@ -1139,7 +1145,7 @@ export default function Home() {
     return () => {
       cleanup?.();
     };
-  }, [handleNewSession, handleNewConversation, handleCloseTab, toggleBottomTerminal, saveCurrentTab, toggleLeftSidebar, toggleRightSidebar]);
+  }, [handleNewSession, handleNewConversation, handleCloseTab, toggleBottomTerminal, saveCurrentTab, toggleLeftSidebar, toggleRightSidebar, selectNextTab, selectPreviousTab]);
 
   // Handle window close confirmation
   useEffect(() => {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -102,6 +102,20 @@ export const SHORTCUTS: Shortcut[] = [
     label: 'Search workspaces',
     category: 'Navigation',
   },
+  {
+    id: 'nextTab',
+    key: ']',
+    modifiers: ['meta', 'alt'],
+    label: 'Next tab',
+    category: 'Navigation',
+  },
+  {
+    id: 'previousTab',
+    key: '[',
+    modifiers: ['meta', 'alt'],
+    label: 'Previous tab',
+    category: 'Navigation',
+  },
 
   // Chat
   {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1041,22 +1041,61 @@ updateFileTabContent: (id, content) => set((state) => ({
   }),
 
   selectNextTab: () => set((state) => {
-    if (state.fileTabs.length === 0) return state;
-    const currentIdx = state.fileTabs.findIndex(
-      (t) => t.id === state.selectedFileTabId
-    );
-    const nextIdx = (currentIdx + 1) % state.fileTabs.length;
-    return { selectedFileTabId: state.fileTabs[nextIdx].id };
+    if (!state.selectedSessionId) return state;
+
+    // Build unified tab list matching TabBar render order: file tabs then conversations
+    const sessionFileTabs = state.fileTabs.filter(t => t.sessionId === state.selectedSessionId);
+    const sessionConvs = state.conversations.filter(c => c.sessionId === state.selectedSessionId);
+    const unified: { id: string; type: 'file' | 'conversation' }[] = [
+      ...sessionFileTabs.map(t => ({ id: t.id, type: 'file' as const })),
+      ...sessionConvs.map(c => ({ id: c.id, type: 'conversation' as const })),
+    ];
+    if (unified.length === 0) return state;
+
+    const activeId = state.selectedFileTabId ?? state.selectedConversationId;
+    const currentIdx = unified.findIndex(t => t.id === activeId);
+    const nextIdx = currentIdx === -1 ? 0 : (currentIdx + 1) % unified.length;
+    const next = unified[nextIdx];
+
+    // Clear selectedFileTabId when navigating to conversation (file tabs take precedence in active-tab logic)
+    if (next.type === 'file') return { selectedFileTabId: next.id };
+    return {
+      selectedFileTabId: null,
+      selectedConversationId: next.id,
+      checkpoints: [],
+      lastActiveConversationPerSession: {
+        ...state.lastActiveConversationPerSession,
+        [state.selectedSessionId]: next.id,
+      },
+    };
   }),
 
   selectPreviousTab: () => set((state) => {
-    if (state.fileTabs.length === 0) return state;
-    const currentIdx = state.fileTabs.findIndex(
-      (t) => t.id === state.selectedFileTabId
-    );
-    const prevIdx =
-      currentIdx <= 0 ? state.fileTabs.length - 1 : currentIdx - 1;
-    return { selectedFileTabId: state.fileTabs[prevIdx].id };
+    if (!state.selectedSessionId) return state;
+
+    const sessionFileTabs = state.fileTabs.filter(t => t.sessionId === state.selectedSessionId);
+    const sessionConvs = state.conversations.filter(c => c.sessionId === state.selectedSessionId);
+    const unified: { id: string; type: 'file' | 'conversation' }[] = [
+      ...sessionFileTabs.map(t => ({ id: t.id, type: 'file' as const })),
+      ...sessionConvs.map(c => ({ id: c.id, type: 'conversation' as const })),
+    ];
+    if (unified.length === 0) return state;
+
+    const activeId = state.selectedFileTabId ?? state.selectedConversationId;
+    const currentIdx = unified.findIndex(t => t.id === activeId);
+    const prevIdx = currentIdx <= 0 ? unified.length - 1 : currentIdx - 1;
+    const prev = unified[prevIdx];
+
+    if (prev.type === 'file') return { selectedFileTabId: prev.id };
+    return {
+      selectedFileTabId: null,
+      selectedConversationId: prev.id,
+      checkpoints: [],
+      lastActiveConversationPerSession: {
+        ...state.lastActiveConversationPerSession,
+        [state.selectedSessionId]: prev.id,
+      },
+    };
   }),
 
   setPendingCloseFileTabId: (id) => set({ pendingCloseFileTabId: id }),


### PR DESCRIPTION
## Summary

Implements keyboard shortcuts (Cmd+Alt+[ and Cmd+Alt+]) to navigate between file tabs and conversation tabs in a unified tab bar. Navigation respects the TabBar render order (files first, then conversations) and properly handles state transitions when navigating to conversation tabs.

## What Changed

- Added menu items for Next Tab and Previous Tab in the native Tauri menu
- Registered keyboard shortcuts in the shortcuts library
- Wired up event handlers in the main page component
- Enhanced `selectNextTab()` and `selectPreviousTab()` to navigate across both file and conversation tabs, with proper state management (resets checkpoints and updates session tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)