### PR TITLE
Add --delete-branch ban to agent worktree rules

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -2151,6 +2151,8 @@ This session uses a git worktree — an isolated working directory with a dedica
 
 **NEVER switch branches.** Do not run `+"`"+`git checkout`+"`"+`, `+"`"+`git switch`+"`"+`, or any command that changes the checked-out branch. The worktree is locked to its branch — switching would corrupt the session state. If the user asks you to switch to main, master, or any other branch, explain that this session is locked to its worktree branch and they should create a new session instead.
 
+**NEVER use --delete-branch with gh commands.** `+"`"+`gh pr merge --delete-branch`+"`"+` and `+"`"+`gh pr close --delete-branch`+"`"+` delete the local branch and silently switch the worktree to the default branch, corrupting the session. Always omit `+"`"+`--delete-branch`+"`"+`. After merging, the session stays on its branch.
+
 **NEVER use `+"`"+`git stash`+"`"+`.** Stash is shared across ALL worktrees in the repository. A stash created here is visible to every other session. Use commits instead — commit work-in-progress to the session branch.
 
 **Stay in the worktree directory.** Do not `+"`"+`cd`+"`"+` outside of %s. All your file operations should be within this directory.
@@ -2161,7 +2163,7 @@ This session uses a git worktree — an isolated working directory with a dedica
 - No `+"`"+`git clean -fd`+"`"+` (deletes untracked files)
 - No `+"`"+`git branch -D`+"`"+` on the session branch (destroys the session)
 
-**After a PR is merged, stay on this branch.** Do not attempt to switch to main or clean up. The session remains active on its branch.
+**After a PR is merged, stay on this branch.** Do not attempt to switch to main or clean up. Do not delete the branch. The session remains active on its branch.
 
 **Branch name may change.** ChatML auto-renames the branch after the first message. Always use `+"`"+`git branch --show-current`+"`"+` rather than hardcoding the branch name.
 


### PR DESCRIPTION
## Summary

- Ban `--delete-branch` flag in `gh pr merge` and `gh pr close` within agent worktree rules
- Strengthen post-merge rule to explicitly prohibit branch deletion

## Context

`gh pr merge --delete-branch` silently switches the worktree to the default branch after deleting the session branch. This corrupts the session state — the worktree ends up on `main` instead of its dedicated branch. The existing rules only blocked explicit `git checkout`/`git switch` but missed this implicit branch switch.

## Changes Made

- **`backend/agent/manager.go`** — Added new rule to `buildAppPrompt()` banning `--delete-branch` with gh commands. Updated post-merge rule to also say "Do not delete the branch."

## Test plan

- [x] `go build ./...` passes
- [ ] Start a new session, merge a PR — verify agent does not use `--delete-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)