### PR TITLE
fix: Handle CI runs startup race when GitHub auth is pending

### DIFF
--- a/backend/server/ci_handlers.go
+++ b/backend/server/ci_handlers.go
@@ -56,6 +56,11 @@ func (h *Handlers) resolveGitHubContext(w http.ResponseWriter, r *http.Request) 
 		return nil, false
 	}
 
+	if !h.ghClient.IsAuthenticated() {
+		writeUnauthorized(w, "GitHub not authenticated")
+		return nil, false
+	}
+
 	return &githubContext{owner: owner, repo: repoName, session: session}, true
 }
 

--- a/src/hooks/useCIRuns.ts
+++ b/src/hooks/useCIRuns.ts
@@ -7,12 +7,14 @@ import {
   getCIJobLogs,
   rerunCI,
   analyzeCIFailure,
+  ApiError,
   type WorkflowRunDTO,
   type WorkflowJobDTO,
   type CIAnalysisResult,
 } from '@/lib/api';
 
 const CI_POLL_INTERVAL_MS = 30000; // 30 seconds
+const AUTH_RETRY_DELAY_MS = 3000; // Retry delay when GitHub auth is pending
 
 interface UseCIRunsResult {
   runs: WorkflowRunDTO[];
@@ -73,10 +75,18 @@ export function useCIRuns(
         setError(null);
       }
     } catch (err) {
-      if (!signal?.aborted) {
-        console.error('Failed to fetch CI runs:', err);
-        setError(err instanceof Error ? err.message : 'Failed to fetch CI runs');
+      if (signal?.aborted) return;
+
+      // GitHub auth not ready yet (startup race) — silently retry after a delay
+      if (err instanceof ApiError && err.status === 401) {
+        setTimeout(() => {
+          if (!signal?.aborted) fetchRuns(signal);
+        }, AUTH_RETRY_DELAY_MS);
+        return;
       }
+
+      console.error('Failed to fetch CI runs:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch CI runs');
     } finally {
       if (!signal?.aborted) {
         setLoading(false);


### PR DESCRIPTION
## Summary
- **Backend**: Added `IsAuthenticated()` check in `resolveGitHubContext` to return 401 instead of 500 when GitHub OAuth token hasn't arrived yet
- **Frontend**: `useCIRuns` hook silently retries after 3s on 401 instead of logging errors and showing error state

## Context
On app startup, the CI panel fetches workflow runs before the GitHub OAuth token is provisioned via `POST /api/auth/token`. This caused a ~3 second window where the backend returned 500 INTERNAL_ERROR with `internal_err=not authenticated`, spamming console errors and briefly showing error state in the UI.

## Test plan
- [ ] Start app fresh — verify no console errors for CI runs during startup
- [ ] CI panel loads correctly after auth token arrives (~3s)
- [ ] CI panel still shows real errors (e.g. network failures) correctly
- [ ] Sessions with GitHub Actions data still display runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)