### PR TITLE
Restore left blue border on approved plan markdown

### DIFF
--- a/src/components/conversation/ApprovedPlanBlock.tsx
+++ b/src/components/conversation/ApprovedPlanBlock.tsx
@@ -55,7 +55,7 @@ export const ApprovedPlanBlock = memo(function ApprovedPlanBlock({
       </CollapsibleTrigger>
 
       <CollapsibleContent>
-        <div className={cn(PROSE_CLASSES, 'mt-0.5 ml-4 space-y-1.5')}>
+        <div className={cn(PROSE_CLASSES, 'mt-0.5 ml-4 space-y-1.5 border-l-2 border-primary/20 pl-3')}>
           <CachedMarkdown cacheKey={cacheKey} content={content} />
         </div>
       </CollapsibleContent>


### PR DESCRIPTION
## Summary
- Restores the `border-l-2 border-primary/20 pl-3` styling on the approved plan markdown content that was removed during the ApprovedPlanBlock refactor (#547)
- Provides clear visual delineation between the plan header and its markdown content

## Test plan
- [ ] Open a conversation with an approved plan
- [ ] Verify the subtle blue left border appears on the plan markdown content
- [ ] Verify it looks correct when collapsing and re-expanding the plan block

🤖 Generated with [Claude Code](https://claude.com/claude-code)