### PR TITLE
Remove amber clock badge from compose queue button

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -29,7 +29,6 @@ import {
   Check,
   Copy,
   MessageSquarePlus,
-  Clock,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
@@ -1404,13 +1403,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
               <TooltipTrigger asChild>
                 <Button
                   size="icon"
-                  className="h-8 w-8 rounded-lg relative"
+                  className="h-8 w-8 rounded-lg"
                   onClick={handleSubmit}
                   disabled={!selectedSessionId || isSending || authDisabled}
                   aria-label="Queue message"
                 >
                   <ArrowUp className="h-4 w-4" />
-                  <Clock className="h-2.5 w-2.5 absolute -top-0.5 -right-0.5 text-amber-500" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="top">Queue message — sent after current response</TooltipContent>


### PR DESCRIPTION
## Summary
- Removes the small amber `Clock` icon that was overlaid on the send button when in queue mode (agent streaming + text typed)
- The badge looked confusing and was mistaken for a queued-message indicator
- The tooltip ("Queue message — sent after current response") already communicates the queue behavior sufficiently

## Test plan
- [ ] Start the app and begin an agent task
- [ ] Type text in the compose input while the agent is running
- [ ] Confirm the queue button shows as a clean arrow-up button without the amber clock badge
- [ ] Hover to confirm the tooltip still reads "Queue message — sent after current response"

🤖 Generated with [Claude Code](https://claude.com/claude-code)