### PR TITLE
fix: Clear merge conflict flag on PR merge/close and reorder status checks

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -446,8 +446,10 @@ func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, bran
 			if sess.CheckStatus == "" {
 				sess.CheckStatus = models.CheckStatusNone
 			}
-			if mergeable != nil {
+			if newStatus == models.PRStatusOpen && mergeable != nil {
 				sess.HasMergeConflict = !*mergeable
+			} else if newStatus == models.PRStatusMerged || newStatus == models.PRStatusClosed {
+				sess.HasMergeConflict = false
 			}
 
 			// Auto-update taskStatus based on PR lifecycle

--- a/backend/branch/pr_watcher_test.go
+++ b/backend/branch/pr_watcher_test.go
@@ -2,6 +2,10 @@ package branch
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
@@ -273,6 +277,217 @@ func TestBoolPtrEqual_BothFalseSame(t *testing.T) {
 
 func TestBoolPtrEqual_Different(t *testing.T) {
 	assert.False(t, boolPtrEqual(boolPtr(true), boolPtr(false)))
+}
+
+// ---------------------------------------------------------------------------
+// HasMergeConflict flag tests
+// ---------------------------------------------------------------------------
+
+func TestPRWatcher_CheckSessionPR_MergedPR_ClearsMergeConflict(t *testing.T) {
+	// Simulate a PR that was open with a merge conflict, then gets merged.
+	// The HasMergeConflict flag should be cleared when the PR transitions to merged.
+	store := newMockStore()
+	store.sessions["sess-1"] = &models.Session{
+		ID:               "sess-1",
+		HasMergeConflict: true, // was conflicting while open
+		PRStatus:         models.PRStatusOpen,
+		PRNumber:         42,
+		TaskStatus:       models.TaskStatusInReview,
+	}
+
+	var capturedEvent *PRChangeEvent
+	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
+	w := newTestPRWatcher(store, repoMgr, nil)
+	w.onChange = func(evt PRChangeEvent) {
+		capturedEvent = &evt
+	}
+	defer w.Close()
+
+	// Set up a mock GitHub API server that returns the PR as merged
+	ts := newMockGitHubServer(t, mockGitHubResponses{
+		prDetails: &mockPRDetails{state: "closed", merged: true, mergeable: nil},
+		prMerged:  boolPtr(true),
+	})
+	defer ts.Close()
+
+	ghClient := github.NewClient("", "")
+	ghClient.SetToken("test-token")
+	ghClient.SetAPIURL(ts.URL)
+	w.ghClient = ghClient
+
+	// Manually set up the watch entry as if PR was previously open
+	w.mu.Lock()
+	w.sessions["sess-1"] = &PRWatchEntry{
+		SessionID: "sess-1",
+		Branch:    "feature/foo",
+		RepoPath:  "/repo/path",
+		PRStatus:  models.PRStatusOpen,
+		PRNumber:  42,
+		PRUrl:     "https://github.com/org/myrepo/pull/42",
+	}
+	w.mu.Unlock()
+
+	// PR is no longer in the open list (it's merged), so pass empty branchToPR
+	w.checkSessionPR("org", "myrepo", w.sessions["sess-1"], map[string]*github.PRListItem{})
+
+	// Verify store was updated
+	sess := store.sessions["sess-1"]
+	assert.False(t, sess.HasMergeConflict, "HasMergeConflict should be cleared for merged PR")
+	assert.Equal(t, models.PRStatusMerged, sess.PRStatus)
+	require.NotNil(t, capturedEvent, "should have emitted a change event")
+}
+
+func TestPRWatcher_CheckSessionPR_OpenPR_SetsMergeConflict(t *testing.T) {
+	// When a PR is open and mergeable is false, HasMergeConflict should be true.
+	store := newMockStore()
+	store.sessions["sess-1"] = &models.Session{
+		ID:         "sess-1",
+		PRStatus:   "none",
+		TaskStatus: models.TaskStatusInProgress,
+	}
+
+	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
+	w := newTestPRWatcher(store, repoMgr, nil)
+	w.onChange = func(evt PRChangeEvent) {}
+	defer w.Close()
+
+	mergeable := false
+	ts := newMockGitHubServer(t, mockGitHubResponses{
+		prDetails: &mockPRDetails{state: "open", merged: false, mergeable: &mergeable},
+	})
+	defer ts.Close()
+
+	ghClient := github.NewClient("", "")
+	ghClient.SetToken("test-token")
+	ghClient.SetAPIURL(ts.URL)
+	w.ghClient = ghClient
+
+	w.mu.Lock()
+	w.sessions["sess-1"] = &PRWatchEntry{
+		SessionID: "sess-1",
+		Branch:    "feature/foo",
+		RepoPath:  "/repo/path",
+		PRStatus:  "none",
+	}
+	w.mu.Unlock()
+
+	// PR is in the open list
+	branchToPR := map[string]*github.PRListItem{
+		"feature/foo": {Number: 42, Branch: "feature/foo", HTMLURL: "https://github.com/org/myrepo/pull/42"},
+	}
+	w.checkSessionPR("org", "myrepo", w.sessions["sess-1"], branchToPR)
+
+	sess := store.sessions["sess-1"]
+	assert.True(t, sess.HasMergeConflict, "HasMergeConflict should be true for open non-mergeable PR")
+	assert.Equal(t, models.PRStatusOpen, sess.PRStatus)
+}
+
+func TestPRWatcher_CheckSessionPR_ClosedPR_ClearsMergeConflict(t *testing.T) {
+	// When a PR is closed (not merged), HasMergeConflict should be cleared.
+	store := newMockStore()
+	store.sessions["sess-1"] = &models.Session{
+		ID:               "sess-1",
+		HasMergeConflict: true,
+		PRStatus:         models.PRStatusOpen,
+		PRNumber:         42,
+	}
+
+	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
+	w := newTestPRWatcher(store, repoMgr, nil)
+	w.onChange = func(evt PRChangeEvent) {}
+	defer w.Close()
+
+	ts := newMockGitHubServer(t, mockGitHubResponses{
+		prDetails: &mockPRDetails{state: "closed", merged: false, mergeable: nil},
+		prMerged:  boolPtr(false),
+	})
+	defer ts.Close()
+
+	ghClient := github.NewClient("", "")
+	ghClient.SetToken("test-token")
+	ghClient.SetAPIURL(ts.URL)
+	w.ghClient = ghClient
+
+	w.mu.Lock()
+	w.sessions["sess-1"] = &PRWatchEntry{
+		SessionID: "sess-1",
+		Branch:    "feature/foo",
+		RepoPath:  "/repo/path",
+		PRStatus:  models.PRStatusOpen,
+		PRNumber:  42,
+		PRUrl:     "https://github.com/org/myrepo/pull/42",
+	}
+	w.mu.Unlock()
+
+	w.checkSessionPR("org", "myrepo", w.sessions["sess-1"], map[string]*github.PRListItem{})
+
+	sess := store.sessions["sess-1"]
+	assert.False(t, sess.HasMergeConflict, "HasMergeConflict should be cleared for closed PR")
+	assert.Equal(t, models.PRStatusClosed, sess.PRStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Mock GitHub server helpers
+// ---------------------------------------------------------------------------
+
+type mockPRDetails struct {
+	state     string
+	merged    bool
+	mergeable *bool
+}
+
+type mockGitHubResponses struct {
+	prDetails *mockPRDetails
+	prMerged  *bool // response for /pulls/:number/merge endpoint
+}
+
+func newMockGitHubServer(t *testing.T, responses mockGitHubResponses) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Match /repos/:owner/:repo/pulls/:number/merge
+		if matched, _ := regexp.MatchString(`/repos/.+/.+/pulls/\d+/merge$`, r.URL.Path); matched {
+			if responses.prMerged != nil && *responses.prMerged {
+				w.WriteHeader(http.StatusNoContent) // 204 = merged
+			} else {
+				w.WriteHeader(http.StatusNotFound) // 404 = not merged
+			}
+			return
+		}
+
+		// Match /repos/:owner/:repo/pulls/:number (PR details)
+		if matched, _ := regexp.MatchString(`/repos/.+/.+/pulls/\d+$`, r.URL.Path); matched {
+			if responses.prDetails == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			pr := map[string]interface{}{
+				"number":          42,
+				"state":           responses.prDetails.state,
+				"title":           "Test PR",
+				"body":            "",
+				"html_url":        "https://github.com/org/myrepo/pull/42",
+				"merged":          responses.prDetails.merged,
+				"mergeable":       responses.prDetails.mergeable,
+				"mergeable_state": "unknown",
+				"head":            map[string]string{"sha": "abc123"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(pr)
+			return
+		}
+
+		// Match /repos/:owner/:repo/commits/:ref/check-runs
+		if matched, _ := regexp.MatchString(`/repos/.+/.+/commits/.+/check-runs$`, r.URL.Path); matched {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 0,
+				"check_runs":  []interface{}{},
+			})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/session-manager/SessionRow.tsx
+++ b/src/components/session-manager/SessionRow.tsx
@@ -37,14 +37,14 @@ export function SessionRow({ session, workspace, onSelect, onUnarchive, onPrevie
     if (session.status === 'active') {
       return { text: 'Working...', color: 'text-text-warning' };
     }
+    if (session.prStatus === 'merged') {
+      return { text: 'Merged', color: 'text-primary' };
+    }
     if (session.hasMergeConflict) {
       return { text: 'Merge conflict', color: 'text-text-error' };
     }
     if (session.hasCheckFailures) {
       return { text: 'Checks failing', color: 'text-text-error' };
-    }
-    if (session.prStatus === 'merged') {
-      return { text: 'Merged', color: 'text-primary' };
     }
     if (session.prStatus === 'open') {
       if (session.checkStatus === 'pending') {

--- a/src/components/session-manager/__tests__/SessionRow.test.tsx
+++ b/src/components/session-manager/__tests__/SessionRow.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionRow } from '../SessionRow';
+import type { WorktreeSession, Workspace } from '@/lib/types';
+
+const baseSession: WorktreeSession = {
+  id: 'sess-1',
+  workspaceId: 'ws-1',
+  name: 'Test Session',
+  branch: 'feature/test',
+  worktreePath: '/path/to/worktree',
+  status: 'idle',
+  priority: 0,
+  taskStatus: 'in_progress',
+  archived: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const workspace: Workspace = {
+  id: 'ws-1',
+  name: 'chatml',
+  path: '/repo',
+  defaultBranch: 'main',
+  remote: 'origin',
+  branchPrefix: 'none',
+  customPrefix: '',
+  createdAt: new Date().toISOString(),
+};
+
+function renderSessionRow(session: Partial<WorktreeSession>) {
+  return render(
+    <SessionRow
+      session={{ ...baseSession, ...session }}
+      workspace={workspace}
+      onSelect={vi.fn()}
+    />
+  );
+}
+
+describe('SessionRow PR status text', () => {
+  it('shows "Merged" for merged PR even when hasMergeConflict is true', () => {
+    renderSessionRow({
+      prStatus: 'merged',
+      prNumber: 42,
+      hasMergeConflict: true,
+    });
+
+    expect(screen.getByText('Merged')).toBeInTheDocument();
+    expect(screen.queryByText('Merge conflict')).not.toBeInTheDocument();
+  });
+
+  it('shows "Merge conflict" for open PR with merge conflict', () => {
+    renderSessionRow({
+      prStatus: 'open',
+      prNumber: 42,
+      hasMergeConflict: true,
+    });
+
+    expect(screen.getByText('Merge conflict')).toBeInTheDocument();
+    expect(screen.queryByText('Merged')).not.toBeInTheDocument();
+  });
+
+  it('shows "Merged" for merged PR without merge conflict', () => {
+    renderSessionRow({
+      prStatus: 'merged',
+      prNumber: 42,
+      hasMergeConflict: false,
+    });
+
+    expect(screen.getByText('Merged')).toBeInTheDocument();
+  });
+
+  it('shows "Ready to merge" for open PR without issues', () => {
+    renderSessionRow({
+      prStatus: 'open',
+      prNumber: 42,
+      hasMergeConflict: false,
+      hasCheckFailures: false,
+    });
+
+    expect(screen.getByText('Ready to merge')).toBeInTheDocument();
+  });
+
+  it('shows "Checks failing" for open PR with check failures', () => {
+    renderSessionRow({
+      prStatus: 'open',
+      prNumber: 42,
+      hasCheckFailures: true,
+    });
+
+    expect(screen.getByText('Checks failing')).toBeInTheDocument();
+  });
+
+  it('shows "Working..." for active session with PR', () => {
+    renderSessionRow({
+      status: 'active',
+      prStatus: 'open',
+      prNumber: 42,
+    });
+
+    expect(screen.getByText('Working...')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed backend to only set HasMergeConflict when PR is open; clears it on merge/close
- Reordered frontend status checks to prioritize merged state over merge conflict flag
- Added 9 comprehensive unit tests (3 backend, 6 frontend) to prevent regression

## Root Cause
Merged PRs incorrectly showed "Merge conflict" instead of "Merged" because: (1) backend set HasMergeConflict for all PR states based on GitHub's mergeable field, and (2) frontend checked hasMergeConflict before prStatus === 'merged'.

## Test Plan
- All backend tests pass: go test ./branch/ ✓
- All frontend tests pass: vitest ✓
- Verified full build: npm run build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)