### PR TITLE
Fix plan mode exit logic and approval UX

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -216,6 +216,7 @@ interface InputMessage {
   // Plan approval response fields
   planApprovalRequestId?: string;
   planApproved?: boolean;
+  planApprovalReason?: string;
   // Max thinking tokens override
   maxThinkingTokens?: number;
   // MCP server management fields (SDK v0.2.21+)
@@ -335,8 +336,12 @@ const PLAN_APPROVAL_HOOK_TIMEOUT_S = 86400; // 24 hours — lets users take as l
 // mode restoration. This flag suppresses those stale messages.
 let suppressStalePlanMode = false;
 
+interface PlanApprovalResult {
+  approved: boolean;
+  reason?: string;
+}
 interface PendingPlanApprovalRequest {
-  resolve: (approved: boolean) => void;
+  resolve: (result: PlanApprovalResult) => void;
   reject: (error: Error) => void;
 }
 const pendingPlanApprovalRequests = new Map<string, PendingPlanApprovalRequest>();
@@ -617,7 +622,7 @@ function setupInputQueue(): void {
         const pending = pendingPlanApprovalRequests.get(input.planApprovalRequestId);
         if (pending) {
           pendingPlanApprovalRequests.delete(input.planApprovalRequestId);
-          pending.resolve(input.planApproved === true);
+          pending.resolve({ approved: input.planApproved === true, reason: input.planApprovalReason });
         } else {
           emit({
             type: "warning",
@@ -1323,17 +1328,34 @@ const exitPlanModeHook: HookCallback = async (_input) => {
     }
   }
 
-  // Emit the plan approval request to the Go backend (with plan content if available)
+  // No plan content means the agent is just exiting plan mode (not proposing a plan).
+  // Auto-approve to avoid showing an empty approval UI that requires user interaction.
+  if (!planContent) {
+    debug("Auto-approving ExitPlanMode — no plan content to review");
+    lastExitPlanApprovalTime = Date.now();
+    emit({
+      type: "plan_mode_auto_exited",
+      sessionId: currentSessionId,
+    });
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse" as const,
+        permissionDecision: "allow" as const,
+      },
+    };
+  }
+
+  // Emit the plan approval request to the Go backend (with plan content)
   emit({
     type: "plan_approval_request",
     requestId,
     sessionId: currentSessionId,
-    ...(planContent && { planContent }),
+    planContent,
   });
 
   // Wait for user response with a safety timeout matching the hook timeout
   try {
-    const approved = await new Promise<boolean>((resolve, reject) => {
+    const result = await new Promise<PlanApprovalResult>((resolve, reject) => {
       pendingPlanApprovalRequests.set(requestId, { resolve, reject });
       // Safety timeout to prevent infinite hang if Go backend crashes/restarts
       setTimeout(() => {
@@ -1344,7 +1366,7 @@ const exitPlanModeHook: HookCallback = async (_input) => {
       }, PLAN_APPROVAL_HOOK_TIMEOUT_S * 1000);
     });
 
-    if (approved) {
+    if (result.approved) {
       // Record approval time to auto-approve retries caused by SDK bug #15755
       lastExitPlanApprovalTime = Date.now();
       // Allow tool execution - SDK will exit plan mode naturally
@@ -1356,11 +1378,12 @@ const exitPlanModeHook: HookCallback = async (_input) => {
       };
     } else {
       // Deny tool execution - SDK stays in plan mode
+      const reason = result.reason || "User requested changes to the plan";
       return {
         hookSpecificOutput: {
           hookEventName: "PreToolUse" as const,
           permissionDecision: "deny" as const,
-          permissionDecisionReason: "User requested changes to the plan",
+          permissionDecisionReason: reason,
         },
       };
     }

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -97,6 +97,7 @@ type InputMessage struct {
 	// Plan approval response fields (for ExitPlanMode tool)
 	PlanApprovalRequestID string `json:"planApprovalRequestId,omitempty"`
 	PlanApproved          *bool  `json:"planApproved,omitempty"`
+	PlanApprovalReason    string `json:"planApprovalReason,omitempty"`
 	// Max thinking tokens override (for runtime adjustment)
 	MaxThinkingTokens int `json:"maxThinkingTokens,omitempty"`
 	// MCP server management fields (SDK v0.2.21+)
@@ -604,11 +605,12 @@ func (p *Process) SendUserQuestionResponse(requestId string, answers map[string]
 }
 
 // SendPlanApprovalResponse sends the user's approval/rejection to a pending ExitPlanMode
-func (p *Process) SendPlanApprovalResponse(requestId string, approved bool) error {
+func (p *Process) SendPlanApprovalResponse(requestId string, approved bool, reason string) error {
 	return p.sendInput(InputMessage{
 		Type:                  "plan_approval_response",
 		PlanApprovalRequestID: requestId,
 		PlanApproved:          &approved,
+		PlanApprovalReason:    reason,
 	})
 }
 

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -358,7 +358,7 @@ func TestInputMessage_Marshal(t *testing.T) {
 func TestProcess_SendPlanApprovalResponse_NotRunning(t *testing.T) {
 	p := NewProcess("test-id", "/tmp", "conv-123")
 
-	err := p.SendPlanApprovalResponse("plan-1", true)
+	err := p.SendPlanApprovalResponse("plan-1", true, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not running")
 }

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -3703,6 +3703,7 @@ func (h *Handlers) SetConversationMaxThinkingTokens(w http.ResponseWriter, r *ht
 type PlanApprovalRequest struct {
 	RequestID string `json:"requestId"`
 	Approved  bool   `json:"approved"`
+	Reason    string `json:"reason,omitempty"`
 }
 
 func (h *Handlers) ApprovePlan(w http.ResponseWriter, r *http.Request) {
@@ -3727,7 +3728,7 @@ func (h *Handlers) ApprovePlan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Send the approval/rejection to the agent process
-	if err := proc.SendPlanApprovalResponse(req.RequestID, req.Approved); err != nil {
+	if err := proc.SendPlanApprovalResponse(req.RequestID, req.Approved, req.Reason); err != nil {
 		writeInternalError(w, "failed to send plan approval", err)
 		return
 	}

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -366,13 +366,19 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     && conversationHasMessages
     && !isSuggestionStale;
 
-  // Sync toggle ON when agent enters plan mode (e.g. EnterPlanMode tool).
-  // Only syncs activation — deactivation is handled by handleApprovePlan.
+  // Sync toggle with agent-driven plan mode changes:
+  // - ON when agent enters plan mode (e.g. EnterPlanMode tool)
+  // - OFF when agent exits plan mode without user interaction (auto-exit with no plan content)
+  // Explicit user deactivation is handled by handleApprovePlan.
   useEffect(() => {
     if (planModeActive && !planModeEnabled) {
       setPlanModeEnabled(true);
+    } else if (!planModeActive && planModeEnabled && isStreaming && !pendingPlanApproval) {
+      // Agent exited plan mode (auto-approved, no plan to review) — sync toggle off.
+      // Only syncs during streaming to avoid fighting with user's manual toggle.
+      setPlanModeEnabled(false);
     }
-  }, [planModeActive, planModeEnabled]);
+  }, [planModeActive, planModeEnabled, isStreaming, pendingPlanApproval]);
 
   // Restore per-session toggle states when switching sessions
   const prevSessionRef = useRef<string | null>(null);
@@ -902,9 +908,10 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         if (pendingPlanApproval && selectedConversationId) {
           // User typed feedback while plan approval is pending — deny the plan first,
           // then send the message. The deny MUST complete before the message send to
-          // guarantee stdin ordering in the agent-runner.
+          // guarantee stdin ordering in the agent-runner. Include the user's text as
+          // the denial reason so the agent gets the feedback in the tool result context.
           try {
-            await approvePlan(selectedConversationId, pendingPlanApproval.requestId, false);
+            await approvePlan(selectedConversationId, pendingPlanApproval.requestId, false, trimmedContent);
           } catch (err) {
             console.error('Failed to deny plan during message submit:', err);
           }

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -625,6 +625,13 @@ export function useWebSocket(enabled: boolean = true) {
         }
         break;
 
+      case 'plan_mode_auto_exited':
+        // ExitPlanMode was auto-approved because there was no plan content to review.
+        // Clear plan mode state so the UI toggle turns off and stale events are suppressed.
+        store.setPlanModeActive(conversationId, false);
+        markPlanModeExited(conversationId);
+        break;
+
       case 'auth_error': {
         // Handle auth error with a clear, actionable message
         const authMessage = event?.message || 'Authentication failed. Check your API key in Settings > Claude Code.';

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1125,11 +1125,11 @@ export async function setConversationMaxThinkingTokens(convId: string, maxThinki
   }
 }
 
-export async function approvePlan(convId: string, requestId: string, approved: boolean): Promise<void> {
+export async function approvePlan(convId: string, requestId: string, approved: boolean, reason?: string): Promise<void> {
   const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/approve-plan`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ requestId, approved }),
+    body: JSON.stringify({ requestId, approved, ...(reason && { reason }) }),
   });
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
## Summary
- Auto-approve `ExitPlanMode` when no plan file was written, avoiding an empty "Propose Plan" approval UI that blocks the agent until the user clicks Approve on nothing
- Pass the user's typed feedback text as the denial reason when they type in the compose area during plan approval, so the agent receives the feedback in the tool result context instead of a generic "User requested changes" message

## Test plan
- [ ] Enable plan mode, ask the agent to do something that triggers ExitPlanMode without writing a plan file (e.g. "let's make a PR") — verify it exits plan mode automatically without showing approval UI
- [ ] Enable plan mode, ask the agent to plan something — verify the plan content displays and Approve/Request Changes buttons work as before
- [ ] With plan approval pending, type feedback text and press Enter — verify the agent receives the typed text as the denial reason (check agent-runner debug logs)
- [ ] Verify "Request Changes" button still works with the default reason string
- [ ] Run Go backend tests: `cd backend && go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)