### PR TITLE
Add keyboard shortcuts for sidebar tab switching

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -69,6 +69,7 @@ import { cn } from '@/lib/utils';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import type { FileTab } from '@/lib/types';
+import { useShortcuts } from '@/hooks/useShortcut';
 
 // Common binary file extensions
 const BINARY_EXTENSIONS = new Set([
@@ -509,6 +510,15 @@ export function ChangesPanel() {
     showResolved,
     onToggleShowResolved: () => setShowResolved((prev) => !prev),
   }), [fetchChanges, fetchBranchCommits, handleResolveAll, prUrl, unresolvedCount, showResolved]);
+
+  // Keyboard shortcuts for switching sidebar tabs
+  const tabShortcuts = useMemo(() => ({
+    sidebarFilesTab: () => setSelectedTab('files'),
+    sidebarChangesTab: () => setSelectedTab('changes'),
+    sidebarChecksTab: () => setSelectedTab('checks'),
+    sidebarReviewTab: () => setSelectedTab('review'),
+  }), []);
+  useShortcuts(tabShortcuts);
 
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -137,6 +137,34 @@ export const SHORTCUTS: Shortcut[] = [
     label: 'Previous tab',
     category: 'Navigation',
   },
+  {
+    id: 'sidebarFilesTab',
+    key: 'f',
+    modifiers: ['alt'],
+    label: 'Switch to Files tab',
+    category: 'Navigation',
+  },
+  {
+    id: 'sidebarChangesTab',
+    key: 'c',
+    modifiers: ['alt'],
+    label: 'Switch to Changes tab',
+    category: 'Navigation',
+  },
+  {
+    id: 'sidebarChecksTab',
+    key: 'c',
+    modifiers: ['alt', 'shift'],
+    label: 'Switch to Checks tab',
+    category: 'Navigation',
+  },
+  {
+    id: 'sidebarReviewTab',
+    key: 'r',
+    modifiers: ['alt'],
+    label: 'Switch to Review tab',
+    category: 'Navigation',
+  },
 
   // Chat
   {
@@ -314,6 +342,13 @@ export function matchesShortcut(event: KeyboardEvent, shortcut: Shortcut): boole
   }
   if (shortcut.key === 'Enter') {
     return event.key === 'Enter';
+  }
+
+  // On macOS, Alt+letter produces special characters (e.g., Alt+F → 'ƒ'),
+  // so event.key won't match the expected letter. Use event.code instead,
+  // which always returns 'Key' + letter.toUpperCase() regardless of modifiers.
+  if (needsAlt && shortcut.key.length === 1 && /^[a-z]$/i.test(shortcut.key)) {
+    return event.code === `Key${shortcut.key.toUpperCase()}`;
   }
 
   return eventKey === shortcutKey;


### PR DESCRIPTION
## Summary
- Add Alt+F/C/Shift+C/R keyboard shortcuts to switch between Files, Changes, Checks, and Review sidebar tabs
- Fix macOS Alt+letter key matching in `matchesShortcut` by using `event.code` instead of `event.key`, which produces special Unicode characters when Alt is held on macOS (e.g., Alt+F → `ƒ`)

## Test plan
- [ ] Press Alt+F → Files tab activates
- [ ] Press Alt+C → Changes tab activates
- [ ] Press Alt+Shift+C → Checks tab activates
- [ ] Press Alt+R → Review tab activates
- [ ] Verify existing Alt-based shortcuts (e.g., Alt+T for toggle thinking) still work
- [ ] Verify non-Alt shortcuts (Cmd+K, Cmd+P, etc.) are unaffected
- [ ] Test on macOS specifically to confirm the `event.code` fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)