### PR TITLE
fix: Include updatedInput in canUseTool allow response

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1223,7 +1223,7 @@ const canUseTool = async (
   if (currentPermissionMode === "plan" && PLAN_MODE_DENIED_TOOLS.has(toolName)) {
     return { behavior: "deny", message: "This tool is not available in plan mode. Present your plan using ExitPlanMode first." };
   }
-  return { behavior: "allow" };
+  return { behavior: "allow", updatedInput: toolInput };
 };
 
 // Hooks configuration - all always enabled


### PR DESCRIPTION
## Summary
- Fixed ZodError when exiting plan mode by including `updatedInput: toolInput` in the `canUseTool` allow response
- The SDK's runtime Zod schema requires `updatedInput` as a mandatory record for the "allow" case, even though the TypeScript type marks it as optional — this mismatch caused the validation to fail

## Test plan
- [ ] Enter plan mode, create a plan, and approve it via ExitPlanMode — should no longer throw ZodError
- [ ] Verify normal tool permission flow still works (bypassPermissions mode)
- [ ] Verify plan mode denied tools (Write/Edit/Bash) are still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)