### PR TITLE
Fix PRWatcher using stale cache for new PR detection

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -395,7 +395,11 @@ func (w *PRWatcher) checkSessionsWithoutPR() {
 		return e.PRStatus == "" || e.PRStatus == models.PRStatusNone
 	})
 
-	w.checkRepoSessions(repoSessions)
+	// Skip the shared cache for sessions without a PR. The cache may contain
+	// a "fresh" entry populated before the PR was created (or kept alive by
+	// BumpTTL after a 304 Not-Modified background refresh), so we must always
+	// hit GitHub directly to discover newly created PRs.
+	w.checkRepoSessions(repoSessions, true)
 }
 
 // checkSessionsWithPR checks sessions that have an associated PR for lifecycle changes.
@@ -424,7 +428,7 @@ func (w *PRWatcher) checkSessionsWithPR() {
 		}
 	}
 
-	w.checkRepoSessions(openSessions)
+	w.checkRepoSessions(openSessions, false)
 }
 
 // backfillMissingPRTitles is a one-time startup pass that fetches PR titles
@@ -520,8 +524,11 @@ func (w *PRWatcher) groupSessionsByRepo(filter func(*PRWatchEntry) bool) map[rep
 }
 
 // checkRepoSessions checks PR status for sessions grouped by repo.
-// Uses the shared PR cache to avoid redundant GitHub API calls.
-func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry) {
+// When skipCache is false, uses the shared PR cache to avoid redundant GitHub
+// API calls. When skipCache is true (used by checkSessionsWithoutPR), always
+// fetches from GitHub directly — the cache may contain stale data from before
+// a PR was created, and BumpTTL can keep it "fresh" indefinitely.
+func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry, skipCache bool) {
 	for key, entries := range repoSessions {
 		// Check context cancellation
 		if w.ctx.Err() != nil {
@@ -529,18 +536,20 @@ func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry) 
 		}
 
 		// Try the shared cache — only use fresh entries (within freshTTL).
-		// Stale entries are skipped so the PRWatcher fetches from GitHub directly,
-		// ensuring eager detection of newly created PRs within ~30 seconds.
+		// Skipped for sessions without a PR: the cache can be kept alive by
+		// BumpTTL (304 Not-Modified) long after a PR is created, so we must
+		// always hit GitHub to discover new PRs.
 		var openPRs []github.PRListItem
-		if w.prCache != nil {
+		if !skipCache && w.prCache != nil {
 			entry, freshness := w.prCache.GetWithStale(key.owner, key.repo)
 			if freshness == github.CacheFresh && entry != nil {
 				openPRs = make([]github.PRListItem, len(entry.PRs))
 				copy(openPRs, entry.PRs)
+				logger.PRWatcher.Debugf("checkRepoSessions %s/%s: using cached PR list (%d PRs)", key.owner, key.repo, len(openPRs))
 			}
 		}
 
-		// Cache miss -- fetch from GitHub and populate shared cache.
+		// Cache miss (or skipped) -- fetch from GitHub and populate shared cache.
 		// NOTE: This stores PRs without details or ETag. If the HTTP handler
 		// hits this entry while fresh, it will serve PRs with unknown check status
 		// until the next background refresh cycle populates details.
@@ -554,6 +563,7 @@ func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry) 
 			if w.prCache != nil {
 				w.prCache.Set(key.owner, key.repo, openPRs)
 			}
+			logger.PRWatcher.Debugf("checkRepoSessions %s/%s: fetched fresh PR list from GitHub (%d PRs)", key.owner, key.repo, len(openPRs))
 		}
 
 		// Build branch -> PR map for quick lookup
@@ -572,6 +582,10 @@ func (w *PRWatcher) checkRepoSessions(repoSessions map[repoKey][]*PRWatchEntry) 
 // checkSessionPR checks and updates PR status for a single session
 func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, branchToPR map[string]*github.PRListItem) {
 	pr, hasPR := branchToPR[entry.Branch]
+
+	if !hasPR && (entry.PRStatus == "" || entry.PRStatus == models.PRStatusNone) {
+		logger.PRWatcher.Debugf("checkSessionPR session=%s: no PR found for branch=%q (%d open PRs in map)", entry.SessionID, entry.Branch, len(branchToPR))
+	}
 
 	// For terminal states (merged/closed), only continue if there's a NEW PR
 	// for this branch (different number). This handles the workflow where a PR

--- a/backend/branch/pr_watcher_test.go
+++ b/backend/branch/pr_watcher_test.go
@@ -876,3 +876,162 @@ func newMockGitHubServerWithPRNumber(t *testing.T, prNumber int, responses mockG
 		w.WriteHeader(http.StatusNotFound)
 	}))
 }
+
+// ---------------------------------------------------------------------------
+// checkSessionsWithoutPR cache-skip tests
+// ---------------------------------------------------------------------------
+
+func TestPRWatcher_CheckSessionsWithoutPR_SkipsCache(t *testing.T) {
+	// Scenario: the shared PRCache contains a "fresh" entry with an empty PR
+	// list (populated before the PR was created). checkSessionsWithoutPR must
+	// skip the cache and fetch from GitHub, where the new PR now exists.
+	store := newMockStore()
+	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
+	prCache := github.NewPRCache(5*time.Minute, 30*time.Minute)
+	defer prCache.Close()
+
+	// Pre-populate the cache with NO open PRs (simulates cache set before PR creation).
+	prCache.Set("org", "myrepo", []github.PRListItem{})
+
+	// Verify the cache is fresh.
+	_, freshness := prCache.GetWithStale("org", "myrepo")
+	require.Equal(t, github.CacheFresh, freshness, "cache entry should be fresh")
+
+	// Set up a GitHub mock that returns a PR for the session's branch.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// /repos/org/myrepo/pulls?state=open&per_page=100
+		if matched, _ := regexp.MatchString(`/repos/.+/.+/pulls\?`, r.URL.RequestURI()); matched {
+			prs := []map[string]interface{}{
+				{
+					"number":   99,
+					"state":    "open",
+					"title":    "New PR",
+					"html_url": "https://github.com/org/myrepo/pull/99",
+					"draft":    false,
+					"head": map[string]interface{}{
+						"ref": "feature/foo",
+						"sha": "def456",
+					},
+					"labels": []interface{}{},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(prs)
+			return
+		}
+
+		// /repos/org/myrepo/pulls/99 (PR details for enrichment)
+		if matched, _ := regexp.MatchString(`/repos/.+/.+/pulls/\d+$`, r.URL.Path); matched {
+			pr := map[string]interface{}{
+				"number":          99,
+				"state":           "open",
+				"title":           "New PR",
+				"body":            "",
+				"html_url":        "https://github.com/org/myrepo/pull/99",
+				"merged":          false,
+				"mergeable":       true,
+				"mergeable_state": "clean",
+				"head":            map[string]string{"sha": "def456"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(pr)
+			return
+		}
+
+		// /repos/org/myrepo/commits/:ref/check-runs
+		if matched, _ := regexp.MatchString(`/repos/.+/.+/commits/.+/check-runs$`, r.URL.Path); matched {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 0,
+				"check_runs":  []interface{}{},
+			})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	var capturedEvent *PRChangeEvent
+	w := newTestPRWatcher(store, repoMgr, prCache)
+	defer w.Close()
+	w.onChange = func(e PRChangeEvent) { capturedEvent = &e }
+
+	ghClient := github.NewClient("", "")
+	ghClient.SetToken("test-token")
+	ghClient.SetAPIURL(ts.URL)
+	w.ghClient = ghClient
+
+	// Add a session without a PR on branch "feature/foo".
+	w.WatchSession("sess-1", "ws-1", "feature/foo", "/repo/path", "none", 0, "")
+
+	// Run the check — should skip the fresh cache and discover the PR.
+	w.checkSessionsWithoutPR()
+
+	// Verify the PR was detected.
+	w.mu.RLock()
+	entry := w.sessions["sess-1"]
+	w.mu.RUnlock()
+
+	assert.Equal(t, 99, entry.PRNumber, "PR number should be detected")
+	assert.Equal(t, models.PRStatusOpen, entry.PRStatus, "PR status should be open")
+	assert.Equal(t, "https://github.com/org/myrepo/pull/99", entry.PRUrl)
+	assert.Equal(t, "New PR", entry.PRTitle)
+
+	// Verify the onChange event was emitted.
+	require.NotNil(t, capturedEvent, "onChange should have been called")
+	assert.Equal(t, 99, capturedEvent.PRNumber)
+	assert.Equal(t, models.PRStatusOpen, capturedEvent.PRStatus)
+
+	// Verify the database was updated.
+	sess := store.sessions["sess-1"]
+	assert.Equal(t, 99, sess.PRNumber)
+	assert.Equal(t, models.PRStatusOpen, sess.PRStatus)
+}
+
+func TestPRWatcher_CheckSessionsWithPR_UsesCache(t *testing.T) {
+	// Verify that checkSessionsWithPR (monitoring existing PRs) DOES use the
+	// cache for the PR list, unlike checkSessionsWithoutPR which skips it.
+	store := newMockStore()
+	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
+	prCache := github.NewPRCache(5*time.Minute, 30*time.Minute)
+	defer prCache.Close()
+
+	// Pre-populate cache with an open PR on "feature/bar" including details,
+	// so no GitHub API calls are needed at all.
+	mergeable := true
+	prCache.SetFull("org", "myrepo",
+		[]github.PRListItem{
+			{Number: 50, Title: "Cached PR", HTMLURL: "https://github.com/org/myrepo/pull/50", Branch: "feature/bar", State: "open"},
+		},
+		map[int]*github.PRDetails{
+			50: {Number: 50, State: "open", Title: "Cached PR", HTMLURL: "https://github.com/org/myrepo/pull/50", Mergeable: &mergeable, CheckStatus: github.CheckStatusSuccess},
+		},
+		"",
+	)
+
+	// GitHub mock should NOT be called if cache is used for both list and details.
+	apiCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	w := newTestPRWatcher(store, repoMgr, prCache)
+	defer w.Close()
+	w.onChange = func(e PRChangeEvent) {}
+
+	ghClient := github.NewClient("", "")
+	ghClient.SetToken("test-token")
+	ghClient.SetAPIURL(ts.URL)
+	w.ghClient = ghClient
+
+	// Add a session WITH an open PR (matching cache entry).
+	w.WatchSession("sess-1", "ws-1", "feature/bar", "/repo/path", "open", 50, "https://github.com/org/myrepo/pull/50")
+
+	// Run the "with PR" check — should use cache, not call GitHub API.
+	w.checkSessionsWithPR()
+
+	assert.False(t, apiCalled, "checkSessionsWithPR should use the cache and not call GitHub API")
+}


### PR DESCRIPTION
## Summary
- `checkSessionsWithoutPR()` was using the shared `PRCache` which could contain stale data kept "fresh" by `BumpTTL()` after 304 Not-Modified background refreshes
- This caused sessions to show "No pull request" indefinitely even when a PR existed on GitHub, while CI checks (fetched by branch name, independent of the cache) displayed correctly
- Fix: skip the cache when polling for NEW PRs (`skipCache=true`), always hitting GitHub directly; existing PR monitoring still uses the cache for efficiency

## Test plan
- [x] New test `TestPRWatcher_CheckSessionsWithoutPR_SkipsCache` verifies fresh cache is bypassed and new PRs are discovered
- [x] New test `TestPRWatcher_CheckSessionsWithPR_UsesCache` verifies existing PR monitoring still uses cache
- [x] All 22 PRWatcher tests pass
- [x] Full backend test suite passes (`go test ./...`)
- [ ] Manual: create a PR externally via `gh pr create`, verify it's detected within 30 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)