### PR TITLE
fix: Allow image-only messages and improve message delivery logging

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1220,9 +1220,13 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 	}
 
 	// Send to process with attachments
+	logger.Manager.Infof("Sending message to conv %s (content=%d chars, attachments=%d, processRestarted=%v)",
+		convID, len(message), len(attachments), needsRestart)
 	if err := proc.SendMessageWithAttachments(message, attachments); err != nil {
+		logger.Manager.Errorf("Failed to send message to conv %s: %v (attachments=%d)", convID, err, len(attachments))
 		return err
 	}
+	logger.Manager.Debugf("Message delivered to conv %s successfully", convID)
 
 	// Generate session title if this is the first message on an idle-started session
 	if shouldGenerateTitle {

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -594,8 +594,10 @@ func (p *Process) sendInput(msg InputMessage) error {
 	}
 
 	// Write JSON line to stdin
+	logger.Process.Debugf("Writing %s to stdin (%d bytes)", msg.Type, len(data))
 	_, err = p.stdin.Write(append(data, '\n'))
 	if err != nil {
+		logger.Process.Errorf("Failed to write %s to stdin: %v", msg.Type, err)
 		return fmt.Errorf("write to stdin: %w", err)
 	}
 

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -3389,8 +3389,8 @@ func (h *Handlers) SendConversationMessage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if req.Content == "" {
-		writeValidationError(w, "content is required")
+	if req.Content == "" && len(req.Attachments) == 0 {
+		writeValidationError(w, "content or attachments required")
 		return
 	}
 
@@ -3414,6 +3414,7 @@ func (h *Handlers) SendConversationMessage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	logger.Handlers.Infof("Accepted message for conv %s (content=%d chars, attachments=%d)", convID, len(req.Content), len(req.Attachments))
 	w.WriteHeader(http.StatusAccepted)
 	writeJSON(w, map[string]string{"status": "sent"})
 }

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -773,7 +773,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
   const handleSubmit = async () => {
     const { text: content, mentionedFiles } = plateInputRef.current?.getContent() ?? { text: '', mentionedFiles: [] };
-    if (!content.trim() || !selectedWorkspaceId || !selectedSessionId || isSending || hasQueuedMessage) return;
+    const hasContent = !!content.trim();
+    const hasAttachments = attachments.length > 0;
+    if ((!hasContent && !hasAttachments) || !selectedWorkspaceId || !selectedSessionId || isSending || hasQueuedMessage) return;
 
     // Can't queue a message to a conversation that doesn't exist yet — check before clearing input
     const conversationMessagesEarly = currentConversation


### PR DESCRIPTION
## Summary
- **Frontend**: Fix `ChatInput.tsx` guard that silently blocked image-only messages (no text). Now checks for attachments in addition to text content before allowing submit.
- **Backend**: Fix `handlers.go` validation that rejected empty content even when attachments were present. Now allows empty content if attachments are included.
- **Logging**: Add info/debug/error logging across the message delivery pipeline (`handlers.go`, `manager.go`, `process.go`) to make it possible to diagnose silent message delivery failures.

## Test plan
- [ ] Attach an image without text, press Enter — message should send
- [ ] Attach an image with text, press Enter — message should send
- [ ] Send a text-only message (no attachments) — still works as before
- [ ] Submit with no text and no attachments — still blocked
- [ ] Check backend logs for new log lines when sending messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)