### PR TITLE
Prune stale remote-tracking refs to fix inflated branch counts

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -1040,6 +1040,29 @@ func (rm *RepoManager) ListBranches(ctx context.Context, repoPath string, opts B
 	}, nil
 }
 
+// PruneRemoteRefs removes stale remote-tracking references that no longer exist on the remote.
+// Uses "git remote prune origin" which is lightweight (only removes stale refs, no data fetch).
+func (rm *RepoManager) PruneRemoteRefs(ctx context.Context, repoPath string) error {
+	cmd, cancel := gitCmdWithContext(ctx, repoPath, "remote", "prune", "origin")
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to prune remote refs: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// FetchAndPrune runs "git fetch --prune origin" to both update refs and remove stale ones.
+func (rm *RepoManager) FetchAndPrune(ctx context.Context, repoPath string) error {
+	cmd, cancel := gitCmdWithContext(ctx, repoPath, "fetch", "--prune", "origin")
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to fetch --prune: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 // sortBranches sorts branches by the specified field using O(n log n) sort
 func sortBranches(branches []BranchInfo, sortBy string, desc bool) {
 	sort.Slice(branches, func(i, j int) bool {

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -85,10 +85,12 @@ func (m *SessionLockManager) Unlock(path string) {
 // BranchCache provides TTL-based caching for branch listing operations.
 // This reduces git operations for frequently accessed branch lists.
 type BranchCache struct {
-	mu      sync.RWMutex
-	entries map[string]*branchCacheEntry
-	ttl     time.Duration
-	done    chan struct{}
+	mu             sync.RWMutex
+	entries        map[string]*branchCacheEntry
+	ttl            time.Duration
+	done           chan struct{}
+	lastPruneTime  map[string]time.Time
+	pruneCooldown  time.Duration
 }
 
 type branchCacheEntry struct {
@@ -99,9 +101,11 @@ type branchCacheEntry struct {
 // NewBranchCache creates a new branch cache with the given TTL
 func NewBranchCache(ttl time.Duration) *BranchCache {
 	c := &BranchCache{
-		entries: make(map[string]*branchCacheEntry),
-		ttl:     ttl,
-		done:    make(chan struct{}),
+		entries:       make(map[string]*branchCacheEntry),
+		ttl:           ttl,
+		done:          make(chan struct{}),
+		lastPruneTime: make(map[string]time.Time),
+		pruneCooldown: 30 * time.Minute,
 	}
 	go c.cleanupLoop()
 	return c
@@ -152,6 +156,24 @@ func (c *BranchCache) InvalidateRepo(repoPath string) {
 			delete(c.entries, key)
 		}
 	}
+}
+
+// ShouldPrune returns true if enough time has passed since the last prune for this repo.
+func (c *BranchCache) ShouldPrune(repoPath string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	last, ok := c.lastPruneTime[repoPath]
+	if !ok {
+		return true
+	}
+	return time.Since(last) > c.pruneCooldown
+}
+
+// MarkPruned records that a prune was performed for a repo.
+func (c *BranchCache) MarkPruned(repoPath string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lastPruneTime[repoPath] = time.Now()
 }
 
 // Close stops the cleanup goroutine. Safe to call multiple times.
@@ -1235,6 +1257,16 @@ func (h *Handlers) ListBranches(w http.ResponseWriter, r *http.Request) {
 	// Check cache first
 	branchResult, cacheHit := h.branchCache.Get(cacheKey)
 	if !cacheHit {
+		// Auto-prune stale remote-tracking refs to prevent inflated branch counts.
+		// Only prune when including remote branches and cooldown has elapsed.
+		if includeRemote && h.branchCache.ShouldPrune(repo.Path) {
+			if pruneErr := h.repoManager.PruneRemoteRefs(ctx, repo.Path); pruneErr != nil {
+				logger.Handlers.Warnf("Auto-prune failed for %s: %v", repo.Path, pruneErr)
+			} else {
+				h.branchCache.MarkPruned(repo.Path)
+			}
+		}
+
 		// Get branches from git
 		branchOpts := git.BranchListOptions{
 			IncludeRemote: includeRemote,
@@ -1405,6 +1437,17 @@ func (h *Handlers) AnalyzeBranchCleanup(w http.ResponseWriter, r *http.Request) 
 		req.StaleDaysThreshold = 90
 	}
 
+	// Prune stale remote-tracking refs before analysis so we don't suggest
+	// deleting branches that are already gone on the remote.
+	if req.IncludeRemote {
+		if pruneErr := h.repoManager.PruneRemoteRefs(ctx, repo.Path); pruneErr != nil {
+			logger.Handlers.Warnf("Pre-analysis prune failed for %s: %v", repo.Path, pruneErr)
+		} else {
+			h.branchCache.MarkPruned(repo.Path)
+			h.branchCache.InvalidateRepo(repo.Path)
+		}
+	}
+
 	// Get sessions for branch -> session mapping
 	sessionBranches, err := h.getSessionBranchMap(ctx, workspaceID)
 	if err != nil {
@@ -1480,6 +1523,42 @@ func (h *Handlers) ExecuteBranchCleanup(w http.ResponseWriter, r *http.Request) 
 	}
 
 	writeJSON(w, result)
+}
+
+// PruneStaleBranches runs git fetch --prune to clean up stale remote-tracking refs
+// POST /api/repos/{id}/branches/prune
+func (h *Handlers) PruneStaleBranches(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	workspaceID := chi.URLParam(r, "id")
+
+	repo, err := h.store.GetRepo(ctx, workspaceID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if repo == nil {
+		writeNotFound(w, "workspace")
+		return
+	}
+
+	if err := h.repoManager.FetchAndPrune(ctx, repo.Path); err != nil {
+		writeInternalError(w, "failed to prune stale branches", err)
+		return
+	}
+
+	h.branchCache.MarkPruned(repo.Path)
+	h.branchCache.InvalidateRepo(repo.Path)
+
+	if h.hub != nil {
+		h.hub.Broadcast(Event{
+			Type: "branch_dashboard_update",
+			Payload: map[string]interface{}{
+				"reason": "prune_complete",
+			},
+		})
+	}
+
+	writeJSON(w, map[string]interface{}{"success": true})
 }
 
 // GetAvatars returns GitHub avatar URLs for a batch of email addresses

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -98,6 +98,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Delete("/{id}", h.DeleteRepo)
 		r.Get("/{id}/remotes", h.GetRepoRemotes)
 		r.Get("/{id}/branches", h.ListBranches)
+		r.Post("/{id}/branches/prune", h.PruneStaleBranches)
 		r.Post("/{id}/branches/analyze-cleanup", h.AnalyzeBranchCleanup)
 		r.Post("/{id}/branches/cleanup", h.ExecuteBranchCleanup)
 		r.Get("/{id}/files", h.ListRepoFiles)

--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -7,7 +7,7 @@ import { navigate } from '@/lib/navigation';
 import { FullContentLayout } from '@/components/layout/FullContentLayout';
 import { useMainToolbarContent } from '@/hooks/useMainToolbarContent';
 import { DataTable, type Column, type ContextMenuItem, type FilterOption, type DisplayOptionsConfig, type DisplayOptions } from '@/components/data-table';
-import { listBranches, type BranchDTO, type BranchListResponse } from '@/lib/api';
+import { listBranches, pruneStaleBranches, type BranchDTO, type BranchListResponse } from '@/lib/api';
 import { useAvatars } from '@/hooks/useAvatars';
 import { Button } from '@/components/ui/button';
 import { AuthorAvatar } from '@/components/ui/author-avatar';
@@ -28,6 +28,7 @@ import {
   Copy,
   Cloud,
   Wand2,
+  Scissors,
 } from 'lucide-react';
 import { BranchCleanupDialog } from '@/components/dialogs/branch-cleanup/BranchCleanupDialog';
 import { copyToClipboard } from '@/lib/tauri';
@@ -228,6 +229,7 @@ export function BranchesDashboard({
   const [searchTerm, setSearchTerm] = useState('');
   const [showRemote, setShowRemote] = useState(false);
   const [cleanupOpen, setCleanupOpen] = useState(false);
+  const [pruning, setPruning] = useState(false);
 
   const fetchBranchesRef = useRef<(isRefresh?: boolean) => void>(() => {});
   const hasFetchedRef = useRef(false);
@@ -242,6 +244,18 @@ export function BranchesDashboard({
     setLastRepoDashboardWorkspaceId(newWorkspaceId);
     navigate({ contentView: { type: 'branches', workspaceId: newWorkspaceId } });
   }, [setLastRepoDashboardWorkspaceId]);
+
+  const handlePrune = useCallback(async () => {
+    setPruning(true);
+    try {
+      await pruneStaleBranches(workspaceId);
+      toast.success('Stale remote branches pruned');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to prune branches');
+    } finally {
+      setPruning(false);
+    }
+  }, [workspaceId, toast]);
 
   // Set dynamic toolbar content (Flutter AppBar-style)
   const toolbarConfig = useMemo(() => ({
@@ -305,6 +319,17 @@ export function BranchesDashboard({
             variant="ghost"
             size="sm"
             className="h-6 gap-1 px-2 text-xs"
+            onClick={handlePrune}
+            disabled={pruning}
+            title="Remove stale remote-tracking references for branches deleted on GitHub"
+          >
+            <Scissors className={cn('h-3.5 w-3.5', pruning && 'animate-spin')} />
+            {pruning ? 'Pruning...' : 'Prune Stale'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs"
             onClick={() => setCleanupOpen(true)}
           >
             <Wand2 className="h-3.5 w-3.5" />
@@ -323,7 +348,7 @@ export function BranchesDashboard({
         </>
       ),
     },
-  }), [workspace, workspaces, workspaceId, branchData, refreshing, handleWorkspaceChange, workspaceColors]);
+  }), [workspace, workspaces, workspaceId, branchData, refreshing, handleWorkspaceChange, handlePrune, pruning, workspaceColors]);
   useMainToolbarContent(toolbarConfig);
 
   const fetchBranches = useCallback(async (isRefresh = false) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -544,6 +544,13 @@ export async function executeBranchCleanup(
   return handleResponse<CleanupResult>(res);
 }
 
+export async function pruneStaleBranches(workspaceId: string): Promise<{ success: boolean }> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/branches/prune`, {
+    method: 'POST',
+  });
+  return handleResponse<{ success: boolean }>(res);
+}
+
 // Avatar types and API
 export interface AvatarResponse {
   avatars: Record<string, string>;


### PR DESCRIPTION
## Summary
- The Branches dashboard was showing hundreds of branches (e.g., 544) when GitHub only listed ~5, because `git branch -a` includes stale remote-tracking references for branches deleted on the remote long ago
- Adds automatic pruning (`git remote prune origin`) with a 30-minute cooldown when the branch cache expires, plus a manual "Prune Stale" button that runs `git fetch --prune origin` for immediate cleanup
- Pre-prunes before branch cleanup analysis so suggestions don't include already-deleted remote branches

## Test plan
- [ ] Open the Branches dashboard for a repo with many stale remote-tracking refs
- [ ] Verify the branch count drops to match GitHub after auto-prune triggers or "Prune Stale" button is clicked
- [ ] Verify the "Prune Stale" button shows a loading state and a toast notification on completion
- [ ] Verify the cooldown prevents repeated prune calls within 30 minutes (check backend logs)
- [ ] Verify "Smart Branch Cleanup" analysis no longer includes already-deleted remote branches
- [ ] Verify the dashboard auto-refreshes after pruning via the WebSocket `branch_dashboard_update` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)