### PR TITLE
feat: Overhaul tool rendering with metadata, icons, and clickable paths

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -221,6 +221,80 @@ function escapeXmlAttr(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+// ---------------------------------------------------------------------------
+// Tool metadata extraction — lightweight structured data from tool results
+// ---------------------------------------------------------------------------
+
+/** Extract text content from a tool_result block.content (string or content array). */
+function extractTextFromToolResult(content: unknown): string | undefined {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const textBlock = content.find((c: { type: string }) => c.type === "text");
+    if (textBlock && "text" in textBlock) return (textBlock as { text: string }).text;
+  }
+  return undefined;
+}
+
+/** Extract structured metadata from tool result content based on tool type. */
+function extractToolMetadata(toolName: string, content: unknown, toolInput?: Record<string, unknown>): Record<string, unknown> | undefined {
+  const text = extractTextFromToolResult(content);
+
+  switch (toolName) {
+    case "Read": {
+      if (!text) return undefined;
+      // Result format: "     1→line1\n     2→line2..." — count non-empty lines
+      const lines = text.split("\n").filter(l => l.length > 0).length;
+      return lines > 0 ? { linesRead: lines } : undefined;
+    }
+    case "Write": {
+      if (!text) return undefined;
+      // Result contains byte count info, e.g. "Successfully wrote 1234 bytes to /path"
+      const match = text.match(/(\d+)\s*bytes/i);
+      return match ? { bytesWritten: parseInt(match[1]) } : undefined;
+    }
+    case "Edit": {
+      if (!text) return undefined;
+      // Result mentions replacement count, e.g. "1 replacement made" or "Replaced N occurrences"
+      const match = text.match(/(\d+)\s*replacement/i) || text.match(/replaced\s+(\d+)/i);
+      return match ? { replacements: parseInt(match[1]) } : undefined;
+    }
+    case "Grep": {
+      if (!text) return undefined;
+      // files_with_matches mode: lines are file paths, preceded by a count header
+      const lines = text.split("\n").filter(l => l.length > 0);
+      // Count mode: "N matches in M files" or similar
+      const countMatch = text.match(/(\d+)\s+match/i);
+      // File paths (non-header lines)
+      const fileLines = lines.filter(l => l.startsWith("/") || l.startsWith("./"));
+      if (fileLines.length > 0) {
+        return { matchCount: fileLines.length, fileCount: fileLines.length };
+      }
+      if (countMatch) {
+        return { matchCount: parseInt(countMatch[1]) };
+      }
+      return undefined;
+    }
+    case "Glob": {
+      if (!text) return undefined;
+      // Result is a list of file paths, one per line
+      const files = text.split("\n").filter(l => l.length > 0 && (l.startsWith("/") || l.startsWith("./")));
+      return files.length > 0 ? { matchCount: files.length } : undefined;
+    }
+    case "TodoWrite": {
+      // Extract metadata from tool input params (the todo list itself)
+      const todos = toolInput?.todos as Array<{status?: string}> | undefined;
+      if (!todos || !Array.isArray(todos)) return undefined;
+      return {
+        todosTotal: todos.length,
+        todosCompleted: todos.filter(t => t.status === "completed").length,
+        todosInProgress: todos.filter(t => t.status === "in_progress").length,
+      };
+    }
+    default:
+      return undefined;
+  }
+}
+
 // Module-level readline interface for proper cleanup
 let rl: readline.Interface | null = null;
 
@@ -683,7 +757,7 @@ function flushBlockBuffer(): void {
 }
 
 // Track active tool uses
-const activeTools = new Map<string, { tool: string; startTime: number }>();
+const activeTools = new Map<string, { tool: string; startTime: number; input?: Record<string, unknown> }>();
 // Retain tool names after completion so duplicate tool_end events during
 // session replay can still report the correct tool name instead of "Unknown".
 const completedToolNames = new Map<string, string>();
@@ -1605,6 +1679,7 @@ function handleMessage(message: SDKMessage): void {
             activeTools.set(block.id, {
               tool: block.name,
               startTime: Date.now(),
+              input: block.input as Record<string, unknown> | undefined,
             });
             trackToolStart(block.name);
             emit({
@@ -1733,6 +1808,9 @@ function handleMessage(message: SDKMessage): void {
             const SKIP_OUTPUT_TOOLS = new Set(["Read", "Write", "Edit", "Glob", "NotebookEdit"]);
             const shouldIncludeOutput = isError || !SKIP_OUTPUT_TOOLS.has(toolInfo?.tool ?? "");
 
+            // Extract lightweight structured metadata (line counts, match counts, etc.)
+            const metadata = toolInfo ? extractToolMetadata(toolInfo.tool, block.content, toolInfo.input) : undefined;
+
             if (toolInfo) {
               const duration = Date.now() - toolInfo.startTime;
               trackToolEnd(duration);
@@ -1745,6 +1823,7 @@ function handleMessage(message: SDKMessage): void {
                 summary,
                 duration,
                 ...(shouldIncludeOutput && stdout ? { stdout } : {}),
+                ...(metadata ? { metadata } : {}),
               });
               activeTools.delete(block.tool_use_id);
             } else if (completedToolNames.has(block.tool_use_id)) {

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -604,6 +604,7 @@ outer:
 						DurationMs: durationMs,
 						Stdout:     truncateOutput(event.Stdout),
 						Stderr:     truncateOutput(event.Stderr),
+						Metadata:   event.Metadata,
 						StartTime:  toolStart,
 					})
 				}

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -141,6 +141,9 @@ type AgentEvent struct {
 	// Input suggestion fields (Haiku-generated prompt suggestions)
 	GhostText string              `json:"ghostText,omitempty"`
 	Pills     []ai.SuggestionPill `json:"pills,omitempty"`
+
+	// Tool metadata (structured data extracted from tool results)
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // McpServerStatus represents MCP server connection status

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -197,6 +197,7 @@ type ToolUsageRecord struct {
 	DurationMs int                    `json:"durationMs,omitempty"`
 	Stdout     string                 `json:"stdout,omitempty"`
 	Stderr     string                 `json:"stderr,omitempty"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
 	StartTime  time.Time              `json:"-"` // Not persisted; used for timeline ordering
 }
 

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -8,12 +8,16 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
-import { Copy, Check, FileText, ClipboardCheck, ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Copy, Check, FileText, ClipboardCheck, ChevronDown, ChevronRight, Wrench } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { Message } from '@/lib/types';
+import type { Message, ToolUsage } from '@/lib/types';
 import { COPY_FEEDBACK_DURATION_MS, PROSE_CLASSES } from '@/lib/constants';
 import { copyToClipboard } from '@/lib/tauri';
-import { ToolUsageHistory } from '@/components/conversation/ToolUsageHistory';
 import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
 import { ThinkingNode } from '@/components/conversation/ThinkingNode';
 import { VerificationBlock } from '@/components/conversation/VerificationBlock';
@@ -26,6 +30,47 @@ import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
 import { MentionText } from '@/components/conversation/MentionText';
+
+// Collapsed tool summary with individual ToolUsageBlock instances when expanded
+const ToolUsageSummary = memo(function ToolUsageSummary({ tools, worktreePath }: { tools: ToolUsage[]; worktreePath?: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+  if (tools.length === 0) return null;
+
+  const successCount = tools.filter(t => t.success !== false).length;
+  const failCount = tools.filter(t => t.success === false).length;
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors">
+        {isOpen ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+        <Wrench className="w-3 h-3" />
+        <span>{tools.length} tool{tools.length !== 1 ? 's' : ''}</span>
+        {successCount > 0 && <span className="text-text-success">{successCount} passed</span>}
+        {failCount > 0 && <span className="text-destructive">{failCount} failed</span>}
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-1 space-y-0.5">
+          {tools.map(tool => (
+            <ToolUsageBlock
+              key={tool.id}
+              id={tool.id}
+              tool={tool.tool}
+              params={tool.params}
+              worktreePath={worktreePath}
+              isActive={false}
+              success={tool.success}
+              summary={tool.summary}
+              duration={tool.durationMs}
+              stdout={tool.stdout}
+              stderr={tool.stderr}
+              metadata={tool.metadata}
+            />
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+});
 
 export interface MessageBlockProps {
   message: Message;
@@ -165,6 +210,7 @@ export const MessageBlock = memo(function MessageBlock({
                         stdout={tool.stdout}
                         stderr={tool.stderr}
                         worktreePath={worktreePath}
+                        metadata={tool.metadata}
                       />
                     );
                   }
@@ -202,13 +248,13 @@ export const MessageBlock = memo(function MessageBlock({
               <ThinkingNode content={message.thinkingContent} />
             )}
 
-            {/* Legacy fallback: Tool Usage History (collapsed) + full content */}
+            {/* Legacy fallback: Tool Usage Summary (collapsed) + full content */}
             {message.toolUsage && message.toolUsage.length > 0 && (
               <ErrorBoundary
                 section="ToolUsage"
                 fallback={<InlineErrorFallback message="Unable to display tool usage" />}
               >
-                <ToolUsageHistory tools={message.toolUsage} worktreePath={worktreePath} />
+                <ToolUsageSummary tools={message.toolUsage} worktreePath={worktreePath} />
               </ErrorBoundary>
             )}
 

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -15,7 +15,7 @@ import { PROSE_CLASSES } from '@/lib/constants';
 // Timeline item types for interleaved display
 type TimelineItem =
   | { type: 'text'; id: string; text: string; timestamp: number }
-  | { type: 'tool'; id: string; tool: string; params?: Record<string, unknown>; startTime: number; endTime?: number; success?: boolean; summary?: string; stdout?: string; stderr?: string; elapsedSeconds?: number }
+  | { type: 'tool'; id: string; tool: string; params?: Record<string, unknown>; startTime: number; endTime?: number; success?: boolean; summary?: string; stdout?: string; stderr?: string; elapsedSeconds?: number; metadata?: import('@/lib/types').ToolMetadata }
   | { type: 'thinking'; id: string; text: string; isActive: boolean; timestamp: number }
   | { type: 'subagent'; agent: import('@/lib/types').SubAgent }
   | { type: 'subagent_group'; agents: import('@/lib/types').SubAgent[] };
@@ -216,6 +216,7 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
         stdout: tool.stdout,
         stderr: tool.stderr,
         elapsedSeconds: tool.elapsedSeconds,
+        metadata: tool.metadata,
       });
     }
 
@@ -343,6 +344,7 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
                   stdout={item.stdout}
                   stderr={item.stderr}
                   elapsedSeconds={item.elapsedSeconds}
+                  metadata={item.metadata}
                 />
               );
             }

--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -15,20 +15,25 @@ import {
   ChevronRight,
   ChevronDown,
   FileText,
-  FileEdit,
+  FilePlus2,
+  Pencil,
   Terminal,
-  Search,
+  FileSearch,
+  FolderSearch2,
   Globe,
   FolderOpen,
   ClipboardCheck,
+  ListTodo,
   Circle,
   Plug,
   type LucideIcon,
 } from 'lucide-react';
 import { cn, toRelativePath } from '@/lib/utils';
-import { parseMcpToolName } from '@/lib/format';
+import { parseMcpToolName, formatToolDuration } from '@/lib/format';
+import { TOOL_TARGET_TRUNCATE, TOOL_COMMAND_TRUNCATE } from '@/lib/constants';
 import { useAppStore } from '@/stores/appStore';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import type { ToolMetadata } from '@/lib/types';
 
 interface ToolUsageBlockProps {
   id: string;
@@ -45,11 +50,9 @@ interface ToolUsageBlockProps {
   stderr?: string;
   /** Elapsed seconds from tool_progress events (live update for active tools) */
   elapsedSeconds?: number;
+  /** Structured metadata extracted from tool results */
+  metadata?: ToolMetadata;
 }
-
-// Truncation limits
-const TARGET_TRUNCATE_LENGTH = 60;
-const COMMAND_TRUNCATE_LENGTH = 80;
 
 // Helper to calculate line stats for Edit tool
 function calculateEditStats(params?: Record<string, unknown>): { additions: number; deletions: number } | null {
@@ -88,6 +91,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   stdout,
   stderr,
   elapsedSeconds,
+  metadata,
 }: ToolUsageBlockProps) {
   const [isOpen, setIsOpen] = useState(success === false && !isActive);
   const mcpInfo = useMemo(() => parseMcpToolName(tool), [tool]);
@@ -98,24 +102,28 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
       case 'read_file':
         return FileText;
       case 'Write':
-      case 'Edit':
       case 'write_file':
+        return FilePlus2;
+      case 'Edit':
       case 'edit_file':
-        return FileEdit;
+        return Pencil;
       case 'Bash':
       case 'bash':
       case 'execute_command':
         return Terminal;
       case 'Grep':
-      case 'Glob':
       case 'search':
-        return Search;
+        return FileSearch;
+      case 'Glob':
+        return FolderSearch2;
       case 'WebFetch':
       case 'WebSearch':
       case 'web':
         return Globe;
       case 'list_dir':
         return FolderOpen;
+      case 'TodoWrite':
+        return ListTodo;
       case 'ExitPlanMode':
         return ClipboardCheck;
       default:
@@ -150,6 +158,8 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
         return 'Search web';
       case 'list_dir':
         return 'List';
+      case 'TodoWrite':
+        return 'Update tasks';
       case 'ExitPlanMode':
         return isActive ? 'Propose Plan' : 'Exiting Plan mode';
       default:
@@ -196,6 +206,15 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
       return other;
     }
 
+    // MCP tool fallback: try first short non-empty string parameter value
+    if (tool.startsWith('mcp__')) {
+      for (const value of Object.values(params)) {
+        if (typeof value === 'string' && value.length > 0 && value.length < 200) {
+          return value;
+        }
+      }
+    }
+
     return null;
   };
 
@@ -205,7 +224,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   // Truncate target for display
   const truncatedTarget = useMemo(() => {
     if (!target) return null;
-    const limit = isBashTool ? COMMAND_TRUNCATE_LENGTH : TARGET_TRUNCATE_LENGTH;
+    const limit = isBashTool ? TOOL_COMMAND_TRUNCATE : TOOL_TARGET_TRUNCATE;
     if (target.length > limit) {
       return target.slice(0, limit - 3) + '...';
     }
@@ -213,6 +232,57 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   }, [target, isBashTool]);
 
   const isTargetTruncated = target && truncatedTarget && target !== truncatedTarget;
+
+  // File tools with clickable paths (Read/Write/Edit)
+  const isFileToolClickable = ['Read', 'Write', 'Edit', 'read_file', 'write_file', 'edit_file'].includes(tool);
+  const fullFilePath = useMemo(() => {
+    if (!isFileToolClickable || !params) return null;
+    const filePath = params.file_path || params.path || params.filepath || params.filename || params.file;
+    return typeof filePath === 'string' ? filePath : null;
+  }, [isFileToolClickable, params]);
+
+  const handleFileClick = useMemo(() => {
+    if (!fullFilePath) return undefined;
+    return (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const state = useAppStore.getState();
+      const workspaceId = state.selectedWorkspaceId;
+      const sessionId = state.selectedSessionId;
+      if (!workspaceId || !sessionId) return;
+      const filename = fullFilePath.split('/').pop() || fullFilePath;
+      const tabId = `${workspaceId}-${sessionId}-${fullFilePath}`;
+      state.openFileTab({
+        id: tabId,
+        workspaceId,
+        sessionId,
+        path: fullFilePath,
+        name: filename,
+        isLoading: true,
+      });
+    };
+  }, [fullFilePath]);
+
+  // Metadata summary text (inline after target)
+  const metadataSummary = useMemo(() => {
+    if (!metadata) return null;
+    if (metadata.linesRead) return `${metadata.linesRead} lines`;
+    if (metadata.bytesWritten) {
+      const kb = metadata.bytesWritten / 1024;
+      return kb >= 1 ? `${kb.toFixed(1)} KB` : `${metadata.bytesWritten} B`;
+    }
+    if (metadata.replacements) return `${metadata.replacements} replacement${metadata.replacements !== 1 ? 's' : ''}`;
+    if (metadata.matchCount !== undefined && metadata.fileCount !== undefined) return `${metadata.matchCount} file${metadata.matchCount !== 1 ? 's' : ''} matched`;
+    if (metadata.matchCount !== undefined) return `${metadata.matchCount} match${metadata.matchCount !== 1 ? 'es' : ''}`;
+    if (metadata.resultCount) return `${metadata.resultCount} result${metadata.resultCount !== 1 ? 's' : ''}`;
+    if (metadata.todosTotal !== undefined) {
+      const parts: string[] = [];
+      if (metadata.todosCompleted) parts.push(`${metadata.todosCompleted} done`);
+      if (metadata.todosInProgress) parts.push(`${metadata.todosInProgress} active`);
+      if (parts.length === 0) parts.push(`${metadata.todosTotal} total`);
+      return parts.join(', ');
+    }
+    return null;
+  }, [metadata]);
 
   const hasDetails = params && Object.keys(params).length > 0;
   const hasOutput = stdout || stderr;
@@ -290,7 +360,13 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
           isTargetTruncated ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <code className="text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground font-mono truncate max-w-[300px] cursor-help">
+                <code
+                  className={cn(
+                    'text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground font-mono truncate max-w-[300px]',
+                    handleFileClick ? 'cursor-pointer hover:underline hover:text-foreground' : 'cursor-help'
+                  )}
+                  onClick={handleFileClick}
+                >
                   {truncatedTarget}
                 </code>
               </TooltipTrigger>
@@ -302,7 +378,13 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
               </TooltipContent>
             </Tooltip>
           ) : (
-            <code className="text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground font-mono truncate max-w-[300px]">
+            <code
+              className={cn(
+                'text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground font-mono truncate max-w-[300px]',
+                handleFileClick && 'cursor-pointer hover:underline hover:text-foreground'
+              )}
+              onClick={handleFileClick}
+            >
               {truncatedTarget}
             </code>
           )
@@ -313,7 +395,13 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
           isTargetTruncated ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <code className="text-2xs px-1 py-0.5 rounded bg-muted/50 text-muted-foreground/70 font-mono truncate max-w-[200px] cursor-help">
+                <code
+                  className={cn(
+                    'text-2xs px-1 py-0.5 rounded bg-muted/50 text-muted-foreground/70 font-mono truncate max-w-[200px]',
+                    handleFileClick ? 'cursor-pointer hover:underline hover:text-foreground' : 'cursor-help'
+                  )}
+                  onClick={handleFileClick}
+                >
                   {truncatedTarget}
                 </code>
               </TooltipTrigger>
@@ -325,7 +413,13 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
               </TooltipContent>
             </Tooltip>
           ) : (
-            <code className="text-2xs px-1 py-0.5 rounded bg-muted/50 text-muted-foreground/70 font-mono truncate max-w-[200px]">
+            <code
+              className={cn(
+                'text-2xs px-1 py-0.5 rounded bg-muted/50 text-muted-foreground/70 font-mono truncate max-w-[200px]',
+                handleFileClick && 'cursor-pointer hover:underline hover:text-foreground'
+              )}
+              onClick={handleFileClick}
+            >
               {truncatedTarget}
             </code>
           )
@@ -339,6 +433,13 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
           </span>
         )}
 
+        {/* Metadata summary (line counts, match counts, etc.) */}
+        {metadataSummary && !isActive && (
+          <span className="text-2xs text-muted-foreground/70 shrink-0">
+            {metadataSummary}
+          </span>
+        )}
+
         {/* Spacer */}
         <span className="flex-1" />
 
@@ -349,7 +450,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
           </span>
         ) : duration && !isActive ? (
           <span className="text-2xs text-muted-foreground/70 shrink-0">
-            {duration < 1000 ? `${duration}ms` : `${(duration / 1000).toFixed(1)}s`}
+            {formatToolDuration(duration)}
           </span>
         ) : null}
 
@@ -400,7 +501,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
               {stdout && (
                 <div className="rounded border bg-muted p-2">
                   <div className="text-2xs text-muted-foreground/60 mb-1">Output</div>
-                  <pre className="font-mono text-2xs text-foreground/80 whitespace-pre-wrap break-all max-h-[150px] overflow-y-auto">
+                  <pre className="font-mono text-2xs text-foreground/80 whitespace-pre-wrap break-all max-h-[500px] overflow-y-auto">
                     {stdout}
                   </pre>
                 </div>
@@ -410,7 +511,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
               {stderr && (
                 <div className="rounded border border-text-error/30 bg-text-error/10 p-2">
                   <div className="text-2xs text-text-error/60 mb-1">Error Output</div>
-                  <pre className="font-mono text-2xs text-text-error whitespace-pre-wrap break-all max-h-[150px] overflow-y-auto">
+                  <pre className="font-mono text-2xs text-text-error whitespace-pre-wrap break-all max-h-[500px] overflow-y-auto">
                     {stderr}
                   </pre>
                 </div>

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -340,11 +340,12 @@ export function useWebSocket(enabled: boolean = true) {
 
       case 'tool_end':
         // Complete active tool with success/summary info
-        // For Bash tools, also capture stdout/stderr
+        // For Bash tools, also capture stdout/stderr; for all tools, capture metadata
         if (event?.id) {
           const toolAgentId = event.agentId as string | undefined;
           const stdout = event.stdout as string | undefined;
           const stderr = event.stderr as string | undefined;
+          const metadata = event.metadata;
 
           if (toolAgentId) {
             // Sub-agent tool completion
@@ -355,7 +356,7 @@ export function useWebSocket(enabled: boolean = true) {
 
             if (activeTool) {
               // Normal path: tool exists in state
-              store.completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr);
+              store.completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr, metadata);
             } else if (event.tool) {
               // Race condition recovery: tool_end arrived but tool wasn't in state.
               // Create a synthetic completed entry so the timeline shows it as finished.
@@ -366,7 +367,7 @@ export function useWebSocket(enabled: boolean = true) {
                 startTime: Date.now(),
                 untracked: true,
               }, { skipTimeout: true });
-              store.completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr);
+              store.completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr, metadata);
             }
             // If no tool name and not in state, silently skip - tool was never shown to user
           }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -26,6 +26,10 @@ export const GIT_STATUS_POLL_INTERVAL_MS = 30000; // 30 seconds
 // Shared Tailwind prose classes for markdown content rendering
 export const PROSE_CLASSES = 'prose prose-base dark:prose-invert max-w-none text-base leading-relaxed prose-p:my-3 prose-pre:my-2 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:font-semibold prose-headings:my-2 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-ul:marker:text-primary prose-ol:marker:text-primary';
 
+// Tool rendering constants
+export const TOOL_TARGET_TRUNCATE = 60;
+export const TOOL_COMMAND_TRUNCATE = 80;
+
 // Feature flags (build-time)
 /** Enable browser-style multi-tab navigation. Set to false to disable. */
 export const ENABLE_BROWSER_TABS = true;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -10,6 +10,19 @@ export const formatTokens = (tokens: number) => {
 };
 
 // ---------------------------------------------------------------------------
+// Tool duration formatting
+// ---------------------------------------------------------------------------
+
+/** Format a tool duration in ms as a compact human-readable string. */
+export function formatToolDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const mins = Math.floor(ms / 60_000);
+  const secs = Math.round((ms % 60_000) / 1000);
+  return `${mins}m ${secs}s`;
+}
+
+// ---------------------------------------------------------------------------
 // MCP tool name formatting
 // ---------------------------------------------------------------------------
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -115,6 +115,20 @@ export interface RunSummary {
   modelUsage?: Record<string, ModelUsageInfo>;
 }
 
+// Structured metadata extracted from tool results (tool-specific)
+export interface ToolMetadata {
+  linesRead?: number;        // Read: number of lines returned
+  bytesWritten?: number;     // Write: bytes written
+  replacements?: number;     // Edit: number of replacements made
+  matchCount?: number;       // Grep/Glob: number of matches or files found
+  fileCount?: number;        // Grep: number of files with matches
+  resultCount?: number;      // WebSearch: number of search results
+  sources?: { title: string; url: string }[];  // WebSearch: top result titles/URLs
+  todosTotal?: number;       // TodoWrite: total todos after update
+  todosCompleted?: number;   // TodoWrite: number of completed todos
+  todosInProgress?: number;  // TodoWrite: number of in-progress todos
+}
+
 // Tool usage record for message history
 export interface ToolUsage {
   id: string;
@@ -125,6 +139,7 @@ export interface ToolUsage {
   durationMs?: number;
   stdout?: string;
   stderr?: string;
+  metadata?: ToolMetadata;
 }
 
 // Timeline entry preserving interleaved text/tool ordering in finalized messages
@@ -144,6 +159,7 @@ export interface ActiveTool {
   summary?: string;
   stdout?: string;
   stderr?: string;
+  metadata?: ToolMetadata;
   untracked?: boolean; // Tool result arrived without matching tool_start (race condition recovery)
   elapsedSeconds?: number; // Updated from tool_progress events for long-running tools
   agentId?: string; // Sub-agent that owns this tool (undefined = parent agent)
@@ -331,6 +347,9 @@ export interface AgentEvent {
   stdout?: string;
   stderr?: string;
   exitCode?: number;
+
+  // Tool metadata (structured data from tool results)
+  metadata?: ToolMetadata;
 
   // Tool progress fields
   toolName?: string;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -329,7 +329,7 @@ interface AppState {
   clearPendingPlanApproval: (conversationId: string) => void;
   setApprovedPlanContent: (conversationId: string, content: string) => void;
   addActiveTool: (conversationId: string, tool: ActiveTool, opts?: { skipTimeout?: boolean }) => void;
-  completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string) => void;
+  completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string, metadata?: import('@/lib/types').ToolMetadata) => void;
   updateToolProgress: (conversationId: string, toolId: string, progress: { elapsedTimeSeconds?: number; toolName?: string }) => void;
   clearActiveTools: (conversationId: string) => void;
 
@@ -1298,7 +1298,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       }),
     }));
   },
-  completeActiveTool: (conversationId, toolId, success, summary, stdout, stderr) => {
+  completeActiveTool: (conversationId, toolId, success, summary, stdout, stderr, metadata) => {
     // Clear the timeout for this tool
     const timeoutKey = `${conversationId}:${toolId}`;
     const timeout = toolTimeouts.get(timeoutKey);
@@ -1317,7 +1317,7 @@ updateFileTabContent: (id, content) => set((state) => ({
           ...state.activeTools,
           [conversationId]: tools.map((t) =>
             t.id === toolId
-              ? { ...t, endTime: Date.now(), success, summary, stdout, stderr }
+              ? { ...t, endTime: Date.now(), success, summary, stdout, stderr, metadata }
               : t
           ),
         },


### PR DESCRIPTION
## Summary

- Extracts structured metadata from tool results in agent-runner (line counts, match counts, byte counts, todo stats) and passes it through the Go backend to the frontend
- Differentiates tool icons (Write, Edit, Grep, Glob, TodoWrite each get unique icons), makes file paths clickable to open in editor, and shows inline metadata summaries
- Replaces ToolUsageHistory with ToolUsageSummary in MessageBlock for consistent rendering between streaming and history views

## Changes

### Agent-runner (`agent-runner/src/index.ts`)
- `extractTextFromToolResult()` — extracts text content from tool result blocks
- `extractToolMetadata()` — parses tool-specific structured data (Read: line counts, Write: byte counts, Edit: replacements, Grep/Glob: match counts, TodoWrite: todo stats)
- Stores tool input on active tools for TodoWrite metadata extraction
- Includes metadata in `tool_end` events (does not change SKIP_OUTPUT_TOOLS behavior)

### Go backend (`parser.go`, `types.go`, `manager.go`)
- Adds `Metadata map[string]interface{}` to `AgentEvent` and `ToolUsageRecord`
- Forwards metadata through the event pipeline to WebSocket clients

### Frontend types & utils (`types.ts`, `constants.ts`, `format.ts`)
- `ToolMetadata` interface with tool-specific fields
- `TOOL_TARGET_TRUNCATE` / `TOOL_COMMAND_TRUNCATE` shared constants
- `formatToolDuration()` standardized duration formatter

### Frontend store (`useWebSocket.ts`, `appStore.ts`)
- Extracts metadata from `tool_end` events and stores on ActiveTool entries

### ToolUsageBlock (`ToolUsageBlock.tsx`)
- Differentiated icons: Write→FilePlus2, Edit→Pencil, Grep→FileSearch, Glob→FolderSearch2, TodoWrite→ListTodo
- Clickable file paths for Read/Write/Edit (opens in editor panel)
- Inline metadata summaries (e.g. "42 lines", "12 files matched", "2 completed, 1 in progress")
- Increased Bash stdout max-height from 150px to 500px
- Standardized duration formatting via `formatToolDuration()`
- MCP tool target fallback (tries first short string param value)

### MessageBlock (`MessageBlock.tsx`)
- Replaces `ToolUsageHistory` with inline `ToolUsageSummary` component
- Consistent rendering between streaming and history views using `ToolUsageBlock` instances

### StreamingMessage (`StreamingMessage.tsx`)
- Passes metadata through timeline items to `ToolUsageBlock`

## Test plan

- [x] Go backend builds clean
- [x] Go parser tests pass (`go test ./agent/... -run TestParse`)
- [x] Agent-runner builds clean (`tsc`)
- [x] Frontend TypeScript check — no errors in changed files
- [x] Frontend vitest — 899/899 tests pass
- [ ] Manual: Start a session, use Read/Write/Edit/Bash/Grep/Glob tools → verify metadata inline
- [ ] Manual: Click a file path in Read/Write/Edit → opens in editor panel
- [ ] Manual: Scroll up to finalized messages → ToolUsageBlock renders (not old flat list)
- [ ] Manual: Use TodoWrite → appears in timeline with stats
- [ ] Manual: Test MCP tools → improved target extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)