### PR TITLE
feat: Overhaul Budget panel into per-conversation Usage dashboard

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -2021,6 +2021,7 @@ function handleMessage(message: SDKMessage): void {
             maxBudgetUsd,
             maxTurns,
             maxThinkingTokens,
+            effort,
           },
         });
         currentSessionId = initMsg.session_id;

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -47,6 +47,7 @@ import { THINKING_LEVELS, type ThinkingLevel, resolveThinkingParams, clampThinki
 import { useSlashCommandStore, type UnifiedSlashCommand } from '@/stores/slashCommandStore';
 import { SummaryPicker } from './SummaryPicker';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
+import { MODELS as SHARED_MODELS } from '@/lib/models';
 import type { MentionItem } from '@/components/ui/mention-node';
 import { listSessionFiles, type FileNodeDTO } from '@/lib/api';
 
@@ -77,9 +78,9 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
 }
 
 const MODELS = [
-  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', icon: Snowflake, supportsThinking: true, supportsEffort: true, badge: 'NEW' as const },
-  { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5', icon: Snowflake, supportsThinking: true, supportsEffort: false },
-  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', icon: Snowflake, supportsThinking: true, supportsEffort: false },
+  { ...SHARED_MODELS[0], icon: Snowflake, badge: 'NEW' as const },
+  { ...SHARED_MODELS[1], icon: Snowflake },
+  { ...SHARED_MODELS[2], icon: Snowflake },
 ];
 
 

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -11,6 +11,7 @@ import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
 import { StreamingMarkdown } from '@/components/shared/StreamingMarkdown';
 import { cn } from '@/lib/utils';
 import { PROSE_CLASSES } from '@/lib/constants';
+import { getModelInfo } from '@/lib/models';
 
 // Timeline item types for interleaved display
 type TimelineItem =
@@ -165,10 +166,9 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
   const tools = useActiveTools(conversationId);
   const subAgents = useSubAgents(conversationId);
   const clearStreamingText = useAppStore((s) => s.clearStreamingText);
-  const budgetStatus = useAppStore((s) => s.budgetStatus);
-
-  // Check if extended thinking is enabled for this conversation
-  const isExtendedThinkingEnabled = budgetStatus?.maxThinkingTokens !== undefined && budgetStatus.maxThinkingTokens > 0;
+  // Check if extended thinking is enabled based on model capabilities
+  const conversationModel = useAppStore((s) => s.conversations.find(c => c.id === conversationId)?.model);
+  const isExtendedThinkingEnabled = conversationModel ? (getModelInfo(conversationModel)?.supportsThinking ?? false) : false;
 
   const [isApprovedPlanExpanded, setIsApprovedPlanExpanded] = useState(true);
 

--- a/src/components/panels/BudgetStatusPanel.tsx
+++ b/src/components/panels/BudgetStatusPanel.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useBudgetStatus } from '@/stores/selectors';
 import { useAppStore } from '@/stores/appStore';
-import { useSettingsStore } from '@/stores/settingsStore';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { AlertCircle, DollarSign, RefreshCw, Brain, Gauge, ArrowDownToLine, ArrowUpFromLine } from 'lucide-react';
+import { AlertCircle, ArrowDownToLine, ArrowUpFromLine, Gauge } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { formatTokens } from '@/lib/format';
+import { formatTokens, formatCost } from '@/lib/format';
+import { getModelInfo, getModelDisplayName } from '@/lib/models';
 import { EmptyState } from '@/components/ui/empty-state';
+import { useShallow } from 'zustand/react/shallow';
 import type { TokenUsage } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
 
 interface CumulativeTokens {
   input: number;
@@ -20,9 +24,8 @@ interface CumulativeTokens {
 
 const EMPTY_CUMULATIVE: CumulativeTokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
 
-/** Derive cumulative token usage directly from the store to avoid unstable array references. */
 const useCumulativeTokens = (conversationId: string | null): CumulativeTokens =>
-  useAppStore((s) => {
+  useAppStore(useShallow((s) => {
     if (!conversationId) return EMPTY_CUMULATIVE;
     let input = 0, output = 0, cacheRead = 0, cacheWrite = 0;
     for (const msg of s.messages) {
@@ -37,189 +40,204 @@ const useCumulativeTokens = (conversationId: string | null): CumulativeTokens =>
     }
     if (input === 0 && output === 0) return EMPTY_CUMULATIVE;
     return { input, output, cacheRead, cacheWrite, total: input + output };
-  });
+  }));
+
+interface ConversationUsage {
+  model?: string;
+  budgetConfig?: { maxBudgetUsd?: number; maxTurns?: number };
+  thinkingConfig?: { effort?: string; maxThinkingTokens?: number };
+  cost?: number;
+  turns?: number;
+  limitExceeded?: 'budget' | 'turns';
+}
+
+const EMPTY_USAGE: ConversationUsage = {};
+
+const useConversationUsage = (conversationId: string | null): ConversationUsage =>
+  useAppStore(useShallow((s) => {
+    if (!conversationId) return EMPTY_USAGE;
+    const conv = s.conversations.find(c => c.id === conversationId);
+    if (!conv) return EMPTY_USAGE;
+
+    // Walk messages backwards to find the latest runSummary
+    let cost: number | undefined;
+    let turns: number | undefined;
+    let limitExceeded: 'budget' | 'turns' | undefined;
+    for (let i = s.messages.length - 1; i >= 0; i--) {
+      const msg = s.messages[i];
+      if (msg.conversationId !== conversationId) continue;
+      if (msg.runSummary) {
+        cost = msg.runSummary.cost;
+        turns = msg.runSummary.turns;
+        limitExceeded = msg.runSummary.limitExceeded;
+        break;
+      }
+    }
+
+    return {
+      model: conv.model,
+      budgetConfig: conv.budgetConfig,
+      thinkingConfig: conv.thinkingConfig,
+      cost,
+      turns,
+      limitExceeded,
+    };
+  }));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getThinkingDisplay(model?: string, thinkingConfig?: { effort?: string; maxThinkingTokens?: number }): string {
+  const info = model ? getModelInfo(model) : null;
+  if (info?.supportsEffort) {
+    const effort = thinkingConfig?.effort ?? 'high';
+    return effort.charAt(0).toUpperCase() + effort.slice(1);
+  }
+  if (thinkingConfig?.maxThinkingTokens) {
+    return `On (${formatTokens(thinkingConfig.maxThinkingTokens)})`;
+  }
+  return 'Off';
+}
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+function SummaryRow({ label, value, className }: { label: string; value: string; className?: string }) {
+  return (
+    <div className="flex items-center justify-between text-xs">
+      <span className="text-muted-foreground">{label}</span>
+      <span className={cn('font-mono', className)}>{value}</span>
+    </div>
+  );
+}
+
+function ProgressRow({ label, current, max, formatValue }: {
+  label: string; current: number; max: number; formatValue: (v: number) => string;
+}) {
+  const percent = max > 0 ? (current / max) * 100 : 0;
+  const isHigh = percent >= 90;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">{label}</span>
+        <span className={cn('font-mono', isHigh && 'text-destructive')}>
+          {formatValue(current)} / {formatValue(max)}
+          <span className="ml-1.5 text-muted-foreground">{Math.round(percent)}%</span>
+        </span>
+      </div>
+      <div className="h-1 bg-muted rounded-full overflow-hidden">
+        <div
+          className={cn('h-full rounded-full transition-all', isHigh ? 'bg-destructive' : 'bg-primary')}
+          style={{ width: `${Math.min(percent, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
 
 export function BudgetStatusPanel() {
-  const budgetStatus = useBudgetStatus();
-  const showTokenUsage = useSettingsStore((s) => s.showTokenUsage);
   const selectedConversationId = useAppStore((s) => s.selectedConversationId);
-  const cumulativeTokens = useCumulativeTokens(selectedConversationId);
+  const usage = useConversationUsage(selectedConversationId);
+  const tokens = useCumulativeTokens(selectedConversationId);
 
-  // Show empty state when no budget status at all
-  if (!budgetStatus) {
+  const hasData = usage.model || tokens.total > 0 || usage.cost !== undefined;
+
+  if (!hasData) {
     return (
       <div className="h-full flex items-center justify-center">
         <EmptyState
           icon={Gauge}
-          title="No budget tracking"
-          description="Budget limits can be configured when starting a session"
+          title="No usage data yet"
+          description="Start a conversation to see usage metrics"
         />
       </div>
     );
   }
 
-  const {
-    maxBudgetUsd,
-    currentCostUsd,
-    maxTurns,
-    currentTurns,
-    maxThinkingTokens,
-    currentThinkingTokens,
-    limitExceeded,
-  } = budgetStatus;
-
-  // Check if any limits are configured
-  const hasLimits = maxBudgetUsd !== undefined || maxTurns !== undefined || maxThinkingTokens !== undefined;
-  const thinkingEnabled = maxThinkingTokens !== undefined && maxThinkingTokens > 0;
-
-  const budgetPercent = maxBudgetUsd ? (currentCostUsd / maxBudgetUsd) * 100 : 0;
-  const turnsPercent = maxTurns ? (currentTurns / maxTurns) * 100 : 0;
-  const thinkingPercent = maxThinkingTokens ? (currentThinkingTokens / maxThinkingTokens) * 100 : 0;
+  const { model, budgetConfig, thinkingConfig, cost, turns, limitExceeded } = usage;
+  const thinkingDisplay = getThinkingDisplay(model, thinkingConfig);
 
   return (
     <ScrollArea className="h-full">
       <div className="p-3 space-y-3">
-      {limitExceeded && (
-        <div className="flex items-center gap-2 p-2 bg-destructive/10 text-destructive rounded-md text-xs">
-          <AlertCircle className="w-4 h-4 shrink-0" />
-          <span>
-            {limitExceeded === 'budget' && 'Budget limit exceeded'}
-            {limitExceeded === 'turns' && 'Turn limit exceeded'}
-            {limitExceeded === 'thinking_tokens' && 'Thinking token limit exceeded'}
-          </span>
-        </div>
-      )}
-
-      {/* Cost - show with or without limit */}
-      <div className="space-y-1">
-        <div className="flex items-center justify-between text-xs">
-          <div className="flex items-center gap-1 text-muted-foreground">
-            <DollarSign className="w-3 h-3" />
-            <span>Cost</span>
-          </div>
-          {maxBudgetUsd !== undefined ? (
-            <span className={cn(budgetPercent >= 90 && 'text-destructive')}>
-              ${currentCostUsd.toFixed(4)} / ${maxBudgetUsd.toFixed(2)}
+        {/* Limit exceeded alert */}
+        {limitExceeded && (
+          <div className="flex items-center gap-2 p-2 bg-destructive/10 text-destructive rounded-md text-xs">
+            <AlertCircle className="w-4 h-4 shrink-0" />
+            <span>
+              {limitExceeded === 'budget' ? 'Budget limit exceeded' : 'Turn limit exceeded'}
             </span>
-          ) : (
-            <span>${currentCostUsd.toFixed(4)}</span>
-          )}
-        </div>
-        {maxBudgetUsd !== undefined && (
-          <div className="h-1 bg-muted rounded-full overflow-hidden">
-            <div
-              className={cn('h-full rounded-full', budgetPercent >= 90 ? 'bg-destructive' : 'bg-primary')}
-              style={{ width: `${Math.min(budgetPercent, 100)}%` }}
-            />
           </div>
         )}
-      </div>
 
-      {/* Turns - show with or without limit */}
-      <div className="space-y-1">
-        <div className="flex items-center justify-between text-xs">
-          <div className="flex items-center gap-1 text-muted-foreground">
-            <RefreshCw className="w-3 h-3" />
-            <span>Turns</span>
-          </div>
-          {maxTurns !== undefined ? (
-            <span className={cn(turnsPercent >= 90 && 'text-destructive')}>
-              {currentTurns} / {maxTurns}
-            </span>
-          ) : (
-            <span>{currentTurns}</span>
-          )}
-        </div>
-        {maxTurns !== undefined && (
-          <div className="h-1 bg-muted rounded-full overflow-hidden">
-            <div
-              className={cn('h-full rounded-full', turnsPercent >= 90 ? 'bg-destructive' : 'bg-primary')}
-              style={{ width: `${Math.min(turnsPercent, 100)}%` }}
-            />
-          </div>
-        )}
-      </div>
-
-      {/* Cumulative token usage */}
-      {showTokenUsage && cumulativeTokens.total > 0 && (
+        {/* Summary grid */}
         <div className="space-y-1.5">
-          <div className="flex items-center justify-between text-xs">
-            <div className="flex items-center gap-1 text-muted-foreground">
-              <ArrowDownToLine className="w-3 h-3" />
-              <span>Input tokens</span>
-            </div>
-            <span className="font-mono">{formatTokens(cumulativeTokens.input)}</span>
-          </div>
-          <div className="flex items-center justify-between text-xs">
-            <div className="flex items-center gap-1 text-muted-foreground">
-              <ArrowUpFromLine className="w-3 h-3" />
-              <span>Output tokens</span>
-            </div>
-            <span className="font-mono">{formatTokens(cumulativeTokens.output)}</span>
-          </div>
-          {cumulativeTokens.cacheRead > 0 && (
-            <div className="flex items-center justify-between text-xs text-muted-foreground/70">
-              <span className="ml-4">Cache read</span>
-              <span className="font-mono">{formatTokens(cumulativeTokens.cacheRead)}</span>
-            </div>
-          )}
-          {cumulativeTokens.cacheWrite > 0 && (
-            <div className="flex items-center justify-between text-xs text-muted-foreground/70">
-              <span className="ml-4">Cache write</span>
-              <span className="font-mono">{formatTokens(cumulativeTokens.cacheWrite)}</span>
-            </div>
-          )}
+          {model && <SummaryRow label="Model" value={getModelDisplayName(model)} />}
+          <SummaryRow label="Thinking" value={thinkingDisplay} />
+          {cost !== undefined && <SummaryRow label="Cost" value={formatCost(cost)} />}
+          {turns !== undefined && <SummaryRow label="Turns" value={String(turns)} />}
         </div>
-      )}
 
-      {/* Extended Thinking — status card */}
-      <div className={cn(
-        'rounded-lg border p-2.5 space-y-2',
-        thinkingEnabled
-          ? 'border-amber-500/20 bg-amber-500/5'
-          : 'border-border bg-muted/30'
-      )}>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <Brain className={cn(
-              'w-3.5 h-3.5',
-              thinkingEnabled ? 'text-amber-500' : 'text-muted-foreground'
-            )} />
-            <span className="text-xs font-medium">Extended Thinking</span>
-          </div>
-          <span className={cn(
-            'inline-flex items-center rounded-full px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-wider',
-            thinkingEnabled
-              ? 'bg-amber-500/15 text-amber-500'
-              : 'bg-muted text-muted-foreground'
-          )}>
-            {thinkingEnabled ? 'On' : 'Off'}
-          </span>
-        </div>
-        {thinkingEnabled && (
-          <div className="space-y-1.5">
+        {/* Token breakdown */}
+        {tokens.total > 0 && (
+          <div className="space-y-1.5 border-t pt-3">
             <div className="flex items-center justify-between text-xs">
-              <span className="text-muted-foreground">Usage</span>
-              <span className={cn('font-mono', thinkingPercent >= 90 && 'text-destructive')}>
-                {currentThinkingTokens.toLocaleString()} / {maxThinkingTokens.toLocaleString()}
-              </span>
+              <div className="flex items-center gap-1 text-muted-foreground">
+                <ArrowDownToLine className="w-3 h-3" />
+                <span>Input</span>
+              </div>
+              <span className="font-mono">{formatTokens(tokens.input)}</span>
             </div>
-            <div className="h-1 bg-muted rounded-full overflow-hidden">
-              <div
-                className={cn('h-full rounded-full', thinkingPercent >= 90 ? 'bg-destructive' : 'bg-amber-500')}
-                style={{ width: `${Math.min(thinkingPercent, 100)}%` }}
-              />
+            <div className="flex items-center justify-between text-xs">
+              <div className="flex items-center gap-1 text-muted-foreground">
+                <ArrowUpFromLine className="w-3 h-3" />
+                <span>Output</span>
+              </div>
+              <span className="font-mono">{formatTokens(tokens.output)}</span>
             </div>
+            {tokens.cacheRead > 0 && (
+              <div className="flex items-center justify-between text-xs text-muted-foreground/70">
+                <span className="ml-4">Cache read</span>
+                <span className="font-mono">{formatTokens(tokens.cacheRead)}</span>
+              </div>
+            )}
+            {tokens.cacheWrite > 0 && (
+              <div className="flex items-center justify-between text-xs text-muted-foreground/70">
+                <span className="ml-4">Cache write</span>
+                <span className="font-mono">{formatTokens(tokens.cacheWrite)}</span>
+              </div>
+            )}
           </div>
         )}
-      </div>
 
-      {/* Info text when no limits are configured */}
-      {!hasLimits && (
-        <p className="text-xs text-muted-foreground pt-2 border-t">
-          No budget limits configured for this session
-        </p>
-      )}
+        {/* Budget/Turns progress bars — only when limits are configured */}
+        {(budgetConfig?.maxBudgetUsd || budgetConfig?.maxTurns) && (
+          <div className="space-y-2 border-t pt-3">
+            {budgetConfig.maxBudgetUsd != null && (
+              <ProgressRow
+                label="Budget"
+                current={cost ?? 0}
+                max={budgetConfig.maxBudgetUsd}
+                formatValue={formatCost}
+              />
+            )}
+            {budgetConfig.maxTurns != null && (
+              <ProgressRow
+                label="Turns"
+                current={turns ?? 0}
+                max={budgetConfig.maxTurns}
+                formatValue={String}
+              />
+            )}
+          </div>
+        )}
       </div>
     </ScrollArea>
   );

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -647,7 +647,7 @@ export function ChangesPanel() {
                 </ErrorBoundary>
               )}
               {bottomTab === 'budget' && (
-                <ErrorBoundary section="BudgetPanel" fallback={<InlineErrorFallback message="Unable to display budget" />}>
+                <ErrorBoundary section="BudgetPanel" fallback={<InlineErrorFallback message="Unable to display usage" />}>
                   <BudgetStatusPanel />
                 </ErrorBoundary>
               )}
@@ -692,7 +692,7 @@ const BOTTOM_TABS_CONFIG: Record<AllBottomPanelTab, { label: string; alwaysVisib
   todos: { label: 'Tasks', alwaysVisible: true },
   history: { label: 'Checkpoints' },
   'file-history': { label: 'File History' },
-  budget: { label: 'Budget' },
+  budget: { label: 'Usage' },
   mcp: { label: 'MCP' },
   scripts: { label: 'Scripts' },
 };

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import type { WSEvent, AgentEvent, AgentTodoItem, BudgetStatus, UserQuestion, ReviewComment, TokenUsage, ModelUsageInfo, McpServerStatus } from '@/lib/types';
+import type { WSEvent, AgentEvent, AgentTodoItem, UserQuestion, ReviewComment, TokenUsage, ModelUsageInfo, McpServerStatus } from '@/lib/types';
 
 import {
   WEBSOCKET_RECONNECT_BASE_DELAY_MS,
@@ -264,18 +264,12 @@ export function useWebSocket(enabled: boolean = true) {
         }
         // Clear stale input suggestions from the previous turn
         store.clearInputSuggestion(conversationId);
-        // Capture budget configuration from init event
+        // Capture budget/thinking configuration from init event (per-conversation)
         if (event?.budgetConfig) {
-          const config = event.budgetConfig as { maxBudgetUsd?: number; maxTurns?: number; maxThinkingTokens?: number };
-          // Initialize budget status with max values from config
-          const existingStatus = store.budgetStatus;
-          store.setBudgetStatus({
-            maxBudgetUsd: config.maxBudgetUsd,
-            maxTurns: config.maxTurns,
-            maxThinkingTokens: config.maxThinkingTokens,
-            currentCostUsd: existingStatus?.currentCostUsd || 0,
-            currentTurns: existingStatus?.currentTurns || 0,
-            currentThinkingTokens: existingStatus?.currentThinkingTokens || 0,
+          const config = event.budgetConfig;
+          store.updateConversation(conversationId, {
+            budgetConfig: { maxBudgetUsd: config.maxBudgetUsd, maxTurns: config.maxTurns },
+            thinkingConfig: { effort: config.effort, maxThinkingTokens: config.maxThinkingTokens },
           });
         }
         // Sync plan mode state from the agent's initial permission mode.
@@ -458,26 +452,11 @@ export function useWebSocket(enabled: boolean = true) {
             errors: event.errors,
             usage: normalizeUsage(event.usage),
             modelUsage: isModelUsageRecord(event.modelUsage) ? event.modelUsage : undefined,
+            limitExceeded: event.subtype === 'error_max_budget_usd' ? 'budget' as const
+                         : event.subtype === 'error_max_turns' ? 'turns' as const
+                         : undefined,
           },
         });
-        // Update budget status from result event, preserving max values
-        if (event.cost !== undefined) {
-          const existingStatus = freshStore.budgetStatus;
-          const budgetStatus: BudgetStatus = {
-            // Preserve max values from init event
-            maxBudgetUsd: existingStatus?.maxBudgetUsd,
-            maxTurns: existingStatus?.maxTurns,
-            maxThinkingTokens: existingStatus?.maxThinkingTokens,
-            // Update current values from result
-            currentCostUsd: (event.cost as number) || 0,
-            currentTurns: (event.turns as number) || 0,
-            currentThinkingTokens: existingStatus?.currentThinkingTokens || 0,
-            limitExceeded: event.subtype === 'error_max_budget_usd' ? 'budget'
-                         : event.subtype === 'error_max_turns' ? 'turns'
-                         : undefined,
-          };
-          freshStore.setBudgetStatus(budgetStatus);
-        }
         // Update context meter from reliable result data.
         // This ensures the meter is always updated at the end of each turn, even if
         // the per-message context_usage events were unreliable during streaming.

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -9,6 +9,14 @@ export const formatTokens = (tokens: number) => {
   return tokens.toString();
 };
 
+/** Format a USD cost value as a compact string. */
+export function formatCost(usd: number): string {
+  if (usd === 0) return '$0.00';
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
 // ---------------------------------------------------------------------------
 // Tool duration formatting
 // ---------------------------------------------------------------------------

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,0 +1,15 @@
+export const MODELS = [
+  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', supportsThinking: true, supportsEffort: true },
+  { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5', supportsThinking: true, supportsEffort: false },
+  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', supportsThinking: true, supportsEffort: false },
+] as const;
+
+export type ModelId = (typeof MODELS)[number]['id'];
+
+export function getModelInfo(modelId: string) {
+  return MODELS.find((m) => m.id === modelId);
+}
+
+export function getModelDisplayName(modelId: string): string {
+  return getModelInfo(modelId)?.name ?? modelId;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,6 +58,8 @@ export interface Conversation {
   name: string; // AI-updatable display name
   status: 'active' | 'idle' | 'completed';
   model?: string; // Last-used model (e.g., "claude-opus-4-5-20251101", "claude-sonnet-4-20250514")
+  budgetConfig?: { maxBudgetUsd?: number; maxTurns?: number };
+  thinkingConfig?: { effort?: string; maxThinkingTokens?: number };
   messages: Message[];
   messageCount?: number; // Total messages (set when messages are loaded lazily)
   toolSummary: ToolAction[];
@@ -117,6 +119,7 @@ export interface RunSummary {
   errors?: unknown[];
   usage?: TokenUsage;
   modelUsage?: Record<string, ModelUsageInfo>;
+  limitExceeded?: 'budget' | 'turns';
 }
 
 // Structured metadata extracted from tool results (tool-specific)
@@ -303,6 +306,7 @@ export interface AgentEvent {
     maxBudgetUsd?: number;
     maxTurns?: number;
     maxThinkingTokens?: number;
+    effort?: string;
   };
 
   // Extended result fields
@@ -551,17 +555,6 @@ export interface CheckpointInfo {
   messageIndex: number;
   isResult?: boolean;
   conversationId?: string;
-}
-
-// Budget and limits status
-export interface BudgetStatus {
-  maxBudgetUsd?: number;
-  currentCostUsd: number;
-  maxTurns?: number;
-  currentTurns: number;
-  maxThinkingTokens?: number;
-  currentThinkingTokens: number;
-  limitExceeded?: 'budget' | 'turns' | 'thinking_tokens';
 }
 
 // Context window usage tracking

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -13,7 +13,6 @@ import type {
   McpServerStatus,
   McpServerConfig,
   CheckpointInfo,
-  BudgetStatus,
   ContextUsage,
   ToolUsage,
   RunSummary,
@@ -194,7 +193,6 @@ interface AppState {
 
   // Checkpoint timeline state
   checkpoints: CheckpointInfo[];
-  budgetStatus: BudgetStatus | null;
 
   // Context window usage (keyed by conversationId)
   contextUsage: { [conversationId: string]: ContextUsage };
@@ -394,7 +392,6 @@ interface AppState {
   setCheckpoints: (checkpoints: CheckpointInfo[]) => void;
   addCheckpoint: (checkpoint: CheckpointInfo) => void;
   clearCheckpoints: () => void;
-  setBudgetStatus: (status: BudgetStatus | null) => void;
 
   // Context usage actions
   setContextUsage: (conversationId: string, usage: Partial<ContextUsage>) => void;
@@ -454,7 +451,6 @@ export const useAppStore = create<AppState>((set, get) => ({
   mcpConfigLoading: false,
   mcpToolsByServer: {},
   checkpoints: [],
-  budgetStatus: null,
   contextUsage: {},
   reviewComments: {},
   branchSyncStatus: {},
@@ -1781,7 +1777,6 @@ updateFileTabContent: (id, content) => set((state) => ({
     checkpoints: [...state.checkpoints, checkpoint]
   })),
   clearCheckpoints: () => set({ checkpoints: [] }),
-  setBudgetStatus: (budgetStatus) => set({ budgetStatus }),
 
   // Context usage actions
   setContextUsage: (conversationId, usage) => set((state) => {

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -312,12 +312,6 @@ export const useTotalCost = () => useAppStore((s) => s.totalCost);
 export const useFileChanges = () => useAppStore((s) => s.fileChanges);
 
 /**
- * Budget status.
- * Use in: BudgetDisplay
- */
-export const useBudgetStatus = () => useAppStore((s) => s.budgetStatus);
-
-/**
  * Checkpoints.
  * Use in: CheckpointTimeline
  *


### PR DESCRIPTION
## Summary

- **Fixes thinking always showing "Off" for Opus 4.6** — Opus uses `effort` (adaptive thinking), not `maxThinkingTokens`. The panel now correctly displays the effort level (e.g. "High", "Low", "Max").
- **Fixes thinking tokens always showing 0** — `currentThinkingTokens` was never updated from SDK results. Removed the broken thinking token progress bar entirely; the panel now shows actual cumulative token usage from `runSummary`.
- **Fixes stale data when switching conversations** — Replaced global `budgetStatus` singleton with per-conversation `budgetConfig`/`thinkingConfig` stored on the `Conversation` type. Usage data (cost, turns, limitExceeded) is derived from per-conversation `runSummary` messages.
- **Renames tab from "Budget" to "Usage"** with a compact dashboard layout showing model, thinking mode, cost, turns, token breakdown, and progress bars (only when limits are configured).
- **Extracts shared `MODELS` array** to `src/lib/models.ts` for reuse across `ChatInput`, `StreamingMessage`, and `UsagePanel`.

## Files changed

| File | Change |
|------|--------|
| `agent-runner/src/index.ts` | Add `effort` to init event budgetConfig |
| `src/lib/types.ts` | Add `budgetConfig`/`thinkingConfig` to Conversation, `limitExceeded` to RunSummary, `effort` to AgentEvent, delete `BudgetStatus` |
| `src/lib/models.ts` | **New** — shared MODELS array + `getModelInfo`/`getModelDisplayName` |
| `src/lib/format.ts` | Add `formatCost()` utility |
| `src/stores/appStore.ts` | Remove `budgetStatus` state + `setBudgetStatus` action |
| `src/stores/selectors.ts` | Remove `useBudgetStatus` selector |
| `src/hooks/useWebSocket.ts` | Per-conversation init/result handling; remove global budget updates |
| `src/components/panels/BudgetStatusPanel.tsx` | Full rewrite as per-conversation Usage dashboard |
| `src/components/panels/ChangesPanel.tsx` | Tab label "Budget" → "Usage", error fallback updated |
| `src/components/conversation/StreamingMessage.tsx` | Fix thinking detection to use model capabilities |
| `src/components/conversation/ChatInput.tsx` | Import MODELS from shared module |

## Test plan

- [ ] `npm run lint` — passes
- [ ] `npm run build` — compiles clean
- [ ] `make dev` → open a session → verify Usage tab shows model, thinking, cost, turns, tokens after agent runs
- [ ] Switch between conversations → verify data updates per-conversation
- [ ] Test with Opus 4.6 session → verify thinking shows effort level (e.g. "High"), not "Off"
- [ ] Test with Sonnet session with thinking off → verify thinking shows "Off"
- [ ] Test with budget/turn limits configured → verify progress bars appear
- [ ] Test empty state (no conversation selected) → verify "No usage data yet" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)