### PR TITLE
Fix tool/task name line wrapping in status blocks

### DIFF
--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -328,14 +328,14 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
 
         {/* Tool icon and label */}
         <ToolIcon className={cn('w-3 h-3 shrink-0', success === false ? 'text-text-error' : 'text-muted-foreground')} />
-        <span className={cn('font-medium', success === false ? 'text-text-error' : 'text-foreground')}>{getToolLabel()}</span>
+        <span className={cn('font-medium shrink-0 whitespace-nowrap', success === false ? 'text-text-error' : 'text-foreground')}>{getToolLabel()}</span>
         {success === false && (
           <span className="text-2xs px-1 py-0.5 rounded bg-text-error/10 text-text-error font-medium shrink-0">
             Error
           </span>
         )}
         {mcpInfo && (
-          <span className="text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground/70">
+          <span className="text-2xs px-1 py-0.5 rounded bg-muted text-muted-foreground/70 shrink-0">
             {mcpInfo.displayServer}
           </span>
         )}


### PR DESCRIPTION
## Summary
- Add `shrink-0 whitespace-nowrap` to the tool label span so tool/task names (e.g., "Get session status") always render on a single line without wrapping
- Add `shrink-0` to the MCP server tag to prevent it from being compressed by flex layout

## Test plan
- [ ] Verify tool names like "Get session status" render on a single line
- [ ] Verify descriptions/targets still truncate with ellipsis when the window is narrow
- [ ] Verify shorter tool names like "Run", "Skill" still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)