### PR TITLE
fix: Fix SVG calc() errors, PR status desync, and stale Merge PR button

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -1080,14 +1080,14 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         {/* Animated marching ants border for plan mode */}
         {planModeEnabled && !isStreaming && (
           <svg
-            className="absolute -inset-[1px] w-[calc(100%+2px)] h-[calc(100%+2px)] pointer-events-none z-10"
+            className="absolute inset-0 w-full h-full pointer-events-none z-10 overflow-visible"
             preserveAspectRatio="none"
           >
             <rect
-              x="1"
-              y="1"
-              width="calc(100% - 2px)"
-              height="calc(100% - 2px)"
+              x="0"
+              y="0"
+              width="100%"
+              height="100%"
               rx="8"
               ry="8"
               fill="none"

--- a/src/components/shared/PrimaryActionButton/index.tsx
+++ b/src/components/shared/PrimaryActionButton/index.tsx
@@ -1,16 +1,20 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useGitStatus } from '@/hooks/useGitStatus';
 import { usePRStatus } from '@/hooks/usePRStatus';
 import { useActionState } from './useActionState';
 import { ActionButton } from './ActionButton';
+import { useAppStore } from '@/stores/appStore';
 import type { GitStatusDTO, PRDetails } from '@/lib/api';
 
 interface WorktreeSession {
   id: string;
   status?: string;
   prStatus?: string;
+  prNumber?: number;
   prUrl?: string;
+  checkStatus?: string;
 }
 
 interface PrimaryActionButtonProps {
@@ -56,6 +60,36 @@ export function PrimaryActionButton({
   // Prefer external data if provided
   const gitStatus = externalGitStatus !== undefined ? externalGitStatus : fetchedGitStatus;
   const prDetails = externalPRDetails !== undefined ? externalPRDetails : fetchedPRDetails;
+
+  // Sync store when GitHub reports a different PR state than what the store has.
+  // This handles the case where a PR was merged/closed externally (e.g. by the agent
+  // running `gh pr merge`) but the PRWatcher hasn't polled yet.
+  // Guard: only sync when the session actually has a PR and the prDetails
+  // belongs to this session (matching PR number) to avoid cross-contamination
+  // when switching between sessions.
+  const updateSession = useAppStore((s) => s.updateSession);
+  useEffect(() => {
+    if (!session?.id || !prDetails) return;
+    if (!session.prNumber || prDetails.number !== session.prNumber) return;
+
+    const updates: Record<string, string> = {};
+
+    // Sync prStatus
+    if (prDetails.merged && session.prStatus !== 'merged') {
+      updates.prStatus = 'merged';
+    } else if (prDetails.state === 'closed' && !prDetails.merged && session.prStatus !== 'closed') {
+      updates.prStatus = 'closed';
+    }
+
+    // Sync checkStatus
+    if (prDetails.checkStatus && prDetails.checkStatus !== session.checkStatus) {
+      updates.checkStatus = prDetails.checkStatus;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      updateSession(session.id, updates);
+    }
+  }, [session?.id, session?.prNumber, session?.prStatus, session?.checkStatus, prDetails, updateSession]);
 
   // Determine if agent is currently working
   const isAgentWorking = session?.status === 'active';

--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -59,14 +59,17 @@ export function useActionState(
     }
 
     // Priority 9: PR is merged - show archive session button
-    if (session?.prStatus === 'merged') {
+    // Check both the session store (updated by PRWatcher) and live prDetails
+    // (fetched from GitHub) to handle the case where the PR was just merged
+    // but the store hasn't been updated yet.
+    if (session?.prStatus === 'merged' || prDetails?.merged) {
       return {
         type: 'archive-session',
         label: 'Archive Session',
 
         icon: Archive,
         variant: 'default',
-        sessionId: session.id,
+        sessionId: session?.id,
       };
     }
 


### PR DESCRIPTION
## Summary
- **SVG calc() console errors**: Replaced invalid CSS `calc()` in SVG `<rect>` attributes with percentage-based sizing and `overflow-visible` on the plan mode marching ants border
- **PR badge state desync**: Added a sync effect in `PrimaryActionButton` that updates the store when GitHub API reports a different PR state (merged/closed/checkStatus) than what the store has, fixing sidebar vs toolbar badge inconsistency
- **Stale Merge PR button**: `useActionState` now checks `prDetails?.merged` in addition to `session.prStatus === 'merged'`, so the button immediately switches to "Archive Session" without waiting for the PRWatcher to poll
- **Cross-contamination guard**: The store sync is guarded by PR number matching to prevent stale `prDetails` from a previously selected session from being applied when switching sessions

## Test plan
- [ ] Enable plan mode on ChatInput — verify animated dashed border renders without console errors
- [ ] Merge a PR via the agent (e.g. `gh pr merge`) — verify "Merge PR" button switches to "Archive Session" immediately
- [ ] After merge, verify sidebar session badge shows "Merged" (not "Checks running" or "Open")
- [ ] Switch between a session with a PR and one without — verify the no-PR session doesn't get marked as "Merged"

🤖 Generated with [Claude Code](https://claude.com/claude-code)