### PR TITLE
feat: Add GitHub OAuth refresh token support for auto-renewal

### DIFF
--- a/backend/github/actions.go
+++ b/backend/github/actions.go
@@ -99,9 +99,9 @@ type githubStep struct {
 
 // ListWorkflowRuns lists workflow runs for a repository, optionally filtered by branch
 func (c *Client) ListWorkflowRuns(ctx context.Context, owner, repo, branch string) ([]WorkflowRun, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	reqURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs?per_page=20", c.apiURL, owner, repo)
@@ -159,9 +159,9 @@ func (c *Client) ListWorkflowRuns(ctx context.Context, owner, repo, branch strin
 
 // GetWorkflowRun fetches a specific workflow run by ID
 func (c *Client) GetWorkflowRun(ctx context.Context, owner, repo string, runID int64) (*WorkflowRun, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	url := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d", c.apiURL, owner, repo, runID)
@@ -216,9 +216,9 @@ func (c *Client) GetWorkflowRun(ctx context.Context, owner, repo string, runID i
 
 // ListWorkflowJobs lists jobs for a workflow run
 func (c *Client) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]WorkflowJob, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	url := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/jobs?per_page=100", c.apiURL, owner, repo, runID)
@@ -302,9 +302,9 @@ func (c *Client) ListWorkflowJobs(ctx context.Context, owner, repo string, runID
 // GetJobLogs fetches logs for a specific job
 // The GitHub API returns a 302 redirect to a temporary URL containing the logs
 func (c *Client) GetJobLogs(ctx context.Context, owner, repo string, jobID int64) (string, error) {
-	token := c.GetToken()
-	if token == "" {
-		return "", fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return "", err
 	}
 
 	url := fmt.Sprintf("%s/repos/%s/%s/actions/jobs/%d/logs", c.apiURL, owner, repo, jobID)
@@ -366,9 +366,9 @@ func (c *Client) GetJobLogs(ctx context.Context, owner, repo string, jobID int64
 
 // RerunWorkflow triggers a re-run of an entire workflow
 func (c *Client) RerunWorkflow(ctx context.Context, owner, repo string, runID int64) error {
-	token := c.GetToken()
-	if token == "" {
-		return fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return err
 	}
 
 	url := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/rerun", c.apiURL, owner, repo, runID)
@@ -398,9 +398,9 @@ func (c *Client) RerunWorkflow(ctx context.Context, owner, repo string, runID in
 
 // RerunFailedJobs re-runs only the failed jobs in a workflow
 func (c *Client) RerunFailedJobs(ctx context.Context, owner, repo string, runID int64) error {
-	token := c.GetToken()
-	if token == "" {
-		return fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return err
 	}
 
 	url := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/rerun-failed-jobs", c.apiURL, owner, repo, runID)

--- a/backend/github/client.go
+++ b/backend/github/client.go
@@ -23,6 +23,15 @@ type User struct {
 	AvatarURL string `json:"avatar_url"`
 }
 
+// TokenSet holds the OAuth token data for GitHub Apps with expiring tokens.
+type TokenSet struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	TokenType    string    `json:"token_type"`
+	Scope        string    `json:"scope"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
 // Client handles GitHub API interactions
 type Client struct {
 	clientID         string
@@ -33,9 +42,11 @@ type Client struct {
 	apiURL           string       // API base URL (api.github.com)
 
 	// In-memory token storage
-	mu    sync.RWMutex
-	token string
-	user  *User
+	mu             sync.RWMutex
+	token          string    // plain token (backward compat for non-expiring tokens)
+	tokens         *TokenSet // token set with refresh support
+	user           *User
+	onTokenRefresh func(*TokenSet) // callback to persist tokens after refresh
 }
 
 // NewClient creates a new GitHub client
@@ -55,9 +66,11 @@ func NewClient(clientID, clientSecret string) *Client {
 	}
 }
 
-// ExchangeCode exchanges an OAuth code for an access token
-// If codeVerifier is provided, it's included for PKCE validation
-func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier string) (string, error) {
+// ExchangeCode exchanges an OAuth code for an access token and optional refresh token.
+// If codeVerifier is provided, it's included for PKCE validation.
+// Returns a TokenSet with refresh token and expiry if the GitHub App has expiring tokens enabled,
+// otherwise returns a TokenSet with only the access token populated (zero ExpiresAt, empty RefreshToken).
+func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier string) (*TokenSet, error) {
 	// Log the exchange attempt (mask sensitive values)
 	hasClientID := c.clientID != ""
 	hasClientSecret := c.clientSecret != ""
@@ -66,10 +79,10 @@ func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier str
 		hasClientID, hasClientSecret, hasCodeVerifier, len(code))
 
 	if !hasClientID {
-		return "", fmt.Errorf("GITHUB_CLIENT_ID not configured")
+		return nil, fmt.Errorf("GITHUB_CLIENT_ID not configured")
 	}
 	if !hasClientSecret {
-		return "", fmt.Errorf("GITHUB_CLIENT_SECRET not configured")
+		return nil, fmt.Errorf("GITHUB_CLIENT_SECRET not configured")
 	}
 
 	data := url.Values{}
@@ -84,7 +97,7 @@ func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier str
 		c.baseURL+"/login/oauth/access_token",
 		strings.NewReader(data.Encode()))
 	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -92,40 +105,56 @@ func (c *Client) ExchangeCode(ctx context.Context, code string, codeVerifier str
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("exchanging code: %w", err)
+		return nil, fmt.Errorf("exchanging code: %w", err)
 	}
 	defer resp.Body.Close()
 
 	// Read body for logging (GitHub returns 200 even on errors)
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("reading response: %w", err)
+		return nil, fmt.Errorf("reading response: %w", err)
 	}
 
 	logger.GitHub.Debugf("OAuth response: status=%d, body_length=%d", resp.StatusCode, len(body))
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
 	}
 
 	var result struct {
-		AccessToken string `json:"access_token"`
-		TokenType   string `json:"token_type"`
-		Scope       string `json:"scope"`
-		Error       string `json:"error"`
-		ErrorDesc   string `json:"error_description"`
+		AccessToken           string `json:"access_token"`
+		RefreshToken          string `json:"refresh_token"`
+		TokenType             string `json:"token_type"`
+		Scope                 string `json:"scope"`
+		ExpiresIn             int64  `json:"expires_in"`               // seconds until access token expires
+		RefreshTokenExpiresIn int64  `json:"refresh_token_expires_in"` // seconds until refresh token expires
+		Error                 string `json:"error"`
+		ErrorDesc             string `json:"error_description"`
 	}
 
 	if err := json.Unmarshal(body, &result); err != nil {
-		return "", fmt.Errorf("decoding response: %w", err)
+		return nil, fmt.Errorf("decoding response: %w", err)
 	}
 
 	if result.Error != "" {
-		return "", fmt.Errorf("GitHub error: %s - %s", result.Error, result.ErrorDesc)
+		return nil, fmt.Errorf("GitHub error: %s - %s", result.Error, result.ErrorDesc)
 	}
 
-	logger.GitHub.Debugf("Token exchange successful, scope=%s", result.Scope)
-	return result.AccessToken, nil
+	tokenSet := &TokenSet{
+		AccessToken:  result.AccessToken,
+		RefreshToken: result.RefreshToken,
+		TokenType:    result.TokenType,
+		Scope:        result.Scope,
+	}
+
+	// If expires_in is present, compute absolute expiration time
+	if result.ExpiresIn > 0 {
+		tokenSet.ExpiresAt = time.Now().Add(time.Duration(result.ExpiresIn) * time.Second)
+	}
+
+	logger.GitHub.Debugf("Token exchange successful, scope=%s, hasRefreshToken=%v, expiresIn=%ds",
+		result.Scope, result.RefreshToken != "", result.ExpiresIn)
+	return tokenSet, nil
 }
 
 // GetUser fetches the authenticated user's profile
@@ -210,6 +239,7 @@ func (c *Client) ClearAuth() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.token = ""
+	c.tokens = nil
 	c.user = nil
 }
 
@@ -217,7 +247,161 @@ func (c *Client) ClearAuth() {
 func (c *Client) IsAuthenticated() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.token != ""
+	return c.token != "" || (c.tokens != nil && c.tokens.AccessToken != "")
+}
+
+// SetOnTokenRefresh sets a callback invoked after a successful token refresh.
+func (c *Client) SetOnTokenRefresh(fn func(*TokenSet)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onTokenRefresh = fn
+}
+
+// SetTokens stores a TokenSet in memory (for expiring tokens with refresh support).
+func (c *Client) SetTokens(tokens *TokenSet) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if tokens == nil {
+		c.tokens = nil
+		c.token = ""
+		return
+	}
+	cp := *tokens
+	c.tokens = &cp
+	c.token = tokens.AccessToken // keep plain token in sync for backward compat
+}
+
+// GetTokens returns a copy of the stored TokenSet.
+func (c *Client) GetTokens() *TokenSet {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.tokens == nil {
+		return nil
+	}
+	cp := *c.tokens
+	return &cp
+}
+
+// RefreshToken refreshes the access token using the refresh token.
+func (c *Client) RefreshToken(ctx context.Context) (*TokenSet, error) {
+	c.mu.RLock()
+	refreshToken := ""
+	if c.tokens != nil {
+		refreshToken = c.tokens.RefreshToken
+	}
+	c.mu.RUnlock()
+
+	if refreshToken == "" {
+		return nil, fmt.Errorf("no refresh token available")
+	}
+
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("client_id", c.clientID)
+	data.Set("client_secret", c.clientSecret)
+	data.Set("refresh_token", refreshToken)
+
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		c.baseURL+"/login/oauth/access_token",
+		strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("refreshing token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		AccessToken           string `json:"access_token"`
+		RefreshToken          string `json:"refresh_token"`
+		TokenType             string `json:"token_type"`
+		Scope                 string `json:"scope"`
+		ExpiresIn             int64  `json:"expires_in"`
+		RefreshTokenExpiresIn int64  `json:"refresh_token_expires_in"`
+		Error                 string `json:"error"`
+		ErrorDesc             string `json:"error_description"`
+	}
+
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if result.Error != "" {
+		return nil, fmt.Errorf("GitHub refresh error: %s - %s", result.Error, result.ErrorDesc)
+	}
+
+	tokens := &TokenSet{
+		AccessToken:  result.AccessToken,
+		RefreshToken: result.RefreshToken,
+		TokenType:    result.TokenType,
+		Scope:        result.Scope,
+	}
+	if result.ExpiresIn > 0 {
+		tokens.ExpiresAt = time.Now().Add(time.Duration(result.ExpiresIn) * time.Second)
+	}
+
+	c.mu.Lock()
+	c.tokens = tokens
+	c.token = tokens.AccessToken
+	callback := c.onTokenRefresh
+	c.mu.Unlock()
+
+	// Persist refreshed tokens
+	if callback != nil {
+		callback(tokens)
+	}
+
+	logger.GitHub.Debugf("Token refresh successful, expiresIn=%ds", result.ExpiresIn)
+	return tokens, nil
+}
+
+// getValidToken returns a valid access token, auto-refreshing if within 5 minutes of expiry.
+// Falls back to plain token if no TokenSet is available (backward compat with non-expiring tokens).
+func (c *Client) getValidToken(ctx context.Context) (string, error) {
+	c.mu.RLock()
+	tokens := c.tokens
+	plainToken := c.token
+	c.mu.RUnlock()
+
+	// If we have a TokenSet with refresh support
+	if tokens != nil {
+		// If ExpiresAt is zero, tokens don't expire (non-expiring OAuth app token)
+		if tokens.ExpiresAt.IsZero() {
+			return tokens.AccessToken, nil
+		}
+		// Refresh if within 5 minutes of expiry
+		if time.Until(tokens.ExpiresAt) < 5*time.Minute {
+			logger.GitHub.Debugf("GitHub token expiring soon, refreshing...")
+			refreshed, err := c.RefreshToken(ctx)
+			if err != nil {
+				return "", fmt.Errorf("auto-refresh failed: %w", err)
+			}
+			return refreshed.AccessToken, nil
+		}
+		return tokens.AccessToken, nil
+	}
+
+	// Fall back to plain token (backward compat)
+	if plainToken != "" {
+		return plainToken, nil
+	}
+
+	return "", fmt.Errorf("not authenticated")
 }
 
 // SetBaseURL sets the OAuth base URL (for testing)
@@ -263,7 +447,7 @@ func (c *Client) GetAvatarByEmail(ctx context.Context, email string) (string, er
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
 	// Use token if available for higher rate limits
-	token := c.GetToken()
+	token, _ := c.getValidToken(ctx)
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
@@ -330,9 +514,9 @@ type CombinedStatus struct {
 
 // CreateCommitStatus posts a status to a commit
 func (c *Client) CreateCommitStatus(ctx context.Context, owner, repo, sha string, status CommitStatus) (*CommitStatusResponse, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	statusURL := fmt.Sprintf("%s/repos/%s/%s/statuses/%s", c.apiURL, owner, repo, sha)
@@ -390,9 +574,9 @@ type CreatePullRequestResponse struct {
 
 // CreatePullRequest creates a new pull request on GitHub
 func (c *Client) CreatePullRequest(ctx context.Context, owner, repo string, pr CreatePullRequestRequest) (*CreatePullRequestResponse, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	prURL := fmt.Sprintf("%s/repos/%s/%s/pulls", c.apiURL, owner, repo)
@@ -432,9 +616,9 @@ func (c *Client) CreatePullRequest(ctx context.Context, owner, repo string, pr C
 
 // GetCombinedStatus gets the combined status for a ref (branch, tag, or SHA)
 func (c *Client) GetCombinedStatus(ctx context.Context, owner, repo, ref string) (*CombinedStatus, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	statusURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/status", c.apiURL, owner, repo, ref)

--- a/backend/github/client_test.go
+++ b/backend/github/client_test.go
@@ -34,12 +34,12 @@ func TestExchangeCode(t *testing.T) {
 	client := NewClient("test_client_id", "test_client_secret")
 	client.baseURL = server.URL // Override for testing
 
-	token, err := client.ExchangeCode(context.Background(), "test_code", "")
+	tokenSet, err := client.ExchangeCode(context.Background(), "test_code", "")
 	if err != nil {
 		t.Fatalf("ExchangeCode failed: %v", err)
 	}
-	if token != "gho_test_token_123" {
-		t.Errorf("Expected token gho_test_token_123, got %s", token)
+	if tokenSet.AccessToken != "gho_test_token_123" {
+		t.Errorf("Expected token gho_test_token_123, got %s", tokenSet.AccessToken)
 	}
 }
 
@@ -648,6 +648,261 @@ func TestClient_CreatePullRequest_NonDraft(t *testing.T) {
 
 	require.NoError(t, err)
 	require.False(t, receivedDraft)
+}
+
+// ============================================================================
+// TokenSet Tests
+// ============================================================================
+
+func TestExchangeCode_WithRefreshToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login/oauth/access_token" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":             "gho_access_token",
+				"refresh_token":            "ghr_refresh_token",
+				"token_type":               "bearer",
+				"scope":                    "repo,read:user",
+				"expires_in":               28800,
+				"refresh_token_expires_in": 15811200,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient("test_client_id", "test_client_secret")
+	client.baseURL = server.URL
+
+	tokenSet, err := client.ExchangeCode(context.Background(), "test_code", "")
+	require.NoError(t, err)
+	require.NotNil(t, tokenSet)
+	require.Equal(t, "gho_access_token", tokenSet.AccessToken)
+	require.Equal(t, "ghr_refresh_token", tokenSet.RefreshToken)
+	require.Equal(t, "bearer", tokenSet.TokenType)
+	require.Equal(t, "repo,read:user", tokenSet.Scope)
+	require.False(t, tokenSet.ExpiresAt.IsZero())
+	// ExpiresAt should be roughly 8 hours from now
+	require.WithinDuration(t, time.Now().Add(28800*time.Second), tokenSet.ExpiresAt, 5*time.Second)
+}
+
+func TestExchangeCode_NoRefreshToken(t *testing.T) {
+	// Non-expiring OAuth App tokens don't include refresh_token or expires_in
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login/oauth/access_token" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"access_token": "gho_plain_token",
+				"token_type":   "bearer",
+				"scope":        "repo",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient("test_client_id", "test_client_secret")
+	client.baseURL = server.URL
+
+	tokenSet, err := client.ExchangeCode(context.Background(), "test_code", "")
+	require.NoError(t, err)
+	require.Equal(t, "gho_plain_token", tokenSet.AccessToken)
+	require.Empty(t, tokenSet.RefreshToken)
+	require.True(t, tokenSet.ExpiresAt.IsZero())
+}
+
+func TestClient_SetTokens_GetTokens(t *testing.T) {
+	client := NewClient("", "")
+
+	require.Nil(t, client.GetTokens())
+
+	tokens := &TokenSet{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		TokenType:    "bearer",
+		ExpiresAt:    time.Now().Add(8 * time.Hour),
+	}
+	client.SetTokens(tokens)
+
+	got := client.GetTokens()
+	require.NotNil(t, got)
+	require.Equal(t, "access", got.AccessToken)
+	require.Equal(t, "refresh", got.RefreshToken)
+
+	// Verify it's a copy
+	tokens.AccessToken = "modified"
+	got2 := client.GetTokens()
+	require.Equal(t, "access", got2.AccessToken)
+
+	// SetTokens keeps plain token in sync
+	require.Equal(t, "access", client.GetToken())
+}
+
+func TestClient_SetTokens_Nil(t *testing.T) {
+	client := NewClient("", "")
+
+	client.SetTokens(&TokenSet{AccessToken: "test"})
+	require.NotNil(t, client.GetTokens())
+
+	client.SetTokens(nil)
+	require.Nil(t, client.GetTokens())
+	require.Empty(t, client.GetToken())
+}
+
+func TestClient_IsAuthenticated_WithTokenSet(t *testing.T) {
+	client := NewClient("", "")
+
+	require.False(t, client.IsAuthenticated())
+
+	client.SetTokens(&TokenSet{AccessToken: "test-access"})
+	require.True(t, client.IsAuthenticated())
+}
+
+func TestClient_ClearAuth_WithTokenSet(t *testing.T) {
+	client := NewClient("", "")
+
+	client.SetTokens(&TokenSet{AccessToken: "test", RefreshToken: "refresh"})
+	client.SetUser(&User{Login: "testuser"})
+
+	require.True(t, client.IsAuthenticated())
+	require.NotNil(t, client.GetTokens())
+
+	client.ClearAuth()
+
+	require.False(t, client.IsAuthenticated())
+	require.Nil(t, client.GetTokens())
+	require.Nil(t, client.GetStoredUser())
+}
+
+func TestClient_RefreshToken_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login/oauth/access_token" {
+			body, _ := io.ReadAll(r.Body)
+			bodyStr := string(body)
+
+			require.Contains(t, bodyStr, "grant_type=refresh_token")
+			require.Contains(t, bodyStr, "refresh_token=old_refresh")
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "new_access",
+				"refresh_token": "new_refresh",
+				"token_type":    "bearer",
+				"scope":         "repo",
+				"expires_in":    28800,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient("test_client_id", "test_client_secret")
+	client.baseURL = server.URL
+	client.SetTokens(&TokenSet{
+		AccessToken:  "old_access",
+		RefreshToken: "old_refresh",
+		ExpiresAt:    time.Now().Add(-1 * time.Hour), // expired
+	})
+
+	var callbackCalled bool
+	client.SetOnTokenRefresh(func(ts *TokenSet) {
+		callbackCalled = true
+		require.Equal(t, "new_access", ts.AccessToken)
+		require.Equal(t, "new_refresh", ts.RefreshToken)
+	})
+
+	refreshed, err := client.RefreshToken(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "new_access", refreshed.AccessToken)
+	require.Equal(t, "new_refresh", refreshed.RefreshToken)
+	require.True(t, callbackCalled)
+
+	// Verify in-memory state was updated
+	require.Equal(t, "new_access", client.GetToken())
+	got := client.GetTokens()
+	require.Equal(t, "new_access", got.AccessToken)
+}
+
+func TestClient_RefreshToken_NoRefreshToken(t *testing.T) {
+	client := NewClient("test_client_id", "test_client_secret")
+	client.SetTokens(&TokenSet{AccessToken: "access"}) // no refresh token
+
+	_, err := client.RefreshToken(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no refresh token available")
+}
+
+func TestClient_getValidToken_PlainToken(t *testing.T) {
+	client := NewClient("", "")
+	client.SetToken("plain-token")
+
+	token, err := client.getValidToken(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "plain-token", token)
+}
+
+func TestClient_getValidToken_NonExpiringTokenSet(t *testing.T) {
+	client := NewClient("", "")
+	client.SetTokens(&TokenSet{
+		AccessToken: "non-expiring",
+		// ExpiresAt is zero — non-expiring
+	})
+
+	token, err := client.getValidToken(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "non-expiring", token)
+}
+
+func TestClient_getValidToken_ValidTokenSet(t *testing.T) {
+	client := NewClient("", "")
+	client.SetTokens(&TokenSet{
+		AccessToken: "still-valid",
+		ExpiresAt:   time.Now().Add(1 * time.Hour), // plenty of time
+	})
+
+	token, err := client.getValidToken(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "still-valid", token)
+}
+
+func TestClient_getValidToken_NotAuthenticated(t *testing.T) {
+	client := NewClient("", "")
+
+	_, err := client.getValidToken(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authenticated")
+}
+
+func TestClient_getValidToken_AutoRefresh(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login/oauth/access_token" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "refreshed_token",
+				"refresh_token": "new_refresh",
+				"token_type":    "bearer",
+				"expires_in":    28800,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient("test_client_id", "test_client_secret")
+	client.baseURL = server.URL
+	client.SetTokens(&TokenSet{
+		AccessToken:  "expiring_soon",
+		RefreshToken: "old_refresh",
+		ExpiresAt:    time.Now().Add(2 * time.Minute), // within 5 minute threshold
+	})
+
+	token, err := client.getValidToken(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "refreshed_token", token)
 }
 
 func TestClient_GetUser_Success_FullFields(t *testing.T) {

--- a/backend/github/issues.go
+++ b/backend/github/issues.go
@@ -131,9 +131,9 @@ func convertToIssueListItem(gh githubIssueListItem) IssueListItem {
 // If etag is non-empty, sends If-None-Match header. Returns ErrNotModified on 304.
 // Filters out pull requests (GitHub's issues endpoint returns both).
 func (c *Client) ListIssuesWithETag(ctx context.Context, owner, repo, state, labels, etag string) (*ListIssuesResult, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if state == "" {
@@ -202,9 +202,9 @@ func (c *Client) ListIssuesWithETag(ctx context.Context, owner, repo, state, lab
 // SearchIssues searches for issues in a repository using the GitHub search API.
 // The query is appended to the repo scope: repo:{owner}/{repo} is:issue {query}
 func (c *Client) SearchIssues(ctx context.Context, owner, repo, query string) (*SearchIssuesResult, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build search query: repo:owner/repo is:issue <user query>
@@ -260,9 +260,9 @@ func (c *Client) SearchIssues(ctx context.Context, owner, repo, query string) (*
 // GetIssue fetches detailed information about a single issue.
 // Returns nil, nil if the issue is not found (404).
 func (c *Client) GetIssue(ctx context.Context, owner, repo string, number int) (*IssueDetails, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	issueURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d", c.apiURL, owner, repo, number)

--- a/backend/github/pr_status.go
+++ b/backend/github/pr_status.go
@@ -73,9 +73,9 @@ type githubCheckRuns struct {
 
 // GetPRDetails fetches detailed information about a pull request including CI status
 func (c *Client) GetPRDetails(ctx context.Context, owner, repo string, prNumber int) (*PRDetails, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Fetch PR details
@@ -242,9 +242,9 @@ type githubPRFull struct {
 // GetPRFullDetails fetches extended pull request information including body, branch refs,
 // labels, reviewers, and diff stats. Used for the "create session from PR" flow.
 func (c *Client) GetPRFullDetails(ctx context.Context, owner, repo string, prNumber int) (*PRFullDetails, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	prURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.apiURL, owner, repo, prNumber)
@@ -404,9 +404,9 @@ func (c *Client) ListOpenPRs(ctx context.Context, owner, repo string) ([]PRListI
 // ListOpenPRsWithETag lists open PRs with ETag support for conditional requests.
 // If etag is non-empty, sends If-None-Match header. Returns ErrNotModified on 304.
 func (c *Client) ListOpenPRsWithETag(ctx context.Context, owner, repo, etag string) (*ListOpenPRsResult, error) {
-	token := c.GetToken()
-	if token == "" {
-		return nil, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Fetch open PRs (includes drafts)
@@ -482,9 +482,9 @@ type githubSearchResult struct {
 
 // FindPRForBranch finds an open PR for a given branch
 func (c *Client) FindPRForBranch(ctx context.Context, owner, repo, branch string) (int, error) {
-	token := c.GetToken()
-	if token == "" {
-		return 0, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return 0, err
 	}
 
 	// Search for PRs with the given head branch
@@ -528,9 +528,9 @@ func (c *Client) FindPRForBranch(ctx context.Context, owner, repo, branch string
 // IsPRMerged checks if a PR was merged using the dedicated GitHub merge endpoint.
 // Returns true if the PR has been merged (HTTP 204), false otherwise (HTTP 404).
 func (c *Client) IsPRMerged(ctx context.Context, owner, repo string, prNumber int) (bool, error) {
-	token := c.GetToken()
-	if token == "" {
-		return false, fmt.Errorf("not authenticated")
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return false, err
 	}
 
 	mergeURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/merge", c.apiURL, owner, repo, prNumber)

--- a/backend/main.go
+++ b/backend/main.go
@@ -125,6 +125,16 @@ func main() {
 	ghConfig := server.LoadGitHubConfig()
 	ghClient := github.NewClient(ghConfig.ClientID, ghConfig.ClientSecret)
 
+	// Set up GitHub token refresh persistence callback
+	ghClient.SetOnTokenRefresh(func(tokens *github.TokenSet) {
+		if err := server.PersistGitHubTokens(ctx, s, tokens); err != nil {
+			logger.GitHub.Errorf("Failed to persist refreshed GitHub tokens: %v", err)
+		}
+	})
+
+	// Restore GitHub auth from persisted settings (uses a temporary AuthHandlers for RestoreFromStore)
+	server.NewAuthHandlers(ghClient, s).RestoreFromStore(ctx)
+
 	// Linear OAuth client
 	linearConfig := server.LoadLinearConfig()
 	linearClient := linear.NewClient(linearConfig.ClientID)

--- a/backend/server/auth_handlers.go
+++ b/backend/server/auth_handlers.go
@@ -2,20 +2,34 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
+	"github.com/chatml/chatml-backend/crypto"
 	"github.com/chatml/chatml-backend/github"
+	"github.com/chatml/chatml-backend/logger"
+	"github.com/chatml/chatml-backend/store"
+)
+
+// Settings keys for encrypted GitHub tokens
+const (
+	settingGitHubAccessToken  = "github-access-token"
+	settingGitHubRefreshToken = "github-refresh-token"
+	settingGitHubTokenExpiry  = "github-token-expiry"
+	settingGitHubUser         = "github-user"
 )
 
 // AuthHandlers handles authentication endpoints
 type AuthHandlers struct {
 	ghClient *github.Client
+	store    *store.SQLiteStore
 }
 
 // NewAuthHandlers creates new auth handlers
-func NewAuthHandlers(ghClient *github.Client) *AuthHandlers {
-	return &AuthHandlers{ghClient: ghClient}
+func NewAuthHandlers(ghClient *github.Client, s *store.SQLiteStore) *AuthHandlers {
+	return &AuthHandlers{ghClient: ghClient, store: s}
 }
 
 // GitHubCallbackRequest is the request body for OAuth callback
@@ -55,32 +69,41 @@ func (h *AuthHandlers) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Exchange code for token (with PKCE verifier if provided)
-	token, err := h.ghClient.ExchangeCode(r.Context(), req.Code, req.CodeVerifier)
+	// Exchange code for tokens (with PKCE verifier if provided)
+	tokenSet, err := h.ghClient.ExchangeCode(r.Context(), req.Code, req.CodeVerifier)
 	if err != nil {
 		writeBadGateway(w, "failed to exchange code", err)
 		return
 	}
 
+	// Store tokens in client memory
+	h.ghClient.SetTokens(tokenSet)
+
 	// Fetch user info
-	user, err := h.ghClient.GetUser(r.Context(), token)
+	user, err := h.ghClient.GetUser(r.Context(), tokenSet.AccessToken)
 	if err != nil {
 		writeBadGateway(w, "failed to fetch user", err)
 		return
 	}
 
-	// Store in memory (frontend will also store in keychain)
-	h.ghClient.SetToken(token)
 	h.ghClient.SetUser(user)
 
+	// Persist encrypted tokens to settings
+	if err := h.persistTokens(r.Context(), tokenSet, user); err != nil {
+		logger.GitHub.Errorf("Failed to persist GitHub tokens: %v", err)
+		// Non-fatal — user is still authenticated in memory
+	}
+
+	// Return access token to frontend (for Stronghold storage as fallback)
 	writeJSON(w, GitHubCallbackResponse{
-		Token: token,
+		Token: tokenSet.AccessToken,
 		User:  user,
 	})
 }
 
 // SetToken handles POST /api/auth/token
-// Called by frontend on startup to provide stored token
+// Called by frontend on startup to provide stored token from Stronghold.
+// If backend already has valid tokens from SQLite restore, this is a no-op migration path.
 func (h *AuthHandlers) SetToken(w http.ResponseWriter, r *http.Request) {
 	var req SetTokenRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -90,6 +113,16 @@ func (h *AuthHandlers) SetToken(w http.ResponseWriter, r *http.Request) {
 
 	if req.Token == "" {
 		writeValidationError(w, "token is required")
+		return
+	}
+
+	// If backend already has valid tokens (restored from SQLite), skip
+	if h.ghClient.IsAuthenticated() {
+		user := h.ghClient.GetStoredUser()
+		writeJSON(w, map[string]interface{}{
+			"ok":   true,
+			"user": user,
+		})
 		return
 	}
 
@@ -120,5 +153,105 @@ func (h *AuthHandlers) GetStatus(w http.ResponseWriter, r *http.Request) {
 // Logout handles POST /api/auth/logout
 func (h *AuthHandlers) Logout(w http.ResponseWriter, r *http.Request) {
 	h.ghClient.ClearAuth()
+
+	// Clear persisted tokens
+	ctx := r.Context()
+	h.store.DeleteSetting(ctx, settingGitHubAccessToken)
+	h.store.DeleteSetting(ctx, settingGitHubRefreshToken)
+	h.store.DeleteSetting(ctx, settingGitHubTokenExpiry)
+	h.store.DeleteSetting(ctx, settingGitHubUser)
+
+	logger.GitHub.Info("GitHub auth cleared")
 	writeJSON(w, map[string]bool{"ok": true})
+}
+
+// RestoreFromStore restores GitHub auth from persisted encrypted settings.
+// Called once at startup.
+func (h *AuthHandlers) RestoreFromStore(ctx context.Context) {
+	encAccess, found, err := h.store.GetSetting(ctx, settingGitHubAccessToken)
+	if err != nil || !found {
+		return
+	}
+
+	accessToken, err := crypto.Decrypt(encAccess)
+	if err != nil {
+		logger.GitHub.Warnf("Failed to decrypt GitHub access token: %v", err)
+		return
+	}
+
+	encRefresh, _, _ := h.store.GetSetting(ctx, settingGitHubRefreshToken)
+	refreshToken, _ := crypto.Decrypt(encRefresh)
+
+	expiryStr, _, _ := h.store.GetSetting(ctx, settingGitHubTokenExpiry)
+	expiresAt, _ := time.Parse(time.RFC3339, expiryStr)
+
+	tokens := &github.TokenSet{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+		ExpiresAt:    expiresAt,
+	}
+	h.ghClient.SetTokens(tokens)
+
+	// Restore user info
+	encUser, found, _ := h.store.GetSetting(ctx, settingGitHubUser)
+	if found {
+		userJSON, err := crypto.Decrypt(encUser)
+		if err == nil {
+			var user github.User
+			if err := json.Unmarshal([]byte(userJSON), &user); err == nil {
+				h.ghClient.SetUser(&user)
+			}
+		}
+	}
+
+	logger.GitHub.Infof("Restored GitHub auth from store (expires %s)", expiresAt.Format(time.RFC3339))
+}
+
+// PersistGitHubTokens encrypts and stores tokens in the settings table.
+// Exported for use by the token-refresh callback in main.go.
+func PersistGitHubTokens(ctx context.Context, s *store.SQLiteStore, tokens *github.TokenSet) error {
+	encAccess, err := crypto.Encrypt(tokens.AccessToken)
+	if err != nil {
+		return err
+	}
+	if err := s.SetSetting(ctx, settingGitHubAccessToken, encAccess); err != nil {
+		return err
+	}
+	if tokens.RefreshToken != "" {
+		encRefresh, err := crypto.Encrypt(tokens.RefreshToken)
+		if err != nil {
+			return err
+		}
+		if err := s.SetSetting(ctx, settingGitHubRefreshToken, encRefresh); err != nil {
+			return err
+		}
+	}
+	if !tokens.ExpiresAt.IsZero() {
+		return s.SetSetting(ctx, settingGitHubTokenExpiry, tokens.ExpiresAt.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// persistTokens encrypts and stores tokens + user in the settings table.
+func (h *AuthHandlers) persistTokens(ctx context.Context, tokens *github.TokenSet, user *github.User) error {
+	if err := PersistGitHubTokens(ctx, h.store, tokens); err != nil {
+		return err
+	}
+
+	if user != nil {
+		userJSON, err := json.Marshal(user)
+		if err != nil {
+			return err
+		}
+		encUser, err := crypto.Encrypt(string(userJSON))
+		if err != nil {
+			return err
+		}
+		if err := h.store.SetSetting(ctx, settingGitHubUser, encUser); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/backend/server/auth_handlers_test.go
+++ b/backend/server/auth_handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/chatml/chatml-backend/github"
+	"github.com/chatml/chatml-backend/store"
 )
 
 // setupMockGitHubServer creates a mock GitHub API server for testing
@@ -53,12 +54,23 @@ func newTestGitHubClient(t *testing.T, mockServer *httptest.Server) *github.Clie
 	return client
 }
 
+// newTestStore creates an in-memory SQLite store for testing
+func newTestAuthStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	s, err := store.NewSQLiteStoreInMemory()
+	if err != nil {
+		t.Fatalf("Failed to create test store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
 func TestAuthHandlers_SetToken(t *testing.T) {
 	mockServer := setupMockGitHubServer(t)
 	defer mockServer.Close()
 
 	ghClient := newTestGitHubClient(t, mockServer)
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	body := bytes.NewBufferString(`{"token":"test_token_123"}`)
 	req := httptest.NewRequest("POST", "/api/auth/token", body)
@@ -88,7 +100,7 @@ func TestAuthHandlers_SetToken_InvalidToken(t *testing.T) {
 	defer mockServer.Close()
 
 	ghClient := newTestGitHubClient(t, mockServer)
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	body := bytes.NewBufferString(`{"token":"invalid_token"}`)
 	req := httptest.NewRequest("POST", "/api/auth/token", body)
@@ -112,7 +124,7 @@ func TestAuthHandlers_SetToken_EmptyToken(t *testing.T) {
 	defer mockServer.Close()
 
 	ghClient := newTestGitHubClient(t, mockServer)
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	body := bytes.NewBufferString(`{"token":""}`)
 	req := httptest.NewRequest("POST", "/api/auth/token", body)
@@ -131,7 +143,7 @@ func TestAuthHandlers_SetToken_InvalidJSON(t *testing.T) {
 	defer mockServer.Close()
 
 	ghClient := newTestGitHubClient(t, mockServer)
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	body := bytes.NewBufferString(`{invalid json}`)
 	req := httptest.NewRequest("POST", "/api/auth/token", body)
@@ -145,9 +157,36 @@ func TestAuthHandlers_SetToken_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestAuthHandlers_SetToken_SkipsWhenAlreadyAuthenticated(t *testing.T) {
+	mockServer := setupMockGitHubServer(t)
+	defer mockServer.Close()
+
+	ghClient := newTestGitHubClient(t, mockServer)
+	// Pre-set tokens (simulating SQLite restore)
+	ghClient.SetTokens(&github.TokenSet{AccessToken: "existing_token"})
+	ghClient.SetUser(&github.User{Login: "existinguser"})
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
+
+	body := bytes.NewBufferString(`{"token":"frontend_token"}`)
+	req := httptest.NewRequest("POST", "/api/auth/token", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handlers.SetToken(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Token should still be the existing one, not the frontend one
+	if ghClient.GetToken() != "existing_token" {
+		t.Errorf("Token should remain existing_token, got %s", ghClient.GetToken())
+	}
+}
+
 func TestAuthHandlers_GetStatus_Unauthenticated(t *testing.T) {
 	ghClient := github.NewClient("", "")
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	req := httptest.NewRequest("GET", "/api/auth/status", nil)
 	w := httptest.NewRecorder()
@@ -175,7 +214,7 @@ func TestAuthHandlers_GetStatus_Authenticated(t *testing.T) {
 	ghClient := github.NewClient("", "")
 	ghClient.SetToken("test_token")
 	ghClient.SetUser(&github.User{Login: "testuser", Name: "Test User"})
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	req := httptest.NewRequest("GET", "/api/auth/status", nil)
 	w := httptest.NewRecorder()
@@ -203,7 +242,7 @@ func TestAuthHandlers_Logout(t *testing.T) {
 	ghClient := github.NewClient("", "")
 	ghClient.SetToken("test_token")
 	ghClient.SetUser(&github.User{Login: "testuser"})
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
 	w := httptest.NewRecorder()
@@ -228,7 +267,7 @@ func TestAuthHandlers_GitHubCallback(t *testing.T) {
 	defer mockServer.Close()
 
 	ghClient := newTestGitHubClient(t, mockServer)
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	body := bytes.NewBufferString(`{"code":"test_oauth_code"}`)
 	req := httptest.NewRequest("POST", "/api/auth/github/callback", body)
@@ -264,7 +303,7 @@ func TestAuthHandlers_GitHubCallback(t *testing.T) {
 
 func TestAuthHandlers_GitHubCallback_EmptyCode(t *testing.T) {
 	ghClient := github.NewClient("", "")
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	body := bytes.NewBufferString(`{"code":""}`)
 	req := httptest.NewRequest("POST", "/api/auth/github/callback", body)
@@ -280,7 +319,7 @@ func TestAuthHandlers_GitHubCallback_EmptyCode(t *testing.T) {
 
 func TestAuthHandlers_GitHubCallback_InvalidJSON(t *testing.T) {
 	ghClient := github.NewClient("", "")
-	handlers := NewAuthHandlers(ghClient)
+	handlers := NewAuthHandlers(ghClient, newTestAuthStore(t))
 
 	body := bytes.NewBufferString(`{invalid}`)
 	req := httptest.NewRequest("POST", "/api/auth/github/callback", body)

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -22,7 +22,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	r := chi.NewRouter()
 	dirCacheConfig := LoadDirListingCacheConfig()
 	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, issueCache, statsCache, aiClient, scriptRunner)
-	auth := NewAuthHandlers(ghClient)
+	auth := NewAuthHandlers(ghClient, s)
 	linearAuth := NewLinearAuthHandlers(linearClient, s)
 
 	r.Use(middleware.Logger)

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -414,10 +414,27 @@ export async function initAuth(): Promise<AuthStatus> {
 
 /**
  * Validate stored token with backend after connection is established
- * Call this after backend is confirmed to be running
+ * Call this after backend is confirmed to be running.
+ *
+ * First checks if backend already has valid tokens (restored from SQLite on startup).
+ * If so, skips Stronghold access entirely. Otherwise falls back to sending the
+ * Stronghold token to backend for validation (migration path).
+ *
  * @returns User info if valid, null if invalid (will clear stored token)
  */
 export async function validateStoredToken(): Promise<GitHubUser | null> {
+  // Check if backend already has valid auth (restored from SQLite)
+  try {
+    const status = await getAuthStatus();
+    if (status.authenticated && status.user) {
+      console.log('[Auth] Backend already authenticated (restored from SQLite), skipping Stronghold');
+      return status.user;
+    }
+  } catch {
+    // Backend not reachable yet, fall through to Stronghold path
+  }
+
+  // Fallback: send Stronghold token to backend
   const token = await loadToken();
 
   if (!token) {


### PR DESCRIPTION
## Summary

- **Backend**: Store GitHub OAuth tokens (access + refresh) encrypted in SQLite, mirroring the existing Linear OAuth pattern. Auto-refresh when within 5 minutes of expiry via `getValidToken(ctx)` across all 14 API call sites.
- **Startup restore**: Decrypt and load persisted tokens from SQLite on server startup, eliminating re-auth after app restart when tokens are still valid (or refreshable).
- **Frontend**: `validateStoredToken()` now checks backend `/api/auth/status` first — if backend already authenticated from SQLite restore, skips Stronghold keychain access entirely.
- **Backward compatible**: Non-expiring tokens (regular OAuth Apps) continue to work unchanged. Existing Stronghold tokens bridge the upgrade path.

## Test plan

- [x] `go test ./...` — all backend tests pass (including new tests for TokenSet, RefreshToken, getValidToken, auto-refresh)
- [x] `go build ./...` — compiles
- [x] `npm run lint` — no lint errors
- [x] `npm run build` — frontend compiles
- [ ] Manual: Login via GitHub OAuth → verify token + user stored in SQLite
- [ ] Manual: Kill app → relaunch → verify auto-restore from SQLite (no re-auth prompt)
- [ ] Manual: Verify Stronghold fallback still works for first launch after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)