### PR TITLE
fix: Merge PR button + plan mode bugs

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -25,6 +25,9 @@ const snapshotDebounceInterval = 500 * time.Millisecond
 // prURLPattern matches GitHub PR URLs in tool output (e.g., "https://github.com/owner/repo/pull/123")
 var prURLPattern = regexp.MustCompile(`github\.com/[^/]+/[^/]+/pull/\d+`)
 
+// prMergedPattern matches merge confirmation messages in Bash stdout (e.g., "Merged pull request", "successfully merged")
+var prMergedPattern = regexp.MustCompile(`(?i)(merged\s+pull\s+request|pull\s+request\s+.+\s+was\s+already\s+merged|successfully\s+merged)`)
+
 // dangerousSuggestionPattern matches destructive operations that should never appear in suggestions.
 // These operations could break the worktree-based session model or destroy work.
 var dangerousSuggestionPattern = regexp.MustCompile(`(?i)(delete\s.*branch|git\s+branch\s+-[dD]|rm\s+-rf|git\s+push\s+--force|git\s+reset\s+--hard|git\s+clean\s+-[fd])`)
@@ -61,6 +64,9 @@ type Manager struct {
 
 	// Callback fired when agent creates a PR via bash (sessionID)
 	onPRCreated func(sessionID string)
+
+	// Callback fired when agent merges a PR via bash (sessionID)
+	onPRMerged func(sessionID string)
 }
 
 func NewManager(ctx context.Context, s *store.SQLiteStore, wm *git.WorktreeManager) *Manager {
@@ -97,6 +103,10 @@ func (m *Manager) SetSessionEventHandler(handler SessionEventHandler) {
 
 func (m *Manager) SetOnPRCreated(handler func(sessionID string)) {
 	m.onPRCreated = handler
+}
+
+func (m *Manager) SetOnPRMerged(handler func(sessionID string)) {
+	m.onPRMerged = handler
 }
 
 // StartConversationOptions contains optional parameters for starting a conversation
@@ -613,6 +623,16 @@ outer:
 						conv, _ := m.store.GetConversationMeta(ctx, convID)
 						if conv != nil {
 							go m.onPRCreated(conv.SessionID)
+						}
+					}
+				}
+
+				// Detect PR merge from Bash tool stdout (e.g., gh pr merge)
+				if event.Tool == "Bash" && event.Success && prMergedPattern.MatchString(event.Stdout) {
+					if m.onPRMerged != nil {
+						conv, _ := m.store.GetConversationMeta(ctx, convID)
+						if conv != nil {
+							go m.onPRMerged(conv.SessionID)
 						}
 					}
 				}

--- a/backend/main.go
+++ b/backend/main.go
@@ -402,9 +402,10 @@ func main() {
 		})
 	}
 
-	// Notify PRWatcher immediately when an agent creates a PR via bash,
+	// Notify PRWatcher immediately when an agent creates or merges a PR via bash,
 	// bypassing the 30-second polling delay for instant UI updates.
 	agentMgr.SetOnPRCreated(prWatcher.ForceCheckSession)
+	agentMgr.SetOnPRMerged(prWatcher.ForceCheckSession)
 
 	// Issue cache for GitHub Issues API
 	issueCache := github.NewIssueCache(2*time.Minute, 10*time.Minute)

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, approvePlan } from '@/lib/api';
+import { markPlanModeExited } from '@/hooks/useWebSocket';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -473,6 +474,15 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     const newValue = !planModeEnabled;
     setPlanModeEnabled(newValue);
 
+    // Update store state optimistically so the banner and toggle react together
+    if (selectedConversationId) {
+      setPlanModeActive(selectedConversationId, newValue);
+      // Suppress stale backend events that would re-activate plan mode
+      if (!newValue) {
+        markPlanModeExited(selectedConversationId);
+      }
+    }
+
     // If there's an active conversation with a running process, notify the backend
     if (selectedConversationId) {
       try {
@@ -482,7 +492,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         // plan mode will be applied when the next message starts
       }
     }
-  }, [planModeEnabled, selectedConversationId]);
+  }, [planModeEnabled, selectedConversationId, setPlanModeActive]);
 
 
   // Handle plan approval — clear UI optimistically so the bar disappears instantly
@@ -502,6 +512,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     // Approving a plan exits plan mode — turn off the toggle and clear active state
     setPlanModeEnabled(false);
     setPlanModeActive(selectedConversationId, false);
+    // Suppress stale backend events (init, permission_mode_changed) from re-activating
+    markPlanModeExited(selectedConversationId);
 
     try {
       await approvePlan(selectedConversationId, requestId, true);

--- a/src/components/shared/PrimaryActionButton/ActionButton.tsx
+++ b/src/components/shared/PrimaryActionButton/ActionButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -21,6 +22,25 @@ export function ActionButton({
   onCreatePR,
   className,
 }: ActionButtonProps) {
+  // Pending action state — blocks duplicate clicks and shows spinner feedback.
+  // pendingActionKey tracks which action was clicked. When the action identity changes
+  // (type or label), the mismatch means the click has been processed → not pending.
+  const [pendingActionKey, setPendingActionKey] = useState<string | null>(null);
+  const actionKey = action ? `${action.type}:${action.label}` : null;
+  const pendingAction = pendingActionKey !== null && pendingActionKey === actionKey;
+
+  // Safety timeout: reset after 3s in case the action object doesn't change
+  useEffect(() => {
+    if (!pendingActionKey) return;
+    const timer = setTimeout(() => setPendingActionKey(null), 3000);
+    return () => clearTimeout(timer);
+  }, [pendingActionKey]);
+
+  // Mark as pending for the current action
+  const markPending = useCallback(() => {
+    setPendingActionKey(actionKey);
+  }, [actionKey]);
+
   // Nothing to render if action is null (e.g., merged PR)
   if (!action) {
     return null;
@@ -28,13 +48,19 @@ export function ActionButton({
 
   const Icon = action.icon;
   const isDisabled = disabled || action.type === 'disabled';
-  // Only show spinner for 'disabled' type (agent working), not during data fetches
-  // This prevents jarring transitions when switching sessions
-  const showSpinner = action.type === 'disabled';
+  // Show spinner for 'disabled' type (agent working) or when pending action
+  const showSpinner = action.type === 'disabled' || pendingAction;
 
   // Handle click based on action type
-  const handleClick = () => {
-    if (isDisabled) return;
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isDisabled || pendingAction) return;
+
+    // For actions that send a message to the agent, block subsequent clicks
+    const isMessageAction = action.type === 'fix-issues' || (action.message != null);
+    if (isMessageAction) {
+      markPending();
+    }
 
     if (action.type === 'fix-issues' && onFixIssues) {
       // Fetch CI failure context and forward to agent
@@ -89,14 +115,14 @@ export function ActionButton({
           size="sm"
           className="h-6 text-xs gap-1 px-2 rounded-r-none rounded-l-sm border-r-0 transition-none"
           onClick={handleClick}
-          disabled={isDisabled}
+          disabled={isDisabled || pendingAction}
         >
           {showSpinner ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
           ) : (
             <Icon className="h-3.5 w-3.5" />
           )}
-          {action.label}
+          {pendingAction ? 'Sending...' : action.label}
         </Button>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -107,7 +133,7 @@ export function ActionButton({
                 'h-6 w-4 px-0.5 rounded-l-none rounded-r-sm transition-none border-l',
                 separatorColor
               )}
-              disabled={isDisabled}
+              disabled={isDisabled || pendingAction}
             >
               <ChevronDown className="size-2.5" />
             </Button>
@@ -151,14 +177,14 @@ export function ActionButton({
       size="sm"
       className={cn("h-6 text-xs gap-1 px-2 rounded-sm transition-none", className)}
       onClick={handleClick}
-      disabled={isDisabled}
+      disabled={isDisabled || pendingAction}
     >
       {showSpinner ? (
         <Loader2 className="h-3.5 w-3.5 animate-spin" />
       ) : (
         <Icon className="h-3.5 w-3.5" />
       )}
-      {action.label}
+      {pendingAction ? 'Sending...' : action.label}
     </Button>
   );
 }

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -17,9 +17,33 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { useBranchCacheStore } from '@/stores/branchCacheStore';
 import { notifyDesktop, getConversationLabel } from '@/hooks/useDesktopNotifications';
 
-// Conversations that recently exited plan mode. Used to suppress stale SDK status
-// messages that try to re-activate plan mode after ExitPlanMode approval (SDK bug #15755).
-const recentlyExitedPlanMode = new Set<string>();
+// Conversations that recently exited plan mode. Maps conversationId → exit timestamp.
+// Used to suppress stale SDK status messages that try to re-activate plan mode after
+// ExitPlanMode approval (SDK bug #15755). A timestamp-based cooldown ensures multiple
+// stale events are all suppressed (not just the first one, as with a Set).
+const recentlyExitedPlanMode = new Map<string, number>();
+const PLAN_MODE_EXIT_COOLDOWN_MS = 5000;
+
+// Check if a conversation is within the plan mode exit cooldown window
+function isInPlanModeExitCooldown(conversationId: string): boolean {
+  const exitTime = recentlyExitedPlanMode.get(conversationId);
+  if (exitTime == null) return false;
+  return Date.now() - exitTime < PLAN_MODE_EXIT_COOLDOWN_MS;
+}
+
+// Allow UI components (e.g. plan approval, toggle) to mark a conversation as recently
+// exited so that stale `init` or `permission_mode_changed` events don't re-activate it.
+export function markPlanModeExited(conversationId: string) {
+  recentlyExitedPlanMode.set(conversationId, Date.now());
+  // Auto-cleanup after cooldown expires
+  setTimeout(() => {
+    // Only delete if timestamp hasn't been refreshed
+    const exitTime = recentlyExitedPlanMode.get(conversationId);
+    if (exitTime != null && Date.now() - exitTime >= PLAN_MODE_EXIT_COOLDOWN_MS) {
+      recentlyExitedPlanMode.delete(conversationId);
+    }
+  }, PLAN_MODE_EXIT_COOLDOWN_MS + 100);
+}
 
 // Safely coerce an unknown value to a number, returning undefined for non-numeric values.
 const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
@@ -231,10 +255,16 @@ export function useWebSocket(enabled: boolean = true) {
             currentThinkingTokens: existingStatus?.currentThinkingTokens || 0,
           });
         }
-        // Sync plan mode state from the agent's initial permission mode
+        // Sync plan mode state from the agent's initial permission mode.
+        // Guard: if the UI recently exited plan mode (approval or toggle),
+        // don't let a stale init event re-activate it during the cooldown window.
         if (event?.permissionMode) {
           const isPlan = event.permissionMode === 'plan';
-          store.setPlanModeActive(conversationId, isPlan);
+          if (isPlan && isInPlanModeExitCooldown(conversationId)) {
+            // Suppress — don't consume the cooldown, more stale events may follow
+          } else {
+            store.setPlanModeActive(conversationId, isPlan);
+          }
         }
         // Extract MCP tools grouped by server from the tools list
         if (event?.tools && Array.isArray(event.tools)) {
@@ -523,14 +553,14 @@ export function useWebSocket(enabled: boolean = true) {
         if (event?.mode) {
           if (event.mode === 'plan') {
             // User-initiated plan mode activations are always honored.
-            // SDK-originated events are suppressed if we just exited plan mode
+            // SDK-originated events are suppressed if within the exit cooldown
             // (guards against SDK bug #15755 stale status messages).
             if (event.source === 'user') {
               recentlyExitedPlanMode.delete(conversationId);
               store.setPlanModeActive(conversationId, true);
               notifyDesktop(conversationId, 'Plan ready for review', 'The AI needs your approval');
-            } else if (recentlyExitedPlanMode.has(conversationId)) {
-              recentlyExitedPlanMode.delete(conversationId);
+            } else if (isInPlanModeExitCooldown(conversationId)) {
+              // Suppress — cooldown window handles multiple stale events
             } else {
               store.setPlanModeActive(conversationId, true);
               notifyDesktop(conversationId, 'Plan ready for review', 'The AI needs your approval');
@@ -539,7 +569,7 @@ export function useWebSocket(enabled: boolean = true) {
             // Exiting plan mode — track so we can suppress stale re-activation
             const current = store.streamingState[conversationId];
             if (current?.planModeActive) {
-              recentlyExitedPlanMode.add(conversationId);
+              markPlanModeExited(conversationId);
             }
             // Only honor plan mode deactivation from explicit sources:
             // - "exit_plan": ExitPlanMode tool completed (postToolUseHook)
@@ -556,7 +586,7 @@ export function useWebSocket(enabled: boolean = true) {
 
       case 'plan_approval_request':
         // ExitPlanMode tool intercepted by PreToolUse hook - show approval UI
-        // Clear stale exit tracking — this is a fresh plan approval cycle
+        // Clear cooldown — this is a fresh plan approval cycle
         recentlyExitedPlanMode.delete(conversationId);
         if (event?.requestId) {
           store.setPendingPlanApproval(


### PR DESCRIPTION
## Summary

- **Merge PR double-click prevention**: ActionButton tracks pending action key to block duplicate clicks, shows spinner + "Sending..." label, auto-resets when action identity changes or after 3s safety timeout
- **Fast PR merge detection**: Backend detects merge confirmation in Bash stdout (regex) and triggers `ForceCheckSession` for instant UI update (mirrors existing PR creation detection)
- **Plan mode stale event suppression**: Replace `Set<string>` with `Map<string, number>` timestamp cooldown (5s) so multiple stale SDK events are all suppressed — fixes SHIFT+TAB 3-state cycling bug
- **Plan mode exit tracking**: ChatInput marks plan mode exited on toggle-off and plan approval to suppress stale init/permission_mode_changed events

## Test plan

- [ ] Click "Merge PR" rapidly → only ONE merge message sent, button shows spinner + "Sending..."
- [ ] After merge succeeds → button transitions to "Archive Session" within seconds (not 2 min)
- [ ] Enter plan mode, approve plan → plan mode stays OFF (wait 10s, watch for re-activation)
- [ ] SHIFT+TAB toggles cleanly between 2 states (on/off), no intermediate state
- [ ] Verify no regressions: Fix Issues, Create PR, View PR, Archive Session buttons all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)