### PR TITLE
feat: Persist conversation scroll position across tab switches

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -53,6 +53,11 @@ import { useBranchSync } from '@/hooks/useBranchSync';
 import { useClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
 import { KeyRound, Settings2 } from 'lucide-react';
 
+// Module-level scroll position cache (singleton — ConversationArea is only rendered once).
+// Stored outside the component to avoid ref-in-render lint issues since we read it during
+// render to compute initialTopMostItemIndex for Virtuoso.
+const scrollPositions = new Map<string, { dataIndex: number; wasAtBottom: boolean }>();
+
 interface ConversationAreaProps {
   children?: React.ReactNode;
 }
@@ -508,15 +513,39 @@ export function ConversationArea({ children }: ConversationAreaProps) {
 
   // Auto-scroll management via Virtuoso
   const messageListRef = useRef<VirtualizedMessageListHandle>(null);
-  const selectedConversationIdRef = useRef(selectedConversationId);
-  useEffect(() => {
-    selectedConversationIdRef.current = selectedConversationId;
-  }, [selectedConversationId]);
   const [showScrollButton, setShowScrollButton] = useState(false);
+
+  // Scroll position memory across tab switches.
+  // We track the first visible data index per conversation via Virtuoso's rangeChanged.
+  // On remount (key change), Virtuoso uses initialTopMostItemIndex — no animation, no flash.
+  const isAtBottomRef = useRef(true);
+
+  // Continuously track the visible range — called by Virtuoso on every scroll
+  const handleRangeChanged = useCallback((range: { startIndex: number; endIndex: number }) => {
+    if (!selectedConversationId) return;
+    scrollPositions.set(selectedConversationId, {
+      dataIndex: range.startIndex,
+      wasAtBottom: isAtBottomRef.current,
+    });
+  }, [selectedConversationId]);
+
+  // Compute initialTopMostItemIndex for the current conversation.
+  // Read from the module-level map — this is computed fresh each render when
+  // selectedConversationId changes (which triggers Virtuoso remount via key).
+  const initialTopMostItemIndex = useMemo(() => {
+    if (!selectedConversationId) return { index: 'LAST' as const, align: 'end' as const };
+    const saved = scrollPositions.get(selectedConversationId);
+    if (saved && !saved.wasAtBottom) {
+      return { index: saved.dataIndex, align: 'start' as const };
+    }
+    // First visit or was at bottom — start at bottom
+    return { index: 'LAST' as const, align: 'end' as const };
+  }, [selectedConversationId]);
 
   // Track at-bottom state from Virtuoso
   const handleAtBottomStateChange = useCallback((atBottom: boolean) => {
     setShowScrollButton(!atBottom);
+    isAtBottomRef.current = atBottom;
   }, []);
 
   // Force scroll to bottom (for manual button click or message submit)
@@ -548,18 +577,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
       </div>
     );
   }, [selectedConversationId, queuedMessage, currentSession?.worktreePath]);
-
-  // Reset scroll on conversation change
-  useEffect(() => {
-    const conversationId = selectedConversationId;
-    // Scroll to bottom after a tick to let Virtuoso render
-    const frameId = requestAnimationFrame(() => {
-      // Guard: skip if conversation changed before this frame fired
-      if (conversationId !== selectedConversationIdRef.current) return;
-      messageListRef.current?.scrollToBottom('auto');
-    });
-    return () => cancelAnimationFrame(frameId);
-  }, [selectedConversationId]);
 
   // Listen for message submit events to force scroll to bottom
   useEffect(() => {
@@ -1086,6 +1103,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
               partialResults={pagination?.hasMore}
             />
             <VirtualizedMessageList
+              key={selectedConversationId ?? 'none'}
               ref={messageListRef}
               messages={conversationMessages}
               worktreePath={currentSession?.worktreePath}
@@ -1093,6 +1111,8 @@ export function ConversationArea({ children }: ConversationAreaProps) {
               currentMatchIndex={clampedMatchIndex}
               searchMatches={searchMatches}
               messageHasMatches={messageHasMatches}
+              initialTopMostItemIndex={initialTopMostItemIndex}
+              onRangeChanged={handleRangeChanged}
               onAtBottomStateChange={handleAtBottomStateChange}
               onStartReached={pagination?.hasMore ? handleStartReached : undefined}
               firstItemIndex={firstItemIndex}

--- a/src/components/conversation/VirtualizedMessageList.tsx
+++ b/src/components/conversation/VirtualizedMessageList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { forwardRef, useCallback, useMemo, useRef, useImperativeHandle } from 'react';
-import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
+import { Virtuoso, type VirtuosoHandle, type ListRange } from 'react-virtuoso';
 import { MessageBlock } from '@/components/conversation/MessageBlock';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { CardErrorFallback } from '@/components/shared/ErrorFallbacks';
@@ -30,6 +30,10 @@ interface VirtualizedMessageListProps {
   isLoadingOlder?: boolean;
   /** When true, use instant scroll for followOutput to prevent bounce during streaming */
   isStreaming?: boolean;
+  /** Initial scroll position — index-based, avoids flash. Defaults to bottom. */
+  initialTopMostItemIndex?: number | { index: number | 'LAST'; align?: 'start' | 'center' | 'end' };
+  /** Called when the visible range changes — use to track scroll position for persistence */
+  onRangeChanged?: (range: ListRange) => void;
 }
 
 export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, VirtualizedMessageListProps>(
@@ -48,6 +52,8 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
       firstItemIndex,
       isLoadingOlder,
       isStreaming,
+      initialTopMostItemIndex,
+      onRangeChanged,
     },
     ref
   ) {
@@ -139,15 +145,20 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
       );
     }
 
+    // Default to bottom if no initial position provided
+    const resolvedInitialIndex = initialTopMostItemIndex ?? { index: 'LAST' as const, align: 'end' as const };
+
     return (
       <Virtuoso
         ref={virtuosoRef}
         data={messages}
         firstItemIndex={firstItemIndex ?? INITIAL_FIRST_ITEM_INDEX}
+        initialTopMostItemIndex={resolvedInitialIndex}
         itemContent={itemContent}
         followOutput={followOutput}
         alignToBottom
         startReached={onStartReached}
+        rangeChanged={onRangeChanged}
         increaseViewportBy={{ top: 2000, bottom: 2000 }}
         atBottomStateChange={onAtBottomStateChange}
         atBottomThreshold={50}


### PR DESCRIPTION
## Summary
- Remembers scroll position per conversation tab — switching away and back restores the exact reading position
- First visit or was-at-bottom conversations always start at the bottom (no visible scroll animation)
- Uses Virtuoso's `initialTopMostItemIndex` + `rangeChanged` for reliable index-based persistence, and `key={conversationId}` for clean remounts (eliminates blank content flashes)

## Test plan
- [ ] Open a session with multiple conversations
- [ ] Scroll up in one conversation, switch to another tab, switch back — should restore position
- [ ] Conversation at bottom: switch tabs and back — should still be at bottom
- [ ] First time opening a conversation — should start at bottom
- [ ] Verify no visible scroll animation on tab switch (position appears instantly)
- [ ] Verify streaming still auto-scrolls when at bottom
- [ ] Verify "scroll to bottom" button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)