### PR TITLE
fix: Stop infinite polling loop in ChangesPanel

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -137,7 +137,7 @@ export function ChangesPanel() {
       const data = await getSessionChanges(selectedWorkspaceId, selectedSessionId);
       setChanges(data || []);
 
-      // Update session stats in the store
+      // Update session stats in the store (only when changed to avoid re-render loop)
       if (data && data.length > 0) {
         const stats = data.reduce(
           (acc, change) => ({
@@ -146,10 +146,16 @@ export function ChangesPanel() {
           }),
           { additions: 0, deletions: 0 }
         );
-        updateSession(selectedSessionId, { stats });
+        const currentStats = useAppStore.getState().sessions.find(s => s.id === selectedSessionId)?.stats;
+        if (!currentStats || currentStats.additions !== stats.additions || currentStats.deletions !== stats.deletions) {
+          updateSession(selectedSessionId, { stats });
+        }
       } else {
-        // Clear stats if no changes
-        updateSession(selectedSessionId, { stats: undefined });
+        // Clear stats if no changes (only if currently set)
+        const currentStats = useAppStore.getState().sessions.find(s => s.id === selectedSessionId)?.stats;
+        if (currentStats !== undefined) {
+          updateSession(selectedSessionId, { stats: undefined });
+        }
       }
     } catch (error) {
       console.error('Failed to fetch changes:', error);
@@ -488,14 +494,19 @@ export function ChangesPanel() {
     debouncedFetchChanges();
   }, [sessionStats, selectedWorkspaceId, selectedSessionId, debouncedFetchChanges]);
 
-  // Polling fallback — catch changes that event-driven paths might miss
+  // Polling fallback — catch changes that event-driven paths might miss (active sessions only)
+  const selectedSessionStatus = useAppStore((s) => {
+    if (!selectedSessionId) return undefined;
+    return s.sessions.find((sess) => sess.id === selectedSessionId)?.status;
+  });
   useEffect(() => {
     if (!selectedWorkspaceId || !selectedSessionId) return;
+    if (selectedSessionStatus !== 'active') return;
     const interval = setInterval(() => {
       fetchChanges();
     }, 30_000);
     return () => clearInterval(interval);
-  }, [selectedWorkspaceId, selectedSessionId, fetchChanges]);
+  }, [selectedWorkspaceId, selectedSessionId, selectedSessionStatus, fetchChanges]);
 
   const unresolvedCount = useMemo(
     () => reviewComments.filter((c) => !c.resolved).length,


### PR DESCRIPTION
## Summary

- **Compare stats before writing to store**: `fetchChanges()` was creating a new `stats` object reference on every call, even when values were unchanged. This triggered a Zustand re-render → `useEffect` → `debouncedFetchChanges` feedback loop (~2 API calls/sec). Now skips `updateSession` when `additions`/`deletions` haven't changed.
- **Gate 30s polling on session activity**: The polling fallback interval now only runs for `active` sessions. Idle/done/error sessions rely on event-driven refetches (file changes, WebSocket stats updates) which still work for all states.

## Test plan

- [ ] `npm run lint && npm run build` passes
- [ ] Open app with idle/done sessions → verify no rapid `GET /changes` or `GET /branch-commits` polling in backend logs
- [ ] Start a session → changes tab still updates during active use
- [ ] Session completes → polling stops, no continued requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)