### PR TITLE
Increase conversation tab widths for better readability

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -668,7 +668,7 @@ code.hljs { padding: 3px 5px; }
   }
   to {
     width: auto;
-    min-width: 120px;
+    min-width: 160px;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
     opacity: 1;

--- a/src/components/tabs/TabItem.tsx
+++ b/src/components/tabs/TabItem.tsx
@@ -75,7 +75,7 @@ export const TabItem = memo(function TabItem({
           data-tab-id={tab.id}
           className={cn(
             // Base styles - full height, no vertical padding
-            'group relative flex items-center gap-1.5 px-2 h-[33px] cursor-pointer select-none',
+            'group relative flex items-center gap-1.5 px-3 h-[33px] cursor-pointer select-none',
             'text-xs font-medium shrink-0',
             // Minimal transition - colors only, no layout shifts
             'transition-[background-color,color] duration-150',

--- a/src/components/tabs/tab.types.ts
+++ b/src/components/tabs/tab.types.ts
@@ -102,7 +102,7 @@ export interface TabScrollState {
 /**
  * Constants for tab sizing
  */
-export const TAB_MIN_WIDTH = 120;
-export const TAB_MAX_WIDTH = 200;
+export const TAB_MIN_WIDTH = 160;
+export const TAB_MAX_WIDTH = 280;
 export const SCROLL_AMOUNT = 200;
 export const ANIMATION_DURATION = 150;


### PR DESCRIPTION
## Summary

- Increased conversation tab widths from 120-200px to 160-280px
- Added horizontal padding (px-2 → px-3) for better text spacing
- Improves readability and usability in the conversation tab bar

## Changes Made

- **tab.types.ts** — Updated `TAB_MIN_WIDTH` (120→160) and `TAB_MAX_WIDTH` (200→280)
- **TabItem.tsx** — Increased horizontal padding from `px-2` to `px-3`
- **globals.css** — Updated CSS animation `min-width` to match new constant (120px→160px)

## Test Plan

- [ ] Run `make dev` to start the development environment
- [ ] Verify conversation tabs are visibly wider
- [ ] Confirm tab text is more readable with increased spacing
- [ ] Check that tabs still fit properly in the tab bar area