### PR TITLE
fix: Persist AutoNamed flag to prevent repeated session renames

### DIFF
--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -681,6 +681,19 @@ func (s *SQLiteStore) runMigrations() error {
 		return err
 	}
 
+	// Migration: Add auto_named column to sessions if it doesn't exist
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'auto_named'`).Scan(&count)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		_, err = s.db.Exec(`ALTER TABLE sessions ADD COLUMN auto_named INTEGER NOT NULL DEFAULT 0`)
+		if err != nil {
+			return err
+		}
+		logger.SQLite.Infof("Migration: Added auto_named column to sessions")
+	}
+
 	return nil
 }
 
@@ -809,8 +822,8 @@ func (s *SQLiteStore) AddSession(ctx context.Context, session *models.Session) e
 			INSERT INTO sessions (id, workspace_id, name, branch, worktree_path, base_commit_sha, target_branch,
 				task, status, agent_id, pr_status, pr_url, pr_number, has_merge_conflict,
 				has_check_failures, stats_additions, stats_deletions, pinned, archived,
-				priority, task_status, archive_summary, archive_summary_status, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				priority, task_status, archive_summary, archive_summary_status, auto_named, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			session.ID, session.WorkspaceID, session.Name, session.Branch,
 			session.WorktreePath, session.BaseCommitSHA, nullString(session.TargetBranch),
 			session.Task, session.Status, session.AgentID,
@@ -819,6 +832,7 @@ func (s *SQLiteStore) AddSession(ctx context.Context, session *models.Session) e
 			statsAdditions, statsDeletions, boolToInt(session.Pinned), boolToInt(session.Archived),
 			session.Priority, session.TaskStatus,
 			session.ArchiveSummary, session.ArchiveSummaryStatus,
+			boolToInt(session.AutoNamed),
 			session.CreatedAt, session.UpdatedAt)
 		return err
 	})
@@ -826,7 +840,7 @@ func (s *SQLiteStore) AddSession(ctx context.Context, session *models.Session) e
 
 func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Session, error) {
 	var session models.Session
-	var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived int
+	var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived, autoNamed int
 	var agentID, targetBranch sql.NullString
 
 	err := s.db.QueryRowContext(ctx, `
@@ -834,7 +848,7 @@ func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Sessio
 			task, status, agent_id,
 			pr_status, pr_url, pr_number, has_merge_conflict, has_check_failures,
 			stats_additions, stats_deletions, pinned, archived, priority, task_status,
-			archive_summary, archive_summary_status, created_at, updated_at
+			archive_summary, archive_summary_status, auto_named, created_at, updated_at
 		FROM sessions WHERE id = ?`, id).Scan(
 		&session.ID, &session.WorkspaceID, &session.Name, &session.Branch,
 		&session.WorktreePath, &session.BaseCommitSHA, &targetBranch,
@@ -843,6 +857,7 @@ func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Sessio
 		&hasMergeConflict, &hasCheckFailures, &statsAdditions, &statsDeletions,
 		&pinned, &archived, &session.Priority, &session.TaskStatus,
 		&session.ArchiveSummary, &session.ArchiveSummaryStatus,
+		&autoNamed,
 		&session.CreatedAt, &session.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -855,6 +870,7 @@ func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Sessio
 	session.HasCheckFailures = intToBool(hasCheckFailures)
 	session.Pinned = intToBool(pinned)
 	session.Archived = intToBool(archived)
+	session.AutoNamed = intToBool(autoNamed)
 	if agentID.Valid {
 		session.AgentID = agentID.String
 	}
@@ -875,14 +891,15 @@ func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Sessio
 // This eliminates the N+1 pattern of fetching session then workspace separately
 func (s *SQLiteStore) GetSessionWithWorkspace(ctx context.Context, id string) (*models.SessionWithWorkspace, error) {
 	var result models.SessionWithWorkspace
-	var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived int
+	var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived, autoNamed int
 	var agentID, targetBranch sql.NullString
 
 	err := s.db.QueryRowContext(ctx, `
 		SELECT s.id, s.workspace_id, s.name, s.branch, s.worktree_path, s.base_commit_sha,
 			s.target_branch, s.task, s.status, s.agent_id, s.pr_status, s.pr_url, s.pr_number,
 			s.has_merge_conflict, s.has_check_failures, s.stats_additions, s.stats_deletions,
-			s.pinned, s.archived, s.priority, s.task_status, s.archive_summary, s.archive_summary_status, s.created_at, s.updated_at,
+			s.pinned, s.archived, s.priority, s.task_status, s.archive_summary, s.archive_summary_status,
+			s.auto_named, s.created_at, s.updated_at,
 			r.path, r.branch, r.remote
 		FROM sessions s
 		JOIN repos r ON s.workspace_id = r.id
@@ -892,7 +909,8 @@ func (s *SQLiteStore) GetSessionWithWorkspace(ctx context.Context, id string) (*
 		&result.Task, &result.Status, &agentID,
 		&result.PRStatus, &result.PRUrl, &result.PRNumber,
 		&hasMergeConflict, &hasCheckFailures, &statsAdditions, &statsDeletions,
-		&pinned, &archived, &result.Priority, &result.TaskStatus, &result.ArchiveSummary, &result.ArchiveSummaryStatus, &result.CreatedAt, &result.UpdatedAt,
+		&pinned, &archived, &result.Priority, &result.TaskStatus, &result.ArchiveSummary, &result.ArchiveSummaryStatus,
+		&autoNamed, &result.CreatedAt, &result.UpdatedAt,
 		&result.WorkspacePath, &result.WorkspaceBranch, &result.WorkspaceRemote)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -905,6 +923,7 @@ func (s *SQLiteStore) GetSessionWithWorkspace(ctx context.Context, id string) (*
 	result.HasCheckFailures = intToBool(hasCheckFailures)
 	result.Pinned = intToBool(pinned)
 	result.Archived = intToBool(archived)
+	result.AutoNamed = intToBool(autoNamed)
 	if agentID.Valid {
 		result.AgentID = agentID.String
 	}
@@ -926,7 +945,7 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, workspaceID string, incl
 		task, status, agent_id,
 		pr_status, pr_url, pr_number, has_merge_conflict, has_check_failures,
 		stats_additions, stats_deletions, pinned, archived, priority, task_status,
-		archive_summary, archive_summary_status, created_at, updated_at
+		archive_summary, archive_summary_status, auto_named, created_at, updated_at
 		FROM sessions WHERE workspace_id = ?`
 	if !includeArchived {
 		query += " AND archived = 0"
@@ -941,7 +960,7 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, workspaceID string, incl
 	sessions := []*models.Session{}
 	for rows.Next() {
 		var session models.Session
-		var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived int
+		var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived, autoNamed int
 		var agentID, targetBranch sql.NullString
 
 		if err := rows.Scan(
@@ -952,6 +971,7 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, workspaceID string, incl
 			&hasMergeConflict, &hasCheckFailures, &statsAdditions, &statsDeletions,
 			&pinned, &archived, &session.Priority, &session.TaskStatus,
 			&session.ArchiveSummary, &session.ArchiveSummaryStatus,
+			&autoNamed,
 			&session.CreatedAt, &session.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("ListSessions scan: %w", err)
 		}
@@ -960,6 +980,7 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, workspaceID string, incl
 		session.HasCheckFailures = intToBool(hasCheckFailures)
 		session.Pinned = intToBool(pinned)
 		session.Archived = intToBool(archived)
+		session.AutoNamed = intToBool(autoNamed)
 		if agentID.Valid {
 			session.AgentID = agentID.String
 		}
@@ -988,7 +1009,7 @@ func (s *SQLiteStore) ListAllSessions(ctx context.Context, includeArchived bool)
 		task, status, agent_id,
 		pr_status, pr_url, pr_number, has_merge_conflict, has_check_failures,
 		stats_additions, stats_deletions, pinned, archived, priority, task_status,
-		archive_summary, archive_summary_status, created_at, updated_at
+		archive_summary, archive_summary_status, auto_named, created_at, updated_at
 		FROM sessions`
 	if !includeArchived {
 		query += " WHERE archived = 0"
@@ -1003,7 +1024,7 @@ func (s *SQLiteStore) ListAllSessions(ctx context.Context, includeArchived bool)
 	sessions := []*models.Session{}
 	for rows.Next() {
 		var session models.Session
-		var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived int
+		var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived, autoNamed int
 		var agentID, targetBranch sql.NullString
 
 		if err := rows.Scan(
@@ -1014,6 +1035,7 @@ func (s *SQLiteStore) ListAllSessions(ctx context.Context, includeArchived bool)
 			&hasMergeConflict, &hasCheckFailures, &statsAdditions, &statsDeletions,
 			&pinned, &archived, &session.Priority, &session.TaskStatus,
 			&session.ArchiveSummary, &session.ArchiveSummaryStatus,
+			&autoNamed,
 			&session.CreatedAt, &session.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("ListAllSessions scan: %w", err)
 		}
@@ -1022,6 +1044,7 @@ func (s *SQLiteStore) ListAllSessions(ctx context.Context, includeArchived bool)
 		session.HasCheckFailures = intToBool(hasCheckFailures)
 		session.Pinned = intToBool(pinned)
 		session.Archived = intToBool(archived)
+		session.AutoNamed = intToBool(autoNamed)
 		if agentID.Valid {
 			session.AgentID = agentID.String
 		}
@@ -1100,7 +1123,8 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, updates func
 				task = ?, status = ?, agent_id = ?, pr_status = ?, pr_url = ?,
 				pr_number = ?, has_merge_conflict = ?, has_check_failures = ?,
 				stats_additions = ?, stats_deletions = ?, pinned = ?, archived = ?,
-				priority = ?, task_status = ?, archive_summary = ?, archive_summary_status = ?, updated_at = ?
+				priority = ?, task_status = ?, archive_summary = ?, archive_summary_status = ?,
+				auto_named = ?, updated_at = ?
 			WHERE id = ?`,
 			session.Name, session.Branch, session.WorktreePath, session.BaseCommitSHA,
 			nullString(session.TargetBranch),
@@ -1110,6 +1134,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, updates func
 			statsAdditions, statsDeletions, boolToInt(session.Pinned), boolToInt(session.Archived),
 			session.Priority, session.TaskStatus,
 			session.ArchiveSummary, session.ArchiveSummaryStatus,
+			boolToInt(session.AutoNamed),
 			session.UpdatedAt, id)
 		return err
 	})
@@ -1117,7 +1142,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, updates func
 
 func (s *SQLiteStore) getSessionNoLock(ctx context.Context, id string) (*models.Session, error) {
 	var session models.Session
-	var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived int
+	var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived, autoNamed int
 	var agentID, targetBranch sql.NullString
 
 	err := s.db.QueryRowContext(ctx, `
@@ -1125,7 +1150,7 @@ func (s *SQLiteStore) getSessionNoLock(ctx context.Context, id string) (*models.
 			task, status, agent_id,
 			pr_status, pr_url, pr_number, has_merge_conflict, has_check_failures,
 			stats_additions, stats_deletions, pinned, archived, priority, task_status,
-			archive_summary, archive_summary_status, created_at, updated_at
+			archive_summary, archive_summary_status, auto_named, created_at, updated_at
 		FROM sessions WHERE id = ?`, id).Scan(
 		&session.ID, &session.WorkspaceID, &session.Name, &session.Branch,
 		&session.WorktreePath, &session.BaseCommitSHA, &targetBranch,
@@ -1134,6 +1159,7 @@ func (s *SQLiteStore) getSessionNoLock(ctx context.Context, id string) (*models.
 		&hasMergeConflict, &hasCheckFailures, &statsAdditions, &statsDeletions,
 		&pinned, &archived, &session.Priority, &session.TaskStatus,
 		&session.ArchiveSummary, &session.ArchiveSummaryStatus,
+		&autoNamed,
 		&session.CreatedAt, &session.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -1146,6 +1172,7 @@ func (s *SQLiteStore) getSessionNoLock(ctx context.Context, id string) (*models.
 	session.HasCheckFailures = intToBool(hasCheckFailures)
 	session.Pinned = intToBool(pinned)
 	session.Archived = intToBool(archived)
+	session.AutoNamed = intToBool(autoNamed)
 	if agentID.Valid {
 		session.AgentID = agentID.String
 	}


### PR DESCRIPTION
## Summary

Fixed a bug where sessions were getting renamed every time a new message was sent, instead of only once.

## Root Cause

The `Session.AutoNamed` field existed in the Go struct but was never persisted to SQLite. Every time a session was fetched from the database, `AutoNamed` was always `false` (the Go zero value), causing the guard in `tryAutoNameSession()` to always pass and trigger title generation repeatedly.

## Changes

Added `auto_named` column to the SQLite `sessions` table and threaded it through all CRUD operations:
- Migration to add the `auto_named` column with `DEFAULT 0`
- Updated `AddSession` INSERT to include `auto_named`
- Updated `UpdateSession` UPDATE to persist `auto_named`
- Updated all SELECT queries (`GetSession`, `GetSessionWithWorkspace`, `ListSessions`, `ListAllSessions`) to read and populate `auto_named`

## Testing

- All Go tests pass
- Backend builds cleanly
- No schema conflicts or migration issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)