### PR TITLE
feat: Improve suggestions with contextual phase-aware flow

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1524,40 +1524,154 @@ func (m *Manager) generateAndApplySessionTitle(sessionID, convID, userMessage st
 	m.tryAutoNameSession(ctx, sessionID, title)
 }
 
+// detectPhase determines the current development lifecycle phase from session and git state.
+// The phase string is the primary dispatch key for the suggestion prompt.
+func detectPhase(sess *models.Session, gitStatus *git.GitStatus) string {
+	// Highest priority: in-progress git operations
+	if gitStatus != nil && gitStatus.InProgress.Type != "none" {
+		return "resolving-" + gitStatus.InProgress.Type // resolving-rebase, resolving-merge, resolving-cherry-pick
+	}
+
+	// Conflicts (from git or session flag)
+	if gitStatus != nil && gitStatus.Conflicts.HasConflicts {
+		return "conflict-resolution"
+	}
+	if sess.HasMergeConflict {
+		return "conflict-resolution"
+	}
+
+	// PR-based phases
+	switch sess.PRStatus {
+	case models.PRStatusOpen:
+		if sess.HasCheckFailures {
+			return "pr-fixing-ci"
+		}
+		return "pr-review"
+	case models.PRStatusMerged:
+		return "post-merge"
+	case models.PRStatusClosed:
+		return "pr-closed"
+	}
+
+	// Git working directory phases
+	if gitStatus != nil {
+		hasUncommitted := gitStatus.WorkingDirectory.HasChanges
+		// Use UnpushedCommits only — AheadBy measures distance from the base branch,
+		// not the remote tracking branch, so it stays >0 even after pushing.
+		hasUnpushed := gitStatus.Sync.UnpushedCommits > 0
+
+		if !hasUncommitted && hasUnpushed {
+			return "ready-for-pr"
+		}
+		// Check staged before general hasUncommitted: staged files are a subset of
+		// uncommitted changes, and "ready-to-commit" is more specific than "development".
+		if gitStatus.WorkingDirectory.StagedCount > 0 {
+			return "ready-to-commit"
+		}
+		if hasUncommitted {
+			return "development"
+		}
+	}
+
+	return "exploration"
+}
+
 // buildSessionContext builds a context string describing the session's current state
-// (PR status, git state) for use in suggestion generation.
+// (phase, git state, PR status, conversation type) for use in suggestion generation.
 func (m *Manager) buildSessionContext(ctx context.Context, convID string) string {
 	conv, err := m.store.GetConversationMeta(ctx, convID)
 	if err != nil || conv == nil {
 		return ""
 	}
 
-	sess, err := m.store.GetSession(ctx, conv.SessionID)
-	if err != nil || sess == nil {
+	sessWithWs, err := m.store.GetSessionWithWorkspace(ctx, conv.SessionID)
+	if err != nil || sessWithWs == nil {
 		return ""
 	}
+	sess := &sessWithWs.Session
 
-	var parts []string
+	var lines []string
 
+	// Get git status (graceful degradation on error)
+	var gitStatus *git.GitStatus
+	if sess.WorktreePath != "" {
+		baseBranch := sessWithWs.DefaultBranch()
+		status, err := git.NewRepoManager().GetStatus(ctx, sess.WorktreePath, baseBranch)
+		if err != nil {
+			logger.Manager.Debugf("Failed to get git status for suggestions (conv %s): %v", convID, err)
+		} else {
+			gitStatus = status
+		}
+	}
+
+	// Phase detection (primary dispatch key for the prompt)
+	phase := detectPhase(sess, gitStatus)
+	lines = append(lines, fmt.Sprintf("Phase: %s", phase))
+
+	// Conversation metadata
+	lines = append(lines, fmt.Sprintf("Conv: %s, %d messages", conv.Type, conv.MessageCount))
+
+	// Git working directory state
+	if gitStatus != nil {
+		wd := gitStatus.WorkingDirectory
+		lines = append(lines, fmt.Sprintf("Git: %d staged, %d unstaged, %d untracked", wd.StagedCount, wd.UnstagedCount, wd.UntrackedCount))
+
+		sync := gitStatus.Sync
+		syncLine := fmt.Sprintf("Sync: %d unpushed, %d behind", sync.UnpushedCommits, sync.BehindBy)
+		if sync.Diverged {
+			syncLine += " (diverged)"
+		}
+		lines = append(lines, syncLine)
+
+		// In-progress operations
+		if gitStatus.InProgress.Type != "none" {
+			if gitStatus.InProgress.Total > 0 {
+				lines = append(lines, fmt.Sprintf("In-progress: %s (%d/%d)", gitStatus.InProgress.Type, gitStatus.InProgress.Current, gitStatus.InProgress.Total))
+			} else {
+				lines = append(lines, fmt.Sprintf("In-progress: %s", gitStatus.InProgress.Type))
+			}
+		}
+
+		// Conflicts
+		if gitStatus.Conflicts.HasConflicts {
+			lines = append(lines, fmt.Sprintf("Conflicts: %d files", gitStatus.Conflicts.Count))
+		}
+	}
+
+	// PR status
 	switch sess.PRStatus {
 	case models.PRStatusOpen:
-		part := fmt.Sprintf("PR #%d is open", sess.PRNumber)
+		prLine := fmt.Sprintf("PR: #%d open", sess.PRNumber)
 		if sess.HasCheckFailures {
-			part += "; CI checks are failing"
-		} else if sess.HasMergeConflict {
-			part += "; has merge conflicts"
+			prLine += ", CI failing"
+		} else if sess.CheckStatus == models.CheckStatusPending {
+			prLine += ", CI pending"
+		} else if sess.CheckStatus == models.CheckStatusSuccess {
+			prLine += ", CI passing"
 		}
-		parts = append(parts, part)
+		if sess.HasMergeConflict {
+			prLine += ", has merge conflicts"
+		}
+		lines = append(lines, prLine)
 	case models.PRStatusMerged:
-		parts = append(parts, fmt.Sprintf("PR #%d has been merged", sess.PRNumber))
+		lines = append(lines, fmt.Sprintf("PR: #%d merged", sess.PRNumber))
 	case models.PRStatusClosed:
-		parts = append(parts, fmt.Sprintf("PR #%d was closed", sess.PRNumber))
+		lines = append(lines, fmt.Sprintf("PR: #%d closed", sess.PRNumber))
+	default:
+		lines = append(lines, "PR: none")
 	}
 
-	if len(parts) == 0 {
-		return ""
+	// Session stats
+	if sess.Stats != nil && (sess.Stats.Additions > 0 || sess.Stats.Deletions > 0) {
+		lines = append(lines, fmt.Sprintf("Stats: +%d/-%d", sess.Stats.Additions, sess.Stats.Deletions))
 	}
-	return strings.Join(parts, "; ")
+
+	// Task status
+	if sess.TaskStatus != "" && sess.TaskStatus != "backlog" {
+		lines = append(lines, fmt.Sprintf("Task: %s", sess.TaskStatus))
+	}
+
+	return strings.Join(lines, "\n")
 }
 
 // generateInputSuggestion uses the AI client to generate a suggested next prompt

--- a/backend/ai/generate.go
+++ b/backend/ai/generate.go
@@ -618,34 +618,77 @@ type SuggestionResponse struct {
 	Pills     []SuggestionPill `json:"pills"`
 }
 
-const suggestionSystemPrompt = `You suggest what the user should say next to an AI coding assistant based on the assistant's last output.
+const suggestionSystemPrompt = `You suggest what the user should say next to an AI coding assistant. You receive the assistant's last output, tool actions, and session context with a "Phase" field indicating the development lifecycle state.
 
-You will receive the assistant's last text output and a list of actions it performed (tools used, files edited, etc.).
-You may also receive session context describing the current state (PR status, git state). Use it to avoid redundant suggestions.
+PHASE-BASED RULES (use the Phase field from session context):
 
-Rules:
-- Suggest a natural follow-up based on what the assistant just did
-- If the assistant completed a task: suggest reviewing, testing, committing, or extending the work
-- If the assistant asked the user a question: provide 2-3 short pill answers the user can click, plus ghost_text with the most likely answer
-- If the assistant just read/explored code: suggest asking for changes, explanations, or next steps
-- If a PR already exists for this session, never suggest creating a PR
-- If the PR is already merged, suggest archiving the session or starting new work
-- If no suggestion is appropriate, return empty ghost_text and empty pills array
-- ghost_text should be 5-15 words, natural language, imperative mood
-- pill labels should be 2-4 words; pill values should be complete sentences the user would type
-- Output valid JSON only, no markdown fences, no extra text
+"exploration" — No code changes yet. Suggest exploring, understanding, or starting work.
+  Pills: "Explain this", "Show the tests", "Let's start implementing"
+  ghost_text: natural follow-up question about what was shown
 
-NEVER suggest any of these destructive operations:
-- Deleting branches, cleaning up branches, or worktree operations (sessions use worktrees)
-- git push --force, git reset --hard, git clean -f, rm -rf
+"development" — Uncommitted changes exist. Suggest testing, reviewing, or continuing.
+  Pills: "Run the tests", "Show what changed", "Continue implementing"
+  ghost_text: most logical next step for the work in progress
+
+"ready-to-commit" — Changes are staged. Suggest committing or reviewing first.
+  Pills: "Commit changes", "Run tests first", "Review the diff"
+  ghost_text: "Commit the changes with a descriptive message"
+
+"ready-for-pr" — Commits exist but no PR. Suggest creating a PR.
+  Pills: "Create a PR", "Push changes", "Run tests before PR"
+  ghost_text: "Create a pull request for these changes"
+
+"pr-review" — PR is open, CI passing or pending. Suggest review actions.
+  Pills: "Check CI status", "Add more tests", "Review the changes"
+  ghost_text: depends on CI state (pending vs passing)
+
+"pr-fixing-ci" — PR open, CI FAILING. Urgently suggest fixing.
+  Pills: "Fix CI failures", "Show CI logs", "Run tests locally"
+  ghost_text: "Fix the failing CI checks"
+
+"conflict-resolution" — Merge conflicts exist. Urgently suggest resolving.
+  Pills: "Resolve conflicts", "Show conflict files", "Sync with main"
+  ghost_text: "Resolve the merge conflicts"
+
+"resolving-rebase" / "resolving-merge" / "resolving-cherry-pick" — Git operation in progress.
+  Pills: "Continue the [op]", "Abort the [op]", "Show conflicts"
+  ghost_text: "Continue the [operation] after resolving conflicts"
+
+"post-merge" — PR was merged. Suggest next steps.
+  Pills: "What's next?", "Start new work", "Update task status"
+  ghost_text: "What should we work on next?"
+
+"pr-closed" — PR was closed without merging.
+  Pills: "Why was it closed?", "Reopen the PR", "Start fresh"
+  ghost_text: "Why was this PR closed?"
+
+OVERRIDES (these take priority over phase rules):
+- If assistant asked a question: provide 2-3 answer pills + ghost_text with the most likely answer
+- If assistant reported an error or failure: suggest fixing or retrying
+- If Git shows 0 staged, 0 unstaged, 0 untracked AND Sync shows 0 unpushed: NEVER suggest commit, push, or create PR
+
+CONVERSATION TYPE (from "Conv:" field):
+- "chat": Focus on questions, exploration, explanations. NEVER suggest commit/PR/push.
+- "review": Focus on fixing issues, addressing feedback, code quality.
+- "task": Follow the phase-based rules above.
+
+FORMAT:
+- ghost_text: 5-15 words, imperative mood, natural language
+- pill labels: 2-4 words
+- pill values: complete sentences the user would type
+- 1-3 pills maximum
+- Output valid JSON only, no markdown fences
+- If no suggestion fits, return empty ghost_text and empty pills
+
+NEVER suggest destructive operations:
+- Deleting branches, worktree cleanup, git push --force, git reset --hard, git clean -f, rm -rf
 - Archiving or deleting the current session
-- Any operation that destroys local work or git history
 
 Output format:
 {"ghost_text": "...", "pills": [{"label": "...", "value": "..."}]}`
 
 const suggestionMaxTokens = 200
-const suggestionMaxInputChars = 2000
+const suggestionMaxInputChars = 3000
 
 // GenerateInputSuggestion calls the Anthropic API to generate a suggested next prompt
 // based on recent conversation messages. Returns an empty suggestion on error.


### PR DESCRIPTION
## Summary
- Replace simple PR-status-only session context with a full development lifecycle phase detector (`detectPhase`) that uses live git status to determine the current phase (exploration, development, ready-to-commit, ready-for-pr, pr-review, pr-fixing-ci, conflict-resolution, resolving-rebase/merge/cherry-pick, post-merge, pr-closed)
- Rewrite the suggestion system prompt with phase-based rules and conversation-type awareness (chat/review/task) for more relevant, context-aware suggestions
- Enrich session context sent to the suggestion model with git working directory state, sync status, in-progress operations, conflicts, session stats, and task status

## Bug fixes included
- Fix `ready-for-pr` phase detection: use only `UnpushedCommits` instead of `UnpushedCommits || AheadBy` (AheadBy measures distance from base branch, not remote tracking branch)
- Use `models.CheckStatusPending` / `models.CheckStatusSuccess` constants instead of string literals
- Trim exploration phase pill examples from 4 to 3 to match the "1-3 pills maximum" format rule
- Add missing `ghost_text` example for the `pr-closed` phase

## Test plan
- [ ] Verify suggestions appear correctly in exploration phase (no code changes)
- [ ] Make code changes and verify "development" phase suggestions (run tests, show changes)
- [ ] Stage files and verify "ready-to-commit" suggestions
- [ ] Push commits without PR and verify "ready-for-pr" suggestions
- [ ] Open a PR and verify "pr-review" suggestions
- [ ] Verify chat conversations never get commit/PR suggestions
- [ ] Verify build passes: `cd backend && go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)