### PR TITLE
Upgrade Agent SDK to 0.2.45 and replace Sonnet 4.5 with 4.6

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chatml-agent-runner",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.42",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.45",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.42",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.42.tgz",
-      "integrity": "sha512-/CugP7AjP57Dqtl2sbsDtxdbpQoPKIhjyF5WrTViGu4NHQdM+UikrRs4MhZ2jeotiC5R7iK9ZUN9SiBgcZ8oLw==",
+      "version": "0.2.45",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.45.tgz",
+      "integrity": "sha512-AKH2hKoJNyjLf9ThAttKqbmCjUFg7qs/8+LR/UTVX20fCLn359YH9WrQc6dAiAfi8RYNA+mWwrNYCAq+Sdo5Ag==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.42",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.45",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -116,7 +116,7 @@ type StartConversationOptions struct {
 	Attachments       []models.Attachment // File attachments for the initial message
 	PlanMode          bool                // Start agent in plan mode
 	Instructions      string              // Additional instructions (e.g., from conversation summaries)
-	Model             string              // Model name override (e.g., "claude-opus-4-5-20251101", "claude-sonnet-4-20250514")
+	Model             string              // Model name override (e.g., "claude-opus-4-6", "claude-sonnet-4-6")
 }
 
 // StartConversation creates and starts a new conversation within a session

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -1316,7 +1316,7 @@ func TestManager_IsConversationInPlanMode_PlanInactive(t *testing.T) {
 
 func TestManager_SetConversationModel_NoProcess(t *testing.T) {
 	m, _ := setupTestManager(t)
-	err := m.SetConversationModel("nonexistent", "claude-sonnet-4-5-20250929")
+	err := m.SetConversationModel("nonexistent", "claude-sonnet-4-6")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no active process")
 }

--- a/backend/agent/parser_test.go
+++ b/backend/agent/parser_test.go
@@ -905,11 +905,11 @@ func TestParseAgentLine_ThinkingDelta(t *testing.T) {
 }
 
 func TestParseAgentLine_ModelChanged(t *testing.T) {
-	line := `{"type":"model_changed","model":"claude-sonnet-4-5-20250929"}`
+	line := `{"type":"model_changed","model":"claude-sonnet-4-6"}`
 	event := ParseAgentLine(line)
 	require.NotNil(t, event)
 	assert.Equal(t, EventTypeModelChanged, event.Type)
-	assert.Equal(t, "claude-sonnet-4-5-20250929", event.Model)
+	assert.Equal(t, "claude-sonnet-4-6", event.Model)
 }
 
 func TestParseAgentLine_HookResponse(t *testing.T) {

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -41,7 +41,7 @@ func TestNewProcessWithOptions(t *testing.T) {
 		SettingSources:      "project,user",
 		Betas:               "feature1,feature2",
 		Model:               "claude-opus-4-5-20251101",
-		FallbackModel:       "claude-sonnet-4-20250514",
+		FallbackModel:       "claude-sonnet-4-6",
 	}
 
 	p := NewProcessWithOptions(opts)

--- a/backend/ai/generate.go
+++ b/backend/ai/generate.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultModel  = "claude-sonnet-4-20250514"
+	defaultModel  = "claude-sonnet-4-6"
 	haikuModel    = "claude-haiku-4-5-20251001"
 	anthropicURL  = "https://api.anthropic.com/v1/messages"
 	apiVersion    = "2023-06-01"

--- a/backend/server/handlers_test.go
+++ b/backend/server/handlers_test.go
@@ -2249,8 +2249,8 @@ func TestCreateConversation_RequestParsing_WithModel(t *testing.T) {
 	}{
 		{
 			name:     "model specified",
-			body:     `{"type": "task", "message": "hello", "model": "claude-sonnet-4-20250514"}`,
-			expected: "claude-sonnet-4-20250514",
+			body:     `{"type": "task", "message": "hello", "model": "claude-sonnet-4-6"}`,
+			expected: "claude-sonnet-4-6",
 		},
 		{
 			name:     "model omitted defaults to empty",
@@ -2292,8 +2292,8 @@ func TestSendConversationMessage_RequestParsing_WithModel(t *testing.T) {
 		},
 		{
 			name:     "model with attachments",
-			body:     `{"content": "check this", "model": "claude-sonnet-4-20250514", "attachments": []}`,
-			expected: "claude-sonnet-4-20250514",
+			body:     `{"content": "check this", "model": "claude-sonnet-4-6", "attachments": []}`,
+			expected: "claude-sonnet-4-6",
 		},
 	}
 
@@ -2354,7 +2354,7 @@ func TestListConversations_IncludesModel(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range []struct{ id, model string }{
 		{"c1", "claude-opus-4-5-20251101"},
-		{"c2", "claude-sonnet-4-20250514"},
+		{"c2", "claude-sonnet-4-6"},
 	} {
 		conv := &models.Conversation{
 			ID: tc.id, SessionID: "sess-1", Type: "task",
@@ -2382,7 +2382,7 @@ func TestListConversations_IncludesModel(t *testing.T) {
 		modelsByID[c.ID] = c.Model
 	}
 	assert.Equal(t, "claude-opus-4-5-20251101", modelsByID["c1"])
-	assert.Equal(t, "claude-sonnet-4-20250514", modelsByID["c2"])
+	assert.Equal(t, "claude-sonnet-4-6", modelsByID["c2"])
 }
 
 // ============================================================================

--- a/backend/store/sqlite_test.go
+++ b/backend/store/sqlite_test.go
@@ -1033,7 +1033,7 @@ func TestAddConversation_WithModel(t *testing.T) {
 		Type:      models.ConversationTypeTask,
 		Name:      "Model Test",
 		Status:    models.ConversationStatusActive,
-		Model:     "claude-sonnet-4-20250514",
+		Model:     "claude-sonnet-4-6",
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
@@ -1042,7 +1042,7 @@ func TestAddConversation_WithModel(t *testing.T) {
 	got, err := s.GetConversation(ctx, "conv-1")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, "claude-sonnet-4-20250514", got.Model)
+	assert.Equal(t, "claude-sonnet-4-6", got.Model)
 }
 
 func TestAddConversation_ModelDefaultsToEmpty(t *testing.T) {
@@ -1092,7 +1092,7 @@ func TestListConversations_IncludesModel(t *testing.T) {
 
 	for _, tc := range []struct{ id, model string }{
 		{"c1", "claude-opus-4-5-20251101"},
-		{"c2", "claude-sonnet-4-20250514"},
+		{"c2", "claude-sonnet-4-6"},
 		{"c3", ""},
 	} {
 		conv := &models.Conversation{
@@ -1117,7 +1117,7 @@ func TestListConversations_IncludesModel(t *testing.T) {
 		modelsByID[c.ID] = c.Model
 	}
 	assert.Equal(t, "claude-opus-4-5-20251101", modelsByID["c1"])
-	assert.Equal(t, "claude-sonnet-4-20250514", modelsByID["c2"])
+	assert.Equal(t, "claude-sonnet-4-6", modelsByID["c2"])
 	assert.Equal(t, "", modelsByID["c3"])
 }
 
@@ -1168,13 +1168,13 @@ func TestUpdateConversation_ModelChange(t *testing.T) {
 	require.NoError(t, s.AddConversation(ctx, conv))
 
 	require.NoError(t, s.UpdateConversation(ctx, "conv-1", func(c *models.Conversation) {
-		c.Model = "claude-sonnet-4-20250514"
+		c.Model = "claude-sonnet-4-6"
 	}))
 
 	got, err := s.GetConversation(ctx, "conv-1")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, "claude-sonnet-4-20250514", got.Model)
+	assert.Equal(t, "claude-sonnet-4-6", got.Model)
 }
 
 // ============================================================================

--- a/docs/api/rest-api-reference.md
+++ b/docs/api/rest-api-reference.md
@@ -513,7 +513,7 @@ Create a new conversation and optionally send the first message.
 {
   "type": "task",
   "message": "Implement the login form component",
-  "model": "claude-sonnet-4-20250514",
+  "model": "claude-sonnet-4-6",
   "toolPreset": "full",
   "enableCheckpointing": true,
   "maxBudgetUsd": 5.0,

--- a/docs/api/websocket-events-reference.md
+++ b/docs/api/websocket-events-reference.md
@@ -145,7 +145,7 @@ Agent SDK initialized with model and capability information.
   conversationId: string;
   payload: {
     type: "init";
-    model: string;              // e.g., "claude-sonnet-4-20250514"
+    model: string;              // e.g., "claude-sonnet-4-6"
     tools: string[];            // Available tool names
     system: string;             // System prompt (truncated)
     permissionMode: string;     // "default" | "plan" | "bypassPermissions" | etc.

--- a/docs/claude-sdk-events.md
+++ b/docs/claude-sdk-events.md
@@ -211,7 +211,7 @@ interface OutputEvent {
 ```typescript
 {
   type: "init",
-  model: "claude-sonnet-4-20250514",
+  model: "claude-sonnet-4-6",
   tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", ...],
   mcpServers: [
     { name: "chatml", status: "connected", tools: [...] }
@@ -280,7 +280,7 @@ interface OutputEvent {
     cache_creation_input_tokens: 0
   },
   modelUsage: {
-    "claude-sonnet-4-20250514": { ... }
+    "claude-sonnet-4-6": { ... }
   },
   structuredOutput: null,         // If outputFormat specified
   sessionId: "abc123",

--- a/docs/technical/claude-agent-sdk-integration.md
+++ b/docs/technical/claude-agent-sdk-integration.md
@@ -31,7 +31,7 @@ node agent-runner/dist/index.js \
   --enable-checkpointing \
   --max-budget-usd 10.0 \
   --max-turns 100 \
-  --model claude-sonnet-4-20250514
+  --model claude-sonnet-4-6
 ```
 
 ### CLI Arguments

--- a/docs/technical/settings-configuration.md
+++ b/docs/technical/settings-configuration.md
@@ -75,7 +75,7 @@ Frontend settings are managed through the `settingsStore` Zustand store and pers
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| Model | `claude-sonnet-4-20250514` | Claude model to use |
+| Model | `claude-sonnet-4-6` | Claude model to use |
 | Extended thinking | false | Enable extended thinking |
 | Max thinking tokens | 50000 | Token budget for thinking |
 | Fallback model | — | Model when primary fails |

--- a/docs/troubleshooting/debugging-guide.md
+++ b/docs/troubleshooting/debugging-guide.md
@@ -233,7 +233,7 @@ If custom MCP servers aren't working:
 If API calls are failing:
 
 1. Check the API key is valid: Settings > Account > Anthropic API Key
-2. Verify the model name is correct: `claude-sonnet-4-20250514`, `claude-opus-4-5-20251101`, etc.
+2. Verify the model name is correct: `claude-sonnet-4-6`, `claude-opus-4-6`, etc.
 3. Check for rate limiting from the Claude API (different from ChatML's internal rate limits)
 4. Look for `error` events in the WebSocket stream with API-specific error codes
 

--- a/src/components/settings/sections/AIModelSettings.tsx
+++ b/src/components/settings/sections/AIModelSettings.tsx
@@ -46,7 +46,7 @@ export function AIModelSettings() {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
-            <SelectItem value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</SelectItem>
+            <SelectItem value="claude-sonnet-4-6">Claude Sonnet 4.6</SelectItem>
             <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
           </SelectContent>
         </Select>
@@ -59,7 +59,7 @@ export function AIModelSettings() {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
-            <SelectItem value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</SelectItem>
+            <SelectItem value="claude-sonnet-4-6">Claude Sonnet 4.6</SelectItem>
             <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
           </SelectContent>
         </Select>

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,6 +1,6 @@
 export const MODELS = [
   { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', supportsThinking: true, supportsEffort: true },
-  { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5', supportsThinking: true, supportsEffort: false },
+  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', supportsThinking: true, supportsEffort: true },
   { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', supportsThinking: true, supportsEffort: false },
 ] as const;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,7 +57,7 @@ export interface Conversation {
   type: 'task' | 'review' | 'chat';
   name: string; // AI-updatable display name
   status: 'active' | 'idle' | 'completed';
-  model?: string; // Last-used model (e.g., "claude-opus-4-5-20251101", "claude-sonnet-4-20250514")
+  model?: string; // Last-used model (e.g., "claude-opus-4-6", "claude-sonnet-4-6")
   budgetConfig?: { maxBudgetUsd?: number; maxTurns?: number };
   thinkingConfig?: { effort?: string; maxThinkingTokens?: number };
   messages: Message[];


### PR DESCRIPTION
## Summary

- Upgrade Agent SDK from 0.2.42 to 0.2.45
- Replace Sonnet 4.5 (claude-sonnet-4-5-20250929) with Sonnet 4.6 (claude-sonnet-4-6) across the full stack
- Update Go backend defaultModel from claude-sonnet-4-20250514 to claude-sonnet-4-6
- Enable supportsEffort: true for Sonnet 4.6 to match Opus 4.6 capabilities

## Changes Made

- **Agent SDK** — Updated @anthropic-ai/claude-agent-sdk from ^0.2.42 to ^0.2.45 in agent-runner
- **Frontend models** — Updated src/lib/models.ts with new model IDs and enabled effort support for Sonnet 4.6
- **Settings UI** — Updated AIModelSettings.tsx select items for both default and review model dropdowns
- **Go backend** — Updated defaultModel constant in backend/ai/generate.go
- **Tests** — Updated all test fixtures to reference the new model IDs across 5 test files
- **Documentation** — Updated 6 doc files with current model ID examples

## Test Plan

- [x] Go backend tests pass: `cd backend && go test ./...`
- [x] All test packages pass (13 packages verified)
- [x] Go backend builds clean: `cd backend && go build ./...`
- [x] Manual: Verify model picker shows "Claude Sonnet 4.6"
- [x] Manual: Verify settings page displays updated model options