### PR TITLE
Refactor checks panel: git status first, conditional PR sections

### DIFF
--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -31,6 +31,7 @@ import {
   Loader2,
   RotateCcw,
   Sparkles,
+  GitBranch,
   GitPullRequest,
   GitMerge,
   ShieldCheck,
@@ -171,7 +172,7 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
     rerunWorkflow,
     analyzeFailure,
   } = useCIRuns(selectedWorkspaceId, selectedSessionId, active);
-  const { status: gitStatus, loading: gitLoading, refetch: refetchGit } = useGitStatus(
+  const { status: gitStatus, loading: gitLoading, error: gitError, errorCode: gitErrorCode, refetch: refetchGit } = useGitStatus(
     selectedWorkspaceId,
     selectedSessionId,
     active
@@ -209,43 +210,89 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
     );
   }
 
+  const branchName = session?.branch;
+
   return (
     <ScrollArea className="h-full">
       <div className="flex flex-col min-w-0">
-        {/* Merge Readiness Banner */}
-        <MergeReadinessBanner
-          readiness={readiness}
-          prStatus={prStatus}
-          isLoading={isLoading}
-          onRefresh={handleRefreshAll}
-        />
+        {/* Merge Readiness Banner - only when PR exists */}
+        {!readiness.hasNoPR && (
+          <MergeReadinessBanner
+            readiness={readiness}
+            prStatus={prStatus}
+            isLoading={isLoading}
+            onRefresh={handleRefreshAll}
+          />
+        )}
 
-        {/* PR Header */}
-        <PRHeaderSection pr={prDetails} prStatus={prStatus} />
+        {/* PR Header - only when PR exists */}
+        {(prDetails || prStatus === 'open') && (
+          <PRHeaderSection pr={prDetails} prStatus={prStatus} />
+        )}
 
-        {/* CI Checks */}
+        {/* Git Status - first section */}
+        <div className="border-b">
+          <div className="flex items-center px-3 py-2">
+            <span className="text-2xs font-medium text-foreground/60 uppercase tracking-wider flex-1">
+              Git Status
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-5 w-5 shrink-0"
+              onClick={refetchGit}
+              disabled={gitLoading}
+            >
+              <RefreshCw className={cn('h-3 w-3', gitLoading && 'animate-spin')} />
+            </Button>
+          </div>
+          <div className="px-1.5 pb-2">
+            {/* Branch name */}
+            {branchName && (
+              <div className="flex items-center gap-2 py-1 px-2 min-w-0">
+                <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="text-xs truncate flex-1" title={branchName}>{branchName}</span>
+              </div>
+            )}
+            {/* "No pull request" line item with Create PR action */}
+            {readiness.hasNoPR && !prLoading && (
+              <div className="flex items-center gap-2 py-1 px-2 min-w-0">
+                <GitPullRequest className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="text-xs flex-1 text-muted-foreground">No pull request</span>
+                {onSendMessage && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 text-xs px-2"
+                    onClick={() => onSendMessage('Create a pull request')}
+                  >
+                    Create PR
+                  </Button>
+                )}
+              </div>
+            )}
+            <GitStatusSection
+              onSendMessage={onSendMessage}
+              status={gitStatus}
+              loading={gitLoading}
+              error={gitError}
+              errorCode={gitErrorCode}
+              onRefresh={refetchGit}
+            />
+          </div>
+        </div>
+
+        {/* CI Checks - second section */}
         <CIChecksSection
           checkDetails={checkDetails}
           runs={runs}
           workspaceId={selectedWorkspaceId}
           sessionId={selectedSessionId}
-          hasNoPR={readiness.hasNoPR}
+          hasNoPR={readiness.hasNoPR && !prLoading}
           onGetJobs={getJobs}
           onRerun={rerunWorkflow}
           onAnalyzeFailure={analyzeFailure}
         />
-
-        {/* Git Status */}
-        <div className="border-b">
-          <div className="px-3 py-2">
-            <span className="text-2xs font-medium text-foreground/60 uppercase tracking-wider">
-              Git Status
-            </span>
-          </div>
-          <div className="px-1.5 pb-2">
-            <GitStatusSection onSendMessage={onSendMessage} active={active} />
-          </div>
-        </div>
       </div>
     </ScrollArea>
   );
@@ -266,7 +313,7 @@ function MergeReadinessBanner({
   isLoading: boolean;
   onRefresh: () => void;
 }) {
-  const { ready, blockers, pendingCount, hasNoPR } = readiness;
+  const { ready, blockers, pendingCount } = readiness;
 
   let bgClass: string;
   let borderClass: string;
@@ -283,11 +330,6 @@ function MergeReadinessBanner({
     borderClass = 'border-border';
     icon = <GitPullRequest className="h-3.5 w-3.5 text-red-400 shrink-0" />;
     message = 'PR closed';
-  } else if (hasNoPR) {
-    bgClass = 'bg-muted/50';
-    borderClass = 'border-border';
-    icon = <Info className="h-3.5 w-3.5 text-muted-foreground shrink-0" />;
-    message = 'No pull request';
   } else if (blockers.some((b) => b.severity === 'error')) {
     const errorCount = blockers.filter((b) => b.severity === 'error').length;
     bgClass = 'bg-red-500/8';
@@ -345,15 +387,6 @@ function PRHeaderSection({
   pr: PRDetails | null;
   prStatus: string | undefined;
 }) {
-  if (!pr && prStatus !== 'open') {
-    return (
-      <div className="flex items-center gap-2 px-3 py-2.5 border-b min-w-0">
-        <GitPullRequest className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-        <span className="text-xs text-muted-foreground">No pull request yet</span>
-      </div>
-    );
-  }
-
   if (!pr) {
     return (
       <div className="flex items-center gap-2 px-3 py-2.5 border-b min-w-0">

--- a/src/components/panels/GitStatusSection.tsx
+++ b/src/components/panels/GitStatusSection.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { useGitStatus } from '@/hooks/useGitStatus';
-import { useSelectedIds } from '@/stores/selectors';
 import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Popover,
   PopoverTrigger,
@@ -292,44 +289,19 @@ function buildStatusItems(
     });
   }
 
-  // Priority 4: Stash
-  if (status.stash.count > 0) {
-    items.push({
-      type: 'neutral',
-      message: `${status.stash.count} stashed change${status.stash.count !== 1 ? 's' : ''}`,
-      action: {
-        label: 'Apply',
-        onClick: () => sendMessage('Apply the latest stash'),
-      },
-      dropdownActions: [
-        {
-          icon: RefreshCw,
-          label: 'Apply Stash',
-          description: 'Apply stashed changes and keep the stash entry',
-          onClick: () => sendMessage('Apply the latest stash'),
-        },
-        {
-          icon: AlertTriangle,
-          label: 'Pop Stash',
-          description: 'Apply stashed changes and remove the stash entry',
-          onClick: () => sendMessage('Pop the latest stash'),
-        },
-      ],
-    });
-  }
-
   return items;
 }
 
 interface GitStatusSectionProps {
   onSendMessage?: (content: string) => void;
-  active?: boolean;
+  status: GitStatusDTO | null;
+  loading: boolean;
+  error: string | null;
+  errorCode: string | null;
+  onRefresh: () => void;
 }
 
-export function GitStatusSection({ onSendMessage, active = true }: GitStatusSectionProps) {
-  const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
-  const { status, loading, error, errorCode, refetch } = useGitStatus(selectedWorkspaceId, selectedSessionId, active);
-
+export function GitStatusSection({ onSendMessage, status, loading, error, errorCode, onRefresh }: GitStatusSectionProps) {
   // Wrapper that handles missing callback
   const sendMessage = (content: string) => {
     if (!onSendMessage) {
@@ -341,8 +313,9 @@ export function GitStatusSection({ onSendMessage, active = true }: GitStatusSect
 
   if (loading && !status) {
     return (
-      <div className="h-full flex items-center justify-center">
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      <div className="flex items-center gap-2 py-2 px-2">
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        <span className="text-xs text-muted-foreground">Loading...</span>
       </div>
     );
   }
@@ -350,7 +323,7 @@ export function GitStatusSection({ onSendMessage, active = true }: GitStatusSect
   if (error) {
     if (errorCode === ErrorCode.WORKTREE_NOT_FOUND) {
       return (
-        <div className="h-full flex flex-col items-center justify-center gap-2 p-4">
+        <div className="flex flex-col items-center gap-2 p-4">
           <FolderX className="h-5 w-5 text-muted-foreground" />
           <p className="text-xs text-muted-foreground text-center">
             Worktree directory no longer exists
@@ -360,10 +333,10 @@ export function GitStatusSection({ onSendMessage, active = true }: GitStatusSect
     }
 
     return (
-      <div className="h-full flex flex-col items-center justify-center gap-2 p-4">
+      <div className="flex flex-col items-center gap-2 p-4">
         <XCircle className="h-5 w-5 text-text-error" />
         <p className="text-xs text-muted-foreground text-center">{error}</p>
-        <Button variant="ghost" size="sm" onClick={refetch}>
+        <Button variant="ghost" size="sm" onClick={onRefresh}>
           <RefreshCw className="h-3 w-3 mr-1" />
           Retry
         </Button>
@@ -373,7 +346,7 @@ export function GitStatusSection({ onSendMessage, active = true }: GitStatusSect
 
   if (!status) {
     return (
-      <div className="h-full flex items-center justify-center">
+      <div className="flex items-center justify-center py-2">
         <p className="text-xs text-muted-foreground">No session selected</p>
       </div>
     );
@@ -382,24 +355,10 @@ export function GitStatusSection({ onSendMessage, active = true }: GitStatusSect
   const items = buildStatusItems(status, sendMessage);
 
   return (
-    <ScrollArea className="h-full">
-      <div>
-        <div className="flex items-center justify-between px-2 py-1">
-          <span className="text-xs font-medium text-purple-500">Git status</span>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-5 w-5"
-            onClick={refetch}
-            disabled={loading}
-          >
-            <RefreshCw className={cn('h-3 w-3', loading && 'animate-spin')} />
-          </Button>
-        </div>
-        {items.map((item) => (
-          <GitStatusItem key={`${item.type}-${item.message}`} {...item} />
-        ))}
-      </div>
-    </ScrollArea>
+    <div>
+      {items.map((item) => (
+        <GitStatusItem key={`${item.type}-${item.message}`} {...item} />
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Reorders the checks panel so **Git Status** appears above **CI Checks**, with branch name shown inline
- Shows merge readiness banner and PR header **only when a PR exists**, replacing the always-visible "No pull request" banner
- Adds an inline "No pull request" row with a **Create PR** action button in the Git Status section
- Lifts `useGitStatus` to the parent component, making `GitStatusSection` a controlled component
- Removes stash UI (not applicable in worktree-based sessions)
- Fixes a flash of "No pull request" during initial PR loading by gating on `prLoading`

## Test plan
- [ ] Open a session **without** a PR — verify "No pull request" row with "Create PR" button appears (no flash)
- [ ] Open a session **with** a PR — verify merge readiness banner and PR header show, "No pull request" row is hidden
- [ ] Verify branch name displays correctly and truncates on narrow panels
- [ ] Verify git status items (ahead/behind, uncommitted changes) still render correctly
- [ ] Verify CI checks section still works (expand, rerun, analyze failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)