### PR TITLE
Fix false timeout error during plan approval

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -349,13 +349,15 @@ export function useWebSocket(enabled: boolean = true) {
             });
           } else {
             // Parent agent tool
+            // User-interactive tools wait for user input and have their own backend
+            // timeouts (24h). Skip the 5-min orphaned-tool timeout.
+            const isUserInteractiveTool = event.tool === 'ExitPlanMode' || event.tool === 'AskUserQuestion';
             store.addActiveTool(conversationId, {
               id: event.id,
               tool: event.tool,
               params: event.params,
               startTime: Date.now(),
-            });
-
+            }, isUserInteractiveTool ? { skipTimeout: true } : undefined);
           }
         }
         break;


### PR DESCRIPTION
## Summary

- Skip the 5-minute frontend orphaned-tool timeout for user-interactive tools (`ExitPlanMode`, `AskUserQuestion`)
- These tools intentionally wait for user input and already have 24-hour backend timeouts
- The premature frontend timeout was showing a confusing "Tool timed out" error while the approval UX still worked fine

## Details

`addActiveTool()` in `appStore.ts` applies a 5-minute timeout to all tools to clean up orphaned tools that never receive a `tool_end` event. However, `ExitPlanMode` and `AskUserQuestion` are not orphaned — they're blocked on user interaction with appropriate backend timeouts (24h). The fix passes `{ skipTimeout: true }` for these tools, using the existing `skipTimeout` mechanism already in use for synthetic tool entries.

## Test plan

- [ ] Start a conversation in plan mode, trigger ExitPlanMode
- [ ] Wait >5 minutes without approving the plan
- [ ] Confirm no "Tool timed out" error appears in the UI
- [ ] Approve the plan and verify it works normally
- [ ] Verify regular tools (Bash, Read, etc.) still timeout after 5 minutes if orphaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)