### PR TITLE
fix: Preserve plan mode state across conversation process restarts

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1033,7 +1033,7 @@ func (m *Manager) handleConversationCompletion(convID string, proc *Process) {
 }
 
 // SendConversationMessage sends a follow-up message to an existing conversation
-func (m *Manager) SendConversationMessage(ctx context.Context, convID, message string, attachments []models.Attachment) error {
+func (m *Manager) SendConversationMessage(ctx context.Context, convID, message string, attachments []models.Attachment, planMode *bool) error {
 	// Track whether we should generate a title (set in the idle-start path)
 	var shouldGenerateTitle bool
 	var titleSessionID string
@@ -1107,6 +1107,13 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 		}
 		if restartOpts.ResumeSession == "" && conv.AgentSessionID != "" {
 			restartOpts.ResumeSession = conv.AgentSessionID
+		}
+
+		// Apply plan mode override from the message request. This covers the
+		// edge case where the process was fully removed from the map (so
+		// SetConversationPlanMode had no process to update).
+		if planMode != nil {
+			restartOpts.PlanMode = *planMode
 		}
 
 		// Check if we should generate a title for this session
@@ -1236,8 +1243,16 @@ func (m *Manager) SetConversationPlanMode(convID string, enabled bool) error {
 	proc, ok := m.convProcesses[convID]
 	m.mu.RUnlock()
 
-	if !ok || proc.IsStopped() || !proc.IsRunning() {
-		return fmt.Errorf("conversation process not running: %s", convID)
+	if !ok {
+		// Process fully cleaned up — return success; plan mode
+		// will be sent with the next message via planMode field.
+		return nil
+	}
+
+	if proc.IsStopped() || !proc.IsRunning() {
+		// Process idle — persist in options so restart picks it up
+		proc.SetOptionsPlanMode(enabled)
+		return nil
 	}
 
 	mode := "bypassPermissions"

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -298,7 +298,7 @@ func TestManager_StartConversation_SessionNotFound(t *testing.T) {
 func TestManager_SendConversationMessage_ConversationNotFound(t *testing.T) {
 	manager, _ := setupTestManager(t)
 
-	err := manager.SendConversationMessage(context.Background(), "nonexistent", "hello", nil)
+	err := manager.SendConversationMessage(context.Background(), "nonexistent", "hello", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "conversation not found")
 }
@@ -686,10 +686,10 @@ func TestHandleConversationCompletion_CompletesNormally(t *testing.T) {
 func TestSetConversationPlanMode_NoProcess(t *testing.T) {
 	m, _ := setupTestManager(t)
 
-	// Should fail when no process exists for the conversation
+	// Should succeed gracefully when no process exists (plan mode will be
+	// sent with the next message via planMode field)
 	err := m.SetConversationPlanMode("nonexistent-conv", true)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "conversation process not running")
+	require.NoError(t, err)
 }
 
 func TestSetConversationPlanMode_StoppedProcess(t *testing.T) {
@@ -703,9 +703,11 @@ func TestSetConversationPlanMode_StoppedProcess(t *testing.T) {
 	m.convProcesses["conv-stopped"] = proc
 	m.mu.Unlock()
 
+	// Should succeed and persist plan mode in options for restart
 	err := m.SetConversationPlanMode("conv-stopped", true)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "conversation process not running")
+	require.NoError(t, err)
+	assert.True(t, proc.Options().PlanMode)
+	assert.True(t, proc.IsPlanModeActive())
 }
 
 // ============================================================================

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -751,4 +751,13 @@ func (p *Process) SetPlanModeFromEvent(active bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.planModeActive = active
+	p.opts.PlanMode = active
+}
+
+// SetOptionsPlanMode updates the plan mode in process options so it survives restart.
+func (p *Process) SetOptionsPlanMode(enabled bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.opts.PlanMode = enabled
+	p.planModeActive = enabled
 }

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -941,12 +941,29 @@ func TestProcess_Options_ReturnsOriginal(t *testing.T) {
 func TestProcess_PlanModeFromEvent(t *testing.T) {
 	p := NewProcess("test-plan-event", "/tmp", "conv-plan-event")
 	assert.False(t, p.IsPlanModeActive())
+	assert.False(t, p.Options().PlanMode)
 
 	p.SetPlanModeFromEvent(true)
 	assert.True(t, p.IsPlanModeActive())
+	assert.True(t, p.Options().PlanMode, "opts.PlanMode should sync with planModeActive")
 
 	p.SetPlanModeFromEvent(false)
 	assert.False(t, p.IsPlanModeActive())
+	assert.False(t, p.Options().PlanMode, "opts.PlanMode should sync with planModeActive")
+}
+
+func TestProcess_SetOptionsPlanMode(t *testing.T) {
+	p := NewProcess("test-opts-plan", "/tmp", "conv-opts-plan")
+	assert.False(t, p.IsPlanModeActive())
+	assert.False(t, p.Options().PlanMode)
+
+	p.SetOptionsPlanMode(true)
+	assert.True(t, p.IsPlanModeActive())
+	assert.True(t, p.Options().PlanMode)
+
+	p.SetOptionsPlanMode(false)
+	assert.False(t, p.IsPlanModeActive())
+	assert.False(t, p.Options().PlanMode)
 }
 
 func TestProcess_SetRunningForTest(t *testing.T) {

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -3367,6 +3367,7 @@ type SendConversationMessageRequest struct {
 	Content     string              `json:"content"`
 	Attachments []models.Attachment `json:"attachments"` // File attachments (optional)
 	Model       string              `json:"model"`       // Model override for this message (optional)
+	PlanMode    *bool               `json:"planMode"`    // Plan mode override for restart (optional)
 }
 
 func (h *Handlers) SendConversationMessage(w http.ResponseWriter, r *http.Request) {
@@ -3408,7 +3409,7 @@ func (h *Handlers) SendConversationMessage(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	if err := h.agentManager.SendConversationMessage(ctx, convID, req.Content, req.Attachments); err != nil {
+	if err := h.agentManager.SendConversationMessage(ctx, convID, req.Content, req.Attachments, req.PlanMode); err != nil {
 		writeInternalError(w, "failed to send message", err)
 		return
 	}

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -741,7 +741,7 @@ func TestSetConversationPlanMode_ProcessNotRunning(t *testing.T) {
 	createTestSession(t, s, "sess-1", "ws-1")
 	createTestConversation(t, s, "conv-1", "sess-1")
 
-	// Conversation exists but no process is running
+	// Conversation exists but no process is running — should succeed gracefully
 	body := strings.NewReader(`{"enabled": true}`)
 	req := httptest.NewRequest("POST", "/api/conversations/conv-1/plan-mode", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -750,14 +750,13 @@ func TestSetConversationPlanMode_ProcessNotRunning(t *testing.T) {
 
 	h.SetConversationPlanMode(w, req)
 
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 
-	// Verify JSON error format
-	var apiErr APIError
-	err := json.Unmarshal(w.Body.Bytes(), &apiErr)
+	// Verify success response
+	var resp map[string]bool
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	assert.Equal(t, ErrCodeInternal, apiErr.Code)
-	assert.Equal(t, "failed to set plan mode", apiErr.Error)
+	assert.True(t, resp["enabled"])
 }
 
 // ============================================================================

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -895,7 +895,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           trimmedContent,
           loadedAttachments.length > 0 ? loadedAttachments : undefined,
           modelChanged ? selectedModel.id : undefined,
-          mentionedFiles.length > 0 ? mentionedFiles : undefined
+          mentionedFiles.length > 0 ? mentionedFiles : undefined,
+          planModeEnabled
         );
       }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1016,12 +1016,13 @@ export async function sendConversationMessage(
   content: string,
   attachments?: AttachmentDTO[],
   model?: string,
-  mentionedFiles?: string[]
+  mentionedFiles?: string[],
+  planMode?: boolean
 ): Promise<void> {
   const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/messages`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content, attachments, model, mentionedFiles }),
+    body: JSON.stringify({ content, attachments, model, mentionedFiles, planMode }),
   });
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
## Summary

Fix an issue where toggling plan mode would fail with a 500 error when the agent process had been cleaned up from memory. The fix implements a graceful fallback mechanism by threading the current plan mode state from the frontend through to the backend restart path.

## Changes

- Add optional `planMode` parameter to `SendConversationMessage` to apply UI state during restart
- Make `SetConversationPlanMode` succeed gracefully when process doesn't exist (stores in options for next restart)
- Sync plan mode state to process options for persistence across restart cycles
- Pass `planMode` from frontend through API layer to backend
- Fix bug where `planMode` could not be sent as `false` to the backend

## Testing

Updated all relevant tests to reflect the new graceful behavior, expecting success instead of errors when setting plan mode on missing/stopped processes.