### PR TITLE
Count skipped checks as passed in Checks Panel

### DIFF
--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -429,7 +429,9 @@ function CIChecksSection({
     });
   }, [checkDetails]);
 
-  const passedCount = checkDetails.filter((c) => c.conclusion === 'success').length;
+  const passedCount = checkDetails.filter(
+    (c) => c.conclusion === 'success' || c.conclusion === 'skipped' || c.conclusion === 'neutral'
+  ).length;
   const failedCount = checkDetails.filter(
     (c) => c.status === 'completed' && (c.conclusion === 'failure' || c.conclusion === 'timed_out' || c.conclusion === 'action_required')
   ).length;


### PR DESCRIPTION
## Summary

Skipped and neutral check conclusions indicate the check was intentionally not needed or was inconclusive—not a failure. The backend already counts these as passed; the frontend now does too.

## Changes

Updated the `passedCount` filter in ChecksPanel.tsx to include `skipped` and `neutral` conclusions alongside `success`, so the "X/Y passed" stats accurately reflect check results.

This aligns the frontend counting logic with the backend behavior in handlers.go.