### PR TITLE
Hide rebase banner and Review button for merged sessions

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -903,7 +903,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   return (
     <div className="flex-1 min-h-0 flex flex-col bg-chat-background">
       {/* Branch sync banner - shows when origin/main has updates */}
-      {branchSyncStatus && branchSyncStatus.behindBy > 0 && !branchSyncDismissed && (
+      {branchSyncStatus && branchSyncStatus.behindBy > 0 && !branchSyncDismissed && currentSession?.prStatus !== 'merged' && (
         <BranchSyncBanner
           status={branchSyncStatus}
           loading={branchSyncing}

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -254,7 +254,7 @@ export function SessionToolbarContent() {
 
             <div className="w-1.5" />
 
-            {(() => {
+            {selectedSession.prStatus !== 'merged' && (() => {
               const reviewVariant =
                 (selectedSession.hasMergeConflict || selectedSession.hasCheckFailures)
                   ? 'destructive' as const


### PR DESCRIPTION
## Summary

When a session PR has been merged, the app no longer displays the "commits behind" rebase banner or the Review button, as these are irrelevant for completed work.

- Hide BranchSyncBanner when session is merged
- Hide Review button when session is merged

## Changes

- `src/components/conversation/ConversationArea.tsx`: Add `currentSession?.prStatus !== 'merged'` condition
- `src/components/navigation/SessionToolbarContent.tsx`: Wrap Review button with `selectedSession.prStatus !== 'merged'` check