### PR TITLE
fix: Use ref-based callbacks for Tauri menu event listeners

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -905,6 +905,23 @@ export default function Home() {
     setPendingCloseFileTabId(null);
   }, [pendingCloseFileTabId, closeFileTab, setPendingCloseFileTabId]);
 
+  // Refs for menu-event handler callbacks — prevents safeListen re-registration race condition.
+  // Without refs, unstable callbacks cause the useEffect to re-run, tearing down the Tauri
+  // listener and asynchronously re-registering it. During the async gap, menu events are lost.
+  const handleNewSessionRef = useRef(handleNewSession);
+  const handleNewConversationRef = useRef(handleNewConversation);
+  const handleCloseTabRef = useRef(handleCloseTab);
+  const handleCloseFileTabRef = useRef(handleCloseFileTab);
+  const toggleBottomTerminalRef = useRef(toggleBottomTerminal);
+  const saveCurrentTabRef = useRef(saveCurrentTab);
+
+  useEffect(() => { handleNewSessionRef.current = handleNewSession; }, [handleNewSession]);
+  useEffect(() => { handleNewConversationRef.current = handleNewConversation; }, [handleNewConversation]);
+  useEffect(() => { handleCloseTabRef.current = handleCloseTab; }, [handleCloseTab]);
+  useEffect(() => { handleCloseFileTabRef.current = handleCloseFileTab; }, [handleCloseFileTab]);
+  useEffect(() => { toggleBottomTerminalRef.current = toggleBottomTerminal; }, [toggleBottomTerminal]);
+  useEffect(() => { saveCurrentTabRef.current = saveCurrentTab; }, [saveCurrentTab]);
+
   // Keyboard shortcuts (only for shortcuts NOT handled by native menu accelerators)
   // Most shortcuts are now native menu accelerators in menu.rs which emit 'menu-event'.
   // This handler covers: shortcuts without menu items, context-dependent shortcuts,
@@ -1023,10 +1040,10 @@ export default function Home() {
 
         // File menu
         case 'new_session':
-          handleNewSession();
+          handleNewSessionRef.current();
           break;
         case 'new_conversation':
-          handleNewConversation();
+          handleNewConversationRef.current();
           break;
         case 'create_from_pr':
           window.dispatchEvent(new CustomEvent('create-from-pr'));
@@ -1035,13 +1052,13 @@ export default function Home() {
           setShowAddWorkspace(true);
           break;
         case 'save_file':
-          saveCurrentTab();
+          saveCurrentTabRef.current();
           break;
         case 'close_tab': {
           // Close file tab first, then browser tab, then conversation
           const fileTabId = useAppStore.getState().selectedFileTabId;
           if (fileTabId) {
-            handleCloseFileTab(fileTabId);
+            handleCloseFileTabRef.current(fileTabId);
           } else if (ENABLE_BROWSER_TABS && useTabStore.getState().tabOrder.length > 1) {
             const tabStore = useTabStore.getState();
             const closingId = tabStore.activeTabId;
@@ -1051,7 +1068,7 @@ export default function Home() {
               switchToTab(newActiveId);
             }
           } else {
-            handleCloseTab();
+            handleCloseTabRef.current();
           }
           break;
         }
@@ -1077,7 +1094,7 @@ export default function Home() {
           }
           break;
         case 'toggle_terminal':
-          toggleBottomTerminal();
+          toggleBottomTerminalRef.current();
           break;
         case 'command_palette':
           window.dispatchEvent(new CustomEvent('open-command-palette'));
@@ -1220,7 +1237,8 @@ export default function Home() {
     return () => {
       cleanup?.();
     };
-  }, [handleNewSession, handleNewConversation, handleCloseTab, handleCloseFileTab, toggleBottomTerminal, saveCurrentTab, toggleLeftSidebar, toggleRightSidebar, selectNextTab, selectPreviousTab, setZenMode, resetLayouts]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Handle window close confirmation
   useEffect(() => {


### PR DESCRIPTION
## Problem
The menu event listener's useEffect was re-running whenever callback functions changed, causing the Tauri listener to tear down and asynchronously re-register. During this async gap, menu events from the OS were lost, breaking sidebar toggle shortcuts and other menu-triggered actions.

## Solution
Store callbacks in refs and sync them via individual useEffect hooks. This allows the main useEffect to run only once (empty dependency array) while always accessing the latest callback implementations through `.current`.

The ref pattern is a standard React solution for this stale-closure problem in event listeners.

## Testing
Verify that sidebar toggle shortcuts (Cmd+Option+B, Cmd+Option+R) and other menu-triggered actions (Cmd+N for new session, Cmd+W to close tabs) work reliably.