### PR TITLE
Add NEW badge to Sonnet 4.6 in model selector

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -79,7 +79,7 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
 
 const MODELS = [
   { ...SHARED_MODELS[0], icon: Snowflake, badge: 'NEW' as const },
-  { ...SHARED_MODELS[1], icon: Snowflake },
+  { ...SHARED_MODELS[1], icon: Snowflake, badge: 'NEW' as const },
   { ...SHARED_MODELS[2], icon: Snowflake },
 ];
 


### PR DESCRIPTION
## Summary
- Adds the green "NEW" badge to Claude Sonnet 4.6 in the Compose area model selector dropdown, matching the existing badge on Claude Opus 4.6

## Test plan
- [ ] Open the model selector in the Compose area
- [ ] Verify both "Claude Opus 4.6" and "Claude Sonnet 4.6" show the green "NEW" badge
- [ ] Verify "Claude Haiku 4.5" has no badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)