### PR TITLE
fix: GitHub repos dialog scroll overflow

### DIFF
--- a/src/components/dialogs/GitHubReposDialog.tsx
+++ b/src/components/dialogs/GitHubReposDialog.tsx
@@ -318,7 +318,7 @@ export function GitHubReposDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="sm:max-w-lg max-h-[85vh] flex flex-col">
+      <DialogContent className="sm:max-w-lg max-h-[85vh] flex flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Github className="h-5 w-5" />
@@ -378,7 +378,7 @@ export function GitHubReposDialog({
             </div>
 
             {/* Repo list */}
-            <ScrollArea className="flex-1 min-h-0 max-h-[340px]">
+            <ScrollArea className="flex-1 min-h-0">
               <div className="space-y-2 pr-3">
                 {isLoadingRepos && repos.length === 0 ? (
                   // Loading skeletons


### PR DESCRIPTION
## Summary
- Fixed repo list overflow beyond dialog boundaries
- Changed ScrollArea from fixed max-h-[340px] to flex-1 for dynamic sizing
- Added overflow-hidden to DialogContent to properly clip content

## Test Plan
- [ ] Open GitHub Repositories dialog
- [ ] Verify repo list scrolls within dialog boundaries
- [ ] Load more repos and confirm scroll works with pagination
- [ ] Resize window and verify layout adapts

🤖 Generated with [Claude Code](https://claude.com/claude-code)