### PR TITLE
fix: Enrich slash command menu with SDK descriptions

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -2125,6 +2125,7 @@ function handleMessage(message: SDKMessage): void {
 
       if (sysMsg.subtype === "init") {
         const initMsg = sysMsg as SDKSystemMessage;
+        lifecycle(`SDK init: slash_commands=${JSON.stringify(initMsg.slash_commands)}, skills=${JSON.stringify(initMsg.skills)}, plugins=${JSON.stringify(initMsg.plugins)}`);
         emit({
           type: "init",
           model: initMsg.model,

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -879,6 +879,16 @@ outer:
 				m.onConversationEvent(convID, event)
 			}
 
+			// After init, request the full slash command list from the SDK.
+			// The init event may have slash_commands but it can be empty if
+			// skills haven't been discovered yet. The supported_commands
+			// response provides the authoritative, enriched command list.
+			if event.Type == EventTypeInit {
+				if err := proc.GetSupportedCommands(); err != nil {
+					logger.Manager.Errorf("Conversation %s: failed to request supported commands: %v", convID, err)
+				}
+			}
+
 			// Generate input suggestion after turn completes (async, fire-and-forget)
 			if event.Type == EventTypeResult {
 				go m.generateInputSuggestion(convID)

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -919,7 +919,11 @@ export function useWebSocket(enabled: boolean = true) {
 
       case 'supported_commands':
         if (event?.commands) {
-          store.setSupportedCommands(event.commands as Array<{ name: string; description: string; argumentHint: string }>);
+          const cmds = event.commands as Array<{ name: string; description: string; argumentHint: string }>;
+          store.setSupportedCommands(cmds);
+          // Also feed into the slash command store so SDK-discovered
+          // commands appear in the slash menu with rich descriptions.
+          useSlashCommandStore.getState().setSdkCommandsRich(cmds);
         }
         break;
 

--- a/src/stores/slashCommandStore.ts
+++ b/src/stores/slashCommandStore.ts
@@ -53,6 +53,13 @@ export interface UserCommandFile {
   content: string;
 }
 
+/** Rich command metadata returned by the SDK's supportedCommands() API. */
+export interface SdkCommandInfo {
+  name: string;
+  description: string;
+  argumentHint?: string;
+}
+
 // ============================================================================
 // Built-in Commands
 // ============================================================================
@@ -179,11 +186,15 @@ interface SlashCommandStoreState {
   installedSkills: SkillDTO[];
   userCommands: UserCommandFile[];
   sdkCommands: string[];
+  /** Rich metadata for SDK commands, keyed by command name. */
+  sdkCommandMeta: Record<string, SdkCommandInfo>;
 
   // Actions
   setInstalledSkills: (skills: SkillDTO[]) => void;
   setUserCommands: (commands: UserCommandFile[]) => void;
   setSdkCommands: (commands: string[]) => void;
+  /** Set SDK commands from the enriched supported_commands response. */
+  setSdkCommandsRich: (commands: SdkCommandInfo[]) => void;
   fetchUserCommands: (workspaceId: string, sessionId: string) => Promise<void>;
 
   // Computed
@@ -238,8 +249,9 @@ function userCommandToCommand(cmd: UserCommandFile): UnifiedSlashCommand {
 /**
  * Convert an SDK-reported slash command name into a UnifiedSlashCommand.
  * SDK commands are strings like "commit", "review-pr", or "superpowers:brainstorming".
+ * If rich metadata is available, uses its description instead of the generic fallback.
  */
-function sdkCommandToSlashCommand(name: string): UnifiedSlashCommand {
+function sdkCommandToSlashCommand(name: string, meta?: SdkCommandInfo): UnifiedSlashCommand {
   const label = name
     .replace(/:/g, ': ')
     .replace(/-/g, ' ')
@@ -249,7 +261,7 @@ function sdkCommandToSlashCommand(name: string): UnifiedSlashCommand {
     id: `sdk:${name}`,
     trigger: name,
     label,
-    description: `Plugin command: ${name}`,
+    description: meta?.description || `Plugin command: ${name}`,
     icon: Plug,
     source: 'sdk',
     executionType: 'skill',
@@ -262,10 +274,20 @@ export const useSlashCommandStore = create<SlashCommandStoreState>((set, get) =>
   installedSkills: [],
   userCommands: [],
   sdkCommands: [],
+  sdkCommandMeta: {},
 
   setInstalledSkills: (skills) => { _commandCache = null; set({ installedSkills: skills }); },
   setUserCommands: (commands) => { _commandCache = null; set({ userCommands: commands }); },
   setSdkCommands: (commands) => { _commandCache = null; set({ sdkCommands: commands }); },
+  setSdkCommandsRich: (commands) => {
+    const names = commands.map((c) => c.name);
+    const meta: Record<string, SdkCommandInfo> = {};
+    for (const c of commands) {
+      meta[c.name] = c;
+    }
+    _commandCache = null;
+    set({ sdkCommands: names, sdkCommandMeta: meta });
+  },
 
   fetchUserCommands: async (workspaceId, sessionId) => {
     try {
@@ -286,7 +308,7 @@ export const useSlashCommandStore = create<SlashCommandStoreState>((set, get) =>
   },
 
   getAllCommands: (availability) => {
-    const { installedSkills, userCommands, sdkCommands } = get();
+    const { installedSkills, userCommands, sdkCommands, sdkCommandMeta } = get();
 
     // Return cached result if sources haven't changed (reference equality)
     if (
@@ -331,7 +353,7 @@ export const useSlashCommandStore = create<SlashCommandStoreState>((set, get) =>
     for (const sdkCmd of sdkCommands) {
       const exists = commands.some((c) => c.trigger === sdkCmd);
       if (!exists) {
-        const cmd = sdkCommandToSlashCommand(sdkCmd);
+        const cmd = sdkCommandToSlashCommand(sdkCmd, sdkCommandMeta[sdkCmd]);
         if (cmd.available?.(availability) ?? true) {
           commands.push(cmd);
         }


### PR DESCRIPTION
## Summary

- After agent init, request the full `supported_commands` list from the SDK so slash commands display real descriptions instead of generic "Plugin command: X" labels
- Pipes rich metadata (description, argumentHint) from the SDK response into the slash command store
- Adds debug logging for SDK init payload to aid future troubleshooting

## Changes Made

- **agent-runner/src/index.ts** — Added lifecycle debug log for `slash_commands`, `skills`, and `plugins` on SDK init
- **backend/agent/manager.go** — After init event, calls `GetSupportedCommands()` to fetch the enriched command list
- **src/hooks/useWebSocket.ts** — On `supported_commands` event, feeds rich command data into `slashCommandStore`
- **src/stores/slashCommandStore.ts** — Added `SdkCommandInfo` type, `sdkCommandMeta` state, and `setSdkCommandsRich` action; `sdkCommandToSlashCommand` now uses real descriptions when available

## Test Plan

- [ ] `make dev` — start the app, open a session, type `/` and verify SDK commands show real descriptions
- [ ] Verify built-in commands (e.g. `/commit`) still appear correctly
- [ ] Check agent-runner logs for the new `SDK init:` debug line
- [ ] `npm run build` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)