### PR TITLE
fix: Fix Changes Panel showing committed files as uncommitted

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -2266,13 +2266,14 @@ func (h *Handlers) GetSessionGitStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, status)
 }
 
-// GetSessionChanges returns the list of changed files in a session's worktree
+// GetSessionChanges returns the list of truly uncommitted files in a session's worktree.
+// It diffs against HEAD (not the base branch), so only staged/unstaged/untracked changes appear.
 func (h *Handlers) GetSessionChanges(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	sessionID := chi.URLParam(r, "sessionId")
 
 	// Use single JOIN query to get session + workspace data
-	session, workingPath, baseRef, err := h.getSessionAndWorkspace(ctx, sessionID)
+	session, workingPath, _, err := h.getSessionAndWorkspace(ctx, sessionID)
 	if err != nil {
 		writeDBError(w, err)
 		return
@@ -2282,8 +2283,8 @@ func (h *Handlers) GetSessionChanges(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get changed files in the session's worktree compared to base ref
-	changes, err := h.repoManager.GetChangedFilesWithStats(ctx, workingPath, baseRef)
+	// Get changed files in the working tree compared to HEAD (truly uncommitted only)
+	changes, err := h.repoManager.GetChangedFilesWithStats(ctx, workingPath, "HEAD")
 	if err != nil {
 		// If there's no diff (e.g., new worktree with no changes), return empty list
 		changes = []git.FileChange{}
@@ -2305,7 +2306,21 @@ func (h *Handlers) GetSessionChanges(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, allChanges)
 }
 
-// GetSessionBranchCommits returns commits on the session's branch that are ahead of the base ref.
+// BranchStats holds total diff statistics for an entire branch vs its base.
+type BranchStats struct {
+	TotalFiles     int `json:"totalFiles"`
+	TotalAdditions int `json:"totalAdditions"`
+	TotalDeletions int `json:"totalDeletions"`
+}
+
+// BranchChangesResponse wraps commits and overall branch stats.
+type BranchChangesResponse struct {
+	Commits     []git.BranchCommit `json:"commits"`
+	BranchStats *BranchStats       `json:"branchStats,omitempty"`
+}
+
+// GetSessionBranchCommits returns commits on the session's branch that are ahead of the base ref,
+// along with total branch diff statistics.
 func (h *Handlers) GetSessionBranchCommits(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	sessionID := chi.URLParam(r, "sessionId")
@@ -2326,7 +2341,22 @@ func (h *Handlers) GetSessionBranchCommits(w http.ResponseWriter, r *http.Reques
 		commits = []git.BranchCommit{}
 	}
 
-	writeJSON(w, commits)
+	// Compute total branch stats (all changes vs base, including working dir)
+	var branchStats *BranchStats
+	allChanges, statsErr := h.repoManager.GetChangedFilesWithStats(ctx, workingPath, baseRef)
+	if statsErr == nil && len(allChanges) > 0 {
+		bs := BranchStats{TotalFiles: len(allChanges)}
+		for _, c := range allChanges {
+			bs.TotalAdditions += c.Additions
+			bs.TotalDeletions += c.Deletions
+		}
+		branchStats = &bs
+	}
+
+	writeJSON(w, BranchChangesResponse{
+		Commits:     commits,
+		BranchStats: branchStats,
+	})
 }
 
 // GetSessionFileDiff returns the diff for a specific file in a session's worktree

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -1888,10 +1888,10 @@ func TestGetSessionBranchCommits_NoCommitsAhead(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var commits []git.BranchCommit
-	err := json.Unmarshal(w.Body.Bytes(), &commits)
+	var resp BranchChangesResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	assert.Empty(t, commits)
+	assert.Empty(t, resp.Commits)
 }
 
 func TestGetSessionBranchCommits_WithCommits(t *testing.T) {
@@ -1910,20 +1910,26 @@ func TestGetSessionBranchCommits_WithCommits(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var commits []git.BranchCommit
-	err := json.Unmarshal(w.Body.Bytes(), &commits)
+	var resp BranchChangesResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	require.Len(t, commits, 2)
+	require.Len(t, resp.Commits, 2)
 
 	// Newest first
-	assert.Equal(t, "Add tests", commits[0].Message)
-	assert.Equal(t, "Add feature", commits[1].Message)
+	assert.Equal(t, "Add tests", resp.Commits[0].Message)
+	assert.Equal(t, "Add feature", resp.Commits[1].Message)
 
 	// Each commit should have files
-	require.Len(t, commits[0].Files, 1)
-	assert.Equal(t, "test.go", commits[0].Files[0].Path)
-	require.Len(t, commits[1].Files, 1)
-	assert.Equal(t, "feature.go", commits[1].Files[0].Path)
+	require.Len(t, resp.Commits[0].Files, 1)
+	assert.Equal(t, "test.go", resp.Commits[0].Files[0].Path)
+	require.Len(t, resp.Commits[1].Files, 1)
+	assert.Equal(t, "feature.go", resp.Commits[1].Files[0].Path)
+
+	// Branch stats should reflect total changes
+	require.NotNil(t, resp.BranchStats)
+	assert.Equal(t, 2, resp.BranchStats.TotalFiles)
+	assert.Equal(t, 2, resp.BranchStats.TotalAdditions) // 1 line each
+	assert.Equal(t, 0, resp.BranchStats.TotalDeletions)
 }
 
 func TestGetSessionBranchCommits_SessionNotFound(t *testing.T) {
@@ -1970,13 +1976,13 @@ func TestGetSessionBranchCommits_ReturnsEmptyArrayOnError(t *testing.T) {
 
 	h.GetSessionBranchCommits(w, req)
 
-	// Should still return 200 with empty array (graceful degradation)
+	// Should still return 200 with empty commits (graceful degradation)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var commits []git.BranchCommit
-	err := json.Unmarshal(w.Body.Bytes(), &commits)
+	var resp BranchChangesResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	assert.Empty(t, commits)
+	assert.Empty(t, resp.Commits)
 }
 
 func TestGetSessionBranchCommits_CommitFilesHaveStats(t *testing.T) {
@@ -1996,15 +2002,21 @@ func TestGetSessionBranchCommits_CommitFilesHaveStats(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var commits []git.BranchCommit
-	err := json.Unmarshal(w.Body.Bytes(), &commits)
+	var resp BranchChangesResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	require.Len(t, commits, 1)
-	require.Len(t, commits[0].Files, 1)
+	require.Len(t, resp.Commits, 1)
+	require.Len(t, resp.Commits[0].Files, 1)
 
-	assert.Equal(t, "stats.txt", commits[0].Files[0].Path)
-	assert.Equal(t, 3, commits[0].Files[0].Additions)
-	assert.Equal(t, 0, commits[0].Files[0].Deletions)
+	assert.Equal(t, "stats.txt", resp.Commits[0].Files[0].Path)
+	assert.Equal(t, 3, resp.Commits[0].Files[0].Additions)
+	assert.Equal(t, 0, resp.Commits[0].Files[0].Deletions)
+
+	// Branch stats should match the commit
+	require.NotNil(t, resp.BranchStats)
+	assert.Equal(t, 1, resp.BranchStats.TotalFiles)
+	assert.Equal(t, 3, resp.BranchStats.TotalAdditions)
+	assert.Equal(t, 0, resp.BranchStats.TotalDeletions)
 }
 
 // ============================================================================

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useSelectedIds, useFileTabState, useTodoState, useFileCommentStats, useReviewComments } from '@/stores/selectors';
-import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, createConversation, updateReviewComment as apiUpdateReviewComment, ApiError, ErrorCode, type FileChangeDTO, type BranchCommitDTO } from '@/lib/api';
+import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, createConversation, updateReviewComment as apiUpdateReviewComment, ApiError, ErrorCode, type FileChangeDTO, type BranchCommitDTO, type BranchStatsDTO } from '@/lib/api';
 import { formatReviewFeedback } from '@/lib/formatReviewFeedback';
 import { FileTree, FileIcon, type FileNode, type FileTreeHandle } from '@/components/files/FileTree';
 import { TodoPanel } from '@/components/panels/TodoPanel';
@@ -118,6 +118,7 @@ export function ChangesPanel() {
   const [changes, setChanges] = useState<FileChangeDTO[]>([]);
   const [changesLoading, setChangesLoading] = useState(false);
   const [branchCommits, setBranchCommits] = useState<BranchCommitDTO[]>([]);
+  const [branchStats, setBranchStats] = useState<BranchStatsDTO | null>(null);
   const [uncommittedOpen, setUncommittedOpen] = useState(true);
   const [commitsOpen, setCommitsOpen] = useState(true);
   const [expandedCommits, setExpandedCommits] = useState<Set<string>>(new Set());
@@ -129,49 +130,43 @@ export function ChangesPanel() {
   const checksPanelRef = useRef<ChecksPanelHandle>(null);
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Fetch changes function (extracted for reuse)
+  // Fetch working changes (truly uncommitted files only — diff against HEAD)
   const fetchChanges = useCallback(async () => {
     if (!selectedWorkspaceId || !selectedSessionId) return;
 
     try {
       const data = await getSessionChanges(selectedWorkspaceId, selectedSessionId);
       setChanges(data || []);
+    } catch (error) {
+      console.error('Failed to fetch changes:', error);
+    }
+  }, [selectedWorkspaceId, selectedSessionId]);
 
-      // Update session stats in the store (only when changed to avoid re-render loop)
-      if (data && data.length > 0) {
-        const stats = data.reduce(
-          (acc, change) => ({
-            additions: acc.additions + change.additions,
-            deletions: acc.deletions + change.deletions,
-          }),
-          { additions: 0, deletions: 0 }
-        );
+  // Fetch branch commits and overall branch stats
+  const fetchBranchCommits = useCallback(async () => {
+    if (!selectedWorkspaceId || !selectedSessionId) return;
+    try {
+      const data = await getSessionBranchCommits(selectedWorkspaceId, selectedSessionId);
+      setBranchCommits(data?.commits || []);
+      setBranchStats(data?.branchStats || null);
+
+      // Update session stats from branch-level totals (used by session list sidebar)
+      if (data?.branchStats) {
+        const { totalAdditions, totalDeletions } = data.branchStats;
         const currentStats = useAppStore.getState().sessions.find(s => s.id === selectedSessionId)?.stats;
-        if (!currentStats || currentStats.additions !== stats.additions || currentStats.deletions !== stats.deletions) {
-          updateSession(selectedSessionId, { stats });
+        if (!currentStats || currentStats.additions !== totalAdditions || currentStats.deletions !== totalDeletions) {
+          updateSession(selectedSessionId, { stats: { additions: totalAdditions, deletions: totalDeletions } });
         }
       } else {
-        // Clear stats if no changes (only if currently set)
         const currentStats = useAppStore.getState().sessions.find(s => s.id === selectedSessionId)?.stats;
         if (currentStats !== undefined) {
           updateSession(selectedSessionId, { stats: undefined });
         }
       }
     } catch (error) {
-      console.error('Failed to fetch changes:', error);
-    }
-  }, [selectedWorkspaceId, selectedSessionId, updateSession]);
-
-  // Fetch branch commits (extracted for reuse)
-  const fetchBranchCommits = useCallback(async () => {
-    if (!selectedWorkspaceId || !selectedSessionId) return;
-    try {
-      const data = await getSessionBranchCommits(selectedWorkspaceId, selectedSessionId);
-      setBranchCommits(data || []);
-    } catch (error) {
       console.error('Failed to fetch branch commits:', error);
     }
-  }, [selectedWorkspaceId, selectedSessionId]);
+  }, [selectedWorkspaceId, selectedSessionId, updateSession]);
 
   // Toggle a commit's expanded state
   const toggleCommitExpanded = useCallback((sha: string) => {
@@ -439,7 +434,8 @@ export function ChangesPanel() {
           .then(([changesData, commitsData]) => {
             if (!cancelled) {
               setChanges(changesData || []);
-              setBranchCommits(commitsData || []);
+              setBranchCommits(commitsData?.commits || []);
+              setBranchStats(commitsData?.branchStats || null);
             }
           })
           .catch(console.error)
@@ -520,7 +516,7 @@ export function ChangesPanel() {
       <TopPanelTabs
         selectedTab={selectedTab}
         setSelectedTab={setSelectedTab}
-        changesCount={changes?.length || 0}
+        changesCount={branchStats?.totalFiles || changes?.length || 0}
         menuContext={menuContext}
       />
 
@@ -583,10 +579,21 @@ export function ChangesPanel() {
             ) : (
               <ScrollArea className="h-full [&>div>div]:!block">
                 <div ref={changesContainerRef} className="p-1 pr-2 overflow-hidden">
-                  {/* Uncommitted Changes Section */}
+                  {/* Branch Summary Header */}
+                  {branchStats && (
+                    <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+                      <span className="font-mono tabular-nums">
+                        <span className="text-green-500">+{branchStats.totalAdditions}</span>
+                        <span className="text-red-500 ml-1">-{branchStats.totalDeletions}</span>
+                      </span>
+                      <span>across {branchStats.totalFiles} file{branchStats.totalFiles !== 1 ? 's' : ''}</span>
+                    </div>
+                  )}
+
+                  {/* Working Changes Section (truly uncommitted only) */}
                   {changes.length > 0 && (
                     <CollapsibleSection
-                      title="Uncommitted Changes"
+                      title="Working Changes"
                       count={changes.length}
                       open={uncommittedOpen}
                       onToggle={() => setUncommittedOpen(!uncommittedOpen)}
@@ -644,10 +651,10 @@ export function ChangesPanel() {
                     </CollapsibleSection>
                   )}
 
-                  {/* Recent Commits Section */}
+                  {/* Branch Commits Section */}
                   {branchCommits.length > 0 && (
                     <CollapsibleSection
-                      title="Recent Commits"
+                      title="Branch Commits"
                       count={branchCommits.length}
                       open={commitsOpen}
                       onToggle={() => setCommitsOpen(!commitsOpen)}

--- a/src/components/panels/__tests__/ChangesPanel.test.tsx
+++ b/src/components/panels/__tests__/ChangesPanel.test.tsx
@@ -60,12 +60,12 @@ describe('formatCommitTime', () => {
 describe('CollapsibleSection', () => {
   it('renders title and count', () => {
     render(
-      <CollapsibleSection title="Uncommitted Changes" count={5} open={true} onToggle={() => {}}>
+      <CollapsibleSection title="Working Changes" count={5} open={true} onToggle={() => {}}>
         <div>child content</div>
       </CollapsibleSection>
     );
 
-    expect(screen.getByText('Uncommitted Changes')).toBeInTheDocument();
+    expect(screen.getByText('Working Changes')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
   });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -580,9 +580,20 @@ export interface BranchCommitDTO {
   files: FileChangeDTO[];
 }
 
-export async function getSessionBranchCommits(workspaceId: string, sessionId: string): Promise<BranchCommitDTO[]> {
+export interface BranchStatsDTO {
+  totalFiles: number;
+  totalAdditions: number;
+  totalDeletions: number;
+}
+
+export interface BranchChangesResponseDTO {
+  commits: BranchCommitDTO[];
+  branchStats?: BranchStatsDTO;
+}
+
+export async function getSessionBranchCommits(workspaceId: string, sessionId: string): Promise<BranchChangesResponseDTO> {
   const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/branch-commits`);
-  return handleResponse<BranchCommitDTO[]>(res);
+  return handleResponse<BranchChangesResponseDTO>(res);
 }
 
 // Git status types matching backend response


### PR DESCRIPTION
## Summary
- **Fixed**: `GetSessionChanges` was diffing against the merge-base (fork point from main), causing all branch changes to appear under "Uncommitted Changes" even after being committed. Changed to diff against `HEAD` so only truly uncommitted working directory changes appear.
- **Renamed** sections: "Uncommitted Changes" → "Working Changes", "Recent Commits" → "Branch Commits"
- **Added** a branch summary header showing total `+N -M across X files` stats
- **Wrapped** the `branch-commits` API response with `branchStats` (total files/additions/deletions) so the frontend can display overall branch impact and update session sidebar stats

## Test plan
- [ ] Start app, create a session, have the agent make changes and commit
- [ ] After commit: "Working Changes" should be empty, "Branch Commits" should list the commit(s)
- [ ] During active editing (before commit): "Working Changes" shows modified files
- [ ] Branch summary header shows correct `+N -M across X files`
- [ ] Session list sidebar stats still reflect total branch impact
- [ ] Backend tests pass: `go test ./backend/server/ -run TestGetSessionBranchCommits`
- [ ] Frontend tests pass: `npx vitest run src/components/panels/__tests__/ChangesPanel.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)