### PR TITLE
fix: Prevent archived sessions from rendering on app restart

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -612,7 +612,7 @@ export default function Home() {
         const workspaceValid = hasPersistedTab && activeTab.selectedWorkspaceId &&
           mappedWorkspaces.some(w => w.id === activeTab.selectedWorkspaceId);
         const sessionValid = hasPersistedTab && activeTab.selectedSessionId &&
-          allSessions.some(s => s.id === activeTab.selectedSessionId);
+          allSessions.some(s => s.id === activeTab.selectedSessionId && !s.archived);
         // Only validate conversation if its session is also valid
         const conversationValid = sessionValid && activeTab.selectedConversationId &&
           allConversations.some(c => c.id === activeTab.selectedConversationId);
@@ -633,7 +633,7 @@ export default function Home() {
             selectWorkspace(activeTab.selectedWorkspaceId);
             // If workspace is valid but session is stale, select first available session in this workspace
             if (!sessionValid) {
-              const fallbackSession = allSessions.find(s => s.workspaceId === activeTab.selectedWorkspaceId);
+              const fallbackSession = allSessions.find(s => s.workspaceId === activeTab.selectedWorkspaceId && !s.archived);
               if (fallbackSession) selectSession(fallbackSession.id);
             }
           }
@@ -644,7 +644,7 @@ export default function Home() {
         } else if (mappedWorkspaces.length > 0) {
           // First launch — select first workspace and session
           selectWorkspace(mappedWorkspaces[0].id);
-          const firstSession = allSessions.find(s => s.workspaceId === mappedWorkspaces[0].id);
+          const firstSession = allSessions.find(s => s.workspaceId === mappedWorkspaces[0].id && !s.archived);
           if (firstSession) {
             // Create a placeholder conversation if none exist for this session
             const sessionConvs = allConversations.filter(c => c.sessionId === firstSession.id);

--- a/src/hooks/useArchiveSession.ts
+++ b/src/hooks/useArchiveSession.ts
@@ -1,6 +1,8 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { useTabStore } from '@/stores/tabStore';
+import { ENABLE_BROWSER_TABS } from '@/lib/constants';
 import { updateSession as updateSessionApi, getGitStatus } from '@/lib/api';
 import type { ArchiveSessionDialogGitStatus } from '@/components/dialogs/ArchiveSessionDialog';
 
@@ -57,6 +59,16 @@ export function useArchiveSession(options?: {
           // Session was archived normally
           archiveSession(sessionId);
         }
+
+        // Sync updated selection to tabStore so persisted state doesn't reference archived/removed session
+        if (ENABLE_BROWSER_TABS) {
+          const { selectedSessionId, selectedConversationId } = useAppStore.getState();
+          useTabStore.getState().updateActiveTab({
+            selectedSessionId,
+            selectedConversationId,
+          });
+        }
+
         onSuccessRef.current?.();
       } catch (error) {
         console.error('Failed to archive session:', error);


### PR DESCRIPTION
## Summary

When archiving the last session in a workspace and restarting the app, the archived session's content would still render in the main area (though correctly hidden from the sidebar). This was caused by two state management gaps:

1. **`archiveSession()` didn't sync to `tabStore`** — The appStore cleared the selected session, but the persisted `tabStore` (localStorage) retained the archived session ID
2. **Startup validation didn't check `archived` flag** — The session validation only verified ID existence, not whether the session was archived. Since the backend returns all sessions including archived ones, validation would pass and the archived session would be restored

## Changes

- Add `!s.archived` checks to session validation and fallback lookups in `src/app/page.tsx` (3 locations)
- Sync updated selection state to `tabStore` after archiving/removing sessions in `src/hooks/useArchiveSession.ts`

## Testing

1. Archive all sessions in a workspace one by one
2. Verify the main area shows EmptyView (not stale session content)
3. Quit and restart the app
4. Verify EmptyView is still shown, not the archived session

🤖 Generated with Claude Code