### PR TITLE
fix: Filter gitignored files from Changes panel

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -259,6 +259,50 @@ func (rm *RepoManager) GetMergeBase(ctx context.Context, repoPath, ref1, ref2 st
 	return strings.TrimSpace(string(out)), nil
 }
 
+// FilterGitIgnored removes files that match .gitignore rules from the changes list.
+// This handles cases where build artifacts (e.g. dist/) get committed by agents
+// or otherwise appear in the diff despite being gitignored.
+func (rm *RepoManager) FilterGitIgnored(ctx context.Context, repoPath string, changes []FileChange) []FileChange {
+	if len(changes) == 0 {
+		return changes
+	}
+
+	// Collect all paths to check
+	paths := make([]string, len(changes))
+	for i, c := range changes {
+		paths[i] = c.Path
+	}
+
+	// Use git check-ignore --stdin to batch-check all paths in a single call
+	cmd, cancel := gitCmdWithContext(ctx, repoPath, "check-ignore", "--stdin")
+	defer cancel()
+	cmd.Stdin = strings.NewReader(strings.Join(paths, "\n"))
+	out, _ := cmd.Output() // exit code 1 means "none ignored", not an error
+
+	// If no files are ignored, return as-is
+	output := strings.TrimSpace(string(out))
+	if output == "" {
+		return changes
+	}
+
+	// Build set of ignored paths
+	ignored := make(map[string]bool)
+	for _, line := range strings.Split(output, "\n") {
+		if line != "" {
+			ignored[line] = true
+		}
+	}
+
+	// Filter out ignored files
+	filtered := make([]FileChange, 0, len(changes))
+	for _, c := range changes {
+		if !ignored[c.Path] {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
 // GetUntrackedFiles returns files that are not tracked by git
 func (rm *RepoManager) GetUntrackedFiles(ctx context.Context, repoPath string) ([]FileChange, error) {
 	// Use -uall to show individual files inside untracked directories

--- a/backend/git/repo_test.go
+++ b/backend/git/repo_test.go
@@ -1210,6 +1210,107 @@ func TestGetUntrackedFiles_IgnoresDirectories(t *testing.T) {
 }
 
 // ============================================================================
+// FilterGitIgnored Tests
+// ============================================================================
+
+func TestFilterGitIgnored_EmptyList(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	rm := NewRepoManager()
+
+	result := rm.FilterGitIgnored(context.Background(), repoPath, []FileChange{})
+	assert.Empty(t, result)
+}
+
+func TestFilterGitIgnored_NoIgnoredFiles(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	rm := NewRepoManager()
+
+	// Create a .gitignore that ignores dist/
+	writeFile(t, repoPath, ".gitignore", "dist/\n")
+	runGit(t, repoPath, "add", ".gitignore")
+	runGit(t, repoPath, "commit", "-m", "Add gitignore")
+
+	changes := []FileChange{
+		{Path: "src/main.go", Status: "modified"},
+		{Path: "README.md", Status: "added"},
+	}
+
+	result := rm.FilterGitIgnored(context.Background(), repoPath, changes)
+	assert.Len(t, result, 2)
+}
+
+func TestFilterGitIgnored_FiltersIgnoredFiles(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	rm := NewRepoManager()
+
+	// Create a .gitignore that ignores dist/ and build/
+	writeFile(t, repoPath, ".gitignore", "dist/\nbuild/\n*.log\n")
+	runGit(t, repoPath, "add", ".gitignore")
+	runGit(t, repoPath, "commit", "-m", "Add gitignore")
+
+	changes := []FileChange{
+		{Path: "src/main.go", Status: "modified"},
+		{Path: "dist/bundle.js", Status: "added"},
+		{Path: "dist/bundle.css", Status: "added"},
+		{Path: "build/output.bin", Status: "added"},
+		{Path: "app.log", Status: "untracked"},
+		{Path: "README.md", Status: "modified"},
+	}
+
+	result := rm.FilterGitIgnored(context.Background(), repoPath, changes)
+	assert.Len(t, result, 2)
+
+	paths := make(map[string]bool)
+	for _, f := range result {
+		paths[f.Path] = true
+	}
+	assert.True(t, paths["src/main.go"])
+	assert.True(t, paths["README.md"])
+}
+
+func TestFilterGitIgnored_NestedGitignore(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	rm := NewRepoManager()
+
+	// Create a nested .gitignore
+	writeFile(t, repoPath, ".gitignore", "*.log\n")
+	writeFile(t, repoPath, "src/.gitignore", "*.generated.go\n")
+	runGit(t, repoPath, "add", ".gitignore", "src/.gitignore")
+	runGit(t, repoPath, "commit", "-m", "Add gitignore files")
+
+	changes := []FileChange{
+		{Path: "src/main.go", Status: "modified"},
+		{Path: "src/types.generated.go", Status: "added"},
+		{Path: "debug.log", Status: "untracked"},
+	}
+
+	result := rm.FilterGitIgnored(context.Background(), repoPath, changes)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "src/main.go", result[0].Path)
+}
+
+func TestFilterGitIgnored_PreservesFileChangeFields(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+	rm := NewRepoManager()
+
+	writeFile(t, repoPath, ".gitignore", "dist/\n")
+	runGit(t, repoPath, "add", ".gitignore")
+	runGit(t, repoPath, "commit", "-m", "Add gitignore")
+
+	changes := []FileChange{
+		{Path: "src/main.go", Additions: 10, Deletions: 5, Status: "modified"},
+		{Path: "dist/bundle.js", Additions: 100, Deletions: 0, Status: "added"},
+	}
+
+	result := rm.FilterGitIgnored(context.Background(), repoPath, changes)
+	require.Len(t, result, 1)
+	assert.Equal(t, "src/main.go", result[0].Path)
+	assert.Equal(t, 10, result[0].Additions)
+	assert.Equal(t, 5, result[0].Deletions)
+	assert.Equal(t, "modified", result[0].Status)
+}
+
+// ============================================================================
 // GetFileCommitHistory Tests
 // ============================================================================
 

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -2298,6 +2298,10 @@ func (h *Handlers) GetSessionChanges(w http.ResponseWriter, r *http.Request) {
 	// Combine untracked files first, then tracked changes
 	allChanges := append(untracked, changes...)
 
+	// Filter out files that match .gitignore rules — this handles cases where
+	// build artifacts (e.g. dist/) get committed by agents and show in the diff
+	allChanges = h.repoManager.FilterGitIgnored(ctx, workingPath, allChanges)
+
 	writeJSON(w, allChanges)
 }
 


### PR DESCRIPTION
## Summary
- Build artifacts (e.g. `dist/`, `build/`, `*.log`) committed by agents were showing in the Changes panel, overwhelming users with irrelevant files
- Added `FilterGitIgnored` to `backend/git/repo.go` that uses `git check-ignore --stdin` to batch-filter all file paths against `.gitignore` rules in a single git call
- Integrated the filter in `GetSessionChanges` handler so gitignored files are stripped before sending to the frontend

## Test plan
- [x] Added 5 unit tests covering: empty list, no ignored files, filtered files, nested `.gitignore`, and field preservation
- [x] All existing git package tests pass
- [x] Backend builds cleanly
- [ ] Manual: create a session, run a build that produces `dist/` output, verify those files don't appear in Changes panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)