### PR TITLE
Optimize markdown preview loading and fix anchor link navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "react-zoom-pan-pinch": "^3.7.0",
         "recharts": "^3.7.0",
         "rehype-highlight": "^7.0.2",
+        "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^3.21.0",
         "tailwind-merge": "^3.4.0",
@@ -8891,6 +8892,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -9064,6 +9071,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -9121,6 +9141,19 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12863,6 +12896,23 @@
         "lowlight": "^3.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-zoom-pan-pinch": "^3.7.0",
     "recharts": "^3.7.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^3.21.0",
     "tailwind-merge": "^3.4.0",

--- a/src/components/files/CodeViewer.tsx
+++ b/src/components/files/CodeViewer.tsx
@@ -131,7 +131,7 @@ export const CodeViewer = memo(function CodeViewer({
         <div className="flex-1 overflow-hidden min-h-0">
           <div className="h-full overflow-auto overscroll-contain">
             <div className={cn(PROSE_CLASSES, 'px-6 py-5')}>
-              <CachedMarkdown cacheKey={`file-preview:${filename}`} content={content} skipCache />
+              <CachedMarkdown cacheKey={`file-preview:${filename}`} content={content} />
             </div>
           </div>
         </div>

--- a/src/components/shared/CachedMarkdown.tsx
+++ b/src/components/shared/CachedMarkdown.tsx
@@ -7,15 +7,12 @@ import { getCachedMarkdown, setCachedMarkdown } from '@/lib/markdownCache';
 interface CachedMarkdownProps {
   cacheKey: string;
   content: string;
-  skipCache?: boolean;
 }
 
-export function CachedMarkdown({ cacheKey, content, skipCache }: CachedMarkdownProps) {
-  if (!skipCache) {
-    const cached = getCachedMarkdown(cacheKey, content);
-    if (cached !== undefined) {
-      return <>{cached}</>;
-    }
+export function CachedMarkdown({ cacheKey, content }: CachedMarkdownProps) {
+  const cached = getCachedMarkdown(cacheKey, content);
+  if (cached !== undefined) {
+    return <>{cached}</>;
   }
 
   const rendered = (
@@ -28,9 +25,6 @@ export function CachedMarkdown({ cacheKey, content, skipCache }: CachedMarkdownP
     </ReactMarkdown>
   );
 
-  if (!skipCache) {
-    setCachedMarkdown(cacheKey, rendered, content);
-  }
-
+  setCachedMarkdown(cacheKey, rendered, content);
   return rendered;
 }

--- a/src/components/shared/MarkdownLink.tsx
+++ b/src/components/shared/MarkdownLink.tsx
@@ -3,6 +3,16 @@
 import type { AnchorHTMLAttributes } from 'react';
 import { openUrlInBrowser } from '@/lib/tauri';
 
+function getFragment(href: string): string | null {
+  if (href.startsWith('#')) return href.slice(1);
+  try {
+    const url = new URL(href);
+    return url.hash ? url.hash.slice(1) : null;
+  } catch {
+    return null;
+  }
+}
+
 export function MarkdownLink({
   href,
   children,
@@ -10,9 +20,18 @@ export function MarkdownLink({
 }: AnchorHTMLAttributes<HTMLAnchorElement>) {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    if (href) {
-      openUrlInBrowser(href);
+    if (!href) return;
+
+    const fragment = getFragment(href);
+    if (fragment) {
+      const target = document.getElementById(fragment);
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        return;
+      }
     }
+
+    openUrlInBrowser(href);
   };
 
   return (

--- a/src/hooks/useExternalLinkGuard.ts
+++ b/src/hooks/useExternalLinkGuard.ts
@@ -18,6 +18,16 @@ export function useExternalLinkGuard() {
 
       // Only intercept external URLs (http/https)
       if (href.startsWith('http://') || href.startsWith('https://')) {
+        // Skip if this URL has a fragment and the target element exists in the DOM
+        // (indicates in-page anchor navigation handled by MarkdownLink)
+        try {
+          const url = new URL(href);
+          if (url.hash) {
+            const target = document.getElementById(url.hash.slice(1));
+            if (target) return;
+          }
+        } catch { /* not a valid URL, fall through */ }
+
         e.preventDefault();
         e.stopPropagation();
         openUrlInBrowser(href);

--- a/src/lib/markdownConfig.ts
+++ b/src/lib/markdownConfig.ts
@@ -1,4 +1,5 @@
 import remarkGfm from 'remark-gfm';
+import rehypeSlug from 'rehype-slug';
 import rehypeHighlight from 'rehype-highlight';
 import { rehypeEmoji } from '@/lib/rehypeEmoji';
 import { MarkdownPre, MarkdownCode } from '@/components/shared/MarkdownCodeBlock';
@@ -7,5 +8,5 @@ import { MarkdownLink } from '@/components/shared/MarkdownLink';
 // Hoisted to module scope to avoid creating new references on every render,
 // which would cause ReactMarkdown to re-parse content unnecessarily.
 export const REMARK_PLUGINS = [remarkGfm];
-export const REHYPE_PLUGINS = [rehypeHighlight, rehypeEmoji];
+export const REHYPE_PLUGINS = [rehypeSlug, rehypeHighlight, rehypeEmoji];
 export const MARKDOWN_COMPONENTS = { pre: MarkdownPre, code: MarkdownCode, a: MarkdownLink };


### PR DESCRIPTION
## Summary
- **Fix markdown preview loading delay**: Remove `skipCache` bypass in CodeViewer so rendered markdown is cached via the existing LRU cache. Switching between previously-opened markdown tabs is now instant instead of re-parsing the full markdown + syntax highlighting every time.
- **Remove unused `skipCache` prop**: Clean up `CachedMarkdown` component since CodeViewer was the only caller.
- **Fix anchor link navigation**: Add `rehype-slug` plugin to generate heading IDs, and update `MarkdownLink` to detect fragment links (`#heading` or `http://localhost:*/#heading`) and scroll to the target element instead of trying to open them externally via Tauri shell.
- **Update `useExternalLinkGuard`**: Skip global link interception for URLs whose fragment targets an existing DOM element, allowing in-page anchor scrolling.

## Test plan
- [ ] Open a markdown file — verify it renders correctly (first render, cache miss)
- [ ] Switch to another tab and back — markdown appears instantly (cache hit, no re-parse)
- [ ] Open a markdown file with headings — inspect DOM to verify headings have `id` attributes
- [ ] Click a `#fragment` anchor link — should smooth-scroll to the heading
- [ ] Click a `http://localhost:.../#fragment` link — should also scroll, not open externally
- [ ] Click a normal external link (e.g. `https://github.com`) — should still open in system browser
- [ ] Click an anchor link whose target doesn't exist — should fall through to open externally

🤖 Generated with [Claude Code](https://claude.com/claude-code)