### PR TITLE
Fix nested button hydration error in CIFailureAnalysis

### DIFF
--- a/src/components/ci/CIFailureAnalysis.tsx
+++ b/src/components/ci/CIFailureAnalysis.tsx
@@ -200,9 +200,17 @@ export function CIFailureAnalysis({
               {/* Raw logs (collapsible) */}
               {logs && (
                 <div className="border rounded-lg">
-                  <button
-                    className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-surface-1"
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-surface-1 cursor-pointer"
                     onClick={() => setLogsExpanded(!logsExpanded)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        setLogsExpanded(!logsExpanded);
+                      }
+                    }}
                   >
                     {logsExpanded ? (
                       <ChevronDown className="h-4 w-4" />
@@ -235,7 +243,7 @@ export function CIFailureAnalysis({
                         </>
                       )}
                     </Button>
-                  </button>
+                  </div>
                   {logsExpanded && (
                     <div className="border-t">
                       <pre className="p-3 text-xs font-mono overflow-auto max-h-64 bg-surface-1">


### PR DESCRIPTION
## Summary
- Fixes a Next.js hydration error caused by a `<Button>` (copy logs) nested inside a `<button>` (toggle Raw Logs expansion) in `CIFailureAnalysis.tsx`
- Replaces the outer `<button>` with a `<div role="button">` to eliminate invalid HTML nesting while preserving accessibility via `tabIndex` and `onKeyDown` handlers

## Test plan
- [ ] Open CI Checks panel with a failed run showing the "Raw Logs" section
- [ ] Verify no hydration error in the console
- [ ] Click the Raw Logs header to toggle expansion
- [ ] Click the Copy button to copy logs
- [ ] Verify keyboard navigation (Tab to focus, Enter/Space to toggle) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)