### PR TITLE
Fix model menu: remove icons, align badges right, use Bot icon

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
 import {
-  Snowflake,
+  Bot,
   ChevronDown,
   Paperclip,
   ArrowUp,
@@ -78,9 +78,9 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
 }
 
 const MODELS = [
-  { ...SHARED_MODELS[0], icon: Snowflake, badge: 'NEW' as const },
-  { ...SHARED_MODELS[1], icon: Snowflake, badge: 'NEW' as const },
-  { ...SHARED_MODELS[2], icon: Snowflake },
+  { ...SHARED_MODELS[0], icon: Bot, badge: 'NEW' as const },
+  { ...SHARED_MODELS[1], icon: Bot, badge: 'NEW' as const },
+  { ...SHARED_MODELS[2], icon: Bot },
 ];
 
 
@@ -1255,10 +1255,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                   key={model.id}
                   onClick={() => setSelectedModel(model)}
                 >
-                  <model.icon className="size-3.5" />
                   {model.name}
                   {'badge' in model && model.badge && (
-                    <span className="ml-1.5 rounded-sm bg-emerald-500 px-1.5 py-px text-[10px] font-semibold text-white">
+                    <span className="ml-auto rounded-sm bg-emerald-500 px-1.5 py-px text-[10px] font-semibold text-white">
                       {model.badge}
                     </span>
                   )}


### PR DESCRIPTION
## Summary
- Removed snowflake icons from inside the model selector dropdown menu items
- Aligned "NEW" badges to the right edge of menu cells using `ml-auto`
- Changed the model selector trigger icon from Snowflake to Bot (robot)

## Test plan
- [ ] Open the model selector dropdown in the chat input toolbar
- [ ] Verify no icons appear inside the dropdown menu items
- [ ] Verify "NEW" badges are right-aligned in the menu cells
- [ ] Verify the trigger button shows a robot icon instead of a snowflake

🤖 Generated with [Claude Code](https://claude.com/claude-code)