### PR TITLE
fix: Resolve agent hang when sending image attachments

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -161,7 +161,9 @@ const sdkDebug = hasFlag("--sdk-debug");
 const sdkDebugFile = getArg("--sdk-debug-file");
 
 // Instructions (e.g., from conversation summaries)
-import { readFileSync, unlinkSync } from "fs";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 let instructions: string | undefined;
 {
   const instructionsFilePath = getArg("--instructions-file");
@@ -727,8 +729,11 @@ function buildUserMessage(msg: QueuedMessage): SDKUserMessage {
         continue;
       }
 
-      // Inline base64 path (fallback if temp file offload failed)
-      // Validate image size — Anthropic API limit is 5MB per image.
+      // Inline base64 fallback: Go backend should have offloaded to temp file,
+      // but if it didn't, save to temp file here. Sending image content blocks
+      // directly through the SDK causes hangs (pipe buffer saturation in the
+      // SDK → CLI child process chain). Instead, write to a temp file and use
+      // the same text-instruction approach as the file-based path.
       const rawSizeBytes = Math.ceil(attachment.base64Data.length * 3 / 4);
       const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB
       if (rawSizeBytes > MAX_IMAGE_BYTES) {
@@ -740,14 +745,32 @@ function buildUserMessage(msg: QueuedMessage): SDKUserMessage {
         });
         continue;
       }
-      contentBlocks.push({
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: attachment.mimeType,
-          data: attachment.base64Data,
-        }
-      });
+
+      // Determine extension from MIME type
+      let ext = ".png";
+      if (attachment.mimeType === "image/jpeg") ext = ".jpg";
+      else if (attachment.mimeType === "image/gif") ext = ".gif";
+      else if (attachment.mimeType === "image/webp") ext = ".webp";
+
+      // Write decoded image to temp file
+      try {
+        const tempPath = join(tmpdir(), `chatml-img-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${ext}`);
+        const raw = Buffer.from(attachment.base64Data, "base64");
+        writeFileSync(tempPath, raw);
+        lifecycle(`image "${attachment.name}" saved to temp file: ${tempPath} (${Math.round(raw.length / 1024)}KB)`);
+        tempFilesToClean.push(tempPath);
+        contentBlocks.push({
+          type: "text",
+          text: `[The user attached an image: "${attachment.name}" (${attachment.mimeType}). ` +
+                `IMPORTANT: Read it now with the Read tool at path: ${tempPath}]`,
+        });
+      } catch (err) {
+        lifecycle(`Failed to save image "${attachment.name}" to temp file: ${err}`);
+        emit({
+          type: "warning",
+          message: `Image "${attachment.name}" could not be processed and was skipped`,
+        });
+      }
     } else if (!attachment.base64Data) {
       emit({
         type: "warning",

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -456,6 +456,8 @@ func (p *Process) SendMessageWithAttachments(content string, attachments []model
 	copy(processed, attachments)
 
 	for i := range processed {
+		logger.Process.Debugf("[%s] Attachment[%d]: type=%q mimeType=%q name=%q base64Len=%d path=%q",
+			p.ID, i, processed[i].Type, processed[i].MimeType, processed[i].Name, len(processed[i].Base64Data), processed[i].Path)
 		if processed[i].Type != "image" || processed[i].Base64Data == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Agent hangs for 90+ seconds when users send messages with image attachments, then times out with "agent has not responded" error
- Root cause: inline base64 `image` content blocks sent through the Claude Agent SDK cause pipe buffer saturation in the SDK→CLI child process chain
- Fix: agent-runner now saves inline images to temp files and uses text instructions (same as the file-based delivery path), so the SDK only receives text content blocks
- Added debug logging to Go backend's image offloading to diagnose why the primary offload path is silently skipped

## Test plan
- [ ] Send a message with an image attachment — agent should respond without hanging
- [ ] Verify lifecycle log shows `image "..." saved to temp file: ...` instead of inline base64
- [ ] Send a message without attachments — confirm no regression
- [ ] Check Go debug logs to understand why backend offloading is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)