### PR TITLE
Refactor MCP tools to use backend APIs

### DIFF
--- a/agent-runner/src/mcp/server.ts
+++ b/agent-runner/src/mcp/server.ts
@@ -6,6 +6,33 @@ import { createLinearTools } from "./tools/linear.js";
 import { createCommentTools } from "./tools/comments.js";
 import { createScriptTools } from "./tools/scripts.js";
 
+const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://localhost:9876";
+
+function sessionApiUrl(context: WorkspaceContext, path: string): string {
+  return `${BACKEND_URL}/api/repos/${context.workspaceId}/sessions/${context.sessionId}${path}`;
+}
+
+interface FileChange {
+  path: string;
+  additions: number;
+  deletions: number;
+  status: string;
+}
+
+interface BranchCommit {
+  sha: string;
+  shortSha: string;
+  message: string;
+  author: string;
+  timestamp: string;
+  files: FileChange[];
+}
+
+interface BranchChangesResponse {
+  commits: BranchCommit[];
+  branchStats?: { totalFiles: number; totalAdditions: number; totalDeletions: number };
+}
+
 export interface McpServerOptions {
   context: WorkspaceContext;
 }
@@ -23,31 +50,54 @@ export function createChatMLMcpServer(options: McpServerOptions) {
         "Get current session status including branch, worktree, and active Linear issue",
         {},
         async () => {
-          const git = context.refreshGitState();
           const issue = context.linearIssue;
 
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify({
-                sessionId: context.sessionId,
-                workspaceId: context.workspaceId,
-                cwd: context.cwd,
-                git: {
-                  branch: git.branch,
-                  baseBranch: git.baseBranch,
-                  uncommittedChanges: git.uncommittedChanges,
-                  aheadBy: git.aheadBy,
-                  behindBy: git.behindBy,
-                },
-                linearIssue: issue ? {
-                  identifier: issue.identifier,
-                  title: issue.title,
-                  state: issue.state,
-                } : null,
-              }, null, 2),
-            }],
-          };
+          try {
+            const res = await fetch(sessionApiUrl(context, "/git-status"));
+            const gitStatus = await res.json();
+
+            return {
+              content: [{
+                type: "text",
+                text: JSON.stringify({
+                  sessionId: context.sessionId,
+                  workspaceId: context.workspaceId,
+                  cwd: context.cwd,
+                  git: gitStatus,
+                  linearIssue: issue ? {
+                    identifier: issue.identifier,
+                    title: issue.title,
+                    state: issue.state,
+                  } : null,
+                }, null, 2),
+              }],
+            };
+          } catch (error) {
+            // Fall back to local git state if backend is unavailable
+            const git = context.refreshGitState();
+            return {
+              content: [{
+                type: "text",
+                text: JSON.stringify({
+                  sessionId: context.sessionId,
+                  workspaceId: context.workspaceId,
+                  cwd: context.cwd,
+                  git: {
+                    branch: git.branch,
+                    baseBranch: git.baseBranch,
+                    uncommittedChanges: git.uncommittedChanges,
+                    aheadBy: git.aheadBy,
+                    behindBy: git.behindBy,
+                  },
+                  linearIssue: issue ? {
+                    identifier: issue.identifier,
+                    title: issue.title,
+                    state: issue.state,
+                  } : null,
+                }, null, 2),
+              }],
+            };
+          }
         },
         { annotations: { readOnlyHint: true } }
       ),
@@ -55,26 +105,93 @@ export function createChatMLMcpServer(options: McpServerOptions) {
       // Workspace diff tool
       tool(
         "get_workspace_diff",
-        "Get a summary of all changes in the workspace compared to the base branch",
+        "Get a summary of all changes in the workspace compared to the base branch, including uncommitted changes",
         {
           detailed: z.boolean().optional().describe("Include full diff output instead of summary"),
+          file: z.string().optional().describe("Get diff for a specific file path"),
         },
-        async ({ detailed }) => {
-          const git = context.gitState;
-          const { execFileSync } = await import("child_process");
-
+        async ({ detailed, file }) => {
           try {
-            const execOpts = { cwd: context.cwd, encoding: "utf-8" as const };
-            if (detailed) {
-              const diff = execFileSync("git", ["diff", `${git.baseBranch}...HEAD`], execOpts);
+            // Single file diff
+            if (file) {
+              const res = await fetch(sessionApiUrl(context, `/diff?path=${encodeURIComponent(file)}`));
+              const diff = await res.json();
               return {
-                content: [{ type: "text", text: diff || "No changes" }],
+                content: [{ type: "text", text: JSON.stringify(diff, null, 2) }],
               };
             }
 
-            const stat = execFileSync("git", ["diff", `${git.baseBranch}...HEAD`, "--stat"], execOpts);
+            // Fetch uncommitted changes + branch commits in parallel
+            const [changesRes, branchRes] = await Promise.all([
+              fetch(sessionApiUrl(context, "/changes")),
+              fetch(sessionApiUrl(context, "/branch-commits")),
+            ]);
+
+            const uncommitted: FileChange[] = await changesRes.json();
+            const branch: BranchChangesResponse = await branchRes.json();
+
+            const hasCommits = branch.commits && branch.commits.length > 0;
+            const hasUncommitted = uncommitted && uncommitted.length > 0;
+
+            if (!hasCommits && !hasUncommitted) {
+              return { content: [{ type: "text", text: "No changes" }] };
+            }
+
+            if (detailed) {
+              // Collect all changed file paths (from both committed and uncommitted)
+              const filePaths = new Set<string>();
+              if (hasUncommitted) {
+                for (const f of uncommitted) filePaths.add(f.path);
+              }
+              if (hasCommits) {
+                for (const c of branch.commits) {
+                  for (const f of c.files) filePaths.add(f.path);
+                }
+              }
+
+              // Fetch full diffs for all files in parallel
+              const diffs = await Promise.all(
+                Array.from(filePaths).map(async (path) => {
+                  try {
+                    const res = await fetch(sessionApiUrl(context, `/diff?path=${encodeURIComponent(path)}`));
+                    const diff = await res.json();
+                    return { path, oldContent: diff.oldContent, newContent: diff.newContent };
+                  } catch {
+                    return { path, error: "Failed to fetch diff" };
+                  }
+                })
+              );
+
+              return {
+                content: [{ type: "text", text: JSON.stringify({ uncommitted, commits: branch.commits, branchStats: branch.branchStats, diffs }, null, 2) }],
+              };
+            }
+
+            // Stat mode: format a concise summary
+            const lines: string[] = [];
+
+            if (branch.branchStats) {
+              const s = branch.branchStats;
+              lines.push(`Branch: ${s.totalFiles} file(s) changed, +${s.totalAdditions} -${s.totalDeletions}`);
+            }
+
+            if (hasCommits) {
+              lines.push(`\nCommits (${branch.commits.length}):`);
+              for (const c of branch.commits) {
+                lines.push(`  ${c.shortSha} ${c.message}`);
+              }
+            }
+
+            if (hasUncommitted) {
+              lines.push(`\nUncommitted changes (${uncommitted.length}):`);
+              for (const f of uncommitted) {
+                const stats = f.additions || f.deletions ? ` (+${f.additions} -${f.deletions})` : "";
+                lines.push(`  ${f.status.padEnd(10)} ${f.path}${stats}`);
+              }
+            }
+
             return {
-              content: [{ type: "text", text: stat || "No changes" }],
+              content: [{ type: "text", text: lines.join("\n") }],
             };
           } catch (error) {
             return {
@@ -89,20 +206,32 @@ export function createChatMLMcpServer(options: McpServerOptions) {
       tool(
         "get_recent_activity",
         "Get recent commits and file changes in the workspace",
-        {
-          limit: z.number().optional().default(10).describe("Number of commits to show"),
-        },
-        async ({ limit }) => {
-          const { execFileSync } = await import("child_process");
-
+        {},
+        async () => {
           try {
-            const logs = execFileSync("git", ["log", `-${limit}`, "--oneline", "--decorate"], { cwd: context.cwd, encoding: "utf-8" as const });
+            const res = await fetch(sessionApiUrl(context, "/branch-commits"));
+            const branch: BranchChangesResponse = await res.json();
+
+            if (!branch.commits || branch.commits.length === 0) {
+              return { content: [{ type: "text", text: "No commits on this branch" }] };
+            }
+
+            const lines: string[] = [];
+            for (const c of branch.commits) {
+              lines.push(`${c.shortSha} ${c.message} (${c.author})`);
+              if (c.files && c.files.length > 0) {
+                for (const f of c.files) {
+                  lines.push(`  ${f.status.padEnd(10)} ${f.path} (+${f.additions} -${f.deletions})`);
+                }
+              }
+            }
+
             return {
-              content: [{ type: "text", text: logs || "No commits" }],
+              content: [{ type: "text", text: lines.join("\n") }],
             };
           } catch (error) {
             return {
-              content: [{ type: "text", text: `Error getting logs: ${error}` }],
+              content: [{ type: "text", text: `Error getting activity: ${error}` }],
             };
           }
         },


### PR DESCRIPTION
## Summary

Fixed the bug where `get_workspace_diff` returned "No changes" for uncommitted work. All three MCP tools now call the existing backend REST endpoints instead of running raw git commands, eliminating code duplication and fixing the root issue.

**Changes:**
- `get_workspace_diff`: Now calls `/changes` + `/branch-commits` endpoints, properly including uncommitted changes, staged changes, and untracked files
- `get_session_status`: Now calls `/git-status` endpoint for comprehensive status (working dir, sync, conflicts, stash, in-progress ops)
- `get_recent_activity`: Now calls `/branch-commits` endpoint with per-file change stats

## Why This Matters

The old implementation ran `git diff baseBranch...HEAD` which only shows committed changes. The new implementation reuses the backend's well-tested logic with merge-base computation, gitignore filtering, and all uncommitted change types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)