### PR TITLE
Add merge conflict status tracking from GitHub API

### DIFF
--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -224,6 +224,7 @@ export function SessionToolbarContent() {
                 prNumber={selectedSession.prNumber}
                 prStatus={selectedSession.prStatus as 'open' | 'merged' | 'closed'}
                 checkStatus={selectedSession.checkStatus}
+                hasMergeConflict={selectedSession.hasMergeConflict}
                 prUrl={selectedSession.prUrl}
                 size="sm"
               />

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1511,6 +1511,7 @@ function SessionRow({
                     prNumber={session.prNumber}
                     prStatus={session.prStatus as 'open' | 'merged' | 'closed'}
                     checkStatus={session.checkStatus}
+                    hasMergeConflict={session.hasMergeConflict}
                     prUrl={session.prUrl}
                     size="sm"
                   />

--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -230,16 +230,20 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
       updates.hasCheckFailures = hasFailures;
     }
 
-    // Sync hasMergeConflict from git status
-    const hasMergeConflict = gitStatus?.conflicts?.hasConflicts ?? false;
-    if (session.hasMergeConflict !== hasMergeConflict) {
-      updates.hasMergeConflict = hasMergeConflict;
+    // Sync hasMergeConflict from PR mergeable state (GitHub API), not local git status.
+    // prDetails.mergeable === false means GitHub considers the PR to have conflicts.
+    // null means GitHub hasn't computed it yet — don't update in that case.
+    if (prDetails.mergeable !== null) {
+      const hasMergeConflict = !prDetails.mergeable;
+      if (session.hasMergeConflict !== hasMergeConflict) {
+        updates.hasMergeConflict = hasMergeConflict;
+      }
     }
 
     if (Object.keys(updates).length > 0) {
       updateSession(selectedSessionId, updates);
     }
-  }, [selectedSessionId, session, prDetails, checkDetails, gitStatus, updateSession]);
+  }, [selectedSessionId, session, prDetails, checkDetails, updateSession]);
 
   if (!selectedWorkspaceId || !selectedSessionId) {
     return (
@@ -317,6 +321,7 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
               error={gitError}
               errorCode={gitErrorCode}
               onRefresh={refetchGit}
+              hasMergeConflict={session?.hasMergeConflict}
             />
           </div>
         </div>

--- a/src/components/panels/GitStatusSection.tsx
+++ b/src/components/panels/GitStatusSection.tsx
@@ -115,7 +115,8 @@ function GitStatusItem({ type, message, action, dropdownActions }: GitStatusItem
 
 function buildStatusItems(
   status: GitStatusDTO,
-  sendMessage: (content: string) => void
+  sendMessage: (content: string) => void,
+  hasMergeConflict?: boolean,
 ): GitStatusItemProps[] {
   const items: GitStatusItemProps[] = [];
 
@@ -127,6 +128,16 @@ function buildStatusItems(
       action: {
         label: 'Resolve',
         onClick: () => sendMessage('Resolve the merge conflicts'),
+      },
+    });
+  } else if (hasMergeConflict) {
+    // PR has conflicts on GitHub but local worktree is clean
+    items.push({
+      type: 'warning',
+      message: 'PR has merge conflicts',
+      action: {
+        label: 'Rebase',
+        onClick: () => sendMessage(`Rebase my branch on ${status.sync.baseBranch}`),
       },
     });
   }
@@ -299,9 +310,10 @@ interface GitStatusSectionProps {
   error: string | null;
   errorCode: string | null;
   onRefresh: () => void;
+  hasMergeConflict?: boolean;
 }
 
-export function GitStatusSection({ onSendMessage, status, loading, error, errorCode, onRefresh }: GitStatusSectionProps) {
+export function GitStatusSection({ onSendMessage, status, loading, error, errorCode, onRefresh, hasMergeConflict }: GitStatusSectionProps) {
   // Wrapper that handles missing callback
   const sendMessage = (content: string) => {
     if (!onSendMessage) {
@@ -352,7 +364,7 @@ export function GitStatusSection({ onSendMessage, status, loading, error, errorC
     );
   }
 
-  const items = buildStatusItems(status, sendMessage);
+  const items = buildStatusItems(status, sendMessage, hasMergeConflict);
 
   return (
     <div>

--- a/src/components/shared/PRHoverCard.tsx
+++ b/src/components/shared/PRHoverCard.tsx
@@ -14,6 +14,7 @@ interface PRHoverCardProps {
   prNumber: number;
   prStatus: 'open' | 'merged' | 'closed';
   checkStatus?: 'none' | 'pending' | 'success' | 'failure';
+  hasMergeConflict?: boolean;
   prUrl?: string;
   size?: 'sm' | 'md';
 }
@@ -178,6 +179,7 @@ export function PRHoverCard({
   prNumber,
   prStatus,
   checkStatus,
+  hasMergeConflict,
   prUrl,
   size,
 }: PRHoverCardProps) {
@@ -185,6 +187,10 @@ export function PRHoverCard({
 
   // Use prDetails checkStatus if available (more accurate), otherwise fall back to session-level
   const effectiveCheckStatus = prDetails?.checkStatus ?? checkStatus;
+  // Use live prDetails mergeable state if available, otherwise fall back to session-level.
+  // When mergeable is null (GitHub hasn't computed yet), fall back to session-level.
+  // When mergeable is true/false, trust the live data over potentially stale session state.
+  const effectiveHasMergeConflict = prDetails?.mergeable != null ? !prDetails.mergeable : (hasMergeConflict ?? false);
 
   // If there's an error fetching details, just render the badge without hover
   if (error) {
@@ -193,6 +199,7 @@ export function PRHoverCard({
         prNumber={prNumber}
         prStatus={prStatus}
         checkStatus={effectiveCheckStatus}
+        hasMergeConflict={effectiveHasMergeConflict}
         prUrl={prUrl}
         size={size}
       />
@@ -207,6 +214,7 @@ export function PRHoverCard({
             prNumber={prNumber}
             prStatus={prStatus}
             checkStatus={effectiveCheckStatus}
+            hasMergeConflict={effectiveHasMergeConflict}
             prUrl={prUrl}
             size={size}
           />

--- a/src/components/shared/PRNumberBadge.tsx
+++ b/src/components/shared/PRNumberBadge.tsx
@@ -10,6 +10,7 @@ interface PRNumberBadgeProps {
   prNumber: number;
   prStatus: 'open' | 'merged' | 'closed';
   checkStatus?: CheckStatus;
+  hasMergeConflict?: boolean;
   prUrl?: string;
   size?: 'sm' | 'md';
   className?: string;
@@ -25,6 +26,11 @@ const STATUS_STYLES = {
     text: 'text-amber-500',
     bg: 'bg-amber-500/10 hover:bg-amber-500/15',
     border: 'border-amber-500/20',
+  },
+  'open-conflict': {
+    text: 'text-orange-400',
+    bg: 'bg-orange-500/10 hover:bg-orange-500/15',
+    border: 'border-orange-500/20',
   },
   'open-failure': {
     text: 'text-text-error',
@@ -43,9 +49,12 @@ const STATUS_STYLES = {
   },
 };
 
-function getStyleKey(prStatus: 'open' | 'merged' | 'closed', checkStatus?: CheckStatus): keyof typeof STATUS_STYLES {
+function getStyleKey(prStatus: 'open' | 'merged' | 'closed', checkStatus?: CheckStatus, hasMergeConflict?: boolean): keyof typeof STATUS_STYLES {
   if (prStatus === 'open') {
+    // Priority: failure > conflict > pending > open
+    // Conflict is above pending because it's immediately actionable (rebase needed).
     if (checkStatus === 'failure') return 'open-failure';
+    if (hasMergeConflict) return 'open-conflict';
     if (checkStatus === 'pending') return 'open-pending';
     return 'open';
   }
@@ -56,11 +65,12 @@ export function PRNumberBadge({
   prNumber,
   prStatus,
   checkStatus,
+  hasMergeConflict,
   prUrl,
   size = 'sm',
   className,
 }: PRNumberBadgeProps) {
-  const styles = STATUS_STYLES[getStyleKey(prStatus, checkStatus)];
+  const styles = STATUS_STYLES[getStyleKey(prStatus, checkStatus, hasMergeConflict)];
   const iconSize = size === 'sm' ? 'h-3 w-3' : 'h-3.5 w-3.5';
   const badgeSize = size === 'sm' ? 'h-5 text-xs' : 'h-6 text-sm';
 


### PR DESCRIPTION
## Summary

- Surface PR merge conflict state from the GitHub API in the PR badge, hover card, and git status panel
- Use GitHub's `mergeable` field instead of local git status for accurate conflict detection
- Add a "Rebase" action in the git status panel when the PR has remote conflicts but the local worktree is clean

## Changes Made

- **ChecksPanel** — Sync `hasMergeConflict` from `prDetails.mergeable` (GitHub API) instead of local `gitStatus.conflicts`; removed stale `gitStatus` dependency from useEffect
- **GitStatusSection** — Show "PR has merge conflicts" warning with rebase action when GitHub reports conflicts but local worktree has none
- **PRHoverCard** — Thread `hasMergeConflict` prop; use live `prDetails.mergeable` when available, correctly clearing stale session state when GitHub says `mergeable=true`
- **PRNumberBadge** — Add distinct orange `open-conflict` style (vs amber `open-pending`); prioritize conflict over pending since it's immediately actionable
- **SessionToolbarContent / WorkspaceSidebar** — Pass `hasMergeConflict` to PR badge components

## Test Plan

- [ ] `npm run lint` — passes (0 errors, pre-existing warnings only)
- [ ] `npx tsc --noEmit` — no errors in changed files
- [ ] Manual: open a PR with merge conflicts → badge shows orange, git status panel shows "PR has merge conflicts" with Rebase button
- [ ] Manual: open a PR without conflicts → badge shows normal green/amber/red based on check status
- [ ] Manual: PR where GitHub hasn't computed mergeable yet (null) → falls back to session-level state

🤖 Generated with [Claude Code](https://claude.com/claude-code)