### PR TITLE
fix: Scope thinking level and plan mode toggles per session

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -135,6 +135,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     clearActiveTools,
     setPlanModeActive,
     clearInputSuggestion,
+    setSessionToggleState,
   } = useAppStore();
   const hasQueuedMessage = useAppStore(
     (s) => selectedConversationId ? s.queuedMessage[selectedConversationId] != null : false
@@ -332,6 +333,30 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       setPlanModeEnabled(true);
     }
   }, [planModeActive, planModeEnabled]);
+
+  // Restore per-session toggle states when switching sessions
+  const prevSessionRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedSessionId || selectedSessionId === prevSessionRef.current) return;
+    prevSessionRef.current = selectedSessionId;
+
+    const saved = useAppStore.getState().sessionToggleState[selectedSessionId];
+    if (saved) {
+      setThinkingLevel(saved.thinkingLevel);
+      setPlanModeEnabled(saved.planModeEnabled);
+    } else {
+      setThinkingLevel(defaultThinkingLevel);
+      setPlanModeEnabled(defaultPlanMode);
+    }
+  }, [selectedSessionId, defaultThinkingLevel, defaultPlanMode]);
+
+  // Persist toggle state changes to the store for the current session.
+  // Skip when the session just changed (prevSessionRef hasn't caught up yet)
+  // to avoid overwriting the old session's state with the new session's values.
+  useEffect(() => {
+    if (!selectedSessionId || selectedSessionId !== prevSessionRef.current) return;
+    setSessionToggleState(selectedSessionId, { thinkingLevel, planModeEnabled });
+  }, [selectedSessionId, thinkingLevel, planModeEnabled, setSessionToggleState]);
 
   // Check if there's a pending user question
   const pendingQuestion = usePendingUserQuestion(selectedConversationId);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -718,3 +718,9 @@ export interface SetupProgress {
   total: number;
   status: 'running' | 'completed' | 'failed';
 }
+
+// Per-session toggle state for ChatInput (thinking level & plan mode)
+export interface SessionToggleState {
+  thinkingLevel: import('@/lib/thinkingLevels').ThinkingLevel;
+  planModeEnabled: boolean;
+}

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -28,6 +28,7 @@ import type {
   SetupProgress,
   TimelineEntry,
   InputSuggestion,
+  SessionToggleState,
 } from '@/lib/types';
 import { useSettingsStore } from './settingsStore';
 
@@ -226,6 +227,9 @@ interface AppState {
   supportedCommands: Array<{ name: string; description: string; argumentHint: string }>;
   accountInfo: Record<string, unknown> | null;
 
+  // Session-scoped ChatInput toggle states (keyed by sessionId)
+  sessionToggleState: Record<string, SessionToggleState>;
+
   // Script runs state (keyed by sessionId)
   scriptRuns: Record<string, ScriptRun[]>;
   setupProgress: Record<string, SetupProgress>;
@@ -254,6 +258,7 @@ interface AppState {
   selectSession: (id: string | null) => void;
   archiveSession: (id: string) => void;
   unarchiveSession: (id: string) => void;
+  setSessionToggleState: (sessionId: string, state: SessionToggleState) => void;
 
   // Conversation actions
   setConversations: (conversations: Conversation[]) => void;
@@ -472,6 +477,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   supportedCommands: [],
   accountInfo: null,
 
+  sessionToggleState: {},
+
   // Script state
   scriptRuns: {},
   setupProgress: {},
@@ -642,6 +649,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { [id]: _comments, ...remainingReviewComments } = state.reviewComments;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [id]: _lastActive, ...remainingLastActive } = state.lastActiveConversationPerSession;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [id]: _toggleState, ...remainingToggleState } = state.sessionToggleState;
 
     return {
       sessions: state.sessions.filter((s) => s.id !== id),
@@ -660,6 +669,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       sessionOutputs: remainingSessionOutputs,
       reviewComments: remainingReviewComments,
       lastActiveConversationPerSession: remainingLastActive,
+      sessionToggleState: remainingToggleState,
       selectedFileTabId: null,
       fileTabs: [],
     };
@@ -696,6 +706,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedFileTabId: newSelectedTabId,
     });
   },
+  setSessionToggleState: (sessionId, toggleState) => set((state) => ({
+    sessionToggleState: {
+      ...state.sessionToggleState,
+      [sessionId]: toggleState,
+    },
+  })),
   archiveSession: (id) => set((state) => {
     const session = state.sessions.find((s) => s.id === id);
     if (!session) return state;


### PR DESCRIPTION
## Summary
- Thinking level and plan mode toggles were global — switching sessions kept the previous session's values instead of restoring per-session state
- Adds `sessionToggleState` to appStore, keyed by sessionId, to persist and restore toggle values on session switch
- Fixes a race condition where the persist effect would overwrite the old session's saved state during transition by guarding writes until `selectedSessionId` stabilizes via `prevSessionRef`

## Test plan
- [ ] Open two sessions, set different thinking levels and plan mode toggles in each
- [ ] Switch between sessions and verify toggles restore correctly
- [ ] Delete a session and verify its toggle state is cleaned up
- [ ] Create a new session and verify it starts with default toggle values

🤖 Generated with [Claude Code](https://claude.com/claude-code)