### PR TITLE
fix: Prevent plan mode sync from racing with WebSocket during streaming

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -392,6 +392,20 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     setSessionToggleState(selectedSessionId, { thinkingLevel, planModeEnabled });
   }, [selectedSessionId, thinkingLevel, planModeEnabled, setSessionToggleState]);
 
+  // Keep streaming state planModeActive in sync with the local toggle.
+  // This ensures the ConversationArea banner is visible immediately when:
+  // - A new session starts with defaultPlanMode = true
+  // - Switching to a session that had planModeEnabled = true
+  // - A new conversation is created in a session with plan mode on
+  useEffect(() => {
+    if (!selectedConversationId) return;
+    const current = useAppStore.getState().streamingState[selectedConversationId];
+    if (current?.isStreaming) return; // Don't fight with WebSocket handler
+    if ((current?.planModeActive ?? false) !== planModeEnabled) {
+      setPlanModeActive(selectedConversationId, planModeEnabled);
+    }
+  }, [selectedConversationId, planModeEnabled, setPlanModeActive]);
+
   // Check if there's a pending user question
   const pendingQuestion = usePendingUserQuestion(selectedConversationId);
 


### PR DESCRIPTION
## Summary
- Adds an `isStreaming` guard to the `planModeActive` sync effect in `ChatInput` so it doesn't overwrite WebSocket-driven plan mode transitions while the agent is actively streaming
- Prevents a race where the local toggle could re-activate plan mode after the agent exits it server-side

## Test plan
- [ ] Enable plan mode, start a conversation, verify the plan banner appears
- [ ] Let the agent exit plan mode via `ExitPlanMode` — banner should disappear and not flicker back
- [ ] Switch between sessions with different plan mode states — banner should reflect the correct state
- [ ] Create a new conversation in a session with plan mode on — banner should appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)