### PR TITLE
Add attachment preview modal viewer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,27 +23,15 @@ importers:
       '@fontsource/instrument-serif':
         specifier: ^5.2.8
         version: 5.2.8
-      '@git-diff-view/file':
-        specifier: ^0.0.39
-        version: 0.0.39
-      '@git-diff-view/lowlight':
-        specifier: ^0.0.39
-        version: 0.0.39
-      '@git-diff-view/react':
-        specifier: ^0.0.39
-        version: 0.0.39(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@git-diff-view/shiki':
-        specifier: ^0.0.39
-        version: 0.0.39
       '@iconify-json/vscode-icons':
         specifier: ^1.2.40
         version: 1.2.42
       '@iconify/react':
         specifier: ^6.0.2
         version: 6.0.2(react@19.2.4)
-      '@monaco-editor/react':
-        specifier: ^4.7.0
-        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@pierre/diffs':
+        specifier: ^1.0.11
+        version: 1.0.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@platejs/combobox':
         specifier: ^52.0.15
         version: 52.0.15(platejs@52.0.17(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.4)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -149,9 +137,6 @@ importers:
       mermaid:
         specifier: ^11.12.2
         version: 11.12.2
-      monaco-themes:
-        specifier: ^0.4.8
-        version: 0.4.8
       next:
         specifier: ^16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -222,9 +207,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
-      '@types/diff':
-        specifier: ^7.0.2
-        version: 7.0.2
       '@types/node':
         specifier: ^22
         version: 22.19.11
@@ -702,24 +684,6 @@ packages:
   '@fontsource/instrument-serif@5.2.8':
     resolution: {integrity: sha512-s+bkz+syj2rO00Rmq9g0P+PwuLig33DR1xDR8pTWmovH1pUjwnncrFk++q9mmOex8fUQ7oW80gPpPDaw7V1MMw==}
 
-  '@git-diff-view/core@0.0.39':
-    resolution: {integrity: sha512-GJGsti+R8XV11XFWVziXiSgZ8T26pcb1/7H/e5PLSByG7JKeDU9O9JPvjvSShQokj/5Zp5kXvtNM+tgCtrRrYQ==}
-
-  '@git-diff-view/file@0.0.39':
-    resolution: {integrity: sha512-hn6qcawYF4GQU7eyOIs78PjTRWhlgsK8lsVEtu0yMnuo3VKmVYiDgTT6Yegf2hoPkJy3Xfs14q0S3j2ELm8NlA==}
-
-  '@git-diff-view/lowlight@0.0.39':
-    resolution: {integrity: sha512-S2hL5YsIl5Ao2JGeV95OswFjDnM3HRUZRlF4etVw/dbTmI27/Qp5Bnymb0cdx50ZLq8dV+BuxaeRu7w7jN8NHg==}
-
-  '@git-diff-view/react@0.0.39':
-    resolution: {integrity: sha512-p4MJOn0RMTrcLbzUYU90n5Ddsnf6wH9BM26uyPlULk8EfnCw5wHOoGlGa8zTrgl8L7ArOtmFauuhmch2d78V0w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@git-diff-view/shiki@0.0.39':
-    resolution: {integrity: sha512-YxZPP1broF30zMIgg77zGHOEsikWBFfYYSVj0/u2b/F//p+eyAj6rJhIC6yBLc7EFqb1uWE2yI2ABIIwkZiEFQ==}
-
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -944,16 +908,6 @@ packages:
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
 
-  '@monaco-editor/loader@1.7.0':
-    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
-
-  '@monaco-editor/react@4.7.0':
-    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
-    peerDependencies:
-      monaco-editor: '>= 0.25.0 < 1'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
@@ -1039,6 +993,12 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@pierre/diffs@1.0.11':
+    resolution: {integrity: sha512-j6zIEoyImQy1HfcJqbrDwP0O5I7V2VNXAaw53FqQ+SykRfaNwABeZHs9uibXO4supaXPmTx6LEH9Lffr03e1Tw==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
 
   '@platejs/combobox@52.0.15':
     resolution: {integrity: sha512-ib5sdP91GA8BhmfyK7Pi57OGDRK/Kjxv399kCNRt/qxk0nLG7b15MUM/Apauf/pm/mvUJNmA7LwWHCZCuEuChw==}
@@ -1705,6 +1665,9 @@ packages:
   '@shikijs/themes@3.22.0':
     resolution: {integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==}
 
+  '@shikijs/transformers@3.22.0':
+    resolution: {integrity: sha512-E7eRV7mwDBjueLF6852n2oYeJYxBq3NSsDk+uyruYAXONv4U8holGmIrT+mPRJQ1J1SNOH6L8G19KRzmBawrFw==}
+
   '@shikijs/types@3.22.0':
     resolution: {integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==}
 
@@ -2057,9 +2020,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/diff@7.0.2':
-    resolution: {integrity: sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==}
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2333,12 +2293,6 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
-
-  '@vue/reactivity@3.5.28':
-    resolution: {integrity: sha512-gr5hEsxvn+RNyu9/9o1WtdYdwDjg5FgjUSBEkZWqgTKlo/fvwZ2+8W6AfKsc9YN2k/+iHYdS9vZYAhpi10kNaw==}
-
-  '@vue/shared@3.5.28':
-    resolution: {integrity: sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==}
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -2870,9 +2824,6 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
-
   dompurify@3.3.1:
     resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
@@ -3091,9 +3042,6 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
@@ -3103,9 +3051,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-plist@0.1.3:
-    resolution: {integrity: sha512-d9cEfo/WcOezgPLAC/8t8wGb6YOD6JTCPMw2QcG2nAdFmyY+9rTUizCTaGjIZAloWENTEUMAPpkUAIJJJ0i96A==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3728,6 +3673,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   lucide-react@0.563.0:
     resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
     peerDependencies:
@@ -3749,11 +3697,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  marked@14.0.0:
-    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
-    engines: {node: '>= 18'}
-    hasBin: true
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
@@ -3923,13 +3866,6 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
-  monaco-editor@0.55.1:
-    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
-
-  monaco-themes@0.4.8:
-    resolution: {integrity: sha512-QEDCwl5XUMPPpsg8TVNfi1VKIDtMsMTJAhUfxHSZ6hzkEfZgfTK2hicwyzkDKhAhrpMkHkwMtG13ynvdztJesw==}
-    engines: {node: '>=22.0.0'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -4270,11 +4206,6 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
-  reactivity-store@0.3.12:
-    resolution: {integrity: sha512-Idz9EL4dFUtQbHySZQzckWOTUfqjdYpUtNW0iOysC32mG7IjiUGB77QrsyR5eAWBkRiS9JscF6A3fuQAIy+LrQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   recharts@3.7.0:
     resolution: {integrity: sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==}
     engines: {node: '>=18'}
@@ -4506,9 +4437,6 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  state-local@1.0.7:
-    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -5465,44 +5393,6 @@ snapshots:
 
   '@fontsource/instrument-serif@5.2.8': {}
 
-  '@git-diff-view/core@0.0.39':
-    dependencies:
-      '@git-diff-view/lowlight': 0.0.39
-      fast-diff: 1.3.0
-      highlight.js: 11.11.1
-      lowlight: 3.3.0
-
-  '@git-diff-view/file@0.0.39':
-    dependencies:
-      '@git-diff-view/core': 0.0.39
-      diff: 8.0.3
-      fast-diff: 1.3.0
-      highlight.js: 11.11.1
-      lowlight: 3.3.0
-
-  '@git-diff-view/lowlight@0.0.39':
-    dependencies:
-      '@types/hast': 3.0.4
-      highlight.js: 11.11.1
-      lowlight: 3.3.0
-
-  '@git-diff-view/react@0.0.39(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@git-diff-view/core': 0.0.39
-      '@types/hast': 3.0.4
-      fast-diff: 1.3.0
-      highlight.js: 11.11.1
-      lowlight: 3.3.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      reactivity-store: 0.3.12(react@19.2.4)
-      use-sync-external-store: 1.6.0(react@19.2.4)
-
-  '@git-diff-view/shiki@0.0.39':
-    dependencies:
-      '@types/hast': 3.0.4
-      shiki: 3.22.0
-
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5681,17 +5571,6 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@monaco-editor/loader@1.7.0':
-    dependencies:
-      state-local: 1.0.7
-
-  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@monaco-editor/loader': 1.7.0
-      monaco-editor: 0.55.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
   '@mswjs/interceptors@0.41.3':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -5760,6 +5639,18 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@pierre/diffs@1.0.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@shikijs/core': 3.22.0
+      '@shikijs/engine-javascript': 3.22.0
+      '@shikijs/transformers': 3.22.0
+      diff: 8.0.3
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      shiki: 3.22.0
 
   '@platejs/combobox@52.0.15(platejs@52.0.17(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.4)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -6448,6 +6339,11 @@ snapshots:
     dependencies:
       '@shikijs/types': 3.22.0
 
+  '@shikijs/transformers@3.22.0':
+    dependencies:
+      '@shikijs/core': 3.22.0
+      '@shikijs/types': 3.22.0
+
   '@shikijs/types@3.22.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
@@ -6804,8 +6700,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/diff@7.0.2': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -7100,12 +6994,6 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
-
-  '@vue/reactivity@3.5.28':
-    dependencies:
-      '@vue/shared': 3.5.28
-
-  '@vue/shared@3.5.28': {}
 
   '@xterm/addon-fit@0.11.0': {}
 
@@ -7676,10 +7564,6 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.2.7:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
   dompurify@3.3.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -8062,8 +7946,6 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-diff@1.3.0: {}
-
   fast-glob@3.3.1:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8075,8 +7957,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-plist@0.1.3: {}
 
   fastq@1.20.1:
     dependencies:
@@ -8686,6 +8566,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru_map@0.4.1: {}
+
   lucide-react@0.563.0(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -8707,8 +8589,6 @@ snapshots:
       semver: 7.7.4
 
   markdown-table@3.0.4: {}
-
-  marked@14.0.0: {}
 
   marked@16.4.2: {}
 
@@ -9109,15 +8989,6 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  monaco-editor@0.55.1:
-    dependencies:
-      dompurify: 3.2.7
-      marked: 14.0.0
-
-  monaco-themes@0.4.8:
-    dependencies:
-      fast-plist: 0.1.3
-
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -9473,13 +9344,6 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
-
-  reactivity-store@0.3.12(react@19.2.4):
-    dependencies:
-      '@vue/reactivity': 3.5.28
-      '@vue/shared': 3.5.28
-      react: 19.2.4
-      use-sync-external-store: 1.6.0(react@19.2.4)
 
   recharts@3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
     dependencies:
@@ -9844,8 +9708,6 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
-
-  state-local@1.0.7: {}
 
   statuses@2.0.2: {}
 

--- a/src/components/conversation/AttachmentCard.tsx
+++ b/src/components/conversation/AttachmentCard.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils';
 interface AttachmentCardProps {
   attachment: Attachment;
   onRemove?: () => void;
+  onClick?: () => void;
   readOnly?: boolean;
 }
 
@@ -28,7 +29,7 @@ const CATEGORY_ICONS: Record<string, LucideIcon> = {
 /**
  * Attachment card component for displaying file attachments in the compose area
  */
-export function AttachmentCard({ attachment, onRemove, readOnly = false }: AttachmentCardProps) {
+export function AttachmentCard({ attachment, onRemove, onClick, readOnly = false }: AttachmentCardProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   // Determine file path for category detection - use path if available, otherwise fall back to name
@@ -45,8 +46,10 @@ export function AttachmentCard({ attachment, onRemove, readOnly = false }: Attac
       className={cn(
         'group relative flex items-center gap-2 rounded-md border border-border bg-muted/50 px-2.5 py-1.5',
         'hover:bg-muted/80 transition-colors',
-        'min-w-0 max-w-[220px]'
+        'min-w-0 max-w-[220px]',
+        onClick && 'cursor-pointer'
       )}
+      onClick={onClick}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/src/components/conversation/AttachmentGrid.tsx
+++ b/src/components/conversation/AttachmentGrid.tsx
@@ -6,24 +6,26 @@ import { AttachmentCard } from './AttachmentCard';
 interface AttachmentGridProps {
   attachments: Attachment[];
   onRemove?: (id: string) => void;
+  onPreview?: (index: number) => void;
   readOnly?: boolean;
 }
 
 /**
  * Grid layout for displaying multiple attachment cards
  */
-export function AttachmentGrid({ attachments, onRemove, readOnly = false }: AttachmentGridProps) {
+export function AttachmentGrid({ attachments, onRemove, onPreview, readOnly = false }: AttachmentGridProps) {
   if (attachments.length === 0) {
     return null;
   }
 
   return (
     <div className="flex flex-wrap gap-2 p-2">
-      {attachments.map((attachment) => (
+      {attachments.map((attachment, index) => (
         <AttachmentCard
           key={attachment.id}
           attachment={attachment}
           onRemove={onRemove ? () => onRemove(attachment.id) : undefined}
+          onClick={onPreview ? () => onPreview(index) : undefined}
           readOnly={readOnly}
         />
       ))}

--- a/src/components/conversation/AttachmentPreviewModal.tsx
+++ b/src/components/conversation/AttachmentPreviewModal.tsx
@@ -1,0 +1,375 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { CodeViewer } from '@/components/files/CodeViewer';
+import { BlockErrorFallback } from '@/components/shared/ErrorFallbacks';
+import {
+  getFileCategory,
+  getAttachmentSubtitle,
+  loadAttachmentContent,
+} from '@/lib/attachments';
+import type { Attachment } from '@/lib/types';
+import {
+  XIcon,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+  AlertTriangle,
+  File,
+  FileText,
+  FileCode,
+  Image,
+  FileJson,
+  Terminal,
+  FileType,
+  type LucideIcon,
+} from 'lucide-react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface AttachmentPreviewModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  attachments: Attachment[];
+  initialIndex: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const CATEGORY_ICONS: Record<string, LucideIcon> = {
+  image: Image,
+  code: FileCode,
+  config: FileJson,
+  shell: Terminal,
+  text: FileText,
+  markup: FileText,
+  data: FileText,
+  documents: File,
+  unknown: FileType,
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function decodeBase64ToString(base64: string): string {
+  return new TextDecoder().decode(
+    Uint8Array.from(atob(base64), (c) => c.charCodeAt(0)),
+  );
+}
+
+// ============================================================================
+// Sub-renderers
+// ============================================================================
+
+function ImagePreview({
+  base64,
+  mimeType,
+  name,
+}: {
+  base64: string;
+  mimeType: string;
+  name: string;
+}) {
+  return (
+    <div className="h-full flex items-center justify-center p-4 overflow-auto">
+      {/* eslint-disable-next-line @next/next/no-img-element -- data URL, not a remote image */}
+      <img
+        src={`data:${mimeType};base64,${base64}`}
+        alt={name}
+        className="max-w-full max-h-full object-contain rounded"
+        draggable={false}
+      />
+    </div>
+  );
+}
+
+function PdfPreview({ base64 }: { base64: string }) {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+    const blob = new Blob([bytes], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setBlobUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [base64]);
+
+  if (!blobUrl) return null;
+
+  return (
+    <iframe
+      src={blobUrl}
+      className="w-full h-full border-0 rounded"
+      title="PDF Preview"
+    />
+  );
+}
+
+// ============================================================================
+// Main component
+// ============================================================================
+
+type AsyncLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; content: string }
+  | { status: 'error'; message: string };
+
+type ResolvedContent =
+  | { status: 'loaded'; content: string }
+  | { status: 'loading' }
+  | { status: 'error'; message: string };
+
+export function AttachmentPreviewModal({
+  open,
+  onOpenChange,
+  attachments,
+  initialIndex,
+}: AttachmentPreviewModalProps) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [asyncState, setAsyncState] = useState<AsyncLoadState>({ status: 'idle' });
+
+  // Sync index when modal re-opens with a different initialIndex
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open && !prevOpen) {
+    setCurrentIndex(initialIndex);
+  }
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+  }
+
+  const attachment = attachments[currentIndex];
+  const filePath = attachment?.path || attachment?.name || '';
+  const category = attachment ? getFileCategory(filePath) : 'unknown';
+  const Icon = CATEGORY_ICONS[category] || FileType;
+
+  const isBinaryPreview = category === 'image' || category === 'documents';
+
+  // Synchronously resolve content when base64Data is already available or path is missing
+  const syncContent = useMemo<ResolvedContent | null>(() => {
+    if (!open || !attachment) return null;
+
+    // Already have inline data (e.g., pasted text)
+    if (attachment.base64Data) {
+      if (isBinaryPreview) {
+        return { status: 'loaded', content: attachment.base64Data };
+      }
+      try {
+        return { status: 'loaded', content: decodeBase64ToString(attachment.base64Data) };
+      } catch {
+        return { status: 'error', message: 'Failed to decode file content' };
+      }
+    }
+
+    // No path and no inline data — can't load
+    if (!attachment.path) {
+      return { status: 'error', message: 'No file path available' };
+    }
+
+    return null; // needs async load from disk
+  }, [open, attachment, isBinaryPreview]);
+
+  // Whether we need to load from disk
+  const needsAsyncLoad = open && attachment && !syncContent && !!attachment.path;
+  const attachmentPath = attachment?.path;
+
+  // Reset async state when switching attachments
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setAsyncState({ status: 'idle' });
+  }, [currentIndex]);
+
+  // Async load from disk when base64Data is not available
+  useEffect(() => {
+    if (!needsAsyncLoad || !attachmentPath) return;
+
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setAsyncState({ status: 'loading' });
+
+    loadAttachmentContent(attachment!)
+      .then((loaded) => {
+        if (cancelled) return;
+        if (!loaded.base64Data) {
+          setAsyncState({ status: 'error', message: 'Failed to read file content' });
+          return;
+        }
+        if (isBinaryPreview) {
+          setAsyncState({ status: 'loaded', content: loaded.base64Data });
+        } else {
+          try {
+            setAsyncState({ status: 'loaded', content: decodeBase64ToString(loaded.base64Data) });
+          } catch {
+            setAsyncState({ status: 'error', message: 'Failed to decode file content' });
+          }
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setAsyncState({ status: 'error', message: err instanceof Error ? err.message : 'Failed to load file' });
+      });
+
+    return () => { cancelled = true; };
+  }, [needsAsyncLoad, attachmentPath, isBinaryPreview]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Derive final state: prefer sync content, fall back to async
+  const loadState: ResolvedContent = syncContent ?? (asyncState.status === 'idle' ? { status: 'loading' } : asyncState);
+
+  // Keyboard navigation
+  const goToPrev = useCallback(() => {
+    setCurrentIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  const goToNext = useCallback(() => {
+    setCurrentIndex((i) => Math.min(attachments.length - 1, i + 1));
+  }, [attachments.length]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        goToPrev();
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        goToNext();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, goToPrev, goToNext]);
+
+  // Render content based on file type
+  function renderContent() {
+    if (loadState.status === 'loading') {
+      return (
+        <div className="h-full flex items-center justify-center">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="w-5 h-5 animate-spin" />
+            <span className="text-sm">Loading preview...</span>
+          </div>
+        </div>
+      );
+    }
+
+    if (loadState.status === 'error') {
+      return (
+        <div className="h-full flex items-center justify-center">
+          <BlockErrorFallback
+            icon={AlertTriangle}
+            title="Failed to load preview"
+            description={loadState.message}
+          />
+        </div>
+      );
+    }
+
+    if (!attachment) return null;
+
+    const { content } = loadState;
+
+    switch (category) {
+      case 'image':
+        return (
+          <ImagePreview
+            base64={content}
+            mimeType={attachment.mimeType}
+            name={attachment.name}
+          />
+        );
+
+      case 'documents':
+        return <PdfPreview base64={content} />;
+
+      // All text-based categories use CodeViewer
+      // (markdown auto-detected by CodeViewer and shown rendered)
+      case 'text':
+      case 'code':
+      case 'config':
+      case 'shell':
+      case 'markup':
+      case 'data':
+      default:
+        return <CodeViewer content={content} filename={attachment.name} />;
+    }
+  }
+
+  if (!attachment) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="sm:max-w-[90vw] max-h-[85vh] h-[85vh] p-0 gap-0 flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="text-sm font-medium truncate">
+              {attachment.name}
+            </span>
+            <span className="text-xs text-muted-foreground shrink-0">
+              {getAttachmentSubtitle(attachment)}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2 shrink-0">
+            {/* Navigation */}
+            {attachments.length > 1 && (
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={goToPrev}
+                  disabled={currentIndex === 0}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <span className="text-xs text-muted-foreground tabular-nums">
+                  {currentIndex + 1} / {attachments.length}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={goToNext}
+                  disabled={currentIndex === attachments.length - 1}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
+
+            {/* Close */}
+            <DialogClose asChild>
+              <Button variant="ghost" size="icon" className="h-7 w-7">
+                <XIcon className="h-4 w-4" />
+              </Button>
+            </DialogClose>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {renderContent()}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -39,6 +39,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { listenForFileDrop, listenForDragEnter, listenForDragLeave, openFileDialog, copyToClipboard } from '@/lib/tauri';
 import type { Attachment, SuggestionPill } from '@/lib/types';
 import { AttachmentGrid } from './AttachmentGrid';
+import { AttachmentPreviewModal } from './AttachmentPreviewModal';
 import { processDroppedFiles, validateAttachments, SUPPORTED_EXTENSIONS, loadAllAttachmentContents, generateAttachmentId } from '@/lib/attachments';
 import { UserQuestionPrompt } from './UserQuestionPrompt';
 import { usePendingUserQuestion, useStreamingState } from '@/stores/selectors';
@@ -114,6 +115,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const [isFocused, setIsFocused] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [summaryPickerOpen, setSummaryPickerOpen] = useState(false);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const [selectedSummaryIds, setSelectedSummaryIds] = useState<string[]>([]);
   const plateInputRef = useRef<PlateInputHandle>(null);
   const attachmentsRef = useRef<Attachment[]>(attachments);
@@ -1166,6 +1168,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           <AttachmentGrid
             attachments={attachments}
             onRemove={handleRemoveAttachment}
+            onPreview={(index) => setPreviewIndex(index)}
           />
         )}
 
@@ -1412,6 +1415,16 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           sessionId={selectedSessionId}
           selectedIds={selectedSummaryIds}
           onSelectionChange={setSelectedSummaryIds}
+        />
+      )}
+
+      {/* Attachment Preview Modal */}
+      {previewIndex !== null && (
+        <AttachmentPreviewModal
+          open
+          onOpenChange={(open) => { if (!open) setPreviewIndex(null); }}
+          attachments={attachments}
+          initialIndex={previewIndex}
         />
       )}
     </div>

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -29,6 +29,7 @@ import { highlightSearchMatches } from '@/components/conversation/ChatSearchBar'
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
+import { AttachmentPreviewModal } from '@/components/conversation/AttachmentPreviewModal';
 import { MentionText } from '@/components/conversation/MentionText';
 import { ApprovedPlanBlock } from '@/components/conversation/ApprovedPlanBlock';
 
@@ -94,6 +95,7 @@ export const MessageBlock = memo(function MessageBlock({
   // comparator below to skip re-renders for messages without search matches.
 }: MessageBlockProps) {
   const [copied, setCopied] = useState(false);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
 
   const copyContent = useCallback(async () => {
     const success = await copyToClipboard(message.content);
@@ -133,7 +135,21 @@ export const MessageBlock = memo(function MessageBlock({
       <div className={cn('py-2 flex justify-end', !isFirst && 'pt-3')}>
         <div className="bg-surface-2 dark:bg-[#090909] rounded-lg px-4 py-2.5">
           {message.attachments && message.attachments.length > 0 && (
-            <AttachmentGrid attachments={message.attachments} readOnly />
+            <>
+              <AttachmentGrid
+                attachments={message.attachments}
+                onPreview={(index) => setPreviewIndex(index)}
+                readOnly
+              />
+              {previewIndex !== null && (
+                <AttachmentPreviewModal
+                  open
+                  onOpenChange={(open) => { if (!open) setPreviewIndex(null); }}
+                  attachments={message.attachments}
+                  initialIndex={previewIndex}
+                />
+              )}
+            </>
           )}
           <p className="text-base leading-relaxed whitespace-pre-wrap">
             {highlightedContent || <MentionText content={message.content} />}

--- a/src/components/conversation/QueuedMessageBubble.tsx
+++ b/src/components/conversation/QueuedMessageBubble.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useState } from 'react';
 import { Clock } from 'lucide-react';
 import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
+import { AttachmentPreviewModal } from '@/components/conversation/AttachmentPreviewModal';
 import { MentionText } from '@/components/conversation/MentionText';
 import type { QueuedMessage } from '@/stores/appStore';
 
@@ -10,11 +12,27 @@ interface QueuedMessageBubbleProps {
 }
 
 export function QueuedMessageBubble({ message }: QueuedMessageBubbleProps) {
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+
   return (
     <div className="py-2 flex justify-end">
       <div className="bg-surface-2 dark:bg-[#090909] rounded-lg px-4 py-2.5 opacity-70">
         {message.attachments && message.attachments.length > 0 && (
-          <AttachmentGrid attachments={message.attachments} readOnly />
+          <>
+            <AttachmentGrid
+              attachments={message.attachments}
+              onPreview={(index) => setPreviewIndex(index)}
+              readOnly
+            />
+            {previewIndex !== null && (
+              <AttachmentPreviewModal
+                open
+                onOpenChange={(open) => { if (!open) setPreviewIndex(null); }}
+                attachments={message.attachments}
+                initialIndex={previewIndex}
+              />
+            )}
+          </>
         )}
         <p className="text-base leading-relaxed whitespace-pre-wrap">
           <MentionText content={message.content} />


### PR DESCRIPTION
## Summary
- Adds a full-screen modal for previewing file attachments (images, PDFs, code, text) by clicking attachment cards
- Supports keyboard navigation (arrow keys) between multiple attachments
- Uses Blob URLs for PDF previews instead of data URIs for better browser compatibility
- Integrates preview into ChatInput, MessageBlock, and QueuedMessageBubble

## Test plan
- [ ] Click an attachment card in the compose area — modal opens with preview
- [ ] Click an attachment on a sent message — modal opens with preview
- [ ] Attach multiple files, click one, use arrow keys to navigate between them
- [ ] Preview an image attachment — renders inline
- [ ] Preview a code/text file — shows syntax-highlighted content
- [ ] Press Escape or click X to close the modal
- [ ] Verify no stale content flashes when navigating between attachments that load from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)