### PR TITLE
Add delay to secondary sidebar tab tooltips

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -842,7 +842,7 @@ const SortableTabButton = memo(function SortableTabButton({
   if (!shortcutDisplay) return button;
 
   return (
-    <Tooltip delayDuration={0}>
+    <Tooltip delayDuration={150}>
       <TooltipTrigger asChild>
         {button}
       </TooltipTrigger>


### PR DESCRIPTION
## Summary
- Adds a 150ms delay to secondary sidebar tab tooltips to prevent flicker when quickly sweeping the mouse across tabs
- Previously `delayDuration` was `0`, causing tooltips to appear instantly on hover

## Test plan
- [ ] Hover slowly over a tab with a keyboard shortcut — tooltip appears after a brief delay
- [ ] Sweep the mouse quickly across multiple tabs — no tooltip flicker
- [ ] Tabs without shortcuts remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)