### PR TITLE
feat: Implement professional macOS menu bar state management

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::Serialize;
+use tauri::menu::MenuItemKind;
 use tauri::{Manager, State};
 
 use crate::error::AppResult;
@@ -272,6 +273,69 @@ pub fn get_user_shell() -> Option<String> {
     {
         std::env::var("COMSPEC").ok()
     }
+}
+
+// ============================================================================
+// Menu state commands
+// ============================================================================
+
+/// Update enabled/disabled state of menu items.
+/// Receives a list of (menu_item_id, enabled) tuples from the frontend.
+#[tauri::command]
+pub fn update_menu_state(app: tauri::AppHandle, items: Vec<(String, bool)>) -> Result<(), String> {
+    if let Some(menu) = app.menu() {
+        for (id, enabled) in items {
+            if let Some(item) = find_menu_item_recursive(&menu, &id) {
+                match item {
+                    MenuItemKind::MenuItem(mi) => {
+                        let _ = mi.set_enabled(enabled);
+                    }
+                    MenuItemKind::Check(ci) => {
+                        let _ = ci.set_enabled(enabled);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Recursively search through menu and all submenus to find an item by ID.
+/// Tauri's `Menu::get()` only searches top-level items, but our menu items
+/// are all inside submenus (and some are nested 2 levels deep).
+fn find_menu_item_recursive<R: tauri::Runtime>(
+    menu: &tauri::menu::Menu<R>,
+    target_id: &str,
+) -> Option<MenuItemKind<R>> {
+    for item in menu.items().unwrap_or_default() {
+        if item.id().as_ref() == target_id {
+            return Some(item);
+        }
+        if let MenuItemKind::Submenu(sub) = &item {
+            if let Some(found) = find_in_submenu(sub, target_id) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+fn find_in_submenu<R: tauri::Runtime>(
+    submenu: &tauri::menu::Submenu<R>,
+    target_id: &str,
+) -> Option<MenuItemKind<R>> {
+    for item in submenu.items().unwrap_or_default() {
+        if item.id().as_ref() == target_id {
+            return Some(item);
+        }
+        if let MenuItemKind::Submenu(sub) = &item {
+            if let Some(found) = find_in_submenu(sub, target_id) {
+                return Some(found);
+            }
+        }
+    }
+    None
 }
 
 /// Count lines in a text file

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,6 +131,7 @@ pub fn run() {
 
     builder
         .invoke_handler(tauri::generate_handler![
+            commands::update_menu_state,
             commands::mark_app_ready,
             commands::restart_sidecar,
             commands::set_minimize_to_tray,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,6 +1,9 @@
 use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 
-/// Create the application menu
+/// Create the application menu.
+///
+/// Items that require application state (workspace selected, session selected, etc.)
+/// start disabled. The frontend enables them dynamically via the `update_menu_state` command.
 pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     // 1. App menu (macOS only shows this as the app name)
     let app_menu = SubmenuBuilder::new(app, "ChatML")
@@ -26,16 +29,19 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(
             &MenuItemBuilder::with_id("new_session", "New Session")
                 .accelerator("CmdOrCtrl+N")
+                .enabled(false)
                 .build(app)?,
         )
         .item(
             &MenuItemBuilder::with_id("new_conversation", "New Conversation")
                 .accelerator("CmdOrCtrl+Shift+N")
+                .enabled(false)
                 .build(app)?,
         )
         .item(
             &MenuItemBuilder::with_id("create_from_pr", "New Session from PR/Branch...")
                 .accelerator("CmdOrCtrl+Shift+O")
+                .enabled(false)
                 .build(app)?,
         )
         .separator()
@@ -44,12 +50,14 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(
             &MenuItemBuilder::with_id("save_file", "Save")
                 .accelerator("CmdOrCtrl+S")
+                .enabled(false)
                 .build(app)?,
         )
         .separator()
         .item(
             &MenuItemBuilder::with_id("close_tab", "Close Tab")
                 .accelerator("CmdOrCtrl+W")
+                .enabled(false)
                 .build(app)?,
         )
         .item(&PredefinedMenuItem::close_window(
@@ -99,22 +107,26 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(
             &MenuItemBuilder::with_id("toggle_right_sidebar", "Right Sidebar")
                 .accelerator("CmdOrCtrl+Alt+B")
+                .enabled(false)
                 .build(app)?,
         )
         .item(
             &MenuItemBuilder::with_id("toggle_terminal", "Terminal")
                 .accelerator("Ctrl+`")
+                .enabled(false)
                 .build(app)?,
         )
         .separator()
         .item(
             &MenuItemBuilder::with_id("next_tab", "Next Tab")
                 .accelerator("CmdOrCtrl+Alt+]")
+                .enabled(false)
                 .build(app)?,
         )
         .item(
             &MenuItemBuilder::with_id("previous_tab", "Previous Tab")
                 .accelerator("CmdOrCtrl+Alt+[")
+                .enabled(false)
                 .build(app)?,
         )
         .separator()
@@ -122,6 +134,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(
             &MenuItemBuilder::with_id("file_picker", "File Picker")
                 .accelerator("CmdOrCtrl+P")
+                .enabled(false)
                 .build(app)?,
         )
         .separator()
@@ -132,6 +145,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(
             &MenuItemBuilder::with_id("toggle_zen_mode", "Zen Mode")
                 .accelerator("CmdOrCtrl+.")
+                .enabled(false)
                 .build(app)?,
         )
         .item(
@@ -152,17 +166,27 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(
             &MenuItemBuilder::with_id("navigate_back", "Back")
                 .accelerator("CmdOrCtrl+[")
+                .enabled(false)
                 .build(app)?,
         )
         .item(
             &MenuItemBuilder::with_id("navigate_forward", "Forward")
                 .accelerator("CmdOrCtrl+]")
+                .enabled(false)
                 .build(app)?,
         )
         .separator()
         .item(&MenuItemBuilder::with_id("go_to_workspace", "Go to Workspace...").build(app)?)
-        .item(&MenuItemBuilder::with_id("go_to_session", "Go to Session...").build(app)?)
-        .item(&MenuItemBuilder::with_id("go_to_conversation", "Go to Conversation...").build(app)?)
+        .item(
+            &MenuItemBuilder::with_id("go_to_session", "Go to Session...")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("go_to_conversation", "Go to Conversation...")
+                .enabled(false)
+                .build(app)?,
+        )
         .separator()
         .item(
             &MenuItemBuilder::with_id("search_workspaces", "Search Workspaces")
@@ -172,40 +196,106 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .build()?;
 
     // 6. Session menu with Thinking Level submenu
+    // All session items start disabled - enabled when a session is selected
     let thinking_submenu = SubmenuBuilder::new(app, "Thinking Level")
-        .item(&MenuItemBuilder::with_id("thinking_off", "Off").build(app)?)
-        .item(&MenuItemBuilder::with_id("thinking_low", "Low").build(app)?)
-        .item(&MenuItemBuilder::with_id("thinking_medium", "Medium").build(app)?)
-        .item(&MenuItemBuilder::with_id("thinking_high", "High").build(app)?)
-        .item(&MenuItemBuilder::with_id("thinking_max", "Max").build(app)?)
+        .item(
+            &MenuItemBuilder::with_id("thinking_off", "Off")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("thinking_low", "Low")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("thinking_medium", "Medium")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("thinking_high", "High")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("thinking_max", "Max")
+                .enabled(false)
+                .build(app)?,
+        )
         .build()?;
 
     let session_menu = SubmenuBuilder::new(app, "Session")
         .item(&thinking_submenu)
-        .item(&MenuItemBuilder::with_id("toggle_plan_mode", "Plan Mode").build(app)?)
-        .separator()
-        .item(&MenuItemBuilder::with_id("approve_plan", "Approve Plan").build(app)?)
         .item(
-            &MenuItemBuilder::with_id("focus_input", "Focus Chat Input")
-                .accelerator("CmdOrCtrl+L")
+            &MenuItemBuilder::with_id("toggle_plan_mode", "Plan Mode")
+                .enabled(false)
                 .build(app)?,
         )
         .separator()
-        .item(&MenuItemBuilder::with_id("quick_review", "Quick Review").build(app)?)
-        .item(&MenuItemBuilder::with_id("deep_review", "Deep Review").build(app)?)
-        .item(&MenuItemBuilder::with_id("security_audit", "Security Audit").build(app)?)
+        .item(
+            &MenuItemBuilder::with_id("approve_plan", "Approve Plan")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("focus_input", "Focus Chat Input")
+                .accelerator("CmdOrCtrl+L")
+                .enabled(false)
+                .build(app)?,
+        )
         .separator()
-        .item(&MenuItemBuilder::with_id("open_in_vscode", "Open in VS Code").build(app)?)
-        .item(&MenuItemBuilder::with_id("open_terminal", "Open in Terminal").build(app)?)
+        .item(
+            &MenuItemBuilder::with_id("quick_review", "Quick Review")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("deep_review", "Deep Review")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("security_audit", "Security Audit")
+                .enabled(false)
+                .build(app)?,
+        )
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id("open_in_vscode", "Open in VS Code")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("open_terminal", "Open in Terminal")
+                .enabled(false)
+                .build(app)?,
+        )
         .build()?;
 
-    // 7. Git menu
+    // 7. Git menu - all items start disabled
     let git_menu = SubmenuBuilder::new(app, "Git")
-        .item(&MenuItemBuilder::with_id("git_commit", "Commit Changes...").build(app)?)
-        .item(&MenuItemBuilder::with_id("git_create_pr", "Create Pull Request...").build(app)?)
-        .item(&MenuItemBuilder::with_id("git_sync", "Sync with Main").build(app)?)
+        .item(
+            &MenuItemBuilder::with_id("git_commit", "Commit Changes...")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("git_create_pr", "Create Pull Request...")
+                .enabled(false)
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("git_sync", "Sync with Main")
+                .enabled(false)
+                .build(app)?,
+        )
         .separator()
-        .item(&MenuItemBuilder::with_id("git_copy_branch", "Copy Branch Name").build(app)?)
+        .item(
+            &MenuItemBuilder::with_id("git_copy_branch", "Copy Branch Name")
+                .enabled(false)
+                .build(app)?,
+        )
         .build()?;
 
     // 8. Window menu

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,6 +39,7 @@ import { useExternalLinkGuard } from '@/hooks/useExternalLinkGuard';
 import { useDesktopNotifications } from '@/hooks/useDesktopNotifications';
 import { useFontSize } from '@/hooks/useFontSize';
 import { useReviewTrigger } from '@/hooks/useReviewTrigger';
+import { useMenuState } from '@/hooks/useMenuState';
 import { useShortcut } from '@/hooks/useShortcut';
 import { getDashboardData, listConversations, createSession, createConversation, deleteConversation, addRepo, mapSessionDTO, getConversationMessages, toStoreMessage, type RepoDTO, type SessionDTO, type ConversationDTO, type MessageDTO } from '@/lib/api';
 import type { SetupInfo } from '@/lib/types';
@@ -470,6 +471,9 @@ export default function Home() {
 
   // Listen for /review, /deep-review, /security slash commands
   useReviewTrigger();
+
+  // Keep macOS menu item enabled/disabled state in sync with app state
+  useMenuState();
 
   // Persist file tabs to backend
   useTabPersistence();

--- a/src/hooks/useMenuState.ts
+++ b/src/hooks/useMenuState.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react';
+import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useNavigationStore } from '@/stores/navigationStore';
+import { useTabStore } from '@/stores/tabStore';
+import { isTauri, safeInvoke } from '@/lib/tauri';
+import { computeMenuState } from '@/lib/menuContext';
+import { ENABLE_BROWSER_TABS } from '@/lib/constants';
+
+/**
+ * Hook that keeps macOS menu item enabled/disabled state in sync
+ * with the current application state. Sends only changed items
+ * to the Rust backend via IPC.
+ */
+export function useMenuState() {
+  const previousStateRef = useRef<Record<string, boolean>>({});
+
+  // Subscribe to minimal state slices
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const selectedSessionId = useAppStore((s) => s.selectedSessionId);
+  const selectedConversationId = useAppStore((s) => s.selectedConversationId);
+  const contentView = useSettingsStore((s) => s.contentView);
+
+  // Derived: any file tab dirty?
+  const hasDirtyFileTabs = useAppStore((s) => s.fileTabs.some((t) => t.isDirty));
+
+  // Derived: pending plan approval for current conversation?
+  const hasPendingPlanApproval = useAppStore((s) => {
+    if (!s.selectedConversationId) return false;
+    const streaming = s.streamingState[s.selectedConversationId];
+    return streaming?.pendingPlanApproval != null;
+  });
+
+  // Navigation: can go back/forward?
+  const canGoBack = useNavigationStore((s) => {
+    const tab = s.tabs[s.activeTabId];
+    return tab ? tab.backStack.length > 0 : false;
+  });
+  const canGoForward = useNavigationStore((s) => {
+    const tab = s.tabs[s.activeTabId];
+    return tab ? tab.forwardStack.length > 0 : false;
+  });
+
+  // Browser tabs: more than one tab open?
+  const hasBrowserTabs = useTabStore((s) => ENABLE_BROWSER_TABS && s.tabOrder.length > 1);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+
+    const state = computeMenuState({
+      contentView,
+      selectedWorkspaceId,
+      selectedSessionId,
+      selectedConversationId,
+      hasDirtyFileTabs,
+      hasPendingPlanApproval,
+      canGoBack,
+      canGoForward,
+      hasBrowserTabs,
+    });
+
+    // Compute diff - only send items that changed
+    const diff: [string, boolean][] = [];
+    for (const [id, enabled] of Object.entries(state) as [string, boolean][]) {
+      if (previousStateRef.current[id] !== enabled) {
+        diff.push([id, enabled]);
+      }
+    }
+
+    if (diff.length === 0) return;
+    previousStateRef.current = state;
+
+    safeInvoke('update_menu_state', { items: diff });
+  }, [
+    contentView,
+    selectedWorkspaceId,
+    selectedSessionId,
+    selectedConversationId,
+    hasDirtyFileTabs,
+    hasPendingPlanApproval,
+    canGoBack,
+    canGoForward,
+    hasBrowserTabs,
+  ]);
+}

--- a/src/lib/menuContext.ts
+++ b/src/lib/menuContext.ts
@@ -1,0 +1,110 @@
+import type { ContentView } from '@/stores/settingsStore';
+
+export interface MenuContextInputs {
+  contentView: ContentView;
+  selectedWorkspaceId: string | null;
+  selectedSessionId: string | null;
+  selectedConversationId: string | null;
+  hasDirtyFileTabs: boolean;
+  hasPendingPlanApproval: boolean;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  hasBrowserTabs: boolean;
+}
+
+/**
+ * Compute the enabled/disabled state for all controllable menu items.
+ * Returns a map of menu item ID -> enabled boolean.
+ *
+ * Only includes items we can control (MenuItemBuilder items).
+ * PredefinedMenuItem items (undo, redo, cut, copy, paste, etc.) are OS-managed.
+ */
+export function computeMenuState(inputs: MenuContextInputs): Record<string, boolean> {
+  const {
+    contentView,
+    selectedWorkspaceId,
+    selectedSessionId,
+    hasDirtyFileTabs,
+    hasPendingPlanApproval,
+    canGoBack,
+    canGoForward,
+    hasBrowserTabs,
+  } = inputs;
+
+  const hasWorkspace = selectedWorkspaceId != null;
+  const hasSession = selectedSessionId != null;
+  const inConversationView = contentView.type === 'conversation';
+  const sessionInConversation = hasSession && inConversationView;
+
+  return {
+    // App menu - always enabled
+    check_for_updates: true,
+    settings: true,
+
+    // File menu
+    new_session: hasWorkspace,
+    new_conversation: hasSession,
+    create_from_pr: hasWorkspace,
+    add_workspace: true,
+    save_file: hasDirtyFileTabs,
+    close_tab: hasSession || hasBrowserTabs,
+
+    // Edit > Find - always enabled
+    find: true,
+    find_next: true,
+    find_previous: true,
+
+    // View menu
+    toggle_left_sidebar: true,
+    toggle_right_sidebar: sessionInConversation,
+    toggle_terminal: sessionInConversation,
+    next_tab: hasSession,
+    previous_tab: hasSession,
+    command_palette: true,
+    file_picker: hasSession,
+    open_session_manager: true,
+    open_pr_dashboard: true,
+    open_repositories: true,
+    toggle_zen_mode: sessionInConversation,
+    reset_layouts: true,
+    enter_full_screen: true,
+
+    // Go menu
+    navigate_back: canGoBack,
+    navigate_forward: canGoForward,
+    go_to_workspace: true,
+    go_to_session: hasWorkspace,
+    go_to_conversation: hasSession,
+    search_workspaces: true,
+
+    // Session menu
+    thinking_off: hasSession,
+    thinking_low: hasSession,
+    thinking_medium: hasSession,
+    thinking_high: hasSession,
+    thinking_max: hasSession,
+    toggle_plan_mode: hasSession,
+    approve_plan: hasSession && hasPendingPlanApproval,
+    focus_input: sessionInConversation,
+    quick_review: hasSession,
+    deep_review: hasSession,
+    security_audit: hasSession,
+    open_in_vscode: hasSession,
+    open_terminal: hasSession,
+
+    // Git menu
+    git_commit: hasSession,
+    git_create_pr: hasSession,
+    git_sync: hasSession,
+    git_copy_branch: hasSession,
+
+    // Window menu - always enabled
+    bring_all_to_front: true,
+
+    // Help menu - always enabled
+    help: true,
+    keyboard_shortcuts: true,
+    release_notes: true,
+    report_issue: true,
+  };
+}


### PR DESCRIPTION
Dynamically enable/disable menu items based on application state (workspace selected, session active, conversation view, navigation history, etc.). Adds Rust backend command to update menu items recursively, frontend hook that subscribes to Zustand stores and sends only state deltas over IPC, and pure utility function computing menu state from app context. Follows macOS HIG by keeping items discoverable (visible but disabled) rather than hidden.

## Changes
- Rust: `update_menu_state` command with recursive menu search for nested submenus
- Menu config: All state-dependent items start disabled
- Frontend hook: Subscribes to minimal store slices, sends only state changes
- Menu utilities: Pure function mapping app state to menu item states
- Integration: Hook wired into main page component