### PR TITLE
fix: Hide duplicate summary text in tool expandable region

### DIFF
--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -489,8 +489,8 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
                 </div>
               )}
 
-              {/* Summary */}
-              {summary && (
+              {/* Summary (hidden when stdout is present since the Output box already shows the full content) */}
+              {summary && !stdout && (
                 <div className={cn(
                   'text-2xs px-2 py-1 rounded',
                   success === false ? 'text-text-error bg-text-error/10' : 'text-muted-foreground bg-muted/30'


### PR DESCRIPTION
## Summary
- When a tool event has both `summary` and `stdout`, the expandable region displayed the same text twice — once as plain summary text and again in the bordered "Output" box
- Skip rendering the inline summary when `stdout` is present, since the Output box already shows the full content
- Tools that only have a summary (no stdout) continue to display it normally

## Test plan
- [ ] Open a conversation with tool events that produce both summary and stdout (e.g., TodoWrite / "Update Tasks")
- [ ] Expand the tool node and confirm only the bordered "Output" box shows the text (no duplicate plain text above it)
- [ ] Verify tools with summary but no stdout still display the summary text in the expandable region

🤖 Generated with [Claude Code](https://claude.com/claude-code)