### PR TITLE
fix: Pause watchdog timer during user interaction waits

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -746,9 +746,16 @@ outer:
 					markSnapshotDirty()
 				}
 
+			case EventTypeUserQuestionRequest:
+				// Agent is waiting for user input — pause the watchdog so it
+				// doesn't fire while the user is answering.
+				activityWatchdog.Stop()
+
 			case EventTypePlanApprovalRequest:
 				pendingPlanContent = event.PlanContent
 				pendingPlanTimestamp = time.Now()
+				// Agent is waiting for plan approval — pause the watchdog.
+				activityWatchdog.Stop()
 
 			case EventTypeCheckpointCreated:
 				if event.CheckpointUuid != "" {


### PR DESCRIPTION
## Summary
- The 90s activity watchdog was firing false alarms when the agent was legitimately waiting for user input (`AskUserQuestion`) or plan approval (`ExitPlanMode`), showing a scary "agent may be stuck" error
- Stop the watchdog timer when these events are received; it auto-restarts when the user responds and the agent emits output again

## Test plan
- [ ] Trigger `AskUserQuestion` and wait >90s before answering — no watchdog error should appear
- [ ] Enter plan mode, let agent propose a plan, wait >90s before approving — no watchdog error
- [ ] Verify watchdog still fires for genuinely stuck agents (no user interaction pending)
- [ ] Run `go test ./agent/...` from backend dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)