### PR TITLE
Fix code viewer stuck on loading spinner when clicking file paths

### DIFF
--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -260,7 +260,6 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
         sessionId,
         path: relativePath,
         name: filename,
-        isLoading: true,
       });
     };
   }, [fullFilePath, worktreePath]);


### PR DESCRIPTION
## Summary
- Clicking a file path link (from Read/Write/Edit tool results) in the conversation area opened the code viewer but it stayed stuck on the "Loading file..." spinner forever
- **Root cause:** `ToolUsageBlock` opened the tab with `isLoading: true`, but `ConversationArea`'s lazy-loading `useEffect` has a guard that skips tabs already marked as loading — so nobody fetched the content and nobody cleared `isLoading`
- **Fix:** Remove `isLoading: true` from `openFileTab` call, matching the FilePicker pattern where the `useEffect` handles the full load lifecycle

## Test plan
- [ ] Click a file path in a Read/Write/Edit tool result → code viewer loads the file (no stuck spinner)
- [ ] Click the same file path again → tab shows content immediately
- [ ] Open a file via Cmd+P (FilePicker) → still works
- [ ] Open a file via ChangesPanel → diff loading still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)