### PR TITLE
Fix thinking effort toggle to respect user's default setting

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -44,7 +44,7 @@ import { processDroppedFiles, validateAttachments, SUPPORTED_EXTENSIONS, loadAll
 import { UserQuestionPrompt } from './UserQuestionPrompt';
 import { usePendingUserQuestion, useStreamingState } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { THINKING_LEVELS, type ThinkingLevel, resolveThinkingParams, clampThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
+import { THINKING_LEVELS, THINKING_TOKEN_MAP, type ThinkingLevel, resolveThinkingParams, clampThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
 import { useSlashCommandStore, type UnifiedSlashCommand } from '@/stores/slashCommandStore';
 import { SummaryPicker } from './SummaryPicker';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
@@ -1269,7 +1269,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                 size="sm"
                 className={cn(
                   'h-7 gap-1.5 px-2 text-xs',
-                  thinkingLevel !== 'high' && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20'
+                  thinkingLevel !== defaultThinkingLevel && 'text-amber-500 hover:text-amber-600 bg-amber-500/10 hover:bg-amber-500/20'
                 )}
                 title={`Thinking: ${thinkingLevel} (⌥T to cycle)`}
                 aria-label={`Thinking: ${thinkingLevel}`}
@@ -1279,23 +1279,48 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                 <ChevronDown className="h-3 w-3" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              {THINKING_LEVELS.map((level) => (
-                <DropdownMenuItem
-                  key={level.id}
-                  disabled={level.id === 'off' && !canDisableThinking(selectedModel)}
-                  onClick={() => setThinkingLevel(level.id)}
-                >
-                  {level.label}
-                  {level.id === 'high' && (
-                    <span className="ml-1.5 text-xs text-muted-foreground">(default)</span>
-                  )}
-                  {level.id === 'off' && !canDisableThinking(selectedModel) && (
-                    <span className="ml-1.5 text-xs text-muted-foreground">(Opus always thinks)</span>
-                  )}
-                  {level.id === thinkingLevel && <Check className="ml-auto h-3.5 w-3.5" />}
-                </DropdownMenuItem>
-              ))}
+            <DropdownMenuContent align="start" className="w-72">
+              {THINKING_LEVELS.map((level) => {
+                const isDisabled = level.id === 'off' && !canDisableThinking(selectedModel);
+                const isSelected = level.id === thinkingLevel;
+                const tokens = THINKING_TOKEN_MAP[level.id];
+                const budgetLabel = level.id === 'off'
+                  ? null
+                  : selectedModel.supportsEffort
+                    ? 'adaptive'
+                    : tokens != null
+                      ? `${(tokens / 1000).toFixed(0)}K tokens`
+                      : null;
+                return (
+                  <DropdownMenuItem
+                    key={level.id}
+                    disabled={isDisabled}
+                    onClick={() => setThinkingLevel(level.id)}
+                    className="flex-col items-start gap-0 py-2"
+                  >
+                    <div className="flex w-full items-center gap-1.5">
+                      <span className="font-medium">{level.label}</span>
+                      {level.id === defaultThinkingLevel && (
+                        <span className="text-xs text-muted-foreground">(default)</span>
+                      )}
+                      {isDisabled && (
+                        <span className="text-xs text-muted-foreground">(Opus always thinks)</span>
+                      )}
+                      <span className="ml-auto flex items-center gap-2">
+                        {budgetLabel && (
+                          <span className="text-[11px] tabular-nums text-muted-foreground/70">
+                            {budgetLabel}
+                          </span>
+                        )}
+                        {isSelected && <Check className="h-3.5 w-3.5" />}
+                      </span>
+                    </div>
+                    <span className="text-xs text-muted-foreground leading-tight">
+                      {level.description}
+                    </span>
+                  </DropdownMenuItem>
+                );
+              })}
             </DropdownMenuContent>
           </DropdownMenu>
 

--- a/src/lib/thinkingLevels.ts
+++ b/src/lib/thinkingLevels.ts
@@ -8,16 +8,16 @@
 
 export type ThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'max';
 
-export const THINKING_LEVELS: { id: ThinkingLevel; label: string }[] = [
-  { id: 'off', label: 'Off' },
-  { id: 'low', label: 'Low' },
-  { id: 'medium', label: 'Medium' },
-  { id: 'high', label: 'High' },
-  { id: 'max', label: 'Max' },
+export const THINKING_LEVELS: { id: ThinkingLevel; label: string; description: string }[] = [
+  { id: 'off', label: 'Off', description: 'Disable extended thinking' },
+  { id: 'low', label: 'Low', description: 'Minimal reasoning, may skip on simple tasks' },
+  { id: 'medium', label: 'Medium', description: 'Balanced reasoning for moderate tasks' },
+  { id: 'high', label: 'High', description: 'Strong reasoning for most problems' },
+  { id: 'max', label: 'Max', description: 'Maximum reasoning depth and capability' },
 ];
 
 /** Default thinking token budgets for non-effort models (Sonnet/Haiku). */
-const THINKING_TOKEN_MAP: Record<ThinkingLevel, number | undefined> = {
+export const THINKING_TOKEN_MAP: Record<ThinkingLevel, number | undefined> = {
   off: undefined,
   low: 8000,
   medium: 10000,


### PR DESCRIPTION
## Summary
- **Fixed highlight bug**: The compose toolbar thinking toggle was hardcoded to highlight when not `'high'`, ignoring the user's configured default in Settings. Now compares against `defaultThinkingLevel` from the settings store.
- **Fixed "(default)" label**: The dropdown always marked "High" as default — now dynamically follows the user's setting.
- **Enhanced dropdown menu**: Each thinking level now shows a description subtitle, and budget info (token count for Haiku, "adaptive" for Opus/Sonnet 4.6).

## Test plan
- [ ] Change default thinking level in Settings to "Low" → compose toggle should show normal (not amber) when "Low" is selected, dropdown marks "Low" as "(default)"
- [ ] Select "High" in compose after changing default to "Low" → toggle should highlight amber
- [ ] Open dropdown → each item shows label, description, and budget info
- [ ] Switch model to Haiku → budget shows token counts (8K, 10K, etc.) instead of "adaptive"
- [ ] Verify "Off" is disabled for Opus models and shows "(Opus always thinks)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)