### PR TITLE
Keep error tool blocks collapsed by default

### DIFF
--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -94,7 +94,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   elapsedSeconds,
   metadata,
 }: ToolUsageBlockProps) {
-  const [isOpen, setIsOpen] = useState(success === false && !isActive);
+  const [isOpen, setIsOpen] = useState(false);
   const mcpInfo = useMemo(() => parseMcpToolName(tool), [tool]);
 
   const ToolIcon = useMemo((): LucideIcon => {


### PR DESCRIPTION
## Summary
- Error tool blocks were auto-expanded when loading conversations from previously ran agents, which was distracting
- Changed default `isOpen` state in `ToolUsageBlock` from `success === false && !isActive` to `false` so all tool blocks start collapsed
- The red styling (status dot, icon, "Error" badge) already makes errors clearly visible at a glance without expanding

## Test plan
- [ ] Run an agent that produces tool errors (e.g., read a nonexistent file)
- [ ] After the agent completes, navigate away and back — error tool blocks should render collapsed with red styling visible
- [ ] Click on an error tool block to verify it still expands correctly on user interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)