### PR TITLE
fix: Resolve stale closure in multi-select question toggling

### DIFF
--- a/src/components/conversation/UserQuestionPrompt.tsx
+++ b/src/components/conversation/UserQuestionPrompt.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { usePendingUserQuestion, useUserQuestionActions } from '@/stores/selectors';
+import { useAppStore } from '@/stores/appStore';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { X, ChevronLeft, ChevronRight, ArrowUp, Check, Loader2 } from 'lucide-react';
@@ -37,19 +38,20 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
     if (!currentQuestion) return;
 
     if (currentQuestion.multiSelect) {
-      // Toggle in set
-      const newSet = new Set(selectedValues);
-      if (newSet.has(label)) {
-        newSet.delete(label);
+      // Read current answer directly from store to avoid stale closure
+      const currentAnswer = useAppStore.getState().pendingUserQuestion[conversationId]?.answers[currentQuestion.header] || '';
+      const currentSet = new Set(currentAnswer.split(',').filter(Boolean));
+      if (currentSet.has(label)) {
+        currentSet.delete(label);
       } else {
-        newSet.add(label);
+        currentSet.add(label);
       }
-      updateUserQuestionAnswer(conversationId, currentQuestion.header, [...newSet].join(','));
+      updateUserQuestionAnswer(conversationId, currentQuestion.header, [...currentSet].join(','));
     } else {
       // Single select - replace
       updateUserQuestionAnswer(conversationId, currentQuestion.header, label);
     }
-  }, [conversationId, currentQuestion, selectedValues, updateUserQuestionAnswer]);
+  }, [conversationId, currentQuestion, updateUserQuestionAnswer]);
 
   const handleDismiss = useCallback(async () => {
     if (!pending || isSubmitting) return;
@@ -122,8 +124,8 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
           </Button>
         </div>
 
-        {/* Options List or Free-text Input */}
-        <div className="px-2 pb-2">
+        {/* Options List or Free-text Input — key forces remount when question changes */}
+        <div key={currentQuestion.header} className="px-2 pb-2">
           {currentQuestion.options.length > 0 ? (
             currentQuestion.options.map((option, index) => {
               const isSelected = selectedValues.has(option.label);

--- a/src/components/conversation/__tests__/UserQuestionPrompt.test.tsx
+++ b/src/components/conversation/__tests__/UserQuestionPrompt.test.tsx
@@ -392,6 +392,30 @@ describe('UserQuestionPrompt', () => {
       expect(screen.getByTestId('submit-question')).not.toBeDisabled();
     });
 
+    it('allows clicking options after navigating to a different question', async () => {
+      const user = userEvent.setup();
+      setPending(makeMultiPending());
+      render(<UserQuestionPrompt conversationId={CONV_ID} />);
+
+      // Answer Q1
+      await user.click(screen.getByText('React'));
+
+      // Navigate to Q2 via store
+      act(() => {
+        useAppStore.getState().nextUserQuestion(CONV_ID);
+      });
+
+      // Q2 options should now be visible and clickable
+      expect(screen.getByText('Pick a database')).toBeInTheDocument();
+      await user.click(screen.getByText('PostgreSQL'));
+
+      const state = useAppStore.getState();
+      const pending = state.pendingUserQuestion[CONV_ID];
+      expect(pending?.answers['Database']).toBe('PostgreSQL');
+      // Q1 answer should still be preserved
+      expect(pending?.answers['Framework']).toBe('React');
+    });
+
     it('sends all answers in a single submit call', async () => {
       const user = userEvent.setup();
       setPending(makeMultiPending());


### PR DESCRIPTION
## Summary
- Fix stale closure bug where toggling multi-select options after navigating between questions used outdated state
- Read current answer directly from the store via `useAppStore.getState()` instead of relying on the `selectedValues` memo captured in the callback closure
- Add `key` prop to force remount of the options container when the active question changes, preventing stale UI

## Test plan
- [ ] Toggle options on a multi-select question, navigate to next question, toggle options there — verify both answers are preserved correctly
- [ ] Verify single-select questions still work as before
- [ ] Run existing test suite (`UserQuestionPrompt.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)