### PR TITLE
feat: Display user-friendly names for MCP tool calls

### DIFF
--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -22,9 +22,11 @@ import {
   FolderOpen,
   ClipboardCheck,
   Circle,
+  Plug,
   type LucideIcon,
 } from 'lucide-react';
 import { cn, toRelativePath } from '@/lib/utils';
+import { parseMcpToolName } from '@/lib/format';
 import { useAppStore } from '@/stores/appStore';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 
@@ -88,6 +90,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   elapsedSeconds,
 }: ToolUsageBlockProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const mcpInfo = useMemo(() => parseMcpToolName(tool), [tool]);
 
   const ToolIcon = useMemo((): LucideIcon => {
     switch (tool) {
@@ -116,6 +119,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
       case 'ExitPlanMode':
         return ClipboardCheck;
       default:
+        if (tool.startsWith('mcp__')) return Plug;
         return Terminal;
     }
   }, [tool]);
@@ -149,7 +153,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
       case 'ExitPlanMode':
         return isActive ? 'Propose Plan' : 'Exiting Plan mode';
       default:
-        return tool;
+        return mcpInfo ? mcpInfo.displayLabel : tool;
     }
   };
 
@@ -265,6 +269,11 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
           <>
             <ToolIcon className="w-3 h-3 text-muted-foreground shrink-0" />
             <span className="font-medium text-foreground">{getToolLabel()}</span>
+            {mcpInfo && (
+              <span className="text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground/70">
+                {mcpInfo.displayServer}
+              </span>
+            )}
 
             {/* Description (if available, shows instead of/before target) */}
             {description && (

--- a/src/components/conversation/ToolUsageHistory.tsx
+++ b/src/components/conversation/ToolUsageHistory.tsx
@@ -13,6 +13,7 @@ import {
   Globe,
   GitBranch,
   Wrench,
+  Plug,
 } from 'lucide-react';
 import {
   Collapsible,
@@ -25,6 +26,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn, toRelativePath } from '@/lib/utils';
+import { parseMcpToolName } from '@/lib/format';
 import type { ToolUsage } from '@/lib/types';
 
 // Truncation limits (increased from original)
@@ -49,6 +51,7 @@ const toolIcons: Record<string, React.ElementType> = {
 };
 
 function getToolIcon(toolName: string) {
+  if (toolName.startsWith('mcp__')) return Plug;
   return toolIcons[toolName] || Wrench;
 }
 
@@ -126,8 +129,19 @@ function formatToolTarget(tool: string, params?: Record<string, unknown>, worktr
         ? full.slice(0, PATH_TRUNCATE_LENGTH - 3) + '...'
         : full;
       break;
-    default:
+    default: {
+      if (tool.startsWith('mcp__')) {
+        const val = params.query || params.issueId || params.id || params.name || params.selector || params.command;
+        if (typeof val === 'string') {
+          full = val;
+          display = full.length > PATH_TRUNCATE_LENGTH
+            ? full.slice(0, PATH_TRUNCATE_LENGTH - 3) + '...'
+            : full;
+          return { display, full, isTruncated: display !== full && full.length > 0 };
+        }
+      }
       return empty;
+    }
   }
 
   return {
@@ -167,6 +181,7 @@ export const ToolUsageHistory = memo(function ToolUsageHistory({ tools, worktree
           {tools.map((tool) => {
             const Icon = getToolIcon(tool.tool);
             const targetInfo = formatToolTarget(tool.tool, tool.params, worktreePath);
+            const mcpInfo = parseMcpToolName(tool.tool);
 
             return (
               <div
@@ -179,7 +194,12 @@ export const ToolUsageHistory = memo(function ToolUsageHistory({ tools, worktree
                   <CheckCircle2 className="w-3 h-3 text-text-success shrink-0" />
                 )}
                 <Icon className="w-3 h-3 shrink-0" />
-                <span className="font-medium">{tool.tool}</span>
+                <span className="font-medium">{mcpInfo ? mcpInfo.displayLabel : tool.tool}</span>
+                {mcpInfo && (
+                  <span className="text-2xs px-0.5 text-muted-foreground/50">
+                    {mcpInfo.displayServer}
+                  </span>
+                )}
                 {targetInfo.display && (
                   targetInfo.isTruncated ? (
                     <Tooltip>

--- a/src/components/conversation/__tests__/ToolUsageBlock.test.tsx
+++ b/src/components/conversation/__tests__/ToolUsageBlock.test.tsx
@@ -116,6 +116,36 @@ describe('ToolUsageBlock', () => {
     expect(screen.getByText('hello')).toBeInTheDocument();
   });
 
+  it('renders formatted label and server badge for MCP tools', () => {
+    render(
+      <ToolUsageBlock
+        id="t-mcp"
+        tool="mcp__chatml__get_session_status"
+        params={{}}
+        success={true}
+        duration={200}
+      />
+    );
+
+    expect(screen.getByText('Get session status')).toBeInTheDocument();
+    expect(screen.getByText('ChatML')).toBeInTheDocument();
+  });
+
+  it('renders formatted label for Linear MCP tools', () => {
+    render(
+      <ToolUsageBlock
+        id="t-mcp-linear"
+        tool="mcp__claude_ai_Linear__get_issue"
+        params={{ id: 'LIN-123' }}
+        success={true}
+        duration={300}
+      />
+    );
+
+    expect(screen.getByText('Get issue')).toBeInTheDocument();
+    expect(screen.getByText('Linear')).toBeInTheDocument();
+  });
+
   it('shows edit stats for Edit tool', () => {
     render(
       <ToolUsageBlock

--- a/src/components/conversation/__tests__/ToolUsageHistory.test.tsx
+++ b/src/components/conversation/__tests__/ToolUsageHistory.test.tsx
@@ -9,6 +9,7 @@ describe('ToolUsageHistory', () => {
     { id: 't1', tool: 'Read', success: true, durationMs: 100, params: { file_path: '/src/app.tsx' } },
     { id: 't2', tool: 'Write', success: true, durationMs: 200, params: { file_path: '/src/new.ts' } },
     { id: 't3', tool: 'Bash', success: false, durationMs: 3000, params: { command: 'npm test' }, stderr: 'fail' },
+    { id: 't4', tool: 'mcp__chatml__get_session_status', success: true, durationMs: 150, params: {} },
   ];
 
   it('renders nothing when tools array is empty', () => {
@@ -19,13 +20,13 @@ describe('ToolUsageHistory', () => {
   it('shows tool count', () => {
     render(<ToolUsageHistory tools={tools} />);
     // Renders "{count} tool(s)" — not "tools used"
-    expect(screen.getByText(/3/)).toBeInTheDocument();
+    expect(screen.getByText(/4/)).toBeInTheDocument();
     expect(screen.getByText(/tool/)).toBeInTheDocument();
   });
 
   it('shows success and fail counts', () => {
     render(<ToolUsageHistory tools={tools} />);
-    expect(screen.getByText('2 passed')).toBeInTheDocument();
+    expect(screen.getByText('3 passed')).toBeInTheDocument();
     expect(screen.getByText('1 failed')).toBeInTheDocument();
   });
 
@@ -47,5 +48,19 @@ describe('ToolUsageHistory', () => {
     expect(screen.getByText('Read')).toBeInTheDocument();
     expect(screen.getByText('Write')).toBeInTheDocument();
     expect(screen.getByText('Bash')).toBeInTheDocument();
+  });
+
+  it('shows formatted label and server badge for MCP tools', async () => {
+    const user = userEvent.setup();
+    render(<ToolUsageHistory tools={tools} />);
+
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+
+    // MCP tool should show formatted label instead of raw name
+    expect(screen.getByText('Get session status')).toBeInTheDocument();
+    expect(screen.getByText('ChatML')).toBeInTheDocument();
+    // Raw name should NOT appear
+    expect(screen.queryByText('mcp__chatml__get_session_status')).toBeNull();
   });
 });

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { parseMcpToolName } from '../format';
+
+describe('parseMcpToolName', () => {
+  it('parses a chatml MCP tool name', () => {
+    const result = parseMcpToolName('mcp__chatml__get_session_status');
+    expect(result).toEqual({
+      serverName: 'chatml',
+      toolName: 'get_session_status',
+      displayLabel: 'Get session status',
+      displayServer: 'ChatML',
+    });
+  });
+
+  it('parses a Linear MCP tool name', () => {
+    const result = parseMcpToolName('mcp__claude_ai_Linear__get_issue');
+    expect(result).toEqual({
+      serverName: 'claude_ai_Linear',
+      toolName: 'get_issue',
+      displayLabel: 'Get issue',
+      displayServer: 'Linear',
+    });
+  });
+
+  it('parses a Tauri MCP tool name', () => {
+    const result = parseMcpToolName('mcp__tauri__webview_screenshot');
+    expect(result).toEqual({
+      serverName: 'tauri',
+      toolName: 'webview_screenshot',
+      displayLabel: 'Webview screenshot',
+      displayServer: 'Tauri',
+    });
+  });
+
+  it('returns null for non-MCP tool names', () => {
+    expect(parseMcpToolName('Read')).toBeNull();
+    expect(parseMcpToolName('Bash')).toBeNull();
+    expect(parseMcpToolName('WebSearch')).toBeNull();
+  });
+
+  it('returns null for malformed MCP names with fewer than 3 parts', () => {
+    expect(parseMcpToolName('mcp__foo')).toBeNull();
+  });
+
+  it('formats unknown server names with title case', () => {
+    const result = parseMcpToolName('mcp__my_custom_server__do_something');
+    expect(result).not.toBeNull();
+    expect(result!.displayServer).toBe('My Custom Server');
+    expect(result!.displayLabel).toBe('Do something');
+  });
+
+  it('handles tool names with multiple underscores', () => {
+    const result = parseMcpToolName('mcp__chatml__get_recent_activity');
+    expect(result).not.toBeNull();
+    expect(result!.displayLabel).toBe('Get recent activity');
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -8,3 +8,59 @@ export const formatTokens = (tokens: number) => {
   if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
   return tokens.toString();
 };
+
+// ---------------------------------------------------------------------------
+// MCP tool name formatting
+// ---------------------------------------------------------------------------
+
+export interface McpToolInfo {
+  serverName: string;     // raw server name, e.g. "chatml"
+  toolName: string;       // raw tool name, e.g. "get_session_status"
+  displayLabel: string;   // human-readable, e.g. "Get session status"
+  displayServer: string;  // human-readable, e.g. "ChatML"
+}
+
+/** Known MCP server display names. */
+const SERVER_DISPLAY_NAMES: Record<string, string> = {
+  chatml: 'ChatML',
+  claude_ai_Linear: 'Linear',
+  tauri: 'Tauri',
+};
+
+/** Convert snake_case to sentence case: "get_session_status" → "Get session status" */
+function formatSnakeCaseToLabel(name: string): string {
+  const words = name.split('_');
+  if (words.length === 0) return name;
+  return words
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+/** Convert raw server name to display-friendly name. */
+function formatServerName(name: string): string {
+  if (SERVER_DISPLAY_NAMES[name]) return SERVER_DISPLAY_NAMES[name];
+  return name
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Parse an MCP tool name (e.g. "mcp__chatml__get_session_status") into
+ * structured display info. Returns null for non-MCP tool names.
+ */
+export function parseMcpToolName(rawTool: string): McpToolInfo | null {
+  if (!rawTool.startsWith('mcp__')) return null;
+
+  const parts = rawTool.split('__');
+  if (parts.length < 3) return null;
+
+  const serverName = parts[1];
+  const toolName = parts.slice(2).join('__');
+
+  return {
+    serverName,
+    toolName,
+    displayLabel: formatSnakeCaseToLabel(toolName),
+    displayServer: formatServerName(serverName),
+  };
+}


### PR DESCRIPTION
## Summary
- MCP tool calls were showing raw internal names like `mcp__chatml__get_session_status` in the conversation UI
- Added `parseMcpToolName()` utility that converts snake_case tool names to sentence case (e.g. "Get session status") and maps server names to display names (e.g. "ChatML")
- Updated both `ToolUsageBlock` (active tools) and `ToolUsageHistory` (completed tools) to show formatted labels, Plug icons, and server name badges

## Test plan
- [x] Unit tests for `parseMcpToolName()` — 7 tests covering chatml, Linear, Tauri, unknown servers, malformed names
- [x] Component tests for `ToolUsageBlock` — MCP tool label and server badge rendering
- [x] Component tests for `ToolUsageHistory` — MCP tool formatted display, raw name not shown
- [ ] Manual: trigger MCP tool calls in a conversation and verify formatted display

🤖 Generated with [Claude Code](https://claude.com/claude-code)