### PR TITLE
Rename Review tab to Code Review

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -852,7 +852,7 @@ export function ChangesPanel() {
 // Top panel tabs configuration (all tabs always visible)
 const TOP_TABS_CONFIG: Record<AllTopPanelTab, { label: string; shortcutId?: string }> = {
   changes: { label: 'Changes', shortcutId: 'sidebarChangesTab' },
-  review: { label: 'Review', shortcutId: 'sidebarReviewTab' },
+  review: { label: 'Code Review', shortcutId: 'sidebarReviewTab' },
   checks: { label: 'Checks', shortcutId: 'sidebarChecksTab' },
   files: { label: 'Files', shortcutId: 'sidebarFilesTab' },
 };


### PR DESCRIPTION
## Summary
- Renames the "Review" tab to "Code Review" in the secondary sidebar

## Test plan
- [ ] Open the secondary sidebar and verify the tab reads "Code Review"
- [ ] Confirm tab order is: Files, Changes, Checks, Code Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)