### PR TITLE
Fix shell open URL regex and add missing DialogTitle

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,6 +45,9 @@
     }
   },
   "plugins": {
+    "shell": {
+      "open": "^((mailto:.+)|(tel:.+)|(https?://.+))"
+    },
     "deep-link": {
       "mobile": [],
       "desktop": {

--- a/src/components/conversation/AttachmentPreviewModal.tsx
+++ b/src/components/conversation/AttachmentPreviewModal.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogContent,
   DialogClose,
+  DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { CodeViewer } from '@/components/files/CodeViewer';
@@ -316,6 +317,7 @@ export function AttachmentPreviewModal({
         showCloseButton={false}
         className="sm:max-w-[90vw] max-h-[85vh] h-[85vh] p-0 gap-0 flex flex-col"
       >
+        <DialogTitle className="sr-only">{attachment.name}</DialogTitle>
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
           <div className="flex items-center gap-2 min-w-0">

--- a/src/components/dialogs/branch-cleanup/BranchCleanupDialog.tsx
+++ b/src/components/dialogs/branch-cleanup/BranchCleanupDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { executeBranchCleanup } from '@/lib/api';
 import { useCleanupReducer } from './useCleanupReducer';
 import { CleanupStepAnalysis } from './CleanupStepAnalysis';
@@ -65,6 +65,7 @@ export function BranchCleanupDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent showCloseButton={state.step !== 'execution'} className="sm:max-w-2xl">
+        <DialogTitle className="sr-only">Branch Cleanup</DialogTitle>
         {state.step === 'analysis' && (
           <CleanupStepAnalysis
             workspaceId={workspaceId}


### PR DESCRIPTION
## Summary
- **Shell open regex**: Widen Tauri shell plugin `open` scope regex from `\w+` to `.+` after the protocol — the default rejects valid URLs with hyphens, dots, ports, etc.
- **DialogTitle accessibility**: Add visually-hidden `DialogTitle` to `AttachmentPreviewModal` and `BranchCleanupDialog` to fix Radix console warning

## Test plan
- [ ] Click external links in the app — should open in browser without console error
- [ ] Open attachment preview modal — no Radix accessibility warning
- [ ] Open branch cleanup dialog — no Radix accessibility warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)