### PR TITLE
fix: Stop watchdog timer when agent turn completes

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -777,9 +777,12 @@ outer:
 				}
 
 			case EventTypeTurnComplete, EventTypeComplete, EventTypeResult:
-				// Turn or session completed — store accumulated message and reset
-				// streaming state. turn_complete means the process stays alive;
-				// complete/result means it will exit shortly.
+				// Turn or session completed — stop the watchdog. For turn_complete
+				// the process stays alive idle; for complete/result it exits shortly.
+				// Either way, silence is expected and not a hang signal.
+				activityWatchdog.Stop()
+
+				// Store accumulated message and reset streaming state.
 				if currentAssistantMessage != "" {
 					// Seal final text segment
 					if currentSegmentStart != nil && currentSegmentText != "" {


### PR DESCRIPTION
## Summary
The 90-second watchdog timer was firing false "agent may be stuck" alarms when the agent went idle between turns. This fix stops the watchdog when a turn completes (EventTypeTurnComplete), mirroring the existing pattern for user interaction waits.

## How it works
- When the agent finishes a turn and goes idle, the watchdog is stopped
- The watchdog automatically re-arms when the next user message triggers new output
- This prevents spurious timeout warnings during normal idle waiting periods

## Testing
- Verified build passes: `go build ./...`
- All tests pass: `go test ./...`
- Manual testing: agent going idle no longer triggers false 90-second warnings

🤖 Generated with Claude Code