### PR TITLE
Remove Close Others/Close to the Right from tab context menus

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -80,8 +80,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     selectFileTab,
     closeFileTab,
     pinFileTab,
-    closeOtherTabs,
-    closeTabsToRight,
     reorderFileTabs,
     updateFileTab,
     setPendingCloseFileTabId,
@@ -848,32 +846,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     [fileTabs, closeFileTab, removeConversation, setPendingCloseFileTabId]
   );
 
-  // Close others handler for TabBar
-  const handleCloseOthers = useCallback(
-    (id: string, type: 'file' | 'conversation') => {
-      if (type === 'file') {
-        startTransition(() => closeOtherTabs(id));
-      } else {
-        startTransition(() => {
-          sessionConversations
-            .filter((c) => c.id !== id)
-            .forEach((c) => removeConversation(c.id));
-        });
-      }
-    },
-    [closeOtherTabs, sessionConversations, removeConversation]
-  );
-
-  // Close to right handler for TabBar (files only)
-  const handleCloseToRight = useCallback(
-    (id: string, type: 'file' | 'conversation') => {
-      if (type === 'file') {
-        closeTabsToRight(id);
-      }
-    },
-    [closeTabsToRight]
-  );
-
   // Rename conversation handler for TabBar
   const handleRenameConversation = useCallback(
     (id: string) => {
@@ -973,8 +945,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
         onSelectTab={handleTabSelect}
         onCloseTab={handleTabClose}
         onPinTab={(id, pinned) => pinFileTab(id, pinned)}
-        onCloseOthers={handleCloseOthers}
-        onCloseToRight={handleCloseToRight}
         onReorder={reorderFileTabs}
         onNewSession={() => handleNewConversation('task')}
         onRenameConversation={handleRenameConversation}

--- a/src/components/navigation/BrowserTabBar.tsx
+++ b/src/components/navigation/BrowserTabBar.tsx
@@ -130,8 +130,6 @@ const SortableBrowserTab = memo(function SortableBrowserTab({
   richTitle,
   onActivate,
   onClose,
-  onCloseOthers,
-  onCloseToRight,
   onDuplicate,
 }: {
   tab: BrowserTab;
@@ -140,8 +138,6 @@ const SortableBrowserTab = memo(function SortableBrowserTab({
   richTitle?: ReactNode;
   onActivate: () => void;
   onClose: () => void;
-  onCloseOthers: () => void;
-  onCloseToRight: () => void;
   onDuplicate: () => void;
 }) {
   const {
@@ -230,12 +226,6 @@ const SortableBrowserTab = memo(function SortableBrowserTab({
         <ContextMenuItem onClick={onClose}>
           Close
         </ContextMenuItem>
-        <ContextMenuItem onClick={onCloseOthers}>
-          Close Others
-        </ContextMenuItem>
-        <ContextMenuItem onClick={onCloseToRight}>
-          Close to the Right
-        </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
   );
@@ -314,17 +304,6 @@ export const BrowserTabStrip = memo(function BrowserTabStrip() {
                 richTitle={tabTitles[tabId]}
                 onActivate={() => switchToTab(tabId)}
                 onClose={() => handleCloseTab(tabId)}
-                onCloseOthers={() => {
-                  const closedIds = tabOrder.filter((id) => id !== tabId);
-                  useTabStore.getState().closeOtherTabs(tabId);
-                  closedIds.forEach((id) => useUIStore.getState().removeTabTitle(id));
-                }}
-                onCloseToRight={() => {
-                  const idx = tabOrder.indexOf(tabId);
-                  const closedIds = tabOrder.slice(idx + 1);
-                  useTabStore.getState().closeTabsToRight(tabId);
-                  closedIds.forEach((id) => useUIStore.getState().removeTabTitle(id));
-                }}
                 onDuplicate={() => {
                   const newId = useTabStore.getState().duplicateTab(tabId);
                   switchToTab(newId);

--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -36,8 +36,6 @@ function SortableTabItem({
   onSelect,
   onClose,
   onPin,
-  onCloseOthers,
-  onCloseToRight,
   onRename,
   onGenerateSummary,
   onViewSummary,
@@ -50,8 +48,6 @@ function SortableTabItem({
   onSelect: () => void;
   onClose: (e?: React.MouseEvent) => void;
   onPin?: (pinned: boolean) => void;
-  onCloseOthers?: () => void;
-  onCloseToRight?: () => void;
   onRename?: () => void;
   onGenerateSummary?: () => void;
   onViewSummary?: () => void;
@@ -83,8 +79,6 @@ function SortableTabItem({
         onSelect={onSelect}
         onClose={onClose}
         onPin={onPin}
-        onCloseOthers={onCloseOthers}
-        onCloseToRight={onCloseToRight}
         onRename={onRename}
         onGenerateSummary={onGenerateSummary}
         onViewSummary={onViewSummary}
@@ -114,8 +108,6 @@ export function TabBar({
   onSelectTab,
   onCloseTab,
   onPinTab,
-  onCloseOthers,
-  onCloseToRight,
   onReorder,
   onNewSession,
   onRenameConversation,
@@ -195,8 +187,6 @@ export function TabBar({
         onSelect={() => onSelectTab(tab.id, tab.type)}
         onClose={(e) => handleClose(tab.id, tab.type, e)}
         onPin={tab.type === 'file' && onPinTab ? (pinned) => onPinTab(tab.id, pinned) : undefined}
-        onCloseOthers={onCloseOthers ? () => onCloseOthers(tab.id, tab.type) : undefined}
-        onCloseToRight={onCloseToRight ? () => onCloseToRight(tab.id, tab.type) : undefined}
         onRename={
           tab.type === 'conversation' && onRenameConversation
             ? () => onRenameConversation(tab.id)
@@ -226,8 +216,6 @@ export function TabBar({
       onSelectTab,
       handleClose,
       onPinTab,
-      onCloseOthers,
-      onCloseToRight,
       onRenameConversation,
       onGenerateSummary,
       onViewSummary,

--- a/src/components/tabs/TabItem.tsx
+++ b/src/components/tabs/TabItem.tsx
@@ -30,8 +30,6 @@ export const TabItem = memo(function TabItem({
   onSelect,
   onClose,
   onPin,
-  onCloseOthers,
-  onCloseToRight,
   onRename,
   onGenerateSummary,
   onViewSummary,
@@ -190,18 +188,6 @@ export const TabItem = memo(function TabItem({
           <X className="size-4" />
           Close
         </ContextMenuItem>
-
-        {onCloseOthers && (
-          <ContextMenuItem onClick={onCloseOthers}>
-            Close Others
-          </ContextMenuItem>
-        )}
-
-        {onCloseToRight && (
-          <ContextMenuItem onClick={onCloseToRight}>
-            Close to the Right
-          </ContextMenuItem>
-        )}
 
         {/* Pin/Unpin - only for file tabs */}
         {tab.type === 'file' && onPin && (

--- a/src/components/tabs/tab.types.ts
+++ b/src/components/tabs/tab.types.ts
@@ -33,8 +33,6 @@ export interface TabBarProps {
   onSelectTab: (id: string, type: 'file' | 'conversation') => void;
   onCloseTab: (id: string, type: 'file' | 'conversation', e?: MouseEvent) => void;
   onPinTab?: (id: string, pinned: boolean) => void;
-  onCloseOthers?: (id: string, type: 'file' | 'conversation') => void;
-  onCloseToRight?: (id: string, type: 'file' | 'conversation') => void;
   onReorder?: (activeId: string, overId: string) => void;
   onNewSession: () => void;
   onRenameConversation?: (id: string) => void;
@@ -53,8 +51,6 @@ export interface TabItemProps {
   onSelect: () => void;
   onClose: (e?: MouseEvent) => void;
   onPin?: (pinned: boolean) => void;
-  onCloseOthers?: () => void;
-  onCloseToRight?: () => void;
   onRename?: () => void;
   onGenerateSummary?: () => void;
   onViewSummary?: () => void;


### PR DESCRIPTION
## Summary
- Remove "Close Others" and "Close to the Right" menu items from all tab context menus (conversation tabs, file tabs, and browser tabs)
- Clean up associated props, types, handlers, and store imports across 5 files

## Test plan
- [ ] Right-click conversation tab — only shows Close, rename, and summary options
- [ ] Right-click file tab — only shows Close and pin options
- [ ] Right-click browser tab — only shows Close and Duplicate Tab options

🤖 Generated with [Claude Code](https://claude.com/claude-code)