### PR TITLE
feat: Move approved plan into chronological timeline

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -352,6 +352,7 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	pendingSubAgentTools := make(map[string][]ActiveToolEntry)
 	var currentThinking string // Accumulated thinking for snapshot/backwards compat
 	var pendingPlanContent string
+	var pendingPlanTimestamp time.Time
 	var isThinking bool
 	var snapshotDirty bool
 
@@ -693,6 +694,7 @@ outer:
 
 			case EventTypePlanApprovalRequest:
 				pendingPlanContent = event.PlanContent
+				pendingPlanTimestamp = time.Now()
 
 			case EventTypeCheckpointCreated:
 				if event.CheckpointUuid != "" {
@@ -760,6 +762,23 @@ outer:
 							entry:     models.TimelineEntry{Type: "tool", ToolID: tool.ID},
 						})
 					}
+					// Only persist plan content if ExitPlanMode succeeded this turn
+					var planContent string
+					if pendingPlanContent != "" {
+						for _, tool := range completedTools {
+							if tool.Tool == "ExitPlanMode" && tool.Success != nil && *tool.Success {
+								planContent = pendingPlanContent
+								break
+							}
+						}
+					}
+					// Add approved plan content to timeline at its chronological position
+					if planContent != "" && !pendingPlanTimestamp.IsZero() {
+						items = append(items, timelineItem{
+							timestamp: pendingPlanTimestamp,
+							entry:     models.TimelineEntry{Type: "plan", Content: planContent},
+						})
+					}
 					sort.Slice(items, func(i, j int) bool {
 						return items[i].timestamp.Before(items[j].timestamp)
 					})
@@ -772,17 +791,6 @@ outer:
 					}
 
 					durationMs := int(time.Since(turnStartTime).Milliseconds())
-
-					// Only persist plan content if ExitPlanMode succeeded this turn
-					var planContent string
-					if pendingPlanContent != "" {
-						for _, tool := range completedTools {
-							if tool.Tool == "ExitPlanMode" && tool.Success != nil && *tool.Success {
-								planContent = pendingPlanContent
-								break
-							}
-						}
-					}
 
 					if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
 						ID:              uuid.New().String()[:8],
@@ -802,6 +810,7 @@ outer:
 				// Reset per-turn accumulation state
 				currentThinking = ""
 				pendingPlanContent = ""
+				pendingPlanTimestamp = time.Time{}
 				isThinking = false
 				thinkingBlocks = nil
 				currentThinkingText = ""
@@ -881,7 +890,18 @@ outer:
 
 		// Build timeline from text segments, thinking blocks, and completed tools
 		var timeline []models.TimelineEntry
-		if len(textSegments) > 0 || len(completedTools) > 0 || len(thinkingBlocks) > 0 {
+		// Only persist plan content if ExitPlanMode succeeded this turn
+		var finalPlanContent string
+		if pendingPlanContent != "" {
+			for _, tool := range completedTools {
+				if tool.Tool == "ExitPlanMode" && tool.Success != nil && *tool.Success {
+					finalPlanContent = pendingPlanContent
+					break
+				}
+			}
+		}
+
+		if len(textSegments) > 0 || len(completedTools) > 0 || len(thinkingBlocks) > 0 || finalPlanContent != "" {
 			type timelineItem struct {
 				timestamp time.Time
 				entry     models.TimelineEntry
@@ -900,6 +920,10 @@ outer:
 				}
 				items = append(items, timelineItem{timestamp: ts, entry: models.TimelineEntry{Type: "tool", ToolID: tool.ID}})
 			}
+			// Add approved plan content to timeline at its chronological position
+			if finalPlanContent != "" && !pendingPlanTimestamp.IsZero() {
+				items = append(items, timelineItem{timestamp: pendingPlanTimestamp, entry: models.TimelineEntry{Type: "plan", Content: finalPlanContent}})
+			}
 			sort.Slice(items, func(i, j int) bool { return items[i].timestamp.Before(items[j].timestamp) })
 			timeline = make([]models.TimelineEntry, len(items))
 			for i, item := range items {
@@ -908,17 +932,6 @@ outer:
 		}
 
 		durationMs := int(time.Since(turnStartTime).Milliseconds())
-
-		// Only persist plan content if ExitPlanMode succeeded this turn
-		var finalPlanContent string
-		if pendingPlanContent != "" {
-			for _, tool := range completedTools {
-				if tool.Tool == "ExitPlanMode" && tool.Success != nil && *tool.Success {
-					finalPlanContent = pendingPlanContent
-					break
-				}
-			}
-		}
 
 		if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
 			ID:              uuid.New().String()[:8],

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -204,8 +204,8 @@ type ToolUsageRecord struct {
 
 // TimelineEntry represents an entry in the interleaved message timeline
 type TimelineEntry struct {
-	Type    string `json:"type"`              // "text", "tool", or "thinking"
-	Content string `json:"content,omitempty"` // For text and thinking entries
+	Type    string `json:"type"`              // "text", "tool", "thinking", or "plan"
+	Content string `json:"content,omitempty"` // For text, thinking, and plan entries
 	ToolID  string `json:"toolId,omitempty"`  // For tool entries, references ToolUsageRecord.ID
 }
 

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -146,8 +146,8 @@ export const MessageBlock = memo(function MessageBlock({
   return (
     <div className="py-2">
       <div className="space-y-1.5">
-        {/* Approved Plan Content */}
-        {message.planContent && (
+        {/* Backward compat: show planContent at top for old messages without plan timeline entry */}
+        {message.planContent && !(message.timeline?.some(e => e.type === 'plan')) && (
           <div className="flex flex-col gap-1">
             <button
               onClick={() => setIsPlanExpanded(!isPlanExpanded)}
@@ -212,6 +212,28 @@ export const MessageBlock = memo(function MessageBlock({
                         worktreePath={worktreePath}
                         metadata={tool.metadata}
                       />
+                    );
+                  } else if (entry.type === 'plan') {
+                    return (
+                      <div key={`tl-plan-${idx}`} className="flex flex-col gap-1">
+                        <button
+                          onClick={() => setIsPlanExpanded(!isPlanExpanded)}
+                          className="flex items-center gap-2 text-xs text-primary hover:text-primary/80 transition-colors"
+                        >
+                          <ClipboardCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                          <span className="font-medium">Approved Plan</span>
+                          {isPlanExpanded ? (
+                            <ChevronDown className="w-3 h-3" />
+                          ) : (
+                            <ChevronRight className="w-3 h-3" />
+                          )}
+                        </button>
+                        {isPlanExpanded && (
+                          <div className={cn(PROSE_CLASSES, 'ml-5 border-l-2 border-primary/20 pl-3')}>
+                            <CachedMarkdown cacheKey={`plan:${message.id}:tl:${idx}`} content={entry.content} />
+                          </div>
+                        )}
+                      </div>
                     );
                   }
                   return null;

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -17,6 +17,7 @@ type TimelineItem =
   | { type: 'text'; id: string; text: string; timestamp: number }
   | { type: 'tool'; id: string; tool: string; params?: Record<string, unknown>; startTime: number; endTime?: number; success?: boolean; summary?: string; stdout?: string; stderr?: string; elapsedSeconds?: number; metadata?: import('@/lib/types').ToolMetadata }
   | { type: 'thinking'; id: string; text: string; isActive: boolean; timestamp: number }
+  | { type: 'plan'; id: string; content: string; timestamp: number }
   | { type: 'subagent'; agent: import('@/lib/types').SubAgent }
   | { type: 'subagent_group'; agents: import('@/lib/types').SubAgent[] };
 
@@ -220,6 +221,26 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
       });
     }
 
+    // Add approved plan content at its chronological position
+    if (streaming?.approvedPlanContent && streaming?.approvedPlanTimestamp) {
+      items.push({
+        type: 'plan',
+        id: 'approved-plan',
+        content: streaming.approvedPlanContent,
+        timestamp: streaming.approvedPlanTimestamp,
+      });
+    }
+
+    // Add pending plan content (awaiting approval) — place at end of current content
+    if (streaming?.pendingPlanApproval?.planContent) {
+      items.push({
+        type: 'plan',
+        id: 'pending-plan',
+        content: streaming.pendingPlanApproval.planContent,
+        timestamp: Number.MAX_SAFE_INTEGER, // Sort to end of current timeline
+      });
+    }
+
     // Add sub-agents into the timeline
     for (const agent of subAgents) {
       items.push({ type: 'subagent', agent });
@@ -230,6 +251,7 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
       switch (item.type) {
         case 'text': return item.timestamp;
         case 'thinking': return item.timestamp;
+        case 'plan': return item.timestamp;
         case 'subagent': return item.agent.startTime;
         case 'subagent_group': return item.agents[0].startTime;
         default: return item.startTime;
@@ -266,8 +288,8 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
     return grouped;
   }, [streaming, tools, subAgents]);
 
-  // Don't render if no streaming content, no active tools, no sub-agents, no thinking, no error, and no pending plan
-  if (timeline.length === 0 && !streaming?.error && !streaming?.isThinking && !streaming?.isStreaming && !streaming?.pendingPlanApproval?.planContent && !streaming?.approvedPlanContent) {
+  // Don't render if no streaming content, no active tools, no sub-agents, no thinking, and no error
+  if (timeline.length === 0 && !streaming?.error && !streaming?.isThinking && !streaming?.isStreaming) {
     return null;
   }
 
@@ -313,6 +335,39 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
                   )}
                 </div>
               );
+            } else if (item.type === 'plan') {
+              const isPending = item.id === 'pending-plan';
+              return isPending ? (
+                <div key={item.id} className={PROSE_CLASSES}>
+                  <CachedMarkdown
+                    cacheKey={`plan:${item.id}`}
+                    content={item.content}
+                  />
+                </div>
+              ) : (
+                <div key={item.id} className="flex flex-col gap-1">
+                  <button
+                    onClick={() => setIsApprovedPlanExpanded(!isApprovedPlanExpanded)}
+                    className="flex items-center gap-2 text-xs text-primary hover:text-primary/80 transition-colors"
+                  >
+                    <ClipboardCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                    <span className="font-medium">Approved Plan</span>
+                    {isApprovedPlanExpanded ? (
+                      <ChevronDown className="w-3 h-3" />
+                    ) : (
+                      <ChevronRight className="w-3 h-3" />
+                    )}
+                  </button>
+                  {isApprovedPlanExpanded && (
+                    <div className={cn(PROSE_CLASSES, 'ml-5 border-l-2 border-primary/20 pl-3')}>
+                      <CachedMarkdown
+                        cacheKey={`approved-plan:${conversationId}`}
+                        content={item.content}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
             } else if (item.type === 'subagent_group') {
               return (
                 <SubAgentGroupedRow
@@ -350,42 +405,6 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
             }
           });
           })()}
-
-          {/* Plan content display - shown when ExitPlanMode sends plan for approval */}
-          {streaming?.pendingPlanApproval?.planContent && (
-            <div className={PROSE_CLASSES}>
-              <CachedMarkdown
-                cacheKey={`plan:${streaming.pendingPlanApproval.requestId}`}
-                content={streaming.pendingPlanApproval.planContent}
-              />
-            </div>
-          )}
-
-          {/* Approved plan content - persists after plan approval during continued streaming */}
-          {!streaming?.pendingPlanApproval?.planContent && streaming?.approvedPlanContent && (
-            <div className="flex flex-col gap-1">
-              <button
-                onClick={() => setIsApprovedPlanExpanded(!isApprovedPlanExpanded)}
-                className="flex items-center gap-2 text-xs text-primary hover:text-primary/80 transition-colors"
-              >
-                <ClipboardCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-                <span className="font-medium">Approved Plan</span>
-                {isApprovedPlanExpanded ? (
-                  <ChevronDown className="w-3 h-3" />
-                ) : (
-                  <ChevronRight className="w-3 h-3" />
-                )}
-              </button>
-              {isApprovedPlanExpanded && (
-                <div className={cn(PROSE_CLASSES, 'ml-5 border-l-2 border-primary/20 pl-3')}>
-                  <CachedMarkdown
-                    cacheKey={`approved-plan:${conversationId}`}
-                    content={streaming.approvedPlanContent}
-                  />
-                </div>
-              )}
-            </div>
-          )}
 
           {/* Enhanced error display */}
           {streaming?.error && (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -890,7 +890,7 @@ export interface ToolUsageDTO {
 }
 
 export interface TimelineEntryDTO {
-  type: 'text' | 'tool';
+  type: 'text' | 'tool' | 'thinking' | 'plan';
   content?: string;
   toolId?: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -150,7 +150,8 @@ export interface ToolUsage {
 export type TimelineEntry =
   | { type: 'text'; content: string }
   | { type: 'tool'; toolId: string }
-  | { type: 'thinking'; content: string };
+  | { type: 'thinking'; content: string }
+  | { type: 'plan'; content: string };
 
 // Active tool during streaming (real-time tracking)
 export interface ActiveTool {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -144,6 +144,7 @@ interface StreamingState {
   planModeActive: boolean; // Whether plan mode is active for this conversation
   pendingPlanApproval: { requestId: string; planContent?: string } | null; // Pending ExitPlanMode approval request
   approvedPlanContent?: string; // Plan content to persist after approval
+  approvedPlanTimestamp?: number; // When the plan was approved (for timeline ordering)
 }
 
 // ActiveTool is imported from @/lib/types
@@ -1283,6 +1284,7 @@ updateFileTabContent: (id, content) => set((state) => ({
   setApprovedPlanContent: (conversationId, content) => set((state) => ({
     streamingState: updateStreamingConv(state.streamingState, conversationId, {
       approvedPlanContent: content,
+      approvedPlanTimestamp: Date.now(),
     }),
   })),
   addActiveTool: (conversationId, tool, opts) => {
@@ -1520,6 +1522,7 @@ updateFileTabContent: (id, content) => set((state) => ({
         planModeActive: streaming?.planModeActive || false,
         pendingPlanApproval: null,
         approvedPlanContent: undefined,
+        approvedPlanTimestamp: undefined,
       };
 
       // If no streaming text, just clear the state
@@ -1554,6 +1557,10 @@ updateFileTabContent: (id, content) => set((state) => ({
           timelineItems.push({ timestamp: tool.startTime, entry: { type: 'tool', toolId: tool.id } });
         }
       }
+      // Add approved plan content at its chronological position
+      if (streaming.approvedPlanContent && streaming.approvedPlanTimestamp) {
+        timelineItems.push({ timestamp: streaming.approvedPlanTimestamp, entry: { type: 'plan', content: streaming.approvedPlanContent } });
+      }
       timelineItems.sort((a, b) => a.timestamp - b.timestamp);
       const timeline: TimelineEntry[] | undefined =
         timelineItems.length > 0 ? timelineItems.map(item => item.entry) : undefined;
@@ -1570,7 +1577,6 @@ updateFileTabContent: (id, content) => set((state) => ({
         runSummary: metadata.runSummary,
         ...(streaming.thinking ? { thinkingContent: streaming.thinking } : {}),
         ...(timeline ? { timeline } : {}),
-        ...(streaming.approvedPlanContent ? { planContent: streaming.approvedPlanContent } : {}),
       };
 
       // Atomically: add message AND clear streaming state


### PR DESCRIPTION
## Summary
- Moves the approved plan display from a fixed position into the chronological timeline, interleaved with text, tools, and thinking blocks
- Fixes a bug where rejected plans leaked into the persisted timeline by gating insertion on `ExitPlanMode` success
- Adds backward-compat handling so old messages with `planContent` but no plan timeline entry still render correctly
- Uses distinct `CachedMarkdown` keys for timeline plan entries to avoid cache collisions

## Test plan
- [ ] Approve a plan via ExitPlanMode and verify it appears inline in the timeline at the correct chronological position
- [ ] Reject a plan and verify it does NOT appear in the persisted timeline after the turn ends
- [ ] Reload a session with old messages that have `planContent` but no plan timeline entry and verify backward-compat rendering still works
- [ ] Verify the plan expand/collapse toggle works in both streaming and persisted message views

🤖 Generated with [Claude Code](https://claude.com/claude-code)