### PR TITLE
fix: Refresh Changes panel on tab click and agent turn completion

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -409,6 +409,8 @@ export function ChangesPanel() {
 
   // Watch for branch sync completion to refresh changes
   const branchSyncCompletedAt = useAppStore((s) => selectedSessionId ? s.branchSyncCompletedAt[selectedSessionId] : undefined);
+  // Watch for agent turn completion to refresh changes
+  const lastTurnCompletedAt = useAppStore((s) => selectedSessionId ? s.lastTurnCompletedAt[selectedSessionId] : undefined);
 
   // Track branch for refetching changes when branch is renamed
   const currentBranch = currentSession?.branch;
@@ -537,6 +539,14 @@ export function ChangesPanel() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [branchSyncCompletedAt]);
 
+  // Refetch changes when an agent turn completes in this session
+  useEffect(() => {
+    if (lastTurnCompletedAt && selectedWorkspaceId && selectedSessionId) {
+      debouncedFetchChanges();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastTurnCompletedAt]);
+
   // React to file change events from centralized store
   // Note: session registration is handled at creation/dashboard load time (page.tsx, WorkspaceSidebar)
   const lastFileChange = useAppStore((s) => s.lastFileChange);
@@ -592,13 +602,22 @@ export function ChangesPanel() {
     onToggleShowResolved: () => setShowResolved((prev) => !prev),
   }), [fetchChanges, fetchBranchCommits, handleResolveAll, prUrl, unresolvedCount, showResolved]);
 
+  // Wrap tab selection to trigger changes refresh when switching to the changes tab
+  const handleTabSelect = useCallback((tabId: string) => {
+    setSelectedTab(tabId);
+    if (tabId === 'changes') {
+      fetchChanges();
+      fetchBranchCommits();
+    }
+  }, [fetchChanges, fetchBranchCommits]);
+
   // Keyboard shortcuts for switching sidebar tabs
   const tabShortcuts = useMemo(() => ({
-    sidebarFilesTab: () => setSelectedTab('files'),
-    sidebarChangesTab: () => setSelectedTab('changes'),
-    sidebarChecksTab: () => setSelectedTab('checks'),
-    sidebarReviewTab: () => setSelectedTab('review'),
-  }), []);
+    sidebarFilesTab: () => handleTabSelect('files'),
+    sidebarChangesTab: () => handleTabSelect('changes'),
+    sidebarChecksTab: () => handleTabSelect('checks'),
+    sidebarReviewTab: () => handleTabSelect('review'),
+  }), [handleTabSelect]);
   useShortcuts(tabShortcuts);
 
   return (
@@ -606,7 +625,7 @@ export function ChangesPanel() {
       {/* Tabs Row */}
       <TopPanelTabs
         selectedTab={selectedTab}
-        setSelectedTab={setSelectedTab}
+        setSelectedTab={handleTabSelect}
         changesCount={branchStats?.totalFiles || changes?.length || 0}
         menuContext={menuContext}
       />

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -491,6 +491,11 @@ export function useWebSocket(enabled: boolean = true) {
         freshStore.clearAgentTodos(conversationId);
         // Clear any stale pending question — the turn is over
         freshStore.clearPendingUserQuestion(conversationId);
+        // Trigger changes panel refresh for this session
+        const resultConv = freshStore.conversations.find((c) => c.id === conversationId);
+        if (resultConv) {
+          freshStore.setLastTurnCompletedAt(resultConv.sessionId, Date.now());
+        }
         // Notify background session (unread dot + in-app sound when focused)
         notifyBackgroundSession(conversationId);
         // Desktop notification for task completion.
@@ -536,6 +541,11 @@ export function useWebSocket(enabled: boolean = true) {
         turnStore.updateConversation(conversationId, { status: 'active' });
         // Clear agent todos — tasks are no longer relevant after turn ends
         turnStore.clearAgentTodos(conversationId);
+        // Trigger changes panel refresh for this session
+        const turnConv = turnStore.conversations.find((c) => c.id === conversationId);
+        if (turnConv) {
+          turnStore.setLastTurnCompletedAt(turnConv.sessionId, Date.now());
+        }
         // Notify background session (unread dot + in-app sound when focused)
         notifyBackgroundSession(conversationId);
         break;
@@ -555,6 +565,11 @@ export function useWebSocket(enabled: boolean = true) {
         store.clearPendingUserQuestion(conversationId);
         // Update conversation status to idle (ready for new input)
         store.updateConversation(conversationId, { status: 'idle' });
+        // Trigger changes panel refresh for this session
+        const completeConv = store.conversations.find((c) => c.id === conversationId);
+        if (completeConv) {
+          store.setLastTurnCompletedAt(completeConv.sessionId, Date.now());
+        }
         break;
       }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -219,6 +219,8 @@ interface AppState {
   branchSyncDismissed: { [sessionId: string]: boolean };
   // Timestamp of last successful sync (triggers changes panel refresh)
   branchSyncCompletedAt: { [sessionId: string]: number };
+  // Timestamp of last agent turn completion per session (triggers changes panel refresh)
+  lastTurnCompletedAt: { [sessionId: string]: number };
 
   // Pending user questions from AskUserQuestion tool (keyed by conversationId)
   pendingUserQuestion: { [conversationId: string]: PendingUserQuestion | null };
@@ -432,6 +434,7 @@ interface AppState {
   setBranchSyncLoading: (sessionId: string, loading: boolean) => void;
   setBranchSyncDismissed: (sessionId: string, dismissed: boolean) => void;
   setBranchSyncCompletedAt: (sessionId: string, timestamp: number) => void;
+  setLastTurnCompletedAt: (sessionId: string, timestamp: number) => void;
   clearBranchSyncStatus: (sessionId: string) => void;
 
   // User question actions (AskUserQuestion tool)
@@ -481,6 +484,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   branchSyncLoading: {},
   branchSyncDismissed: {},
   branchSyncCompletedAt: {},
+  lastTurnCompletedAt: {},
   pendingUserQuestion: {},
   inputSuggestions: {},
   summaries: {},
@@ -1926,6 +1930,12 @@ updateFileTabContent: (id, content) => set((state) => ({
   setBranchSyncCompletedAt: (sessionId, timestamp) => set((state) => ({
     branchSyncCompletedAt: {
       ...state.branchSyncCompletedAt,
+      [sessionId]: timestamp,
+    },
+  })),
+  setLastTurnCompletedAt: (sessionId, timestamp) => set((state) => ({
+    lastTurnCompletedAt: {
+      ...state.lastTurnCompletedAt,
       [sessionId]: timestamp,
     },
   })),


### PR DESCRIPTION
## Summary
- **Tab click refresh**: Clicking the Changes tab (or using its keyboard shortcut) now immediately fetches fresh data instead of just showing cached content
- **Turn completion refresh**: Agent turn completion (`result`, `turn_complete`, `complete` WebSocket events) now proactively triggers a debounced refresh via a new `lastTurnCompletedAt` store field, following the existing `branchSyncCompletedAt` pattern
- Fixes stale/empty Changes panel that previously required switching sessions to refresh

## Test plan
- [ ] Open a session, switch to Files tab, have agent make file changes, click Changes tab — should show updated files immediately
- [ ] Send a message to the agent, wait for turn completion — Changes panel should auto-refresh within ~500ms
- [ ] Verify keyboard shortcut for Changes tab also triggers refresh
- [ ] Confirm no regressions in session switching, branch sync, or file watcher refresh paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)