### PR TITLE
fix: Clean up temp image files on agent process exit

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -713,6 +713,7 @@ function buildUserMessage(msg: QueuedMessage): SDKUserMessage {
         // bypassing the stdin pipe entirely.
         lifecycle(`image "${attachment.name}" via file: ${attachment.path}`);
         tempFilesToClean.push(attachment.path);
+        pendingTempFiles.add(attachment.path);
         contentBlocks.push({
           type: "text",
           text: `[The user attached an image: "${attachment.name}" (${attachment.mimeType}). ` +
@@ -759,6 +760,7 @@ function buildUserMessage(msg: QueuedMessage): SDKUserMessage {
         writeFileSync(tempPath, raw);
         lifecycle(`image "${attachment.name}" saved to temp file: ${tempPath} (${Math.round(raw.length / 1024)}KB)`);
         tempFilesToClean.push(tempPath);
+        pendingTempFiles.add(tempPath);
         contentBlocks.push({
           type: "text",
           text: `[The user attached an image: "${attachment.name}" (${attachment.mimeType}). ` +
@@ -796,8 +798,10 @@ function buildUserMessage(msg: QueuedMessage): SDKUserMessage {
       for (const filePath of tempFilesToClean) {
         try {
           unlinkSync(filePath);
+          pendingTempFiles.delete(filePath);
           debug(`Cleaned up temp image: ${filePath}`);
         } catch {
+          pendingTempFiles.delete(filePath);
           // File may already be gone — that's fine
         }
       }
@@ -852,6 +856,9 @@ function flushBlockBuffer(): void {
     blockBuffer = "";
   }
 }
+
+// Track temp image files for cleanup on exit (module-level so cleanup() can access them)
+const pendingTempFiles = new Set<string>();
 
 // Track active tool uses
 const activeTools = new Map<string, { tool: string; startTime: number; input?: Record<string, unknown> }>();
@@ -2275,6 +2282,17 @@ async function cleanup(reason: string): Promise<void> {
 
   // 5. Flush any remaining buffered text
   flushBlockBuffer();
+
+  // 5b. Clean up any temp image files that haven't been cleaned by their deferred timers
+  for (const filePath of pendingTempFiles) {
+    try {
+      unlinkSync(filePath);
+      debug(`Cleanup: removed temp image: ${filePath}`);
+    } catch {
+      // File may already be gone — that's fine
+    }
+  }
+  pendingTempFiles.clear();
 
   // 6. Interrupt the query if active (may be null between turns).
   // Note: MCP servers (chatmlMcp and user-configured servers) are managed by the SDK


### PR DESCRIPTION
## Summary

- Temp image files (used for file-based image delivery to Claude) were only cleaned by a deferred 5-minute `setTimeout`. If the agent process exited before the timer fired, files were orphaned in the OS temp directory.
- Added a module-level `pendingTempFiles` set that tracks all temp image files across message builds, and cleans them up in `cleanup()` on process shutdown.
- The deferred 5-minute timer is preserved as the primary cleanup path (gives Claude time to read the files during the turn).

## Test plan

- [ ] Send an image attachment to an agent session
- [ ] Verify the temp file is created in the OS temp dir (`/tmp/chatml-img-*`)
- [ ] Stop the agent before 5 minutes elapse
- [ ] Verify the temp file is cleaned up on shutdown (check debug logs for "Cleanup: removed temp image")
- [ ] Let a session run past 5 minutes with an image — verify the deferred timer still cleans up normally

Closes CM-147

🤖 Generated with [Claude Code](https://claude.com/claude-code)