### PR TITLE
fix: Eliminate sidebar tab rendering flash and reduce background polling

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -395,15 +395,15 @@ export function ChangesPanel() {
     }
   }, [selectedWorkspaceId, selectedSessionId, updateReviewComment]);
 
-  // Fetch files from session's worktree when session changes or tab switches to files
-  // Deferred via requestIdleCallback so it doesn't block the main conversation render on navigation
+  // Fetch files from session's worktree when session changes.
+  // Decoupled from tab visibility so data is ready when the user switches tabs.
+  // Debounced to avoid redundant API calls when rapidly switching sessions.
   useEffect(() => {
-    if (selectedTab === 'files' && selectedWorkspaceId && selectedSessionId) {
+    if (selectedWorkspaceId && selectedSessionId) {
       let cancelled = false;
-      const schedule = () => {
-        if (cancelled) return;
-        setFilesLoading(true);
-        setFilesError(null);
+      setFilesLoading(true);
+      setFilesError(null);
+      const timeout = setTimeout(() => {
         listSessionFiles(selectedWorkspaceId, selectedSessionId, 'all')
           .then((data) => {
             if (!cancelled) setFiles(data as FileNode[]);
@@ -415,29 +415,23 @@ export function ChangesPanel() {
               } else {
                 setFilesError('error');
               }
+              console.error(err);
             }
-            console.error(err);
           })
           .finally(() => { if (!cancelled) setFilesLoading(false); });
-      };
-      if (typeof requestIdleCallback === 'function') {
-        const id = requestIdleCallback(schedule, { timeout: 3000 });
-        return () => { cancelled = true; cancelIdleCallback(id); };
-      } else {
-        const id = setTimeout(schedule, 150);
-        return () => { cancelled = true; clearTimeout(id); };
-      }
+      }, 150);
+      return () => { cancelled = true; clearTimeout(timeout); };
     }
-  }, [selectedTab, selectedWorkspaceId, selectedSessionId]);
+  }, [selectedWorkspaceId, selectedSessionId]);
 
-  // Fetch changes and branch commits when session changes, tab switches to changes, or branch is renamed
-  // Deferred via requestIdleCallback so it doesn't block the main conversation render on navigation
+  // Fetch changes and branch commits when session changes or branch is renamed.
+  // Decoupled from tab visibility so data is ready when the user switches tabs.
+  // Debounced to avoid redundant API calls when rapidly switching sessions.
   useEffect(() => {
-    if (selectedTab === 'changes' && selectedWorkspaceId && selectedSessionId) {
+    if (selectedWorkspaceId && selectedSessionId) {
       let cancelled = false;
-      const schedule = () => {
-        if (cancelled) return;
-        setChangesLoading(true);
+      setChangesLoading(true);
+      const timeout = setTimeout(() => {
         Promise.all([
           getSessionChanges(selectedWorkspaceId, selectedSessionId),
           getSessionBranchCommits(selectedWorkspaceId, selectedSessionId),
@@ -450,16 +444,10 @@ export function ChangesPanel() {
           })
           .catch(console.error)
           .finally(() => { if (!cancelled) setChangesLoading(false); });
-      };
-      if (typeof requestIdleCallback === 'function') {
-        const id = requestIdleCallback(schedule, { timeout: 3000 });
-        return () => { cancelled = true; cancelIdleCallback(id); };
-      } else {
-        const id = setTimeout(schedule, 150);
-        return () => { cancelled = true; clearTimeout(id); };
-      }
+      }, 150);
+      return () => { cancelled = true; clearTimeout(timeout); };
     }
-  }, [selectedTab, selectedWorkspaceId, selectedSessionId, currentBranch, currentTargetBranch]);
+  }, [selectedWorkspaceId, selectedSessionId, currentBranch, currentTargetBranch]);
 
   // Refetch changes when branch sync completes (rebase/merge)
   useEffect(() => {
@@ -545,8 +533,9 @@ export function ChangesPanel() {
       >
         {/* File List */}
         <ResizablePanel id="file-list" defaultSize="65%" minSize="20%" className="overflow-hidden">
-          {selectedTab === 'files' ? (
-            filesLoading ? (
+          {/* All panels stay mounted; CSS visibility toggling prevents unmount/remount flash */}
+          <div className={cn("h-full", selectedTab !== 'files' && 'hidden')}>
+            {filesLoading && files.length === 0 ? (
               <div className="h-full flex items-center justify-center">
                 <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
               </div>
@@ -577,9 +566,10 @@ export function ChangesPanel() {
                   />
                 </ErrorBoundary>
               </div>
-            )
-          ) : selectedTab === 'changes' ? (
-            changesLoading ? (
+            )}
+          </div>
+          <div className={cn("h-full", selectedTab !== 'changes' && 'hidden')}>
+            {changesLoading && !changes?.length && !branchCommits?.length ? (
               <div className="h-full flex items-center justify-center">
                 <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
               </div>
@@ -677,23 +667,18 @@ export function ChangesPanel() {
                   )}
                 </div>
               </ScrollArea>
-            )
-          ) : selectedTab === 'review' ? (
+            )}
+          </div>
+          <div className={cn("h-full", selectedTab !== 'review' && 'hidden')}>
             <ErrorBoundary section="ReviewPanel" fallback={<InlineErrorFallback message="Unable to display review" />}>
               <ReviewPanel workspaceId={selectedWorkspaceId} sessionId={selectedSessionId} onFileSelect={handleFileSelect} onSendFeedback={handleSendFeedback} showResolved={showResolved} />
             </ErrorBoundary>
-          ) : selectedTab === 'checks' ? (
+          </div>
+          <div className={cn("h-full", selectedTab !== 'checks' && 'hidden')}>
             <ErrorBoundary section="ChecksPanel" fallback={<InlineErrorFallback message="Unable to display checks" />}>
-              <ChecksPanel ref={checksPanelRef} onSendMessage={handleGitActionMessage} onPrUrlChange={setPrUrl} />
+              <ChecksPanel ref={checksPanelRef} onSendMessage={handleGitActionMessage} onPrUrlChange={setPrUrl} active={selectedTab === 'checks'} />
             </ErrorBoundary>
-          ) : (
-            <div className="h-full flex items-center justify-center">
-              <div className="text-center text-muted-foreground">
-                <FileText className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                <p className="text-sm">No content</p>
-              </div>
-            </div>
-          )}
+          </div>
         </ResizablePanel>
 
         <ResizableHandle direction="vertical" />

--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -43,6 +43,7 @@ import {
 interface ChecksPanelProps {
   onSendMessage?: (content: string) => void;
   onPrUrlChange?: (url: string | null) => void;
+  active?: boolean;
 }
 
 export interface ChecksPanelHandle {
@@ -145,7 +146,7 @@ function computeMergeReadiness(
 // Main component
 // ---------------------------------------------------------------------------
 
-export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(function ChecksPanel({ onSendMessage, onPrUrlChange }, ref) {
+export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(function ChecksPanel({ onSendMessage, onPrUrlChange, active = true }, ref) {
   const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
 
   // Get session's prStatus from store to pass to usePRStatus hook
@@ -159,7 +160,8 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
   const { prDetails, loading: prLoading, refetch: refetchPR } = usePRStatus(
     selectedWorkspaceId,
     selectedSessionId,
-    prStatus
+    prStatus,
+    active
   );
   const {
     runs,
@@ -168,10 +170,11 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
     getJobs,
     rerunWorkflow,
     analyzeFailure,
-  } = useCIRuns(selectedWorkspaceId, selectedSessionId);
+  } = useCIRuns(selectedWorkspaceId, selectedSessionId, active);
   const { status: gitStatus, loading: gitLoading, refetch: refetchGit } = useGitStatus(
     selectedWorkspaceId,
-    selectedSessionId
+    selectedSessionId,
+    active
   );
 
   // Compute merge readiness
@@ -240,7 +243,7 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
             </span>
           </div>
           <div className="px-1.5 pb-2">
-            <GitStatusSection onSendMessage={onSendMessage} />
+            <GitStatusSection onSendMessage={onSendMessage} active={active} />
           </div>
         </div>
       </div>

--- a/src/components/panels/GitStatusSection.tsx
+++ b/src/components/panels/GitStatusSection.tsx
@@ -323,11 +323,12 @@ function buildStatusItems(
 
 interface GitStatusSectionProps {
   onSendMessage?: (content: string) => void;
+  active?: boolean;
 }
 
-export function GitStatusSection({ onSendMessage }: GitStatusSectionProps) {
+export function GitStatusSection({ onSendMessage, active = true }: GitStatusSectionProps) {
   const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
-  const { status, loading, error, errorCode, refetch } = useGitStatus(selectedWorkspaceId, selectedSessionId);
+  const { status, loading, error, errorCode, refetch } = useGitStatus(selectedWorkspaceId, selectedSessionId, active);
 
   // Wrapper that handles missing callback
   const sendMessage = (content: string) => {

--- a/src/hooks/useCIRuns.ts
+++ b/src/hooks/useCIRuns.ts
@@ -36,7 +36,8 @@ interface UseCIRunsResult {
  */
 export function useCIRuns(
   workspaceId: string | null,
-  sessionId: string | null
+  sessionId: string | null,
+  active: boolean = true
 ): UseCIRunsResult {
   const [runs, setRuns] = useState<WorkflowRunDTO[]>([]);
   const [loading, setLoading] = useState(false);
@@ -154,14 +155,14 @@ export function useCIRuns(
 
   // Periodic polling when there are in-progress runs
   useEffect(() => {
-    if (!workspaceId || !sessionId || !hasInProgressRuns) return;
+    if (!active || !workspaceId || !sessionId || !hasInProgressRuns) return;
 
     const interval = setInterval(() => {
       fetchRuns();
     }, CI_POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [workspaceId, sessionId, hasInProgressRuns, fetchRuns]);
+  }, [active, workspaceId, sessionId, hasInProgressRuns, fetchRuns]);
 
   return {
     runs,

--- a/src/hooks/useGitStatus.ts
+++ b/src/hooks/useGitStatus.ts
@@ -25,7 +25,8 @@ interface UseGitStatusResult {
  */
 export function useGitStatus(
   workspaceId: string | null,
-  sessionId: string | null
+  sessionId: string | null,
+  active: boolean = true
 ): UseGitStatusResult {
   const [status, setStatus] = useState<GitStatusDTO | null>(null);
   const [loading, setLoading] = useState(true);
@@ -119,7 +120,7 @@ export function useGitStatus(
 
   // Periodic polling
   useEffect(() => {
-    if (!workspaceId || !sessionId) return;
+    if (!active || !workspaceId || !sessionId) return;
 
     const interval = setInterval(() => {
       if (!permanentErrorRef.current) {
@@ -128,15 +129,15 @@ export function useGitStatus(
     }, GIT_STATUS_POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [workspaceId, sessionId, fetchStatus]);
+  }, [active, workspaceId, sessionId, fetchStatus]);
 
   // React to file change events from centralized store
   useEffect(() => {
-    if (!workspaceId || !lastFileChange) return;
+    if (!active || !workspaceId || !lastFileChange) return;
     if (lastFileChange.workspaceId === workspaceId) {
       debouncedRefetch();
     }
-  }, [lastFileChange, workspaceId, debouncedRefetch]);
+  }, [active, lastFileChange, workspaceId, debouncedRefetch]);
 
   return { status, loading, error, errorCode, refetch };
 }

--- a/src/hooks/usePRStatus.ts
+++ b/src/hooks/usePRStatus.ts
@@ -23,7 +23,8 @@ interface UsePRStatusResult {
 export function usePRStatus(
   workspaceId: string | null,
   sessionId: string | null,
-  prStatus: string | undefined
+  prStatus: string | undefined,
+  active: boolean = true
 ): UsePRStatusResult {
   const [prDetails, setPRDetails] = useState<PRDetails | null>(null);
   const [loading, setLoading] = useState(false);
@@ -90,14 +91,14 @@ export function usePRStatus(
 
   // Slow fallback poll when PR is open (WebSocket is the primary update mechanism)
   useEffect(() => {
-    if (!workspaceId || !sessionId || prStatus !== 'open') return;
+    if (!active || !workspaceId || !sessionId || prStatus !== 'open') return;
 
     const interval = setInterval(() => {
       fetchStatus();
     }, PR_STATUS_FALLBACK_POLL_MS);
 
     return () => clearInterval(interval);
-  }, [workspaceId, sessionId, prStatus, fetchStatus]);
+  }, [active, workspaceId, sessionId, prStatus, fetchStatus]);
 
   return { prDetails, loading, error, refetch };
 }


### PR DESCRIPTION
## Summary
- Switch ChangesPanel tab content from conditional rendering to CSS `hidden` class toggling, keeping all panels mounted to prevent unmount/remount flash when switching tabs
- Decouple data fetching from tab visibility so files/changes data is pre-loaded before the user switches tabs
- Add 150ms debounce to files and changes fetch effects to prevent redundant API calls when rapidly switching sessions
- Thread an `active` prop through ChecksPanel into its polling hooks (`usePRStatus`, `useCIRuns`, `useGitStatus`, `GitStatusSection`) so they pause polling when the Checks tab is hidden — avoids unnecessary background network traffic
- Fix `console.error` leaking past the cancellation guard in the files fetch error handler

## Test plan
- [ ] Switch between Files, Changes, Review, and Checks tabs — verify no flash/loading spinner on revisit
- [ ] Rapidly click between sessions — verify no burst of redundant API calls (check network tab)
- [ ] Open Checks tab — verify polling resumes (CI runs refresh, git status updates)
- [ ] Switch away from Checks tab — verify polling stops (no periodic network requests for CI/git/PR)
- [ ] Verify sidebar PR badges and toolbar status still update in real-time via WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)