### PR TITLE
fix: Check all conversations for session activity indicator

### DIFF
--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -145,15 +145,21 @@ export const useSessionActivityState = (sessionId: string): SessionActivityState
   useAppStore(
     useCallback(
       (state) => {
-        const activeConv = state.conversations.find(
-          (c) => c.sessionId === sessionId && c.status === 'active'
-        );
-        if (!activeConv) return 'idle';
-        const convId = activeConv.id;
-        if (state.pendingUserQuestion[convId]) return 'awaiting_input';
-        if (state.streamingState[convId]?.pendingPlanApproval) return 'awaiting_approval';
-        if (state.streamingState[convId]?.isStreaming) return 'working';
-        return 'idle';
+        let highestState: SessionActivityState = 'idle';
+
+        for (const c of state.conversations) {
+          if (c.sessionId !== sessionId || c.status !== 'active') continue;
+
+          const convId = c.id;
+          if (state.pendingUserQuestion[convId]) return 'awaiting_input';
+          if (state.streamingState[convId]?.pendingPlanApproval) {
+            highestState = 'awaiting_approval';
+          } else if (state.streamingState[convId]?.isStreaming && highestState === 'idle') {
+            highestState = 'working';
+          }
+        }
+
+        return highestState;
       },
       [sessionId]
     )


### PR DESCRIPTION
## Summary
- The sidebar session activity indicator (spinner) only checked the **first** active conversation found via `Array.find()`, ignoring other conversations in the same session
- When a session had multiple Chat Tabs and the first conversation was idle while another had an active agent, the spinner wouldn't show
- Now iterates over **all** conversations for the session and returns the highest-priority activity state (`awaiting_input` > `awaiting_approval` > `working` > `idle`)

## Test plan
- [ ] Open a session and create two Chat Tabs (conversations)
- [ ] Leave one idle, start an agent task in the other
- [ ] Confirm the sidebar session cell shows the working spinner
- [ ] Verify `awaiting_input` and `awaiting_approval` indicators also surface correctly across tabs
- [ ] Confirm idle shows correctly when all tabs are idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)