### PR TITLE
Standardize Approved Plan rendering to match tool blocks

### DIFF
--- a/src/components/conversation/ApprovedPlanBlock.tsx
+++ b/src/components/conversation/ApprovedPlanBlock.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, memo } from 'react';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Circle, ClipboardCheck, ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { PROSE_CLASSES } from '@/lib/constants';
+import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
+
+interface ApprovedPlanBlockProps {
+  cacheKey: string;
+  content: string;
+  defaultExpanded?: boolean;
+}
+
+export const ApprovedPlanBlock = memo(function ApprovedPlanBlock({
+  cacheKey,
+  content,
+  defaultExpanded = true,
+}: ApprovedPlanBlockProps) {
+  const [isOpen, setIsOpen] = useState(defaultExpanded);
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger
+        className={cn(
+          'flex items-center gap-1.5 text-base w-full rounded px-1.5 py-1 transition-colors',
+          'hover:bg-surface-2',
+        )}
+      >
+        {/* Status indicator — green success circle (plan was approved) */}
+        <span className="flex items-center justify-center w-3 h-3 shrink-0">
+          <Circle className="w-2 h-2 fill-text-success text-text-success" />
+        </span>
+
+        {/* Icon and label */}
+        <ClipboardCheck className="w-3 h-3 shrink-0 text-muted-foreground" />
+        <span className="font-medium text-foreground">Approved Plan</span>
+
+        {/* Spacer */}
+        <span className="flex-1" />
+
+        {/* Expand indicator */}
+        <span className="shrink-0 text-muted-foreground">
+          {isOpen ? (
+            <ChevronDown className="w-2.5 h-2.5" />
+          ) : (
+            <ChevronRight className="w-2.5 h-2.5" />
+          )}
+        </span>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <div className={cn(PROSE_CLASSES, 'mt-0.5 ml-4 space-y-1.5')}>
+          <CachedMarkdown cacheKey={cacheKey} content={content} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+});

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -13,7 +13,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
-import { Copy, Check, FileText, ClipboardCheck, ChevronDown, ChevronRight, Wrench } from 'lucide-react';
+import { Copy, Check, FileText, ChevronDown, ChevronRight, Wrench } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Message, ToolUsage } from '@/lib/types';
 import { COPY_FEEDBACK_DURATION_MS, PROSE_CLASSES } from '@/lib/constants';
@@ -30,6 +30,7 @@ import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
 import { MentionText } from '@/components/conversation/MentionText';
+import { ApprovedPlanBlock } from '@/components/conversation/ApprovedPlanBlock';
 
 // Collapsed tool summary with individual ToolUsageBlock instances when expanded
 const ToolUsageSummary = memo(function ToolUsageSummary({ tools, worktreePath }: { tools: ToolUsage[]; worktreePath?: string }) {
@@ -93,7 +94,6 @@ export const MessageBlock = memo(function MessageBlock({
   // comparator below to skip re-renders for messages without search matches.
 }: MessageBlockProps) {
   const [copied, setCopied] = useState(false);
-  const [isPlanExpanded, setIsPlanExpanded] = useState(false);
 
   const copyContent = useCallback(async () => {
     const success = await copyToClipboard(message.content);
@@ -148,25 +148,10 @@ export const MessageBlock = memo(function MessageBlock({
       <div className="space-y-1.5">
         {/* Backward compat: show planContent at top for old messages without plan timeline entry */}
         {message.planContent && !(message.timeline?.some(e => e.type === 'plan')) && (
-          <div className="flex flex-col gap-1">
-            <button
-              onClick={() => setIsPlanExpanded(!isPlanExpanded)}
-              className="flex items-center gap-2 text-xs text-primary hover:text-primary/80 transition-colors"
-            >
-              <ClipboardCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-              <span className="font-medium">Approved Plan</span>
-              {isPlanExpanded ? (
-                <ChevronDown className="w-3 h-3" />
-              ) : (
-                <ChevronRight className="w-3 h-3" />
-              )}
-            </button>
-            {isPlanExpanded && (
-              <div className={cn(PROSE_CLASSES, 'ml-5 border-l-2 border-primary/20 pl-3')}>
-                <CachedMarkdown cacheKey={`plan:${message.id}`} content={message.planContent} />
-              </div>
-            )}
-          </div>
+          <ApprovedPlanBlock
+            cacheKey={`plan:${message.id}`}
+            content={message.planContent}
+          />
         )}
 
         {/* Interleaved timeline rendering (preserves text/tool ordering from streaming) */}
@@ -215,25 +200,11 @@ export const MessageBlock = memo(function MessageBlock({
                     );
                   } else if (entry.type === 'plan') {
                     return (
-                      <div key={`tl-plan-${idx}`} className="flex flex-col gap-1">
-                        <button
-                          onClick={() => setIsPlanExpanded(!isPlanExpanded)}
-                          className="flex items-center gap-2 text-xs text-primary hover:text-primary/80 transition-colors"
-                        >
-                          <ClipboardCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-                          <span className="font-medium">Approved Plan</span>
-                          {isPlanExpanded ? (
-                            <ChevronDown className="w-3 h-3" />
-                          ) : (
-                            <ChevronRight className="w-3 h-3" />
-                          )}
-                        </button>
-                        {isPlanExpanded && (
-                          <div className={cn(PROSE_CLASSES, 'ml-5 border-l-2 border-primary/20 pl-3')}>
-                            <CachedMarkdown cacheKey={`plan:${message.id}:tl:${idx}`} content={entry.content} />
-                          </div>
-                        )}
-                      </div>
+                      <ApprovedPlanBlock
+                        key={`tl-plan-${idx}`}
+                        cacheKey={`plan:${message.id}:tl:${idx}`}
+                        content={entry.content}
+                      />
                     );
                   }
                   return null;

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -3,10 +3,11 @@
 import { useState, useEffect, useRef, useMemo, memo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useStreamingState, useActiveTools, useSubAgents } from '@/stores/selectors';
-import { AlertCircle, Brain, ChevronDown, ChevronRight, ClipboardCheck, Clock } from 'lucide-react';
+import { AlertCircle, Brain, ChevronDown, ChevronRight, Clock } from 'lucide-react';
 import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
 import { ThinkingNode } from '@/components/conversation/ThinkingNode';
 import { SubAgentRow, SubAgentGroupedRow } from '@/components/conversation/SubAgentGroup';
+import { ApprovedPlanBlock } from '@/components/conversation/ApprovedPlanBlock';
 import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
 import { StreamingMarkdown } from '@/components/shared/StreamingMarkdown';
 import { cn } from '@/lib/utils';
@@ -170,8 +171,6 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
   // Check if extended thinking is enabled based on model capabilities
   const conversationModel = useAppStore((s) => s.conversations.find(c => c.id === conversationId)?.model);
   const isExtendedThinkingEnabled = conversationModel ? (getModelInfo(conversationModel)?.supportsThinking ?? false) : false;
-
-  const [isApprovedPlanExpanded, setIsApprovedPlanExpanded] = useState(true);
 
   // Build interleaved timeline from segments, tools, and thinking
   const timeline = useMemo((): TimelineItem[] => {
@@ -345,28 +344,11 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
                   />
                 </div>
               ) : (
-                <div key={item.id} className="flex flex-col gap-1">
-                  <button
-                    onClick={() => setIsApprovedPlanExpanded(!isApprovedPlanExpanded)}
-                    className="flex items-center gap-2 text-xs text-primary hover:text-primary/80 transition-colors"
-                  >
-                    <ClipboardCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-                    <span className="font-medium">Approved Plan</span>
-                    {isApprovedPlanExpanded ? (
-                      <ChevronDown className="w-3 h-3" />
-                    ) : (
-                      <ChevronRight className="w-3 h-3" />
-                    )}
-                  </button>
-                  {isApprovedPlanExpanded && (
-                    <div className={cn(PROSE_CLASSES, 'ml-5 border-l-2 border-primary/20 pl-3')}>
-                      <CachedMarkdown
-                        cacheKey={`approved-plan:${conversationId}`}
-                        content={item.content}
-                      />
-                    </div>
-                  )}
-                </div>
+                <ApprovedPlanBlock
+                  key={item.id}
+                  cacheKey={`approved-plan:${conversationId}`}
+                  content={item.content}
+                />
               );
             } else if (item.type === 'subagent_group') {
               return (


### PR DESCRIPTION
## Summary
- Extract a shared `ApprovedPlanBlock` component that uses the same `Collapsible` pattern and styling as `ToolUsageBlock` (consistent padding, hover states, status indicator, chevron placement)
- Replace 3 inline ad-hoc plan renderings across `StreamingMessage.tsx` and `MessageBlock.tsx` with the new component
- Default the Approved Plan to expanded after approval so the plan content is immediately visible

## Test plan
- [ ] Approve a plan in a conversation and verify it renders expanded by default with styling matching tool blocks (green dot, hover bg, consistent font size)
- [ ] Collapse and re-expand the plan to verify toggle works
- [ ] Reload a conversation with a persisted approved plan and verify it renders correctly
- [ ] Check older messages with `planContent` but no timeline plan entry still render via backward-compat path

🤖 Generated with [Claude Code](https://claude.com/claude-code)