### PR TITLE
Fix image preview showing binary text in composer

### DIFF
--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -17,7 +17,7 @@ export const ATTACHMENT_LIMITS = {
 };
 
 export const SUPPORTED_EXTENSIONS: Record<string, string[]> = {
-  images: ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'],
+  image: ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'],
   text: ['.txt', '.md', '.markdown', '.csv', '.log'],
   code: [
     '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',


### PR DESCRIPTION
## Summary

- Fix image attachments in the Composer rendering as binary text in CodeViewer instead of displaying as images
- The `SUPPORTED_EXTENSIONS` key was `"images"` (plural) but all consumers (`getFileCategory`, `isImage`, `AttachmentPreviewModal`, `AttachmentCard`) expected `"image"` (singular). An unsafe `as` cast in `getFileCategory()` masked the mismatch at compile time.

## Test plan

- [ ] Attach an image file (PNG, JPG, GIF, WebP, SVG) to the Composer
- [ ] Verify the attachment card shows the image icon
- [ ] Click the attachment to open the preview modal
- [ ] Verify the image renders visually (not as binary text in CodeViewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)