### PR TITLE
fix: Eliminate cold-start delay in dashboard loading

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -181,7 +181,45 @@ func (rm *RepoManager) GetChangedFilesWithStats(ctx context.Context, repoPath, b
 	if err := ValidateGitRef(baseRef); err != nil {
 		return nil, fmt.Errorf("invalid base ref: %w", err)
 	}
-	// First get the diff stats
+
+	// Get file statuses (A/M/D/R) in a single git command instead of per-file ls-tree
+	statusCmd, statusCancel := gitCmdWithContext(ctx, repoPath, "diff", "--name-status", baseRef)
+	statusOut, err := statusCmd.Output()
+	statusCancel()
+	if err != nil {
+		return nil, err
+	}
+	fileStatus := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(statusOut)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		code := parts[0]
+		path := parts[1]
+		// Handle renames (R100\told\tnew) — use the new path
+		if strings.HasPrefix(code, "R") {
+			renameParts := strings.SplitN(path, "\t", 2)
+			if len(renameParts) == 2 {
+				path = renameParts[1]
+			}
+		}
+		switch {
+		case code == "A":
+			fileStatus[path] = "added"
+		case code == "D":
+			fileStatus[path] = "deleted"
+		case strings.HasPrefix(code, "R"):
+			fileStatus[path] = "added"
+		default:
+			fileStatus[path] = "modified"
+		}
+	}
+
+	// Get diff stats (additions/deletions per file)
 	cmd, cancel := gitCmdWithContext(ctx, repoPath, "diff", "--numstat", baseRef)
 	defer cancel()
 	out, err := cmd.Output()
@@ -213,20 +251,9 @@ func (rm *RepoManager) GetChangedFilesWithStats(ctx context.Context, repoPath, b
 		// Reconstruct file path (may contain spaces)
 		filePath := strings.Join(parts[2:], " ")
 
-		status := "modified"
-		if additions > 0 && deletions == 0 {
-			// Check if it's a new file
-			checkCmd, checkCancel := gitCmdWithContext(ctx, repoPath, "ls-tree", baseRef, "--", filePath)
-			checkOut, _ := checkCmd.Output()
-			checkCancel()
-			if len(checkOut) == 0 {
-				status = "added"
-			}
-		} else if deletions > 0 && additions == 0 {
-			// Check if file still exists
-			if _, err := os.Stat(filepath.Join(repoPath, filePath)); os.IsNotExist(err) {
-				status = "deleted"
-			}
+		status := fileStatus[filePath]
+		if status == "" {
+			status = "modified"
 		}
 
 		changes = append(changes, FileChange{

--- a/backend/main.go
+++ b/backend/main.go
@@ -464,6 +464,69 @@ func main() {
 
 	router := server.NewRouter(s, hub, agentMgr, ghClient, linearClient, branchWatcher, prWatcher, prCache, issueCache, statsCache, aiClient, scriptRunner)
 
+	// Pre-warm session stats cache in background so the first getDashboardData
+	// returns stats from cache instead of computing them on-the-fly.
+	go func() {
+		repos, err := s.ListRepos(ctx)
+		if err != nil {
+			logger.Main.Warnf("Stats pre-warm: failed to list repos: %v", err)
+			return
+		}
+		for _, repo := range repos {
+			sessions, err := s.ListSessions(ctx, repo.ID, false)
+			if err != nil {
+				continue
+			}
+			for _, sess := range sessions {
+				if sess.WorktreePath == "" || sess.Archived {
+					continue
+				}
+				// Skip if already cached (e.g. branch watcher beat us)
+				if _, ok := statsCache.Get(sess.ID); ok {
+					continue
+				}
+				effectiveTarget := sess.TargetBranch
+				if effectiveTarget == "" {
+					remote := "origin"
+					branch := "main"
+					if repo.Remote != "" {
+						remote = repo.Remote
+					}
+					if repo.Branch != "" {
+						branch = repo.Branch
+					}
+					effectiveTarget = remote + "/" + branch
+				}
+				baseRef, mbErr := repoManager.GetMergeBase(ctx, sess.WorktreePath, effectiveTarget, "HEAD")
+				if mbErr != nil || baseRef == "" {
+					baseRef = sess.BaseCommitSHA
+					if baseRef == "" {
+						baseRef = effectiveTarget
+					}
+				}
+				changes, err := repoManager.GetChangedFilesWithStats(ctx, sess.WorktreePath, baseRef)
+				if err != nil {
+					continue
+				}
+				untracked, _ := repoManager.GetUntrackedFiles(ctx, sess.WorktreePath)
+				var additions, deletions int
+				for _, c := range changes {
+					additions += c.Additions
+					deletions += c.Deletions
+				}
+				for _, u := range untracked {
+					additions += u.Additions
+				}
+				var stats *models.SessionStats
+				if additions > 0 || deletions > 0 {
+					stats = &models.SessionStats{Additions: additions, Deletions: deletions}
+				}
+				statsCache.Set(sess.ID, stats)
+			}
+		}
+		logger.Main.Info("Stats cache pre-warm complete")
+	}()
+
 	// Create HTTP server with graceful shutdown support
 	srv := &http.Server{
 		Handler:     router,

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -706,6 +706,58 @@ func (h *Handlers) computeSessionStats(ctx context.Context, session *models.Sess
 	return &models.SessionStats{Additions: additions, Deletions: deletions}
 }
 
+// uncachedSession pairs a session with its workspace for background stats computation.
+type uncachedSession struct {
+	session   *models.Session
+	workspace *models.Repo
+}
+
+// computeAndBroadcastStats computes stats for sessions not in cache and pushes
+// results via WebSocket. Runs as a background goroutine so getDashboardData
+// returns immediately.
+func (h *Handlers) computeAndBroadcastStats(sessions []uncachedSession) {
+	sem := make(chan struct{}, 10)
+	var wg sync.WaitGroup
+	ctx := context.Background()
+
+	for _, us := range sessions {
+		wg.Add(1)
+		go func(s *models.Session, ws *models.Repo) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			effectiveTarget := s.TargetBranch
+			if effectiveTarget == "" {
+				remote := "origin"
+				branch := "main"
+				if ws != nil {
+					if ws.Remote != "" {
+						remote = ws.Remote
+					}
+					if ws.Branch != "" {
+						branch = ws.Branch
+					}
+				}
+				effectiveTarget = remote + "/" + branch
+			}
+
+			stats := h.computeSessionStats(ctx, s, effectiveTarget)
+			h.statsCache.Set(s.ID, stats)
+
+			h.hub.Broadcast(Event{
+				Type:      "session_stats_update",
+				SessionID: s.ID,
+				Payload: map[string]interface{}{
+					"sessionId": s.ID,
+					"stats":     stats,
+				},
+			})
+		}(us.session, us.workspace)
+	}
+	wg.Wait()
+}
+
 // validatePath ensures the requested path stays within the base directory
 // Returns the cleaned path if valid, or an error if the path escapes the base
 func validatePath(basePath, requestedPath string) (string, error) {
@@ -883,57 +935,30 @@ func (h *Handlers) GetDashboardData(w http.ResponseWriter, r *http.Request) {
 		workspaceByID[repo.ID] = repo
 	}
 
-	// Compute stats in parallel (bounded to 5 concurrent)
-	// Only compute stats if cache is available
-	if h.statsCache != nil {
-		sem := make(chan struct{}, 5)
-		var wg sync.WaitGroup
-		var mu sync.Mutex
+	// Serve cached stats immediately; compute uncached ones in background.
+	// This prevents cold-start blocking where getDashboardData would stall
+	// while computing git stats for every session.
+	var uncached []uncachedSession
 
+	if h.statsCache != nil {
 		for _, session := range allSessions {
-			// Skip stats for archived sessions (no need to compute git diffs)
 			if session.Archived {
 				continue
 			}
-			// Check cache first
 			if cached, ok := h.statsCache.Get(session.ID); ok {
 				session.Stats = cached
-				continue
+			} else {
+				uncached = append(uncached, uncachedSession{
+					session:   session,
+					workspace: workspaceByID[session.WorkspaceID],
+				})
 			}
-
-			wg.Add(1)
-			go func(s *models.Session) {
-				defer wg.Done()
-				sem <- struct{}{}        // Acquire
-				defer func() { <-sem }() // Release
-
-				workspace := workspaceByID[s.WorkspaceID]
-				// Compute effective target branch, matching EffectiveTargetBranch() logic
-				effectiveTarget := s.TargetBranch
-				if effectiveTarget == "" {
-					remote := "origin"
-					branch := "main"
-					if workspace != nil {
-						if workspace.Remote != "" {
-							remote = workspace.Remote
-						}
-						if workspace.Branch != "" {
-							branch = workspace.Branch
-						}
-					}
-					effectiveTarget = remote + "/" + branch
-				}
-
-				stats := h.computeSessionStats(ctx, s, effectiveTarget)
-
-				mu.Lock()
-				s.Stats = stats
-				mu.Unlock()
-
-				h.statsCache.Set(s.ID, stats)
-			}(session)
 		}
-		wg.Wait()
+	}
+
+	// Fire-and-forget: compute uncached stats in background and push via WebSocket
+	if len(uncached) > 0 && h.hub != nil {
+		go h.computeAndBroadcastStats(uncached)
 	}
 
 	// Get all session IDs for batch conversation fetch


### PR DESCRIPTION
## Summary
- **Fix N+1 git process spawns**: `GetChangedFilesWithStats` previously spawned a separate `git ls-tree` per file to determine added/modified/deleted status. Replaced with a single `git diff --name-status` call (2 git commands total instead of 2+N).
- **Non-blocking dashboard response**: `getDashboardData` no longer blocks on computing stats for uncached sessions. Returns immediately with cached stats; uncached ones are computed in a background goroutine and pushed via the existing `session_stats_update` WebSocket event.
- **Pre-warm stats cache on startup**: Background goroutine computes stats for all active sessions when the backend starts, so even the first dashboard request finds warm cache.

## Problem
On cold start (or first session creation), `getDashboardData` would block for 3-8 seconds while synchronously computing git stats for every active session. Each session required 3-5+ git process spawns (merge-base, diff --numstat, ls-tree per file, status --porcelain), throttled to 5 concurrent. This caused a noticeable delay before the UI rendered.

## Test plan
- [x] All Go tests pass (`go test ./...`)
- [x] ESLint passes (`npm run lint`)
- [x] Next.js build passes (`npm run build`)
- [ ] Manual: Start app fresh — dashboard should load instantly, stats appear shortly after via WebSocket
- [ ] Manual: Create new session — no multi-second delay on first creation
- [ ] Manual: Verify stats numbers match before/after (no regression in accuracy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)