### PR TITLE
fix: Make Changes tab badge update in real-time

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -434,10 +434,32 @@ export function ChangesPanel() {
   const lastFileChange = useAppStore((s) => s.lastFileChange);
   useEffect(() => {
     if (!selectedSessionId || !lastFileChange) return;
-    if (lastFileChange.workspaceId === selectedSessionId) {
+    if (lastFileChange.workspaceId === selectedWorkspaceId) {
       debouncedFetchChanges();
     }
-  }, [lastFileChange, selectedSessionId, debouncedFetchChanges]);
+  }, [lastFileChange, selectedWorkspaceId, selectedSessionId, debouncedFetchChanges]);
+
+  // React to session stats updates (WebSocket push from backend git index watcher).
+  // When the agent commits or stages files, the backend detects git index changes and
+  // broadcasts session_stats_update. Use this as an additional trigger to refetch changes.
+  const sessionStats = useAppStore((s) => {
+    if (!selectedSessionId) return undefined;
+    const session = s.sessions.find((sess) => sess.id === selectedSessionId);
+    return session?.stats;
+  });
+  useEffect(() => {
+    if (!selectedWorkspaceId || !selectedSessionId || !sessionStats) return;
+    debouncedFetchChanges();
+  }, [sessionStats, selectedWorkspaceId, selectedSessionId, debouncedFetchChanges]);
+
+  // Polling fallback — catch changes that event-driven paths might miss
+  useEffect(() => {
+    if (!selectedWorkspaceId || !selectedSessionId) return;
+    const interval = setInterval(() => {
+      fetchChanges();
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, [selectedWorkspaceId, selectedSessionId, fetchChanges]);
 
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">


### PR DESCRIPTION
## Summary

Fixed the Changes tab badge to update in real-time without requiring the user to click on the Changes tab. The issue had three root causes, all now addressed:

1. **Tauri file watcher event bug**: The reactive effect compared `lastFileChange.workspaceId === selectedSessionId` (workspace ID vs session ID), so the condition never matched. Fixed to use `selectedWorkspaceId`.

2. **Missing WebSocket signal**: The backend broadcasts `session_stats_update` when git index changes (commits/staging), but the frontend wasn't using it to trigger a changes refetch. Now reacts to `session.stats` updates from the store.

3. **No polling fallback**: Added 30-second polling as a safety net to catch changes the event-driven paths might miss, matching the pattern used in `useGitStatus`.

The badge now updates robustly via three independent paths: Tauri file events, WebSocket git index events, and periodic polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)