### PR TITLE
fix: Add retry with backoff for transient backend connection errors

### DIFF
--- a/src/hooks/useGitStatus.ts
+++ b/src/hooks/useGitStatus.ts
@@ -70,8 +70,12 @@ export function useGitStatus(
           permanentErrorRef.current = true;
         }
 
+        // Only log as error for unexpected failures, not transient network issues
         if (!isPermanent) {
-          console.error('Failed to fetch git status:', err);
+          const isTransientNetwork = err instanceof ApiError && err.status === 0;
+          if (!isTransientNetwork) {
+            console.error('Failed to fetch git status:', err);
+          }
         }
         setError(err instanceof Error ? err.message : 'Failed to fetch git status');
         setErrorCode(err instanceof ApiError ? (err.code ?? null) : null);

--- a/src/hooks/usePRStatus.ts
+++ b/src/hooks/usePRStatus.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getPRStatus, refreshPRStatus, type PRDetails } from '@/lib/api';
+import { getPRStatus, refreshPRStatus, ApiError, type PRDetails } from '@/lib/api';
 
 const PR_STATUS_FALLBACK_POLL_MS = 300000; // 5 minutes (fallback, WebSocket is primary)
 
@@ -49,7 +49,11 @@ export function usePRStatus(
       }
     } catch (err) {
       if (isMountedRef.current) {
-        console.error('Failed to fetch PR status:', err);
+        // Only log as error for unexpected failures, not transient network issues
+        const isTransientNetwork = err instanceof ApiError && err.status === 0;
+        if (!isTransientNetwork) {
+          console.error('Failed to fetch PR status:', err);
+        }
         setError(err instanceof Error ? err.message : 'Failed to fetch PR status');
       }
     } finally {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -55,23 +55,47 @@ export const ErrorCode = {
   WORKTREE_NOT_FOUND: 'WORKTREE_NOT_FOUND',
 } as const;
 
-// Fetch helper that adds authentication token for Tauri builds
-// Also catches network-level TypeErrors (e.g. server unreachable) and
-// re-throws them as ApiError with status 0 for consistent error handling.
+// Retry configuration for transient network failures.
+// Retries handle brief backend hiccups (sleep/wake, sidecar restart, resource pressure)
+// so callers don't have to implement their own retry logic.
+const FETCH_RETRY_COUNT = 2; // 2 retries = 3 total attempts
+const FETCH_RETRY_BASE_DELAY_MS = 300;
+
+// Fetch helper that adds authentication token for Tauri builds.
+// Automatically retries on network-level TypeErrors (e.g. server momentarily unreachable)
+// with exponential backoff. Only throws ApiError after all retries are exhausted.
 async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {
   const token = await getAuthToken();
   const headers = new Headers(options.headers);
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
   }
-  try {
-    return await fetch(url, { ...options, headers });
-  } catch (err) {
-    if (err instanceof TypeError) {
-      throw new ApiError('Cannot connect to backend. Is the server running?', 0);
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= FETCH_RETRY_COUNT; attempt++) {
+    try {
+      return await fetch(url, { ...options, headers });
+    } catch (err) {
+      lastError = err;
+      if (!(err instanceof TypeError)) {
+        // Not a network error — don't retry
+        throw err;
+      }
+      // Don't retry if the request was already aborted (e.g. AbortController)
+      if (options.signal?.aborted) {
+        break;
+      }
+      if (attempt < FETCH_RETRY_COUNT) {
+        const delay = FETCH_RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
-    throw err;
   }
+  // All retries exhausted
+  if (lastError instanceof TypeError) {
+    throw new ApiError('Cannot connect to backend. Is the server running?', 0);
+  }
+  throw lastError;
 }
 
 // Helper to handle API responses consistently


### PR DESCRIPTION
## Summary
- Adds automatic retry (3 attempts with exponential backoff: 300ms → 600ms) to `fetchWithAuth` for `TypeError` network failures, making the entire API layer resilient to brief backend hiccups (sleep/wake, sidecar restart, resource pressure)
- Suppresses noisy `console.error` logs in `useGitStatus` and `usePRStatus` polling hooks for transient network errors — the `ConnectionStatusHandler` toast already handles user-visible disconnect notifications
- Skips retry when the request was already aborted via `AbortController`

## Test plan
- [ ] Start app normally and verify all API calls work as before
- [ ] Kill and restart the Go backend while the app is running — verify no error overlay/console spam, and the app recovers silently
- [ ] Sleep/wake the Mac with the app open — verify no "Cannot connect to backend" errors
- [ ] Verify git status and PR status polling continue to work after a brief backend hiccup

🤖 Generated with [Claude Code](https://claude.com/claude-code)