### PR TITLE
fix: Defer React root unmounts to prevent race condition

### DIFF
--- a/src/lib/monaco/CommentZoneManager.ts
+++ b/src/lib/monaco/CommentZoneManager.ts
@@ -164,8 +164,10 @@ export class CommentZoneManager {
       accessor.removeZone(zone.zoneId);
     });
 
-    // Cleanup React root
-    zone.root.unmount();
+    // Defer unmount to avoid "synchronously unmount a root while React was
+    // already rendering" warning in React 19 when called from useEffect.
+    const root = zone.root;
+    setTimeout(() => root.unmount(), 0);
 
     // Cleanup ResizeObserver
     const observer = this.observers.get(commentId);
@@ -325,9 +327,11 @@ export class CommentZoneManager {
       }
     });
 
-    // Cleanup React roots
+    // Defer unmount to avoid "synchronously unmount a root while React was
+    // already rendering" warning in React 19 when called from useEffect.
     for (const zone of this.zones.values()) {
-      zone.root.unmount();
+      const root = zone.root;
+      setTimeout(() => root.unmount(), 0);
     }
 
     // Cleanup observers


### PR DESCRIPTION
## Summary

Fixes a React 19 error that occurs when switching file tabs rapidly: "Attempted to synchronously unmount a root while React was already rendering." The issue happens because `CommentZoneManager.dispose()` calls `zone.root.unmount()` synchronously inside a `useEffect` cleanup during React's commit phase.

## Changes Made

- **CommentZoneManager.ts** — Apply deferred unmount pattern using `setTimeout(() => root.unmount(), 0)` to both `removeZone()` (line 169) and `dispose()` (line 334) methods. This matches the existing pattern already used in `hideCommentInput()` (line 306).

## Test Plan

- [ ] Manual: Open app, switch between file tabs rapidly, confirm no console errors
- [ ] Manual: Create, delete, and modify comments in code viewer, confirm no unmount errors

The change is minimal and mirrors an existing, proven pattern in the same file.