### PR TITLE
fix: Remove duplicate plan mode banner from chat area

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -26,7 +26,6 @@ import {
   Sparkles,
   GitBranch,
   FileQuestion,
-  BookOpen,
   AlertCircle,
   File,
   ChevronDown,
@@ -580,9 +579,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     messageListRef.current?.scrollToBottom('smooth');
   }, []);
 
-  // Check if plan mode is active for the current conversation
-  const planModeActive = selectedStreaming?.planModeActive ?? false;
-
   // Stable footer for VirtualizedMessageList (avoids remounting on every render)
   const messageListFooter = useMemo(() => {
     if (!selectedConversationId) return undefined;
@@ -1098,19 +1094,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
         </>
       ) : (
         <>
-          {/* Plan Mode Banner */}
-          {planModeActive && (
-            <div className="shrink-0 flex items-center gap-2 px-4 py-2 bg-amber-500/10 border-b border-amber-500/20">
-              <BookOpen className="w-4 h-4 text-amber-500" />
-              <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">
-                Plan Mode Active
-              </span>
-              <span className="text-xs text-amber-500/70">
-                Claude is in read-only planning mode
-              </span>
-            </div>
-          )}
-
           {/* Messages */}
           <div className="relative flex-1 min-h-0">
             {/* Chat Search Bar */}


### PR DESCRIPTION
## Summary
- Removes the "Plan Mode Active" banner from the top of the chat area in `ConversationArea.tsx`
- The compose area already has a plan mode toggle indicator (amber button + animated dashed border), making the banner redundant
- Cleans up the unused `BookOpen` import and `planModeActive` variable

## Test plan
- [ ] Toggle plan mode on via Shift+Tab — confirm no banner appears at the top of the chat area
- [ ] Confirm the compose area toggle still shows the amber "Plan" indicator and animated border
- [ ] Toggle plan mode off — confirm compose area returns to normal state

🤖 Generated with [Claude Code](https://claude.com/claude-code)