### PR TITLE
fix: Persist messages when agent is stopped

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -135,6 +135,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     clearPendingPlanApproval,
     setApprovedPlanContent,
     clearActiveTools,
+    finalizeStreamingMessage,
     setPlanModeActive,
     clearInputSuggestion,
     setSessionToggleState,
@@ -698,6 +699,17 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     try {
       // Commit any queued message to history before stopping
       commitQueuedMessage(selectedConversationId);
+      // Finalize streaming content into a committed message before stopping
+      // so it persists in the message list (same as normal turn completion)
+      finalizeStreamingMessage(selectedConversationId, {});
+      // Add system message indicating the agent was stopped
+      addMessage({
+        id: `msg-stopped-${Date.now()}`,
+        conversationId: selectedConversationId,
+        role: 'system',
+        content: 'Agent was stopped by user.',
+        timestamp: new Date().toISOString(),
+      });
       await stopConversation(selectedConversationId);
       setStreaming(selectedConversationId, false);
       updateConversation(selectedConversationId, { status: 'idle' });
@@ -706,7 +718,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       console.error('Failed to stop conversation:', error);
       showError('Failed to stop conversation. Please try again.');
     }
-  }, [selectedConversationId, isStreaming, commitQueuedMessage, setStreaming, updateConversation, clearActiveTools, showError]);
+  }, [selectedConversationId, isStreaming, commitQueuedMessage, finalizeStreamingMessage, addMessage, setStreaming, updateConversation, clearActiveTools, showError]);
 
   // Global keyboard shortcuts
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -555,12 +555,9 @@ export function useWebSocket(enabled: boolean = true) {
         // Complete event signals the entire conversation ended (stdin closed)
         // Commit any queued message so it appears in history
         store.commitQueuedMessage(conversationId);
-        // Clear any remaining state
-        store.clearStreamingText(conversationId);
+        // Finalize any remaining streaming content into a committed message
+        store.finalizeStreamingMessage(conversationId, {});
         store.setStreaming(conversationId, false);
-        store.clearThinking(conversationId);
-        store.clearActiveTools(conversationId);
-        store.clearSubAgents(conversationId);
         store.clearAgentTodos(conversationId);
         store.clearPendingUserQuestion(conversationId);
         // Update conversation status to idle (ready for new input)
@@ -839,11 +836,16 @@ export function useWebSocket(enabled: boolean = true) {
       case 'interrupted':
         // Commit any queued message so it appears in history
         store.commitQueuedMessage(conversationId);
-        store.clearStreamingText(conversationId);
+        // Finalize streaming content into a committed message so it persists
+        store.finalizeStreamingMessage(conversationId, {});
+        store.addMessage({
+          id: `msg-stopped-${Date.now()}`,
+          conversationId,
+          role: 'system',
+          content: 'Agent was stopped by user.',
+          timestamp: new Date().toISOString(),
+        });
         store.setStreaming(conversationId, false);
-        store.clearActiveTools(conversationId);
-        store.clearThinking(conversationId);
-        store.clearSubAgents(conversationId);
         store.clearPendingUserQuestion(conversationId);
         store.updateConversation(conversationId, { status: 'idle' });
         break;


### PR DESCRIPTION
## Summary

- Fixes a race condition where stopping an agent mid-conversation caused all messages to disappear
- Streaming messages are now preserved as committed messages before any clearing occurs
- Adds a system message to indicate the agent was stopped by the user

## Changes Made

- **ChatInput.tsx** — `handleStop` now calls `finalizeStreamingMessage()` to atomically convert streaming content into a Message, then adds a "Agent was stopped by user." system message
- **useWebSocket.ts** — `interrupted` event handler: replaced `clearStreamingText` with `finalizeStreamingMessage` + system message; `complete` event handler: replaced `clearStreamingText` with `finalizeStreamingMessage` to preserve any remaining content

## Test Plan

- [ ] Run `npm run build` — TypeScript compiles with no new errors
- [ ] Manual test: Start a conversation, let agent stream several messages
- [ ] Click Stop or press Escape — all messages remain visible + "Agent was stopped" message appears
- [ ] Manual test: Verify conversation can be resumed with a new message
- [ ] Manual test: Verify normal completion (without stopping) still works correctly
- [ ] Manual test: Switch away from and back to the conversation — messages persist

## Notes

The WebSocket safety net at `conversation_status: idle` already handles the timing correctly now — since `finalizeStreamingMessage` sets `isStreaming: false`, the safety net's condition skips, preventing double-clearing.