### PR TITLE
fix: Prevent silent agent exit when process crashes or produces no output

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -691,7 +691,16 @@ function buildUserMessage(msg: QueuedMessage): SDKUserMessage {
   }
 
   for (const attachment of msg.attachments) {
-    if (attachment.type === "image" && attachment.base64Data) {
+    if (!attachment.base64Data) {
+      // Attachment arrived without content data — warn so the issue is visible
+      emit({
+        type: "warning",
+        message: `Attachment "${attachment.name}" (${attachment.type}) has no base64Data and was skipped`,
+      });
+      continue;
+    }
+
+    if (attachment.type === "image") {
       contentBlocks.push({
         type: "image",
         source: {
@@ -700,7 +709,7 @@ function buildUserMessage(msg: QueuedMessage): SDKUserMessage {
           data: attachment.base64Data,
         }
       });
-    } else if (attachment.base64Data) {
+    } else {
       let content = Buffer.from(attachment.base64Data, "base64").toString("utf-8");
       content = content.replace(/<\/attached_file>/g, "&lt;/attached_file&gt;");
       const lineInfo = attachment.lineCount ? ` lines="${attachment.lineCount}"` : "";
@@ -2200,17 +2209,36 @@ async function cleanup(reason: string): Promise<void> {
   emit({ type: "shutdown", reason });
 }
 
+// Drain stdout before exiting to ensure all emitted events reach the Go backend.
+// console.log uses buffered I/O when stdout is a pipe; process.exit() would
+// terminate before the buffer is flushed, silently dropping error events.
+function drainAndExit(code: number): void {
+  // If stdout is already destroyed or not writable, exit immediately
+  if (!process.stdout.writable) {
+    process.exit(code);
+    return;
+  }
+  // Write an empty string and wait for the callback — this ensures all
+  // previously buffered data has been flushed to the OS pipe.
+  process.stdout.write("", () => {
+    process.exit(code);
+  });
+  // Safety net: if the drain callback never fires (broken pipe, etc.),
+  // force-exit after a short timeout so we don't hang forever.
+  setTimeout(() => process.exit(code), 500).unref();
+}
+
 // Handle graceful shutdown
 process.on("SIGTERM", () => {
   if (isShuttingDown) return;
   isShuttingDown = true;
-  cleanup("SIGTERM").finally(() => process.exit(0));
+  cleanup("SIGTERM").finally(() => drainAndExit(0));
 });
 
 process.on("SIGINT", () => {
   if (isShuttingDown) return;
   isShuttingDown = true;
-  cleanup("SIGINT").finally(() => process.exit(0));
+  cleanup("SIGINT").finally(() => drainAndExit(0));
 });
 
 process.on("unhandledRejection", async (reason) => {
@@ -2222,7 +2250,7 @@ process.on("unhandledRejection", async (reason) => {
       ? `${reason.message}\n${reason.stack || ""}`
       : String(reason);
   emit({ type: "error", message: `Unhandled rejection: ${errorMessage}` });
-  process.exit(1);
+  drainAndExit(1);
 });
 
 main().catch(async (err) => {
@@ -2241,5 +2269,5 @@ main().catch(async (err) => {
   }
 
   emit({ type: "error", message: `Unhandled error: ${errorMessage}` });
-  process.exit(1);
+  drainAndExit(1);
 });

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -502,6 +502,8 @@ outer:
 				}
 				isThinking = false
 
+				// Track that the process produced user-visible output (for zero-output detection)
+				proc.SetProducedOutput()
 				currentAssistantMessage += event.Content
 				// Track text segments for timeline persistence
 				if currentSegmentStart == nil {
@@ -991,24 +993,55 @@ func (m *Manager) handleConversationCompletion(convID string, proc *Process) {
 	}
 
 	exitErr := proc.ExitError()
+	var synthesizedError string
+
 	if exitErr != nil {
 		logger.Manager.Warnf("Conversation %s process exited with error: %v", convID, exitErr)
 
 		// If the agent-runner didn't emit its own error event, synthesize one
 		// so the frontend shows a useful message instead of silently going idle.
-		if !proc.SawErrorEvent() && m.onConversationEvent != nil {
+		if !proc.SawErrorEvent() {
 			stderrLines := proc.LastStderrLines()
-			errMsg := fmt.Sprintf("Claude Code process exited with code 1")
+			synthesizedError = "Claude Code process exited with code 1"
 			if len(stderrLines) > 0 {
-				errMsg += ": " + strings.Join(stderrLines, "\n")
+				synthesizedError += ": " + strings.Join(stderrLines, "\n")
 			}
-			m.onConversationEvent(convID, &AgentEvent{
-				Type:    EventTypeError,
-				Message: errMsg,
-			})
 		}
 	} else {
 		logger.Manager.Infof("Conversation %s process exited cleanly", convID)
+	}
+
+	// Safety net: if the process exited (cleanly or not) without producing any
+	// assistant output AND without an error event, synthesize a user-visible error.
+	// This prevents the conversation from going silently idle with zero feedback.
+	// Only fires if the crash fallback above didn't already synthesize an error.
+	if synthesizedError == "" && !proc.ProducedOutput() && !proc.SawErrorEvent() {
+		stderrLines := proc.LastStderrLines()
+		synthesizedError = "The agent process exited without producing any response"
+		if len(stderrLines) > 0 {
+			synthesizedError += ": " + strings.Join(stderrLines, "\n")
+		}
+		logger.Manager.Warnf("Conversation %s zero-output safety net triggered", convID)
+	}
+
+	// Persist the synthesized error as an assistant message so it survives app
+	// restarts, and broadcast it via WebSocket for immediate display.
+	if synthesizedError != "" {
+		if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
+			ID:        uuid.New().String()[:8],
+			Role:      "assistant",
+			Content:   synthesizedError,
+			Timeline:  []models.TimelineEntry{{Type: "text", Content: synthesizedError}},
+			Timestamp: time.Now(),
+		}); err != nil {
+			logger.Manager.Errorf("Failed to persist synthesized error for conv %s: %v", convID, err)
+		}
+		if m.onConversationEvent != nil {
+			m.onConversationEvent(convID, &AgentEvent{
+				Type:    EventTypeError,
+				Message: synthesizedError,
+			})
+		}
 	}
 
 	// Remove completed process from map to prevent unbounded growth.

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -79,6 +79,7 @@ type Process struct {
 	opts               ProcessOptions // Original options for restart
 	lastStderrLines    []string      // Ring buffer of last N stderr lines for crash diagnostics
 	sawErrorEvent      bool          // Whether the agent emitted an error/auth_error event
+	producedOutput     bool          // Whether any assistant text was emitted during this process lifetime
 }
 
 // InputMessage represents a message sent to the agent runner via stdin
@@ -701,6 +702,20 @@ func (p *Process) SawErrorEvent() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.sawErrorEvent
+}
+
+// SetProducedOutput marks that the agent emitted assistant text during this process lifetime.
+func (p *Process) SetProducedOutput() {
+	p.mu.Lock()
+	p.producedOutput = true
+	p.mu.Unlock()
+}
+
+// ProducedOutput returns whether any assistant text was emitted during this process lifetime.
+func (p *Process) ProducedOutput() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.producedOutput
 }
 
 // SetRunningForTest sets the running flag. Intended for testing only.

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -3394,6 +3394,14 @@ func (h *Handlers) SendConversationMessage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Validate that image attachments have base64 data
+	for _, att := range req.Attachments {
+		if att.Type == "image" && att.Base64Data == "" {
+			writeValidationError(w, fmt.Sprintf("image attachment %q is missing base64Data", att.Name))
+			return
+		}
+	}
+
 	// Switch model if specified
 	if req.Model != "" {
 		// Always persist model to DB first - this ensures auto-restart will use the correct model


### PR DESCRIPTION
## Summary
- **Stdout flush race**: Added `drainAndExit()` in agent-runner that flushes stdout before calling `process.exit()`, preventing error events from being silently dropped when stdout is a pipe
- **Zero-output safety net**: Backend now detects when a process exits without producing any assistant text and synthesizes a persistent error message (stored in DB + broadcast via WebSocket)
- **Attachment validation**: Image attachments without `base64Data` are now rejected at the HTTP handler level, and the agent-runner emits a warning instead of silently skipping them

## Test plan
- [x] Go backend builds and all tests pass
- [x] TypeScript agent-runner compiles cleanly
- [x] Frontend lint passes
- [ ] Manual: Create session with image attachment → verify response appears (or error shown if API fails)
- [ ] Manual: Kill agent-runner process mid-session → verify error message appears and survives app restart
- [ ] Manual: Restart app after an agent crash → verify error is visible in conversation history

🤖 Generated with [Claude Code](https://claude.com/claude-code)