### PR TITLE
Enable skill/plugin discovery across the full stack

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -224,6 +224,7 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 		WorkspaceID:         session.WorkspaceID, // Backend workspace ID for MCP tools
 		BackendSessionID:    sessionID,           // Backend session ID for MCP tools
 		EnableCheckpointing: true,
+		SettingSources:      "project,user,local", // Load all settings scopes so SDK discovers user plugins/skills
 	}
 
 	// Always pass the effective target branch to the agent-runner so it doesn't

--- a/backend/server/skill_handlers.go
+++ b/backend/server/skill_handlers.go
@@ -1,12 +1,50 @@
 package server
 
 import (
+	"fmt"
+	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/chatml/chatml-backend/models"
 	"github.com/chatml/chatml-backend/skills"
 	"github.com/go-chi/chi/v5"
 )
+
+// skillFileDir returns the path to ~/.claude/skills/chatml-{id}/
+func skillFileDir(skillID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude", "skills", "chatml-"+skillID), nil
+}
+
+// writeSkillFile writes a SKILL.md file to ~/.claude/skills/chatml-{id}/SKILL.md
+func writeSkillFile(skill *models.Skill) error {
+	dir, err := skillFileDir(skill.ID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("cannot create skill directory: %w", err)
+	}
+
+	// Build SKILL.md with frontmatter matching the SDK's expected format
+	content := fmt.Sprintf("---\nname: %s\ndescription: %s\n---\n\n%s", skill.ID, skill.Description, skill.Content)
+
+	return os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0644)
+}
+
+// removeSkillFile removes ~/.claude/skills/chatml-{id}/
+func removeSkillFile(skillID string) error {
+	dir, err := skillFileDir(skillID)
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(dir)
+}
 
 // ListSkills returns the full skill catalog with install status
 func (h *Handlers) ListSkills(w http.ResponseWriter, r *http.Request) {
@@ -68,7 +106,7 @@ func (h *Handlers) ListInstalledSkills(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, result)
 }
 
-// InstallSkill installs a skill (records preference)
+// InstallSkill installs a skill (records preference and writes SKILL.md to ~/.claude/skills/)
 func (h *Handlers) InstallSkill(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	skillID := chi.URLParam(r, "id")
@@ -86,6 +124,12 @@ func (h *Handlers) InstallSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Write SKILL.md to ~/.claude/skills/chatml-{id}/ so the SDK discovers it globally
+	if err := writeSkillFile(skill); err != nil {
+		log.Printf("WARN: Failed to write skill file for %s: %v", skillID, err)
+		// Non-fatal: skill is recorded in DB, file write is best-effort
+	}
+
 	writeJSON(w, map[string]bool{"success": true})
 }
 
@@ -97,6 +141,12 @@ func (h *Handlers) UninstallSkill(w http.ResponseWriter, r *http.Request) {
 	if err := h.store.UninstallSkill(ctx, skillID); err != nil {
 		writeDBError(w, err)
 		return
+	}
+
+	// Remove SKILL.md from ~/.claude/skills/chatml-{id}/
+	if err := removeSkillFile(skillID); err != nil {
+		log.Printf("WARN: Failed to remove skill file for %s: %v", skillID, err)
+		// Non-fatal: preference is removed from DB, file removal is best-effort
 	}
 
 	writeJSON(w, map[string]bool{"success": true})

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -15,6 +15,7 @@ import { useConnectionStore } from '@/stores/connectionStore';
 import { getConversationDropStats, getActiveStreamingConversations, getConversationMessages, getStreamingSnapshot, toStoreMessage, updateSession as updateSessionApi } from '@/lib/api';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useBranchCacheStore } from '@/stores/branchCacheStore';
+import { useSlashCommandStore } from '@/stores/slashCommandStore';
 import { notifyDesktop, getConversationLabel } from '@/hooks/useDesktopNotifications';
 import { playSound } from '@/lib/sounds';
 
@@ -282,6 +283,10 @@ export function useWebSocket(enabled: boolean = true) {
           } else {
             store.setPlanModeActive(conversationId, isPlan);
           }
+        }
+        // Forward SDK-discovered slash commands to the slash command store
+        if (event?.slashCommands && Array.isArray(event.slashCommands)) {
+          useSlashCommandStore.getState().setSdkCommands(event.slashCommands as string[]);
         }
         // Extract MCP tools grouped by server from the tools list
         if (event?.tools && Array.isArray(event.tools)) {

--- a/src/stores/slashCommandStore.ts
+++ b/src/stores/slashCommandStore.ts
@@ -11,6 +11,7 @@ import {
   MessageSquareText,
   Sparkles,
   FileText,
+  Plug,
 } from 'lucide-react';
 import type { SkillDTO } from '@/lib/api';
 
@@ -18,7 +19,7 @@ import type { SkillDTO } from '@/lib/api';
 // Types
 // ============================================================================
 
-export type SlashCommandSource = 'builtin' | 'skill' | 'user';
+export type SlashCommandSource = 'builtin' | 'skill' | 'user' | 'sdk';
 export type SlashCommandExecutionType = 'action' | 'prompt' | 'skill';
 
 export interface SlashCommandAvailability {
@@ -166,6 +167,7 @@ const BUILTIN_COMMANDS: UnifiedSlashCommand[] = [
 interface CommandCache {
   skills: SkillDTO[];
   userCmds: UserCommandFile[];
+  sdkCmds: string[];
   hasSession: boolean;
   result: UnifiedSlashCommand[];
 }
@@ -176,10 +178,12 @@ interface SlashCommandStoreState {
   // Sources
   installedSkills: SkillDTO[];
   userCommands: UserCommandFile[];
+  sdkCommands: string[];
 
   // Actions
   setInstalledSkills: (skills: SkillDTO[]) => void;
   setUserCommands: (commands: UserCommandFile[]) => void;
+  setSdkCommands: (commands: string[]) => void;
   fetchUserCommands: (workspaceId: string, sessionId: string) => Promise<void>;
 
   // Computed
@@ -231,12 +235,37 @@ function userCommandToCommand(cmd: UserCommandFile): UnifiedSlashCommand {
   };
 }
 
+/**
+ * Convert an SDK-reported slash command name into a UnifiedSlashCommand.
+ * SDK commands are strings like "commit", "review-pr", or "superpowers:brainstorming".
+ */
+function sdkCommandToSlashCommand(name: string): UnifiedSlashCommand {
+  const label = name
+    .replace(/:/g, ': ')
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+
+  return {
+    id: `sdk:${name}`,
+    trigger: name,
+    label,
+    description: `Plugin command: ${name}`,
+    icon: Plug,
+    source: 'sdk',
+    executionType: 'skill',
+    available: requiresSession,
+    execute: (ctx) => ctx.sendMessage(`/${name}`),
+  };
+}
+
 export const useSlashCommandStore = create<SlashCommandStoreState>((set, get) => ({
   installedSkills: [],
   userCommands: [],
+  sdkCommands: [],
 
   setInstalledSkills: (skills) => { _commandCache = null; set({ installedSkills: skills }); },
   setUserCommands: (commands) => { _commandCache = null; set({ userCommands: commands }); },
+  setSdkCommands: (commands) => { _commandCache = null; set({ sdkCommands: commands }); },
 
   fetchUserCommands: async (workspaceId, sessionId) => {
     try {
@@ -257,13 +286,14 @@ export const useSlashCommandStore = create<SlashCommandStoreState>((set, get) =>
   },
 
   getAllCommands: (availability) => {
-    const { installedSkills, userCommands } = get();
+    const { installedSkills, userCommands, sdkCommands } = get();
 
     // Return cached result if sources haven't changed (reference equality)
     if (
       _commandCache &&
       _commandCache.skills === installedSkills &&
       _commandCache.userCmds === userCommands &&
+      _commandCache.sdkCmds === sdkCommands &&
       _commandCache.hasSession === availability.hasSession
     ) {
       return _commandCache.result;
@@ -297,12 +327,24 @@ export const useSlashCommandStore = create<SlashCommandStoreState>((set, get) =>
       }
     }
 
+    // Add SDK-reported commands (from plugins and user-level skills)
+    for (const sdkCmd of sdkCommands) {
+      const exists = commands.some((c) => c.trigger === sdkCmd);
+      if (!exists) {
+        const cmd = sdkCommandToSlashCommand(sdkCmd);
+        if (cmd.available?.(availability) ?? true) {
+          commands.push(cmd);
+        }
+      }
+    }
+
     commands.sort((a, b) => a.trigger.localeCompare(b.trigger));
 
     // Cache the result for subsequent calls with the same inputs
     _commandCache = {
       skills: installedSkills,
       userCmds: userCommands,
+      sdkCmds: sdkCommands,
       hasSession: availability.hasSession,
       result: commands,
     };


### PR DESCRIPTION
## Summary

Configure the agent to load settings from all scopes (project, user, local) so it discovers user-installed plugins and skills. Persist installed skills to disk as SKILL.md files in ~/.claude/skills/chatml-{id}/, and surface SDK-discovered slash commands in the UI menu.

## Changes

- **backend/agent/manager.go**: Add SettingSources config to load project, user, and local settings
- **backend/server/skill_handlers.go**: Write/remove SKILL.md files on skill install/uninstall for SDK discovery
- **src/hooks/useWebSocket.ts**: Forward SDK-discovered slash commands to the store
- **src/stores/slashCommandStore.ts**: Add sdk source type, deduplicate and cache SDK commands alongside other sources

This enables end-to-end skill/plugin support: skills installed in the UI are written to disk where the SDK reads them, the agent is configured to actually look there, and any commands exposed by those skills are surfaced in the slash command menu.