### PR TITLE
feat: Overhaul Welcome screen into Smart Launcher

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1478,7 +1478,8 @@ export default function Home() {
                   <EmptyView
                     onOpenProject={handleOpenProject}
                     onCloneFromUrl={() => setShowCloneFromUrl(true)}
-                    onQuickStart={() => setShowQuickStart(true)}
+                    onNewSession={handleNewSession}
+                    onCreateFromPR={() => setShowCreateFromPR(true)}
                     onOpenSettings={() => setShowSettings(true)}
                     onOpenShortcuts={() => setShowShortcuts(true)}
                     showLeftSidebar={!leftSidebarCollapsed}

--- a/src/components/dashboards/PRDashboard.tsx
+++ b/src/components/dashboards/PRDashboard.tsx
@@ -8,6 +8,7 @@ import { FullContentLayout } from '@/components/layout/FullContentLayout';
 import { useMainToolbarContent } from '@/hooks/useMainToolbarContent';
 import { DataTable, type Column, type ContextMenuItem, type FilterOption, type DisplayOptionsConfig } from '@/components/data-table';
 import { getPRs, sendSessionMessage, type PRDashboardItem } from '@/lib/api';
+import { computePRStatus, STATUS_ORDER, STATUS_LABELS, type PRWithStatus, type PRStatusCategory } from '@/lib/pr-utils';
 import { Button } from '@/components/ui/button';
 import {
   HoverCard,
@@ -52,19 +53,6 @@ interface PRDashboardProps {
   initialWorkspaceId?: string;
 }
 
-// PR Status categories for grouping
-type PRStatusCategory = 'ready' | 'pending' | 'failures' | 'conflicts' | 'draft';
-
-const STATUS_ORDER: PRStatusCategory[] = ['ready', 'failures', 'conflicts', 'pending', 'draft'];
-
-const STATUS_LABELS: Record<PRStatusCategory, string> = {
-  ready: 'Ready to Merge',
-  pending: 'Checks Pending',
-  failures: 'Check Failures',
-  conflicts: 'Merge Conflicts',
-  draft: 'Draft',
-};
-
 // Helper to open URLs in browser
 async function openInBrowser(url: string) {
   if (isTauri()) {
@@ -73,46 +61,6 @@ async function openInBrowser(url: string) {
   } else {
     window.open(url, '_blank');
   }
-}
-
-// Extended PR item with computed status
-interface PRWithStatus extends PRDashboardItem {
-  statusCategory: PRStatusCategory;
-  pendingCount: number;
-  hasConflicts: boolean;
-  allPassed: boolean;
-}
-
-// Compute PR status category
-function computePRStatus(pr: PRDashboardItem): PRWithStatus {
-  const hasChecks = pr.checksTotal > 0;
-  const hasFailures = pr.checksFailed > 0;
-  const pendingCount = pr.checksTotal - pr.checksPassed - pr.checksFailed;
-  const hasPending = pendingCount > 0;
-  const allPassed = hasChecks && !hasFailures && !hasPending;
-  const hasConflicts = pr.mergeableState === 'dirty' || pr.mergeable === false;
-
-  let statusCategory: PRStatusCategory;
-
-  if (pr.isDraft) {
-    statusCategory = 'draft';
-  } else if (hasConflicts) {
-    statusCategory = 'conflicts';
-  } else if (hasFailures) {
-    statusCategory = 'failures';
-  } else if (hasPending) {
-    statusCategory = 'pending';
-  } else {
-    statusCategory = 'ready';
-  }
-
-  return {
-    ...pr,
-    statusCategory,
-    pendingCount,
-    hasConflicts,
-    allPassed,
-  };
 }
 
 // Status icon cell component

--- a/src/components/shared/EmptyView.tsx
+++ b/src/components/shared/EmptyView.tsx
@@ -1,44 +1,46 @@
 'use client';
 
-import { Folder, Globe, SquarePlus, Sparkles } from 'lucide-react';
+import { useMemo } from 'react';
+import { useWorkspaceSelection } from '@/stores/selectors';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { FullContentLayout } from '@/components/layout/FullContentLayout';
+import { QuickActions } from './smart-launcher/QuickActions';
+import { RecentSessions } from './smart-launcher/RecentSessions';
+import { PRSummary } from './smart-launcher/PRSummary';
+import { ShortcutsGrid } from './smart-launcher/ShortcutsGrid';
+import { useLauncherPRSummary } from './smart-launcher/useLauncherPRSummary';
 
 interface EmptyViewProps {
   onOpenProject: () => void;
   onCloneFromUrl: () => void;
-  onQuickStart: () => void;
+  onNewSession: () => void;
+  onCreateFromPR: () => void;
   onOpenSettings?: () => void;
   onOpenShortcuts?: () => void;
   showLeftSidebar?: boolean;
 }
 
-const ACTION_CARDS = [
-  { icon: Folder, label: 'Open project', key: 'open' },
-  { icon: Globe, label: 'Clone from URL', key: 'clone' },
-  { icon: SquarePlus, label: 'Quick start', key: 'quickstart' },
-] as const;
-
 export function EmptyView({
   onOpenProject,
   onCloneFromUrl,
-  onQuickStart,
+  onNewSession,
+  onCreateFromPR,
   onOpenSettings,
   onOpenShortcuts,
   showLeftSidebar = true,
 }: EmptyViewProps) {
-  const handleCardClick = (key: string) => {
-    switch (key) {
-      case 'open':
-        onOpenProject();
-        break;
-      case 'clone':
-        onCloneFromUrl();
-        break;
-      case 'quickstart':
-        onQuickStart();
-        break;
-    }
-  };
+  const { workspaces, sessions, selectedWorkspaceId } = useWorkspaceSelection();
+  const workspaceColors = useSettingsStore((s) => s.workspaceColors);
+  const prSummary = useLauncherPRSummary();
+
+  const recentSessions = useMemo(() => {
+    return [...sessions]
+      .filter((s) => !s.archived)
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+      .slice(0, 5);
+  }, [sessions]);
+
+  const hasWorkspace = !!selectedWorkspaceId;
 
   return (
     <FullContentLayout
@@ -47,35 +49,42 @@ export function EmptyView({
       onOpenShortcuts={onOpenShortcuts}
       showLeftSidebar={showLeftSidebar}
     >
-      <div className="h-full flex flex-col items-center justify-center bg-content-background">
-      {/* Logo */}
-      <div className="mb-12">
-        <div className="relative">
-          {/* Glow effect */}
-          <div className="absolute inset-0 bg-gradient-to-br from-primary to-purple-500 rounded-2xl blur-xl opacity-30" />
-          {/* Logo */}
-          <div className="relative flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-purple-500 shadow-lg">
-            <Sparkles className="h-10 w-10 text-white" />
+      <div className="h-full overflow-y-auto bg-content-background">
+        <div className="max-w-2xl mx-auto px-6 py-12 stagger-children">
+          {/* Quick Actions */}
+          <div>
+            <QuickActions
+              onOpenProject={onOpenProject}
+              onCloneFromUrl={onCloneFromUrl}
+              onNewSession={onNewSession}
+              onCreateFromPR={onCreateFromPR}
+              hasWorkspace={hasWorkspace}
+            />
+          </div>
+
+          {/* Recent Sessions */}
+          <div className="mt-10">
+            <RecentSessions
+              sessions={recentSessions}
+              workspaces={workspaces}
+              workspaceColors={workspaceColors}
+            />
+          </div>
+
+          {/* Pull Requests Summary */}
+          <div className="mt-10">
+            <PRSummary
+              summary={prSummary.summary}
+              loading={prSummary.loading}
+              error={prSummary.error}
+            />
+          </div>
+
+          {/* Keyboard Shortcuts */}
+          <div className="mt-10">
+            <ShortcutsGrid onOpenShortcuts={onOpenShortcuts} />
           </div>
         </div>
-      </div>
-
-      {/* Action Cards */}
-      <div className="flex gap-4">
-        {ACTION_CARDS.map(({ icon: Icon, label, key }) => (
-          <button
-            key={key}
-            onClick={() => handleCardClick(key)}
-            className="group flex flex-col w-40 h-28 p-4 rounded-xl border border-border/50 bg-card/50 hover:bg-card hover:border-border transition-all duration-200"
-            {...(key === 'open' ? { 'data-tour-target': 'add-workspace' } : {})}
-          >
-            <Icon className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
-            <span className="mt-auto text-sm text-muted-foreground group-hover:text-foreground transition-colors">
-              {label}
-            </span>
-          </button>
-        ))}
-      </div>
       </div>
     </FullContentLayout>
   );

--- a/src/components/shared/smart-launcher/PRSummary.tsx
+++ b/src/components/shared/smart-launcher/PRSummary.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { navigate } from '@/lib/navigation';
+import type { PRSummaryData } from './useLauncherPRSummary';
+
+interface PRSummaryProps {
+  summary: PRSummaryData | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function PRSummary({ summary, loading, error }: PRSummaryProps) {
+  // Hide entirely on error
+  if (error) return null;
+
+  const handleViewAll = () => {
+    navigate({ contentView: { type: 'pr-dashboard' } });
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Pull Requests
+        </h2>
+        {summary && summary.total > 0 && (
+          <button
+            onClick={handleViewAll}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            View all
+          </button>
+        )}
+      </div>
+
+      {loading && (
+        <div className="animate-pulse bg-muted-foreground/10 rounded h-5 w-64" />
+      )}
+
+      {!loading && summary && summary.total === 0 && (
+        <p className="text-sm text-muted-foreground">No open pull requests</p>
+      )}
+
+      {!loading && summary && summary.total > 0 && (
+        <p className="text-sm">
+          <span className="text-foreground font-medium">{summary.total} open</span>
+          {summary.ready > 0 && (
+            <>
+              <span className="text-muted-foreground"> · </span>
+              <span className="text-emerald-500">{summary.ready} ready to merge</span>
+            </>
+          )}
+          {summary.failing > 0 && (
+            <>
+              <span className="text-muted-foreground"> · </span>
+              <span className="text-red-500">{summary.failing} failing</span>
+            </>
+          )}
+          {summary.conflicts > 0 && (
+            <>
+              <span className="text-muted-foreground"> · </span>
+              <span className="text-amber-500">{summary.conflicts} conflicts</span>
+            </>
+          )}
+          {summary.pending > 0 && (
+            <>
+              <span className="text-muted-foreground"> · </span>
+              <span className="text-muted-foreground">{summary.pending} pending</span>
+            </>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/smart-launcher/QuickActions.tsx
+++ b/src/components/shared/smart-launcher/QuickActions.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Folder, Globe, Plus, GitBranch } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface QuickActionsProps {
+  onOpenProject: () => void;
+  onCloneFromUrl: () => void;
+  onNewSession: () => void;
+  onCreateFromPR: () => void;
+  hasWorkspace: boolean;
+}
+
+const ACTION_CARDS = [
+  { icon: Folder, label: 'Open project', key: 'open' },
+  { icon: Globe, label: 'Clone from URL', key: 'clone' },
+  { icon: Plus, label: 'New session', key: 'new-session', requiresWorkspace: true },
+  { icon: GitBranch, label: 'From PR/Branch', key: 'from-pr' },
+] as const;
+
+export function QuickActions({
+  onOpenProject,
+  onCloneFromUrl,
+  onNewSession,
+  onCreateFromPR,
+  hasWorkspace,
+}: QuickActionsProps) {
+  const handleCardClick = (key: string) => {
+    switch (key) {
+      case 'open':
+        onOpenProject();
+        break;
+      case 'clone':
+        onCloneFromUrl();
+        break;
+      case 'new-session':
+        onNewSession();
+        break;
+      case 'from-pr':
+        onCreateFromPR();
+        break;
+    }
+  };
+
+  return (
+    <div className="flex gap-3 flex-wrap justify-center">
+      {ACTION_CARDS.map(({ icon: Icon, label, key, ...rest }) => {
+        const disabled = 'requiresWorkspace' in rest && rest.requiresWorkspace && !hasWorkspace;
+        return (
+          <button
+            key={key}
+            onClick={() => !disabled && handleCardClick(key)}
+            disabled={disabled}
+            className={cn(
+              'group flex flex-col w-36 h-24 p-4 rounded-xl border border-border/50 bg-card/50 transition-all duration-200',
+              disabled
+                ? 'opacity-40 cursor-not-allowed'
+                : 'hover:bg-card hover:border-border cursor-pointer'
+            )}
+            {...(key === 'open' ? { 'data-tour-target': 'add-workspace' } : {})}
+          >
+            <Icon className={cn(
+              'h-5 w-5 text-muted-foreground transition-colors',
+              !disabled && 'group-hover:text-foreground'
+            )} />
+            <span className={cn(
+              'mt-auto text-sm text-muted-foreground transition-colors',
+              !disabled && 'group-hover:text-foreground'
+            )}>
+              {label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/shared/smart-launcher/RecentSessionItem.tsx
+++ b/src/components/shared/smart-launcher/RecentSessionItem.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { MessageCircleQuestion, ClipboardCheck } from 'lucide-react';
+import { useSessionActivityState } from '@/stores/selectors';
+import { navigate } from '@/lib/navigation';
+import { formatRelativeTime } from '@/components/shared/SessionInfoParts';
+import { resolveWorkspaceColor } from '@/lib/workspace-colors';
+import type { WorktreeSession, Workspace } from '@/lib/types';
+
+interface RecentSessionItemProps {
+  session: WorktreeSession;
+  workspace: Workspace | undefined;
+  workspaceColors: Record<string, string>;
+}
+
+export function RecentSessionItem({ session, workspace, workspaceColors }: RecentSessionItemProps) {
+  const activityState = useSessionActivityState(session.id);
+
+  const handleClick = () => {
+    navigate({
+      workspaceId: session.workspaceId,
+      sessionId: session.id,
+      contentView: { type: 'conversation' },
+    });
+  };
+
+  const color = resolveWorkspaceColor(session.workspaceId, workspaceColors);
+
+  return (
+    <button
+      onClick={handleClick}
+      className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-card/50 transition-colors text-left cursor-pointer"
+    >
+      {/* Workspace color dot */}
+      <div
+        className="w-2 h-2 rounded-full shrink-0"
+        style={{ backgroundColor: color }}
+      />
+
+      {/* Session name */}
+      <span className="text-sm text-foreground truncate min-w-0 flex-1">
+        {session.name || session.branch}
+      </span>
+
+      {/* Workspace name */}
+      {workspace && (
+        <span className="text-xs text-muted-foreground truncate max-w-[120px]">
+          {workspace.name}
+        </span>
+      )}
+
+      {/* Activity indicator */}
+      {activityState === 'working' && (
+        <div className="w-4 shrink-0 flex items-center justify-center">
+          <div className="session-active-indicator">
+            <div className="bar" />
+            <div className="bar" />
+            <div className="bar" />
+          </div>
+        </div>
+      )}
+      {activityState === 'awaiting_input' && (
+        <div className="w-4 shrink-0 flex items-center justify-center">
+          <div className="session-awaiting-input-indicator">
+            <MessageCircleQuestion className="w-3.5 h-3.5 text-amber-400" />
+          </div>
+        </div>
+      )}
+      {activityState === 'awaiting_approval' && (
+        <div className="w-4 shrink-0 flex items-center justify-center">
+          <div className="session-awaiting-approval-indicator">
+            <ClipboardCheck className="w-3.5 h-3.5 text-blue-400" />
+          </div>
+        </div>
+      )}
+
+      {/* Relative time */}
+      <span className="text-xs text-muted-foreground shrink-0">
+        {formatRelativeTime(session.updatedAt)}
+      </span>
+    </button>
+  );
+}

--- a/src/components/shared/smart-launcher/RecentSessions.tsx
+++ b/src/components/shared/smart-launcher/RecentSessions.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { RecentSessionItem } from './RecentSessionItem';
+import type { WorktreeSession, Workspace } from '@/lib/types';
+
+interface RecentSessionsProps {
+  sessions: WorktreeSession[];
+  workspaces: Workspace[];
+  workspaceColors: Record<string, string>;
+}
+
+export function RecentSessions({ sessions, workspaces, workspaceColors }: RecentSessionsProps) {
+  const workspaceMap = new Map(workspaces.map((w) => [w.id, w]));
+
+  return (
+    <div>
+      <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+        Recent Sessions
+      </h2>
+
+      {sessions.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No sessions yet</p>
+      ) : (
+        <div className="flex flex-col gap-0.5">
+          {sessions.map((session) => (
+            <RecentSessionItem
+              key={session.id}
+              session={session}
+              workspace={workspaceMap.get(session.workspaceId)}
+              workspaceColors={workspaceColors}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/smart-launcher/ShortcutsGrid.tsx
+++ b/src/components/shared/smart-launcher/ShortcutsGrid.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { SHORTCUTS, formatShortcutKeys } from '@/lib/shortcuts';
+
+const LAUNCHER_SHORTCUT_IDS = [
+  'commandPalette',
+  'newSession',
+  'focusChat',
+  'createFromPR',
+  'filePicker',
+  'shortcutsDialog',
+];
+
+interface ShortcutsGridProps {
+  onOpenShortcuts?: () => void;
+}
+
+export function ShortcutsGrid({ onOpenShortcuts }: ShortcutsGridProps) {
+  const shortcuts = LAUNCHER_SHORTCUT_IDS
+    .map((id) => SHORTCUTS.find((s) => s.id === id))
+    .filter(Boolean);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Keyboard Shortcuts
+        </h2>
+        {onOpenShortcuts && (
+          <button
+            onClick={onOpenShortcuts}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            View all
+          </button>
+        )}
+      </div>
+      <div className="grid grid-cols-2 gap-x-8 gap-y-2">
+        {shortcuts.map((shortcut) => (
+          <div key={shortcut!.id} className="flex items-center gap-3">
+            <kbd className="inline-flex items-center justify-center min-w-[2rem] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-mono text-xs">
+              {formatShortcutKeys(shortcut!).join('')}
+            </kbd>
+            <span className="text-xs text-muted-foreground">
+              {shortcut!.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/smart-launcher/useLauncherPRSummary.ts
+++ b/src/components/shared/smart-launcher/useLauncherPRSummary.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getPRs } from '@/lib/api';
+import { computePRStatus } from '@/lib/pr-utils';
+
+export interface PRSummaryData {
+  total: number;
+  ready: number;
+  failing: number;
+  pending: number;
+  draft: number;
+  conflicts: number;
+}
+
+export function useLauncherPRSummary(): {
+  summary: PRSummaryData | null;
+  loading: boolean;
+  error: string | null;
+} {
+  const [summary, setSummary] = useState<PRSummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    getPRs()
+      .then((prs) => {
+        if (controller.signal.aborted) return;
+
+        const categorized = prs.map(computePRStatus);
+        const data: PRSummaryData = {
+          total: categorized.length,
+          ready: 0,
+          failing: 0,
+          pending: 0,
+          draft: 0,
+          conflicts: 0,
+        };
+
+        for (const pr of categorized) {
+          switch (pr.statusCategory) {
+            case 'ready': data.ready++; break;
+            case 'failures': data.failing++; break;
+            case 'pending': data.pending++; break;
+            case 'draft': data.draft++; break;
+            case 'conflicts': data.conflicts++; break;
+          }
+        }
+
+        setSummary(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to fetch PRs');
+        setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  return { summary, loading, error };
+}

--- a/src/lib/pr-utils.ts
+++ b/src/lib/pr-utils.ts
@@ -1,0 +1,54 @@
+import type { PRDashboardItem } from '@/lib/api';
+
+// PR Status categories for grouping
+export type PRStatusCategory = 'ready' | 'pending' | 'failures' | 'conflicts' | 'draft';
+
+export const STATUS_ORDER: PRStatusCategory[] = ['ready', 'failures', 'conflicts', 'pending', 'draft'];
+
+export const STATUS_LABELS: Record<PRStatusCategory, string> = {
+  ready: 'Ready to Merge',
+  pending: 'Checks Pending',
+  failures: 'Check Failures',
+  conflicts: 'Merge Conflicts',
+  draft: 'Draft',
+};
+
+// Extended PR item with computed status
+export interface PRWithStatus extends PRDashboardItem {
+  statusCategory: PRStatusCategory;
+  pendingCount: number;
+  hasConflicts: boolean;
+  allPassed: boolean;
+}
+
+// Compute PR status category
+export function computePRStatus(pr: PRDashboardItem): PRWithStatus {
+  const hasChecks = pr.checksTotal > 0;
+  const hasFailures = pr.checksFailed > 0;
+  const pendingCount = pr.checksTotal - pr.checksPassed - pr.checksFailed;
+  const hasPending = pendingCount > 0;
+  const allPassed = hasChecks && !hasFailures && !hasPending;
+  const hasConflicts = pr.mergeableState === 'dirty' || pr.mergeable === false;
+
+  let statusCategory: PRStatusCategory;
+
+  if (pr.isDraft) {
+    statusCategory = 'draft';
+  } else if (hasConflicts) {
+    statusCategory = 'conflicts';
+  } else if (hasFailures) {
+    statusCategory = 'failures';
+  } else if (hasPending) {
+    statusCategory = 'pending';
+  } else {
+    statusCategory = 'ready';
+  }
+
+  return {
+    ...pr,
+    statusCategory,
+    pendingCount,
+    hasConflicts,
+    allPassed,
+  };
+}


### PR DESCRIPTION
## Summary
- Replace minimal EmptyView placeholder (sparkle icon + 3 action cards) with an information-rich **Smart Launcher** that helps users get back to work quickly
- Add **Recent Sessions** (top 5, sorted by activity, with live activity indicators), **PR Summary** (compact status line with colored counts), and **Keyboard Shortcuts** grid
- Extract `computePRStatus` into shared `src/lib/pr-utils.ts` for reuse across PRDashboard and the new launcher
- Replace "Quick start" action with "New session" (disabled when no workspace selected), add "From PR/Branch" action

## Test plan
- [ ] Open app with no sessions → verify Quick Actions show, "No sessions yet" text, shortcuts grid renders
- [ ] Create 2-3 sessions → deselect all → verify recent sessions list sorted by time with activity indicators
- [ ] Click a session row → should navigate to that session's conversation
- [ ] Verify PR summary shows counts with colored labels (or "No open pull requests" if none)
- [ ] Click "View all" on PRs → navigates to PR Dashboard
- [ ] Click "View all" on Shortcuts → opens shortcuts dialog
- [ ] Verify all 4 Quick Action cards work (Open, Clone, New Session, From PR/Branch)
- [ ] "New Session" card disabled when no workspace is selected
- [ ] Resize window → layout doesn't break, action cards wrap
- [ ] Verify stagger fade-in animation on load
- [ ] Open PR Dashboard directly → verify it still works after `computePRStatus` extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)