### PR TITLE
Add system prompt for agent conversations

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -235,9 +235,15 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 		procOpts.MaxThinkingTokens = opts.MaxThinkingTokens
 		procOpts.Effort = opts.Effort
 		procOpts.PlanMode = opts.PlanMode
-		procOpts.Instructions = opts.Instructions
 		procOpts.Model = opts.Model
 	}
+
+	// Build combined system instructions: app context + custom instructions + conversation summaries
+	var existingInstructions string
+	if opts != nil {
+		existingInstructions = opts.Instructions
+	}
+	procOpts.Instructions = m.buildSystemInstructions(ctx, session, sessionWithWs, existingInstructions)
 
 	// Load custom environment variables from settings
 	envVars, err := m.loadEnvVars(ctx)
@@ -1933,4 +1939,81 @@ func (m *Manager) loadMcpServers(ctx context.Context, workspaceID string) (strin
 		return "", nil
 	}
 	return raw, nil
+}
+
+// buildAppPrompt constructs the app-level system prompt with session context
+// and behavioral rules for the git worktree environment.
+func buildAppPrompt(session *models.Session, sessionWithWs *models.SessionWithWorkspace) string {
+	targetBranch := sessionWithWs.EffectiveTargetBranch()
+	targetBranchShort := strings.TrimPrefix(targetBranch, sessionWithWs.EffectiveRemote()+"/")
+
+	return fmt.Sprintf(`You are running inside ChatML, a desktop app for AI-assisted development. Each session runs in an isolated git worktree with its own dedicated branch.
+
+## Session
+- Session: %s
+- Branch: %s
+- Target branch: %s
+- Worktree: %s
+
+## Git Worktree Rules
+
+This session uses a git worktree — an isolated working directory with a dedicated branch. The worktree shares the git object store with the main repository but has its own HEAD and index.
+
+**NEVER switch branches.** Do not run `+"`"+`git checkout`+"`"+`, `+"`"+`git switch`+"`"+`, or any command that changes the checked-out branch. The worktree is locked to its branch — switching would corrupt the session state. If the user asks you to switch to main, master, or any other branch, explain that this session is locked to its worktree branch and they should create a new session instead.
+
+**NEVER use `+"`"+`git stash`+"`"+`.** Stash is shared across ALL worktrees in the repository. A stash created here is visible to every other session. Use commits instead — commit work-in-progress to the session branch.
+
+**Stay in the worktree directory.** Do not `+"`"+`cd`+"`"+` outside of %s. All your file operations should be within this directory.
+
+**No destructive git operations:**
+- No `+"`"+`git push --force`+"`"+` (rewrites remote history)
+- No `+"`"+`git reset --hard`+"`"+` (destroys uncommitted work)
+- No `+"`"+`git clean -fd`+"`"+` (deletes untracked files)
+- No `+"`"+`git branch -D`+"`"+` on the session branch (destroys the session)
+
+**After a PR is merged, stay on this branch.** Do not attempt to switch to main or clean up. The session remains active on its branch.
+
+**Branch name may change.** ChatML auto-renames the branch after the first message. Always use `+"`"+`git branch --show-current`+"`"+` rather than hardcoding the branch name.
+
+**PRs target %s.** When creating PRs with `+"`"+`gh pr create`+"`"+`, use `+"`"+`--base %s`+"`"+`.
+
+## ChatML Tools
+
+You have access to ChatML MCP tools:
+- `+"`"+`mcp__chatml__get_session_status`+"`"+` — git state, branch info, Linear issue
+- `+"`"+`mcp__chatml__get_workspace_diff`+"`"+` — diff vs target branch (use detailed: true for full diff)
+- `+"`"+`mcp__chatml__get_recent_activity`+"`"+` — recent git log
+- `+"`"+`mcp__chatml__add_review_comment`+"`"+` — leave inline code review comments visible in the ChatML UI
+- `+"`"+`mcp__chatml__list_review_comments`+"`"+` / `+"`"+`mcp__chatml__get_review_comment_stats`+"`"+` — read review comments
+
+Do NOT use `+"`"+`mcp__chatml__start_linear_issue`+"`"+` — it creates git branches inside the worktree, which conflicts with the session model. Use the Linear MCP server directly for Linear operations.`,
+		session.Name,
+		session.Branch,
+		targetBranch,
+		session.WorktreePath,
+		session.WorktreePath,
+		targetBranchShort,
+		targetBranchShort,
+	)
+}
+
+// buildSystemInstructions combines app-level prompt, user custom instructions,
+// and conversation summaries into the full instructions string for the agent.
+func (m *Manager) buildSystemInstructions(ctx context.Context, session *models.Session, sessionWithWs *models.SessionWithWorkspace, existingInstructions string) string {
+	var parts []string
+
+	// 1. App-level context + rules
+	parts = append(parts, buildAppPrompt(session, sessionWithWs))
+
+	// 2. User's global custom instructions (from settings)
+	if custom, found, err := m.store.GetSetting(ctx, "custom-instructions"); err == nil && found && custom != "" {
+		parts = append(parts, "## Custom Instructions\n\n"+custom)
+	}
+
+	// 3. Conversation summaries (existing, passed from handler)
+	if existingInstructions != "" {
+		parts = append(parts, existingInstructions)
+	}
+
+	return strings.Join(parts, "\n\n")
 }

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -4676,6 +4676,48 @@ func (h *Handlers) SetWorkspaceReviewPrompts(w http.ResponseWriter, r *http.Requ
 	h.setReviewPrompts(w, r, fmt.Sprintf("review-prompts:%s", workspaceID))
 }
 
+// GetCustomInstructions returns the global custom instructions for agent system prompts
+func (h *Handlers) GetCustomInstructions(w http.ResponseWriter, r *http.Request) {
+	value, found, err := h.store.GetSetting(r.Context(), "custom-instructions")
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if !found {
+		writeJSON(w, map[string]string{"instructions": ""})
+		return
+	}
+	writeJSON(w, map[string]string{"instructions": value})
+}
+
+// SetCustomInstructions updates the global custom instructions for agent system prompts
+func (h *Handlers) SetCustomInstructions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req struct {
+		Instructions string `json:"instructions"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	trimmed := strings.TrimSpace(req.Instructions)
+	if trimmed == "" {
+		if err := h.store.DeleteSetting(ctx, "custom-instructions"); err != nil {
+			writeDBError(w, err)
+			return
+		}
+	} else {
+		if err := h.store.SetSetting(ctx, "custom-instructions", trimmed); err != nil {
+			writeDBError(w, err)
+			return
+		}
+	}
+
+	writeJSON(w, map[string]string{"status": "ok"})
+}
+
 // GetSessionBranchSyncStatus returns how far behind the session is from the target branch
 func (h *Handlers) GetSessionBranchSyncStatus(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -191,6 +191,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	r.Put("/api/settings/workspaces-base-dir", h.SetWorkspacesBaseDir)
 	r.Get("/api/settings/review-prompts", h.GetReviewPrompts)
 	r.Put("/api/settings/review-prompts", h.SetReviewPrompts)
+	r.Get("/api/settings/custom-instructions", h.GetCustomInstructions)
+	r.Put("/api/settings/custom-instructions", h.SetCustomInstructions)
 	r.Get("/api/settings/env", h.GetEnvSettings)
 	r.Put("/api/settings/env", h.SetEnvSettings)
 	r.Get("/api/settings/pr-template", h.GetGlobalPRTemplate)

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
   User,
   Wrench,
   Info,
+  ScrollText,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useMainToolbarContent } from '@/hooks/useMainToolbarContent';
@@ -24,6 +25,7 @@ import { ReviewSettings } from './sections/ReviewSettings';
 import { AccountSettings } from './sections/AccountSettings';
 import { AdvancedSettings } from './sections/AdvancedSettings';
 import { AboutSettings } from './sections/AboutSettings';
+import { InstructionsSettings } from './sections/InstructionsSettings';
 
 interface SettingsPageProps {
   onBack: () => void;
@@ -34,6 +36,7 @@ type SettingsCategory =
   | 'general'
   | 'appearance'
   | 'ai-models'
+  | 'instructions'
   | 'git'
   | 'review'
   | 'account'
@@ -50,6 +53,7 @@ const mainNavItems: NavItem[] = [
   { id: 'general', label: 'General', icon: <Settings2 className="w-3.5 h-3.5" /> },
   { id: 'appearance', label: 'Appearance', icon: <Palette className="w-3.5 h-3.5" /> },
   { id: 'ai-models', label: 'AI & Models', icon: <Bot className="w-3.5 h-3.5" /> },
+  { id: 'instructions', label: 'Instructions', icon: <ScrollText className="w-3.5 h-3.5" /> },
   { id: 'git', label: 'Git', icon: <GitBranch className="w-3.5 h-3.5" /> },
   { id: 'review', label: 'Review & PRs', icon: <Eye className="w-3.5 h-3.5" /> },
   { id: 'account', label: 'Account', icon: <User className="w-3.5 h-3.5" /> },
@@ -147,6 +151,7 @@ export function SettingsPage({ onBack, initialCategory = 'general' }: SettingsPa
             {selectedCategory === 'general' && <GeneralSettings />}
             {selectedCategory === 'appearance' && <AppearanceSettings />}
             {selectedCategory === 'ai-models' && <AIModelSettings />}
+            {selectedCategory === 'instructions' && <InstructionsSettings />}
             {selectedCategory === 'git' && <GitSettings />}
             {selectedCategory === 'review' && <ReviewSettings />}
             {selectedCategory === 'account' && <AccountSettings />}

--- a/src/components/settings/sections/InstructionsSettings.tsx
+++ b/src/components/settings/sections/InstructionsSettings.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/toast';
+import { getCustomInstructions, setCustomInstructions } from '@/lib/api';
+
+export function InstructionsSettings() {
+  const [instructions, setInstructions] = useState('');
+  const [saved, setSaved] = useState('');
+  const [saving, setSaving] = useState(false);
+  const { error: showError } = useToast();
+
+  useEffect(() => {
+    getCustomInstructions()
+      .then((data) => {
+        setInstructions(data);
+        setSaved(data);
+      })
+      .catch(() => {
+        showError('Failed to load custom instructions');
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const hasChanges = instructions !== saved;
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const trimmed = instructions.trim();
+      await setCustomInstructions(trimmed);
+      setInstructions(trimmed);
+      setSaved(trimmed);
+    } catch {
+      showError('Failed to save custom instructions');
+    } finally {
+      setSaving(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [instructions]);
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-1">Custom Instructions</h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        These instructions are included in the system prompt for every new conversation.
+        Use this to set behavioral rules, coding standards, or preferences that apply across all sessions.
+      </p>
+
+      <Textarea
+        className="text-sm min-h-[200px]"
+        placeholder="e.g., Always write tests before implementation. Use TypeScript strict mode. Prefer functional components with hooks."
+        value={instructions}
+        onChange={(e) => setInstructions(e.target.value)}
+      />
+
+      {hasChanges && (
+        <div className="mt-4 flex justify-end">
+          <Button size="sm" disabled={saving} onClick={handleSave}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1833,6 +1833,25 @@ export async function setWorkspaceReviewPrompts(
   await handleVoidResponse(res, 'Failed to save workspace review prompts');
 }
 
+// ---------------------------------------------------------------------------
+// Custom Instructions
+// ---------------------------------------------------------------------------
+
+export async function getCustomInstructions(): Promise<string> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/custom-instructions`);
+  const data = await handleResponse<{ instructions: string }>(res);
+  return data.instructions;
+}
+
+export async function setCustomInstructions(instructions: string): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/custom-instructions`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ instructions }),
+  });
+  await handleVoidResponse(res, 'Failed to save custom instructions');
+}
+
 // ==================== Scripts API ====================
 
 import type { ChatMLConfig, ScriptRun } from '@/lib/types';


### PR DESCRIPTION
## Summary
- Inject app-level instructions into every conversation with session context (name, branch, target branch, worktree path)
- Encode critical git worktree behavioral rules (never switch branches, never stash, no destructive ops, stay in worktree, post-merge behavior)
- Add user-configurable global instructions via Settings > Instructions tab
- Backend: buildAppPrompt() + buildSystemInstructions() in manager.go, API endpoints in handlers.go/router.go
- Frontend: new InstructionsSettings component integrated into SettingsPage

## Test Plan
- [x] Backend Go tests pass
- [x] New code type-checks cleanly (no TypeScript errors in our changes)
- Manual verification on `make dev`:
  - [ ] Navigate to Settings > Instructions, save custom instructions
  - [ ] Create new session and conversation
  - [ ] Ask agent "What session and branch are you on?" — should know from injected context
  - [ ] Ask "Switch to main branch" — should refuse and explain worktree constraint
  - [ ] Ask "What custom instructions were you given?" — should mention user's custom text

🤖 Generated with [Claude Code](https://claude.com/claude-code)