### PR TITLE
fix: Preserve PR data when session transitions to Done

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -323,6 +323,11 @@ func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry) 
 
 // checkSessionPR checks and updates PR status for a single session
 func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, branchToPR map[string]*github.PRListItem) {
+	// Terminal states are final — don't re-evaluate
+	if entry.PRStatus == models.PRStatusMerged || entry.PRStatus == models.PRStatusClosed {
+		return
+	}
+
 	pr, hasPR := branchToPR[entry.Branch]
 
 	// Determine new status based on current state and PR existence
@@ -370,6 +375,14 @@ func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, bran
 				}
 				prNumber = entry.PRNumber
 				prUrl = details.HTMLURL
+			} else {
+				// PR not in open list but details say it's still open.
+				// This can happen due to GitHub API eventual consistency.
+				// Carry forward existing data to avoid wiping PR association.
+				newStatus = entry.PRStatus
+				prNumber = entry.PRNumber
+				prUrl = entry.PRUrl
+				checkStatus = entry.CheckStatus
 			}
 		} else {
 			// Couldn't fetch details - check merge endpoint directly


### PR DESCRIPTION
## Summary

Fixed PR badges disappearing from sessions when they move to Done status. The issue was caused by a fall-through path in `pr_watcher.checkSessionPR` that left PR variables at zero values, which were then written to the database and broadcast to the frontend.

## Changes

- Added early return for terminal PR states (merged/closed) to skip re-evaluation and prevent accidental overwrites
- Added explicit handling for eventual consistency edge case where a PR disappears from the open list but `GetPRDetails` still shows it as open, now carries forward existing PR data instead of wiping it

## Testing

- ✅ Backend builds successfully (`go build ./...`)
- ✅ All 12 backend test suites pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)