### PR TITLE
fix: Remove 90-second watchdog timer

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -486,43 +486,14 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 
 	outputCh := proc.Output()
 
-	// Activity watchdog: if no output events arrive within this period,
-	// emit a visible warning so the user isn't stuck watching a spinner.
-	const processActivityTimeout = 90 * time.Second
-	activityWatchdog := time.NewTimer(processActivityTimeout)
-	defer activityWatchdog.Stop()
-	watchdogFired := false
-
 outer:
 	for {
 		select {
-		case <-activityWatchdog.C:
-			if !watchdogFired {
-				watchdogFired = true
-				logger.Manager.Warnf("Conversation %s: no agent output for %v — process may be hung", convID, processActivityTimeout)
-				if m.onConversationEvent != nil {
-					m.onConversationEvent(convID, &AgentEvent{
-						Type:    EventTypeError,
-						Message: "The agent has not responded for over 90 seconds. It may be stuck. Try sending another message or restarting the session.",
-					})
-				}
-			}
-
 		case line, ok := <-outputCh:
 			if !ok {
 				// Channel closed - process ended
 				break outer
 			}
-
-			// Reset watchdog on any activity
-			if !activityWatchdog.Stop() {
-				select {
-				case <-activityWatchdog.C:
-				default:
-				}
-			}
-			activityWatchdog.Reset(processActivityTimeout)
-			watchdogFired = false
 
 			event := ParseAgentLine(line)
 			if event == nil {
@@ -747,15 +718,11 @@ outer:
 				}
 
 			case EventTypeUserQuestionRequest:
-				// Agent is waiting for user input — pause the watchdog so it
-				// doesn't fire while the user is answering.
-				activityWatchdog.Stop()
+				// Nothing to do — the agent is waiting for user input.
 
 			case EventTypePlanApprovalRequest:
 				pendingPlanContent = event.PlanContent
 				pendingPlanTimestamp = time.Now()
-				// Agent is waiting for plan approval — pause the watchdog.
-				activityWatchdog.Stop()
 
 			case EventTypeCheckpointCreated:
 				if event.CheckpointUuid != "" {
@@ -780,12 +747,6 @@ outer:
 				// Turn or session completed — store accumulated message and reset
 				// streaming state. turn_complete means the process stays alive;
 				// complete/result means it will exit shortly.
-				if event.Type == EventTypeTurnComplete {
-					// Pause the watchdog while idle between turns so it doesn't
-					// fire when the user hasn't sent a message yet. It resets
-					// automatically when the next output event arrives.
-					activityWatchdog.Stop()
-				}
 				if currentAssistantMessage != "" {
 					// Seal final text segment
 					if currentSegmentStart != nil && currentSegmentText != "" {


### PR DESCRIPTION
## Summary
- Removes the 90-second activity watchdog timer from the conversation output handler
- The watchdog caused false "agent may be stuck" errors in idle mode, during user interaction waits, and between turns
- Also removes the associated pause logic added in #528 since the watchdog no longer exists

## Test plan
- [ ] Start a conversation, let the agent complete a turn, wait > 90 seconds — confirm no error appears
- [ ] Verify normal agent operation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)