### PR TITLE
Fix SDK/plugin commands not appearing in Compose slash menu

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -240,10 +240,11 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const getAllCommands = useSlashCommandStore((s) => s.getAllCommands);
   const installedSkills = useSlashCommandStore((s) => s.installedSkills);
   const userCommands = useSlashCommandStore((s) => s.userCommands);
+  const sdkCommands = useSlashCommandStore((s) => s.sdkCommands);
   const slashCommands = useMemo(
     () => getAllCommands({ hasSession: selectedSessionId !== null }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- need to recompute when skills/commands change
-    [getAllCommands, selectedSessionId, installedSkills, userCommands]
+    [getAllCommands, selectedSessionId, installedSkills, userCommands, sdkCommands]
   );
 
   // sendMessage: programmatically set text and trigger submit
@@ -303,7 +304,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   // Fetch user commands when session changes
   const fetchUserCommands = useSlashCommandStore((s) => s.fetchUserCommands);
   const setInstalledSkills = useSlashCommandStore((s) => s.setInstalledSkills);
-  // Note: installedSkills and userCommands are subscribed above for slashCommands derivation
+  // Note: installedSkills, userCommands, and sdkCommands are subscribed above for slashCommands derivation
   useEffect(() => {
     if (selectedWorkspaceId && selectedSessionId) {
       fetchUserCommands(selectedWorkspaceId, selectedSessionId);


### PR DESCRIPTION
## Summary

- **Bug:** Superpowers plugin commands (and all SDK-reported commands) were not showing up in the Compose area's slash command menu, despite working fine in the CLI
- **Root cause:** The `useMemo` in `ChatInput.tsx` that computes the slash command list was missing `sdkCommands` in its dependency array — so it never recomputed when plugin commands arrived via WebSocket
- **Fix:** Added the missing Zustand selector and dependency (1 file, 3 lines changed)

## Test plan

- [ ] Start the app and connect to a session with superpowers plugin commands
- [ ] Type `/` in the Compose area — SDK/plugin commands should now appear in the slash menu
- [ ] Verify built-in, skill, and user commands still appear correctly
- [ ] Verify commands update when switching sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)