### PR TITLE
Set new sessions to start with in_progress task status

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -1808,7 +1808,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 		Status:        "idle",
 		PRStatus:      "none",
 		Priority:      models.PriorityNone,
-		TaskStatus:    models.TaskStatusBacklog,
+		TaskStatus:    models.TaskStatusInProgress,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}


### PR DESCRIPTION
When a session is created, it now starts with taskStatus set to 'in_progress' instead of 'backlog', reflecting that creating a session implies active work.