### PR TITLE
feat: Context-aware panel menus and render stability fixes

### DIFF
--- a/src/components/files/FileTree.tsx
+++ b/src/components/files/FileTree.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useImperativeHandle, forwardRef } from 'react';
 import { Icon } from '@iconify/react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
@@ -31,11 +31,56 @@ interface FileTreeProps {
   workspaceName?: string;
 }
 
-export function FileTree({ files, onFileSelect }: FileTreeProps) {
+export interface FileTreeHandle {
+  collapseAll: () => void;
+  expandAll: () => void;
+}
+
+function collectAllDirPaths(nodes: FileNode[]): string[] {
+  const paths: string[] = [];
+  function walk(list: FileNode[]) {
+    for (const node of list) {
+      if (node.isDir) {
+        paths.push(node.path);
+        if (node.children) walk(node.children);
+      }
+    }
+  }
+  walk(nodes);
+  return paths;
+}
+
+export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileTree({ files, onFileSelect }, ref) {
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+  const [prevFiles, setPrevFiles] = useState(files);
+
   // Preload folder icons on first render
   useEffect(() => {
     ensureIconsPreloaded();
   }, []);
+
+  // Reset expanded state when files change (e.g., switching sessions)
+  if (prevFiles !== files) {
+    setPrevFiles(files);
+    setExpandedPaths(new Set());
+  }
+
+  const togglePath = useCallback((path: string) => {
+    setExpandedPaths(prev => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
+
+  useImperativeHandle(ref, () => ({
+    collapseAll: () => setExpandedPaths(new Set()),
+    expandAll: () => setExpandedPaths(new Set(collectAllDirPaths(files))),
+  }), [files]);
 
   return (
     <ScrollArea className="h-full w-full">
@@ -46,25 +91,29 @@ export function FileTree({ files, onFileSelect }: FileTreeProps) {
             node={node}
             depth={0}
             onFileSelect={onFileSelect}
+            expandedPaths={expandedPaths}
+            onToggle={togglePath}
           />
         ))}
       </div>
     </ScrollArea>
   );
-}
+});
 
 interface FileTreeNodeProps {
   node: FileNode;
   depth: number;
   onFileSelect?: (path: string) => void;
+  expandedPaths: Set<string>;
+  onToggle: (path: string) => void;
 }
 
-function FileTreeNode({ node, depth, onFileSelect }: FileTreeNodeProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+function FileTreeNode({ node, depth, onFileSelect, expandedPaths, onToggle }: FileTreeNodeProps) {
+  const isExpanded = node.isDir && expandedPaths.has(node.path);
 
   const handleClick = () => {
     if (node.isDir) {
-      setIsExpanded(!isExpanded);
+      onToggle(node.path);
     } else {
       onFileSelect?.(node.path);
     }
@@ -122,6 +171,8 @@ function FileTreeNode({ node, depth, onFileSelect }: FileTreeNodeProps) {
                 node={child}
                 depth={depth + 1}
                 onFileSelect={onFileSelect}
+                expandedPaths={expandedPaths}
+                onToggle={onToggle}
               />
             </ErrorBoundary>
           ))}

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -3,13 +3,13 @@
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useSelectedIds, useFileTabState, useTodoState, useFileCommentStats, useReviewComments } from '@/stores/selectors';
-import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, createConversation, ApiError, ErrorCode, type FileChangeDTO, type BranchCommitDTO } from '@/lib/api';
+import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, createConversation, updateReviewComment as apiUpdateReviewComment, ApiError, ErrorCode, type FileChangeDTO, type BranchCommitDTO } from '@/lib/api';
 import { formatReviewFeedback } from '@/lib/formatReviewFeedback';
-import { FileTree, FileIcon, type FileNode } from '@/components/files/FileTree';
+import { FileTree, FileIcon, type FileNode, type FileTreeHandle } from '@/components/files/FileTree';
 import { TodoPanel } from '@/components/panels/TodoPanel';
 import { CheckpointTimeline } from '@/components/panels/CheckpointTimeline';
 import { BudgetStatusPanel } from '@/components/panels/BudgetStatusPanel';
-import { ChecksPanel } from '@/components/panels/ChecksPanel';
+import { ChecksPanel, type ChecksPanelHandle } from '@/components/panels/ChecksPanel';
 
 
 import { McpServersPanel } from '@/components/panels/McpServersPanel';
@@ -25,7 +25,7 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
-import { useSettingsStore, type BottomPanelTab, type AllBottomPanelTab, type TopPanelTab, type AllTopPanelTab } from '@/stores/settingsStore';
+import { useSettingsStore, type BottomPanelTab, type AllBottomPanelTab, type AllTopPanelTab } from '@/stores/settingsStore';
 import {
   DndContext,
   closestCenter,
@@ -53,11 +53,17 @@ import {
   FileText,
   FolderX,
   Search,
-  SplitSquareHorizontal,
   Loader2,
   MessageSquare,
   ChevronRight,
   GitCommitHorizontal,
+  RefreshCw,
+  ChevronsDownUp,
+  ChevronsUpDown,
+  ExternalLink,
+  CheckCheck,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -116,7 +122,11 @@ export function ChangesPanel() {
   const [commitsOpen, setCommitsOpen] = useState(true);
   const [expandedCommits, setExpandedCommits] = useState<Set<string>>(new Set());
   const [containerWidth, setContainerWidth] = useState(400);
+  const [prUrl, setPrUrl] = useState<string | null>(null);
+  const [showResolved, setShowResolved] = useState(false);
   const changesContainerRef = useRef<HTMLDivElement>(null);
+  const fileTreeRef = useRef<FileTreeHandle>(null);
+  const checksPanelRef = useRef<ChecksPanelHandle>(null);
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Fetch changes function (extracted for reuse)
@@ -352,6 +362,33 @@ export function ChangesPanel() {
     }
   }, [selectedWorkspaceId, selectedSessionId, reviewComments]);
 
+  // Resolve all unresolved review comments
+  const updateReviewComment = useAppStore((s) => s.updateReviewComment);
+  const handleResolveAll = useCallback(async () => {
+    if (!selectedWorkspaceId || !selectedSessionId) return;
+
+    // Read comments from store directly to avoid closing over the array (keeps callback stable)
+    const comments = useAppStore.getState().reviewComments[selectedSessionId] ?? [];
+    const unresolved = comments.filter((c) => !c.resolved);
+    if (unresolved.length === 0) return;
+
+    // Optimistically resolve all
+    for (const comment of unresolved) {
+      updateReviewComment(selectedSessionId, comment.id, {
+        resolved: true,
+        resolvedBy: 'user',
+      });
+    }
+
+    // Fire API calls (best-effort, no rollback for bulk)
+    for (const comment of unresolved) {
+      apiUpdateReviewComment(selectedWorkspaceId, selectedSessionId, comment.id, {
+        resolved: true,
+        resolvedBy: 'user',
+      }).catch(console.error);
+    }
+  }, [selectedWorkspaceId, selectedSessionId, updateReviewComment]);
+
   // Fetch files from session's worktree when session changes or tab switches to files
   // Deferred via requestIdleCallback so it doesn't block the main conversation render on navigation
   useEffect(() => {
@@ -460,6 +497,24 @@ export function ChangesPanel() {
     return () => clearInterval(interval);
   }, [selectedWorkspaceId, selectedSessionId, fetchChanges]);
 
+  const unresolvedCount = useMemo(
+    () => reviewComments.filter((c) => !c.resolved).length,
+    [reviewComments]
+  );
+
+  const menuContext = useMemo<TopPanelMenuContext>(() => ({
+    onCollapseAllFiles: () => fileTreeRef.current?.collapseAll(),
+    onExpandAllFiles: () => fileTreeRef.current?.expandAll(),
+    onRefreshChanges: () => { fetchChanges(); fetchBranchCommits(); },
+    onCollapseAllCommits: () => setExpandedCommits(new Set()),
+    onRefreshChecks: () => checksPanelRef.current?.refreshAll(),
+    prUrl,
+    onResolveAll: handleResolveAll,
+    unresolvedCount,
+    showResolved,
+    onToggleShowResolved: () => setShowResolved((prev) => !prev),
+  }), [fetchChanges, fetchBranchCommits, handleResolveAll, prUrl, unresolvedCount, showResolved]);
+
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
       {/* Tabs Row */}
@@ -467,6 +522,7 @@ export function ChangesPanel() {
         selectedTab={selectedTab}
         setSelectedTab={setSelectedTab}
         changesCount={changes?.length || 0}
+        menuContext={menuContext}
       />
 
       {/* Resizable content area */}
@@ -502,6 +558,7 @@ export function ChangesPanel() {
               <div className="h-full min-h-0 p-1 overflow-hidden">
                 <ErrorBoundary section="FileTree" fallback={<InlineErrorFallback message="Unable to display file tree" />}>
                   <FileTree
+                    ref={fileTreeRef}
                     files={files}
                     onFileSelect={handleFileSelect}
                     workspacePath={currentSession?.worktreePath}
@@ -612,11 +669,11 @@ export function ChangesPanel() {
             )
           ) : selectedTab === 'review' ? (
             <ErrorBoundary section="ReviewPanel" fallback={<InlineErrorFallback message="Unable to display review" />}>
-              <ReviewPanel workspaceId={selectedWorkspaceId} sessionId={selectedSessionId} onFileSelect={handleFileSelect} onSendFeedback={handleSendFeedback} />
+              <ReviewPanel workspaceId={selectedWorkspaceId} sessionId={selectedSessionId} onFileSelect={handleFileSelect} onSendFeedback={handleSendFeedback} showResolved={showResolved} />
             </ErrorBoundary>
           ) : selectedTab === 'checks' ? (
             <ErrorBoundary section="ChecksPanel" fallback={<InlineErrorFallback message="Unable to display checks" />}>
-              <ChecksPanel onSendMessage={handleGitActionMessage} />
+              <ChecksPanel ref={checksPanelRef} onSendMessage={handleGitActionMessage} onPrUrlChange={setPrUrl} />
             </ErrorBoundary>
           ) : (
             <div className="h-full flex items-center justify-center">
@@ -679,12 +736,12 @@ export function ChangesPanel() {
   );
 }
 
-// Top panel tabs configuration
-const TOP_TABS_CONFIG: Record<AllTopPanelTab, { label: string; alwaysVisible?: boolean }> = {
-  changes: { label: 'Changes', alwaysVisible: true },
+// Top panel tabs configuration (all tabs always visible)
+const TOP_TABS_CONFIG: Record<AllTopPanelTab, { label: string }> = {
+  changes: { label: 'Changes' },
   review: { label: 'Review' },
   checks: { label: 'Checks' },
-  files: { label: 'Files', alwaysVisible: true },
+  files: { label: 'Files' },
 };
 
 // Bottom panel tabs configuration
@@ -869,17 +926,30 @@ function BottomPanelTabs({
   );
 }
 
+interface TopPanelMenuContext {
+  onCollapseAllFiles?: () => void;
+  onExpandAllFiles?: () => void;
+  onRefreshChanges?: () => void;
+  onCollapseAllCommits?: () => void;
+  onRefreshChecks?: () => void;
+  prUrl?: string | null;
+  onResolveAll?: () => void;
+  unresolvedCount?: number;
+  showResolved?: boolean;
+  onToggleShowResolved?: () => void;
+}
+
 function TopPanelTabs({
   selectedTab,
   setSelectedTab,
   changesCount,
+  menuContext,
 }: {
   selectedTab: string;
   setSelectedTab: (tab: string) => void;
   changesCount: number;
+  menuContext: TopPanelMenuContext;
 }) {
-  const hiddenTopTabs = useSettingsStore((s) => s.hiddenTopTabs);
-  const toggleTopTab = useSettingsStore((s) => s.toggleTopTab);
   const topTabOrder = useSettingsStore((s) => s.topTabOrder);
   const setTopTabOrder = useSettingsStore((s) => s.setTopTabOrder);
 
@@ -894,12 +964,10 @@ function TopPanelTabs({
     })
   );
 
+  // All tabs are always visible — just filter out any that don't have config
   const visibleTabIds = useMemo(() =>
-    topTabOrder.filter((tabId) => {
-      const config = TOP_TABS_CONFIG[tabId];
-      return config && (config.alwaysVisible || !hiddenTopTabs.includes(tabId as TopPanelTab));
-    }),
-    [topTabOrder, hiddenTopTabs]
+    topTabOrder.filter((tabId) => TOP_TABS_CONFIG[tabId]),
+    [topTabOrder]
   );
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
@@ -941,7 +1009,7 @@ function TopPanelTabs({
         </DndContext>
       </div>
 
-      {/* Settings dropdown - always visible */}
+      {/* Context-aware dropdown menu */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
@@ -953,32 +1021,83 @@ function TopPanelTabs({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem>
-            <SplitSquareHorizontal className="size-4" />
-            Split View
-          </DropdownMenuItem>
+          {/* Search Files — available on all tabs */}
           <DropdownMenuItem onSelect={() => window.dispatchEvent(new CustomEvent('open-file-picker'))}>
             <Search className="size-4" />
             Search Files
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          {topTabOrder.map((tabId) => {
-            const config = TOP_TABS_CONFIG[tabId];
-            return (
-              <DropdownMenuCheckboxItem
-                key={tabId}
-                checked={config.alwaysVisible || !hiddenTopTabs.includes(tabId as TopPanelTab)}
-                disabled={config.alwaysVisible}
-                onCheckedChange={() => {
-                  if (!config.alwaysVisible) {
-                    toggleTopTab(tabId as TopPanelTab);
-                  }
-                }}
+
+          {/* Files tab context menu */}
+          {selectedTab === 'files' && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={menuContext.onCollapseAllFiles}>
+                <ChevronsDownUp className="size-4" />
+                Collapse All
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={menuContext.onExpandAllFiles}>
+                <ChevronsUpDown className="size-4" />
+                Expand All
+              </DropdownMenuItem>
+            </>
+          )}
+
+          {/* Changes tab context menu */}
+          {selectedTab === 'changes' && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={menuContext.onRefreshChanges}>
+                <RefreshCw className="size-4" />
+                Refresh
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={menuContext.onCollapseAllCommits}>
+                <ChevronsDownUp className="size-4" />
+                Collapse All
+              </DropdownMenuItem>
+            </>
+          )}
+
+          {/* Checks tab context menu */}
+          {selectedTab === 'checks' && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={menuContext.onRefreshChecks}>
+                <RefreshCw className="size-4" />
+                Refresh
+              </DropdownMenuItem>
+              {menuContext.prUrl && (
+                <DropdownMenuItem onSelect={() => window.open(menuContext.prUrl!, '_blank')}>
+                  <ExternalLink className="size-4" />
+                  View PR on GitHub
+                </DropdownMenuItem>
+              )}
+            </>
+          )}
+
+          {/* Review tab context menu */}
+          {selectedTab === 'review' && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={menuContext.onResolveAll}
+                disabled={!menuContext.unresolvedCount}
               >
-                {config.label}
+                <CheckCheck className="size-4" />
+                Resolve All
+              </DropdownMenuItem>
+              <DropdownMenuCheckboxItem
+                checked={menuContext.showResolved}
+                onCheckedChange={menuContext.onToggleShowResolved}
+              >
+                {menuContext.showResolved ? (
+                  <EyeOff className="size-4" />
+                ) : (
+                  <Eye className="size-4" />
+                )}
+                Show Resolved
               </DropdownMenuCheckboxItem>
-            );
-          })}
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
 import { useSelectedIds } from '@/stores/selectors';
 import { useAppStore } from '@/stores/appStore';
 import { usePRStatus } from '@/hooks/usePRStatus';
@@ -41,6 +41,11 @@ import {
 
 interface ChecksPanelProps {
   onSendMessage?: (content: string) => void;
+  onPrUrlChange?: (url: string | null) => void;
+}
+
+export interface ChecksPanelHandle {
+  refreshAll: () => void;
 }
 
 interface BlockingItem {
@@ -139,7 +144,7 @@ function computeMergeReadiness(
 // Main component
 // ---------------------------------------------------------------------------
 
-export function ChecksPanel({ onSendMessage }: ChecksPanelProps) {
+export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(function ChecksPanel({ onSendMessage, onPrUrlChange }, ref) {
   const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
 
   // Get session's prStatus from store to pass to usePRStatus hook
@@ -177,11 +182,20 @@ export function ChecksPanel({ onSendMessage }: ChecksPanelProps) {
 
   const isLoading = prLoading || ciLoading || gitLoading;
 
-  const handleRefreshAll = () => {
+  const handleRefreshAll = useCallback(() => {
     refetchPR();
     refetchCI();
     refetchGit();
-  };
+  }, [refetchPR, refetchCI, refetchGit]);
+
+  useImperativeHandle(ref, () => ({
+    refreshAll: handleRefreshAll,
+  }), [handleRefreshAll]);
+
+  // Notify parent of PR URL changes
+  useEffect(() => {
+    onPrUrlChange?.(prDetails?.htmlUrl ?? null);
+  }, [prDetails?.htmlUrl, onPrUrlChange]);
 
   if (!selectedWorkspaceId || !selectedSessionId) {
     return (
@@ -230,7 +244,7 @@ export function ChecksPanel({ onSendMessage }: ChecksPanelProps) {
       </div>
     </ScrollArea>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // MergeReadinessBanner

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -33,9 +33,10 @@ interface ReviewPanelProps {
   sessionId: string | null;
   onFileSelect?: (path: string, line?: number) => void;
   onSendFeedback?: () => void;
+  showResolved?: boolean;
 }
 
-export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedback }: ReviewPanelProps) {
+export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedback, showResolved }: ReviewPanelProps) {
   const [filter, setFilter] = useState<CommentSeverity | 'all'>('all');
   const [loading, setLoading] = useState(false);
   const [fetchSession, setFetchSession] = useState<string | null>(null);
@@ -76,9 +77,9 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
     return () => { cancelled = true; };
   }, [workspaceId, sessionId, setReviewComments]);
 
-  // Filter comments by severity and only show unresolved
+  // Filter comments by severity and resolved state
   const filteredComments = comments.filter((c) => {
-    if (c.resolved) return false;
+    if (c.resolved && !showResolved) return false;
     if (filter === 'all') return true;
     return c.severity === filter;
   });
@@ -228,6 +229,7 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
                 comment={comment}
                 onClick={() => onFileSelect?.(comment.filePath, comment.lineNumber)}
                 onResolve={() => handleResolve(comment.id)}
+                isResolved={comment.resolved}
               />
             ))}
           </div>
@@ -241,10 +243,12 @@ function ReviewCommentCard({
   comment,
   onClick,
   onResolve,
+  isResolved,
 }: {
   comment: ReviewComment;
   onClick?: () => void;
   onResolve?: () => void;
+  isResolved?: boolean;
 }) {
   const fileName = comment.filePath.split('/').pop() || comment.filePath;
   const dirPath = comment.filePath.split('/').slice(0, -1).join('/');
@@ -288,15 +292,19 @@ function ReviewCommentCard({
     <div
       className={cn(
         'rounded-lg border p-2.5 cursor-pointer transition-colors hover:bg-surface-2',
-        severityColor
+        isResolved ? 'opacity-50 border-border bg-surface-1' : severityColor
       )}
       onClick={onClick}
     >
       {/* Header row */}
       <div className="flex items-start gap-2">
-        <SeverityIcon className="h-4 w-4 shrink-0 mt-0.5" />
+        {isResolved ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5 text-green-500" />
+        ) : (
+          <SeverityIcon className="h-4 w-4 shrink-0 mt-0.5" />
+        )}
         <div className="flex-1 min-w-0">
-          <div className="font-medium text-sm leading-tight">{title}</div>
+          <div className={cn('font-medium text-sm leading-tight', isResolved && 'line-through')}>{title}</div>
           {description && (
             <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
               {description}
@@ -304,18 +312,20 @@ function ReviewCommentCard({
           )}
         </div>
         <div className="flex items-center gap-0.5 shrink-0">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-5 w-5 p-0 hover:bg-green-500/20 hover:text-green-500"
-            onClick={(e) => {
-              e.stopPropagation();
-              onResolve?.();
-            }}
-            title="Resolve comment"
-          >
-            <Check className="h-3 w-3" />
-          </Button>
+          {!isResolved && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-5 w-5 p-0 hover:bg-green-500/20 hover:text-green-500"
+              onClick={(e) => {
+                e.stopPropagation();
+                onResolve?.();
+              }}
+              title="Resolve comment"
+            >
+              <Check className="h-3 w-3" />
+            </Button>
+          )}
           <ChevronRight className="h-4 w-4 text-muted-foreground" />
         </div>
       </div>

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -102,7 +102,6 @@ interface SettingsState {
   zenMode: boolean; // Distraction-free mode that hides sidebars
   hiddenBottomTabs: BottomPanelTab[]; // Bottom panel tabs that are hidden (Tasks always visible)
   bottomTabOrder: AllBottomPanelTab[]; // Order of bottom panel tabs
-  hiddenTopTabs: TopPanelTab[]; // Top panel tabs that are hidden (Changes always visible)
   topTabOrder: AllTopPanelTab[]; // Order of top panel tabs
   // Full Content Area view state (not persisted - always starts in conversation view)
   contentView: ContentView;
@@ -175,7 +174,6 @@ interface SettingsState {
   markSessionRead: (sessionId: string) => void;
   toggleBottomTab: (tab: BottomPanelTab) => void;
   setBottomTabOrder: (order: AllBottomPanelTab[]) => void;
-  toggleTopTab: (tab: TopPanelTab) => void;
   setTopTabOrder: (order: AllTopPanelTab[]) => void;
   setContentView: (view: ContentView) => void;
   setLayoutOuter: (layout: PanelLayout) => void;
@@ -236,7 +234,6 @@ export const useSettingsStore = create<SettingsState>()(
       zenMode: false,
       hiddenBottomTabs: [], // All tabs visible by default
       bottomTabOrder: DEFAULT_BOTTOM_TAB_ORDER, // Default tab order
-      hiddenTopTabs: [], // All top tabs visible by default
       topTabOrder: DEFAULT_TOP_TAB_ORDER, // Default top tab order
       contentView: { type: 'conversation' }, // Always start in conversation view
       layoutOuter: undefined, // Use defaults until user resizes
@@ -330,12 +327,6 @@ export const useSettingsStore = create<SettingsState>()(
             : [...state.hiddenBottomTabs, tab],
         })),
       setBottomTabOrder: (order) => set({ bottomTabOrder: order }),
-      toggleTopTab: (tab) =>
-        set((state) => ({
-          hiddenTopTabs: state.hiddenTopTabs.includes(tab)
-            ? state.hiddenTopTabs.filter((t) => t !== tab)
-            : [...state.hiddenTopTabs, tab],
-        })),
       setTopTabOrder: (order) => set({ topTabOrder: order }),
       setContentView: (view) => set({ contentView: view }),
       setLayoutOuter: (layout) => set({ layoutOuter: layout }),
@@ -434,10 +425,9 @@ export const useSettingsStore = create<SettingsState>()(
           merged.topTabOrder = [...existingOrder, ...missingTabs];
         }
 
-        // Filter out stale hidden tab entries for removed tabs
-        if (persisted.hiddenTopTabs) {
-          const validTopTabs = DEFAULT_TOP_TAB_ORDER.filter((t) => t !== 'changes');
-          merged.hiddenTopTabs = persisted.hiddenTopTabs.filter((t) => validTopTabs.includes(t));
+        // Clean up legacy hiddenTopTabs from persisted state
+        if ('hiddenTopTabs' in merged) {
+          delete (merged as Record<string, unknown>).hiddenTopTabs;
         }
         if (persisted.hiddenBottomTabs) {
           const validBottomTabs = DEFAULT_BOTTOM_TAB_ORDER.filter((t) => t !== 'todos');


### PR DESCRIPTION
## Summary
- Replace hide/show tab toggles with always-visible tabs and context-aware dropdown menus (Files: collapse/expand all, Changes: refresh/collapse, Checks: refresh/view PR on GitHub, Review: resolve all/show resolved)
- Lift FileTree expand/collapse state to parent via `forwardRef`/`useImperativeHandle` for programmatic control
- Fix render stability: memoize `menuContext` with `useMemo`, read store state inside `handleResolveAll` callback via `getState()` to avoid unstable dependency arrays
- Replace global `window.addEventListener('checks-refresh')` event bus with ref-based `ChecksPanelHandle.refreshAll()` for consistent React-tree communication
- Clean up legacy `hiddenTopTabs` from persisted settings store state

## Test plan
- [ ] Switch between all top panel tabs (Files, Changes, Review, Checks) and verify context-aware dropdown menus show correct actions per tab
- [ ] Files tab: Collapse All / Expand All via dropdown menu
- [ ] Changes tab: Refresh and Collapse All via dropdown menu
- [ ] Checks tab: Refresh via dropdown menu; View PR on GitHub link appears when PR exists
- [ ] Review tab: Resolve All resolves all comments; Show Resolved toggle works
- [ ] Verify no unnecessary re-renders in React DevTools Profiler on the TopPanelTabs component

🤖 Generated with [Claude Code](https://claude.com/claude-code)