### PR TITLE
fix: Isolate compose input state per session

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -115,6 +115,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const [summaryPickerOpen, setSummaryPickerOpen] = useState(false);
   const [selectedSummaryIds, setSelectedSummaryIds] = useState<string[]>([]);
   const plateInputRef = useRef<PlateInputHandle>(null);
+  const attachmentsRef = useRef<Attachment[]>(attachments);
+  attachmentsRef.current = attachments;
 
   const {
     selectedConversationId,
@@ -136,6 +138,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     setPlanModeActive,
     clearInputSuggestion,
     setSessionToggleState,
+    setDraftInput,
+    clearDraftInput,
   } = useAppStore();
   const hasQueuedMessage = useAppStore(
     (s) => selectedConversationId ? s.queuedMessage[selectedConversationId] != null : false
@@ -178,6 +182,40 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     };
     loadFiles();
   }, [selectedWorkspaceId, selectedSessionId]);
+
+  // Save/restore compose draft per session so switching sessions doesn't lose or leak input
+  const prevSessionIdRef = useRef<string | null>(selectedSessionId);
+  useEffect(() => {
+    const prevId = prevSessionIdRef.current;
+    if (prevId === selectedSessionId) return;
+
+    // Save draft for the previous session
+    if (prevId) {
+      const currentText = plateInputRef.current?.getText() ?? '';
+      const currentAttachments = attachmentsRef.current;
+      if (currentText || currentAttachments.length > 0) {
+        setDraftInput(prevId, { text: currentText, attachments: currentAttachments });
+      } else {
+        clearDraftInput(prevId);
+      }
+    }
+
+    // Restore draft for the new session (or clear)
+    const draft = selectedSessionId ? useAppStore.getState().draftInputs[selectedSessionId] : undefined;
+    if (draft) {
+      plateInputRef.current?.setText(draft.text);
+      setMessage(draft.text);
+      setAttachments(draft.attachments);
+      clearDraftInput(selectedSessionId!);
+    } else {
+      plateInputRef.current?.clear();
+      setMessage('');
+      setAttachments([]);
+    }
+
+    prevSessionIdRef.current = selectedSessionId;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on session switch
+  }, [selectedSessionId]);
 
   // Get current conversation
   const currentConversation = conversations.find((c) => c.id === selectedConversationId);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -230,11 +230,18 @@ interface AppState {
   // Session-scoped ChatInput toggle states (keyed by sessionId)
   sessionToggleState: Record<string, SessionToggleState>;
 
+  // Draft compose input per session (keyed by sessionId)
+  draftInputs: Record<string, { text: string; attachments: Attachment[] }>;
+
   // Script runs state (keyed by sessionId)
   scriptRuns: Record<string, ScriptRun[]>;
   setupProgress: Record<string, SetupProgress>;
   // Monotonic counter bumped on each output line to trigger re-renders
   scriptOutputVersion: number;
+
+  // Draft input actions
+  setDraftInput: (sessionId: string, draft: { text: string; attachments: Attachment[] }) => void;
+  clearDraftInput: (sessionId: string) => void;
 
   // Script actions
   addScriptRun: (sessionId: string, run: ScriptRun) => void;
@@ -479,10 +486,23 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   sessionToggleState: {},
 
+  // Draft input state
+  draftInputs: {},
+
   // Script state
   scriptRuns: {},
   setupProgress: {},
   scriptOutputVersion: 0,
+
+  // Draft input actions
+  setDraftInput: (sessionId, draft) => set((state) => ({
+    draftInputs: { ...state.draftInputs, [sessionId]: draft },
+  })),
+  clearDraftInput: (sessionId) => set((state) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [sessionId]: _, ...rest } = state.draftInputs;
+    return { draftInputs: rest };
+  }),
 
   // Script actions
   addScriptRun: (sessionId, run) => {
@@ -651,6 +671,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { [id]: _lastActive, ...remainingLastActive } = state.lastActiveConversationPerSession;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [id]: _toggleState, ...remainingToggleState } = state.sessionToggleState;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [id]: _draft, ...remainingDraftInputs } = state.draftInputs;
 
     return {
       sessions: state.sessions.filter((s) => s.id !== id),
@@ -670,6 +692,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       reviewComments: remainingReviewComments,
       lastActiveConversationPerSession: remainingLastActive,
       sessionToggleState: remainingToggleState,
+      draftInputs: remainingDraftInputs,
       selectedFileTabId: null,
       fileTabs: [],
     };


### PR DESCRIPTION
## Summary
- Save and restore compose text + attachments when switching sessions, preventing input from leaking between sessions
- Uses `attachmentsRef` and `useAppStore.getState()` to avoid stale closures and unnecessary re-renders from subscribing to the entire `draftInputs` map
- Cleans up draft state when a session is deleted

## Test plan
- [ ] Type text in compose input, switch to another session, verify input is cleared
- [ ] Switch back to the original session, verify the draft text is restored
- [ ] Add attachments, switch sessions, switch back — verify attachments are restored
- [ ] Delete a session that has a draft, verify no state leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)