### PR TITLE
fix: Pass backend workspace/session IDs to MCP tools via agent-runner

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -76,6 +76,11 @@ const forkSession = hasFlag("--fork");
 // Typically set to the conversation ID so session tracking aligns with our data model.
 const customSessionId = getArg("--session-id");
 
+// Backend IDs for MCP tools — these correspond to the backend's workspace/session IDs
+// (distinct from the SDK's internal session UUID).
+const backendWorkspaceId = getArg("--workspace-id");
+const backendSessionId = getArg("--backend-session-id");
+
 const linearIssue = getArg("--linear-issue");
 const toolPreset = (getArg("--tool-preset") || "full") as "full" | "read-only" | "no-bash" | "safe-edit";
 const enableCheckpointing = hasFlag("--enable-checkpointing");
@@ -1356,11 +1361,13 @@ async function main(): Promise<void> {
   let turnCount = 0;
 
   try {
-    // Create workspace context for MCP tools
+    // Create workspace context for MCP tools.
+    // Use backend IDs (workspace/session) when available so MCP tools hit the correct
+    // backend API endpoints. Fall back to conversationId for backwards compatibility.
     const workspaceContext = new WorkspaceContext({
       cwd,
-      workspaceId: conversationId,
-      sessionId: currentSessionId || "pending",
+      workspaceId: backendWorkspaceId || conversationId,
+      sessionId: backendSessionId || "pending",
       linearIssue,
       targetBranch,
     });
@@ -1498,8 +1505,11 @@ async function main(): Promise<void> {
           blockBuffer = "";
           resetRunStats();
 
-          // Update workspace context with current session ID if it changed
-          if (currentSessionId && workspaceContext.sessionId !== currentSessionId) {
+          // Update workspace context with current session ID if it changed.
+          // When backendSessionId is provided, keep using it — the SDK's internal
+          // session UUID is different from the backend session ID and must not
+          // overwrite it (MCP tools need the backend session ID for API calls).
+          if (!backendSessionId && currentSessionId && workspaceContext.sessionId !== currentSessionId) {
             workspaceContext.updateSessionId(currentSessionId);
           }
 

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -221,6 +221,8 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 		Workdir:             session.WorktreePath,
 		ConversationID:      convID,
 		SdkSessionID:        uuid.New().String(), // Full UUID required by SDK
+		WorkspaceID:         session.WorkspaceID, // Backend workspace ID for MCP tools
+		BackendSessionID:    sessionID,           // Backend session ID for MCP tools
 		EnableCheckpointing: true,
 	}
 
@@ -1088,6 +1090,13 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 			restartOpts.EnableCheckpointing = true
 		}
 		restartOpts.Workdir = session.WorktreePath
+		// Always ensure backend IDs are set for MCP tools (may be missing from old opts)
+		if restartOpts.WorkspaceID == "" {
+			restartOpts.WorkspaceID = session.WorkspaceID
+		}
+		if restartOpts.BackendSessionID == "" {
+			restartOpts.BackendSessionID = conv.SessionID
+		}
 		// Restore model from conversation record if not already set
 		if restartOpts.Model == "" && conv.Model != "" {
 			restartOpts.Model = conv.Model

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -36,6 +36,8 @@ type ProcessOptions struct {
 	Workdir             string
 	ConversationID      string
 	SdkSessionID        string // Full UUID for SDK session tracking (must be valid UUID)
+	WorkspaceID         string // Backend workspace/repo ID for MCP tools
+	BackendSessionID    string // Backend session ID for MCP tools (distinct from SDK session ID)
 	ResumeSession       string // Session ID to resume
 	ForkSession         bool   // Whether to fork the session
 	LinearIssue         string // Linear issue identifier (e.g., "LIN-123")
@@ -150,6 +152,14 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 		agentRunnerPath,
 		"--cwd", opts.Workdir,
 		"--conversation-id", opts.ConversationID,
+	}
+
+	// Pass workspace and session IDs so MCP tools can reach the correct backend endpoints
+	if opts.WorkspaceID != "" {
+		args = append(args, "--workspace-id", opts.WorkspaceID)
+	}
+	if opts.BackendSessionID != "" {
+		args = append(args, "--backend-session-id", opts.BackendSessionID)
 	}
 
 	// Pass a custom session ID to align SDK session tracking with our data model


### PR DESCRIPTION
## Summary
- Plumbs backend workspace ID and session ID from the Go backend through CLI args (`--workspace-id`, `--backend-session-id`) to the agent-runner's `WorkspaceContext`
- MCP tools were previously using the SDK's internal conversation ID and session UUID, which don't match the backend's actual IDs — causing MCP tools to hit incorrect API endpoints
- Prevents the SDK's internal session UUID from overwriting the backend session ID on turn boundaries
- Backfills backend IDs on conversation restart for backwards compatibility with old `ProcessOptions`

## Test plan
- [ ] Verify MCP tools (e.g., code review, workspace diff) resolve to the correct backend endpoints during a conversation
- [ ] Verify MCP tools still work after a conversation process restart
- [ ] Verify backwards compatibility: conversations started without the new flags should fall back to `conversationId` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)