### PR TITLE
feat: Persist tool stdout in tool_end events for reload

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1715,6 +1715,24 @@ function handleMessage(message: SDKMessage): void {
               }
             }
 
+            // Extract full output for persistence (capped at 100KB to match backend truncateOutput)
+            const MAX_TOOL_OUTPUT = 100 * 1024;
+            let stdout = "";
+            if (typeof block.content === "string") {
+              stdout = block.content.slice(0, MAX_TOOL_OUTPUT);
+            } else if (Array.isArray(block.content)) {
+              const textContent = block.content.find(
+                (c: { type: string }) => c.type === "text"
+              );
+              if (textContent && "text" in textContent) {
+                stdout = (textContent as { text: string }).text.slice(0, MAX_TOOL_OUTPUT);
+              }
+            }
+
+            // Tools whose success output is not useful to persist (file contents, glob lists)
+            const SKIP_OUTPUT_TOOLS = new Set(["Read", "Write", "Edit", "Glob", "NotebookEdit"]);
+            const shouldIncludeOutput = isError || !SKIP_OUTPUT_TOOLS.has(toolInfo?.tool ?? "");
+
             if (toolInfo) {
               const duration = Date.now() - toolInfo.startTime;
               trackToolEnd(duration);
@@ -1726,6 +1744,7 @@ function handleMessage(message: SDKMessage): void {
                 success: !isError,
                 summary,
                 duration,
+                ...(shouldIncludeOutput && stdout ? { stdout } : {}),
               });
               activeTools.delete(block.tool_use_id);
             } else if (completedToolNames.has(block.tool_use_id)) {
@@ -1746,6 +1765,7 @@ function handleMessage(message: SDKMessage): void {
                 summary,
                 duration: 0,
                 untracked: true,
+                ...(shouldIncludeOutput && stdout ? { stdout } : {}),
               });
             }
           }

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -359,7 +359,7 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	turnStartTime := time.Now()
 
 	// maxOutputSize limits stdout/stderr stored per tool to prevent DB bloat
-	const maxOutputSize = 10 * 1024
+	const maxOutputSize = 100 * 1024
 	truncateOutput := func(s string) string {
 		if len(s) > maxOutputSize {
 			return s[:maxOutputSize] + "\n... (truncated)"
@@ -496,6 +496,7 @@ outer:
 				entry := ActiveToolEntry{
 					ID:        event.ID,
 					Tool:      event.Tool,
+					Params:    event.Params,
 					StartTime: time.Now().Unix(),
 					AgentId:   event.AgentId,
 				}
@@ -578,7 +579,8 @@ outer:
 					// may emit tool_end twice for the same tool (once from the original execution,
 					// once from the replayed conversation history). The duplicate arrives with
 					// tool="Unknown" and causes UNIQUE constraint failures and ghost UI entries.
-					if _, ok := activeToolsMap[event.ID]; !ok {
+					toolEntry, entryOk := activeToolsMap[event.ID]
+				if !entryOk {
 						logger.Manager.Debugf("Skipping duplicate tool_end for conv %s: tool=%s id=%s", convID, event.Tool, event.ID)
 						continue
 					}
@@ -596,7 +598,7 @@ outer:
 					completedTools = append(completedTools, models.ToolUsageRecord{
 						ID:         event.ID,
 						Tool:       event.Tool,
-						Params:     event.Params,
+						Params:     toolEntry.Params,
 						Success:    &success,
 						Summary:    event.Summary,
 						DurationMs: durationMs,

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -309,10 +309,11 @@ type StreamingSnapshot struct {
 
 // ActiveToolEntry represents a tool currently in-flight during streaming.
 type ActiveToolEntry struct {
-	ID        string `json:"id"`
-	Tool      string `json:"tool"`
-	StartTime int64  `json:"startTime"`
-	AgentId   string `json:"agentId,omitempty"`
+	ID        string                 `json:"id"`
+	Tool      string                 `json:"tool"`
+	Params    map[string]interface{} `json:"params,omitempty"`
+	StartTime int64                  `json:"startTime"`
+	AgentId   string                 `json:"agentId,omitempty"`
 }
 
 // SubAgentEntry represents a sub-agent spawned during streaming.

--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -89,7 +89,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   stderr,
   elapsedSeconds,
 }: ToolUsageBlockProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(success === false && !isActive);
   const mcpInfo = useMemo(() => parseMcpToolName(tool), [tool]);
 
   const ToolIcon = useMemo((): LucideIcon => {
@@ -254,38 +254,39 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
           )}
         </span>
 
-        {/* Tool icon and label - show "Error" when tool failed */}
-        {success === false ? (
-          <>
-            <ToolIcon className="w-3 h-3 text-text-error shrink-0" />
-            <span className="font-medium text-text-error">Error</span>
-            {summary && (
-              <span className="text-text-error/80 text-2xs truncate max-w-[350px]">
-                {summary}
-              </span>
-            )}
-          </>
-        ) : (
-          <>
-            <ToolIcon className="w-3 h-3 text-muted-foreground shrink-0" />
-            <span className="font-medium text-foreground">{getToolLabel()}</span>
-            {mcpInfo && (
-              <span className="text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground/70">
-                {mcpInfo.displayServer}
-              </span>
-            )}
-
-            {/* Description (if available, shows instead of/before target) */}
-            {description && (
-              <span className="text-muted-foreground italic truncate max-w-[200px]">
-                {description}
-              </span>
-            )}
-          </>
+        {/* Tool icon and label */}
+        <ToolIcon className={cn('w-3 h-3 shrink-0', success === false ? 'text-text-error' : 'text-muted-foreground')} />
+        <span className={cn('font-medium', success === false ? 'text-text-error' : 'text-foreground')}>{getToolLabel()}</span>
+        {success === false && (
+          <span className="text-2xs px-1 py-0.5 rounded bg-text-error/10 text-text-error font-medium shrink-0">
+            Error
+          </span>
+        )}
+        {mcpInfo && (
+          <span className="text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground/70">
+            {mcpInfo.displayServer}
+          </span>
         )}
 
-        {/* Target with tooltip for truncated content - hide when error */}
-        {success !== false && truncatedTarget && !description && (
+        {/* Description (if available, shows instead of/before target) */}
+        {description && (
+          <span className={cn('italic truncate max-w-[200px]', success === false ? 'text-text-error/70' : 'text-muted-foreground')}>
+            {description}
+          </span>
+        )}
+
+        {/* Summary fallback when no target/description (e.g., params missing from DB) */}
+        {!truncatedTarget && !description && summary && (
+          <span className={cn(
+            'text-2xs truncate max-w-[350px]',
+            success === false ? 'text-text-error/80' : 'text-muted-foreground'
+          )}>
+            {summary}
+          </span>
+        )}
+
+        {/* Target with tooltip for truncated content */}
+        {truncatedTarget && !description && (
           isTargetTruncated ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -307,8 +308,8 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
           )
         )}
 
-        {/* Target when description is shown (smaller, secondary) - hide when error */}
-        {success !== false && truncatedTarget && description && (
+        {/* Target when description is shown (smaller, secondary) */}
+        {truncatedTarget && description && (
           isTargetTruncated ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -330,8 +331,8 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
           )
         )}
 
-        {/* Git line stats for Edit tools - hide when error or no net change */}
-        {success !== false && isEditTool && editStats && !isActive && (editStats.additions > 0 || editStats.deletions > 0) && (
+        {/* Git line stats for Edit tools */}
+        {isEditTool && editStats && !isActive && (editStats.additions > 0 || editStats.deletions > 0) && (
           <span className="flex items-center gap-0.5 text-2xs font-mono shrink-0">
             <span className="text-text-success">+{editStats.additions}</span>
             <span className="text-text-error">-{editStats.deletions}</span>
@@ -387,7 +388,10 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
 
               {/* Summary */}
               {summary && (
-                <div className="text-2xs text-muted-foreground px-2 py-1 rounded bg-muted/30">
+                <div className={cn(
+                  'text-2xs px-2 py-1 rounded',
+                  success === false ? 'text-text-error bg-text-error/10' : 'text-muted-foreground bg-muted/30'
+                )}>
                   {summary}
                 </div>
               )}


### PR DESCRIPTION
## Summary

- Emit full tool output (stdout) in `tool_end` events from agent-runner, so tool blocks retain their output content after app restart/reload
- Gate by tool type: skip persisting stdout for noisy tools (Read, Write, Edit, Glob, NotebookEdit) unless the tool errored
- Bump stdout truncation limit from 10KB to 100KB in both agent-runner and backend to capture full build/test output
- Store tool params from `tool_start` in `ActiveToolEntry` for accurate persistence in `ToolUsageRecord`
- Improve error tool block UI: show tool name + target (not just "Error"), auto-expand failed tools on reload

## Test plan

- [ ] Run a Bash command that produces output, restart app, reload conversation — tool block should show the command output
- [ ] Run a Bash command that fails (e.g., `ls /nonexistent`) — verify error output persists across reload
- [ ] Verify Read/Edit/Write/Glob tools do NOT have large stdout blobs persisted on success
- [ ] Verify Read/Edit/Write/Glob tools DO persist stdout when they error
- [ ] Check that error tool blocks auto-expand and show tool name + target info

🤖 Generated with [Claude Code](https://claude.com/claude-code)