### PR TITLE
fix: Add content-based validation to markdown cache

### DIFF
--- a/src/components/shared/CachedMarkdown.tsx
+++ b/src/components/shared/CachedMarkdown.tsx
@@ -12,7 +12,7 @@ interface CachedMarkdownProps {
 
 export function CachedMarkdown({ cacheKey, content, skipCache }: CachedMarkdownProps) {
   if (!skipCache) {
-    const cached = getCachedMarkdown(cacheKey);
+    const cached = getCachedMarkdown(cacheKey, content);
     if (cached !== undefined) {
       return <>{cached}</>;
     }
@@ -29,7 +29,7 @@ export function CachedMarkdown({ cacheKey, content, skipCache }: CachedMarkdownP
   );
 
   if (!skipCache) {
-    setCachedMarkdown(cacheKey, rendered);
+    setCachedMarkdown(cacheKey, rendered, content);
   }
 
   return rendered;

--- a/src/lib/__tests__/markdownCache.test.ts
+++ b/src/lib/__tests__/markdownCache.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getCachedMarkdown, setCachedMarkdown, clearMarkdownCache } from '../markdownCache';
+
+describe('markdownCache', () => {
+  beforeEach(() => {
+    clearMarkdownCache();
+  });
+
+  it('returns undefined for missing keys', () => {
+    expect(getCachedMarkdown('missing')).toBeUndefined();
+  });
+
+  it('stores and retrieves cached nodes', () => {
+    const node = 'rendered-node';
+    setCachedMarkdown('key1', node, 'hello');
+    expect(getCachedMarkdown('key1')).toBe(node);
+  });
+
+  it('returns cached node when content matches', () => {
+    const node = 'rendered-node';
+    setCachedMarkdown('key1', node, 'hello');
+    expect(getCachedMarkdown('key1', 'hello')).toBe(node);
+  });
+
+  it('invalidates cache when content changes for same key', () => {
+    const node = 'old-rendered-node';
+    setCachedMarkdown('key1', node, 'old content');
+
+    // Same key, different content → cache miss
+    expect(getCachedMarkdown('key1', 'new content')).toBeUndefined();
+
+    // Entry should be deleted after mismatch
+    expect(getCachedMarkdown('key1')).toBeUndefined();
+  });
+
+  it('skips content validation when content param is omitted', () => {
+    const node = 'rendered-node';
+    setCachedMarkdown('key1', node, 'some content');
+
+    // No content param → return cached regardless
+    expect(getCachedMarkdown('key1')).toBe(node);
+  });
+
+  it('invalidates when stored without content but retrieved with content', () => {
+    setCachedMarkdown('key1', 'node');
+
+    // Stored without content tracking, so content validation cannot match
+    expect(getCachedMarkdown('key1', 'anything')).toBeUndefined();
+  });
+
+  it('overwrites existing entry on set with new content', () => {
+    setCachedMarkdown('key1', 'old-node', 'old');
+    setCachedMarkdown('key1', 'new-node', 'new');
+
+    expect(getCachedMarkdown('key1', 'new')).toBe('new-node');
+    expect(getCachedMarkdown('key1', 'old')).toBeUndefined();
+  });
+
+  it('evicts oldest entry when over capacity', () => {
+    // Fill cache to capacity (MAX_CACHE_SIZE = 500)
+    for (let i = 0; i < 501; i++) {
+      setCachedMarkdown(`key-${i}`, `node-${i}`, `content-${i}`);
+    }
+
+    // Oldest entry should be evicted
+    expect(getCachedMarkdown('key-0')).toBeUndefined();
+    // Newest should still exist
+    expect(getCachedMarkdown('key-500', 'content-500')).toBe('node-500');
+  });
+});

--- a/src/lib/markdownCache.ts
+++ b/src/lib/markdownCache.ts
@@ -2,31 +2,45 @@ import type { ReactNode } from 'react';
 
 const MAX_CACHE_SIZE = 500;
 
-const cache = new Map<string, ReactNode>();
+interface CacheEntry {
+  node: ReactNode;
+  content: string | undefined;
+}
+
+const cache = new Map<string, CacheEntry>();
 
 /**
  * Get a cached ReactNode by key, promoting it to most-recent for LRU.
+ * When `content` is provided, validates that the cached entry matches —
+ * returns undefined (cache miss) if the content has changed, preventing
+ * stale renders when the same cache key is reused across conversations.
  */
-export function getCachedMarkdown(key: string): ReactNode | undefined {
-  const node = cache.get(key);
-  if (node === undefined) return undefined;
+export function getCachedMarkdown(key: string, content?: string): ReactNode | undefined {
+  const entry = cache.get(key);
+  if (entry === undefined) return undefined;
+
+  // If content provided and doesn't match, treat as cache miss
+  if (content !== undefined && entry.content !== content) {
+    cache.delete(key);
+    return undefined;
+  }
 
   // Promote to most-recent (delete + re-insert keeps Map insertion order)
   cache.delete(key);
-  cache.set(key, node);
-  return node;
+  cache.set(key, entry);
+  return entry.node;
 }
 
 /**
  * Store a rendered ReactNode. Evicts the oldest entry when over capacity.
  */
-export function setCachedMarkdown(key: string, node: ReactNode): void {
+export function setCachedMarkdown(key: string, node: ReactNode, content?: string): void {
   // If key already exists, delete first so re-insert moves it to end
   if (cache.has(key)) {
     cache.delete(key);
   }
 
-  cache.set(key, node);
+  cache.set(key, { node, content });
 
   // Evict oldest (first entry) if over capacity
   if (cache.size > MAX_CACHE_SIZE) {


### PR DESCRIPTION
## Summary
- Adds content fingerprinting to the markdown LRU cache so entries are invalidated when the underlying markdown changes, preventing stale renders when the same cache key is reused across conversations (e.g., plan items)
- Passes `content` through `CachedMarkdown` to both `getCachedMarkdown` and `setCachedMarkdown` for validation
- Stores `content` as `undefined` (not `''`) when not provided, correctly distinguishing "no content tracking" from "content is empty string"
- Adds unit tests for the markdown cache including the content validation and edge cases

## Test plan
- [x] `vitest run src/lib/__tests__/markdownCache.test.ts` — all 8 tests pass
- [ ] Open a plan in one conversation, switch to another conversation with a different plan, verify the plan content updates correctly (no stale render)
- [ ] Verify non-plan cached markdown (message segments, subagent output) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)