### PR TITLE
Update session activity indicator colors for better visibility

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1419,13 +1419,13 @@ function SessionRow({
             ) : activityState === 'awaiting_input' ? (
               <div className="w-4 shrink-0 flex items-center justify-center">
                 <div className="session-awaiting-input-indicator">
-                  <MessageCircleQuestion className="w-3.5 h-3.5 text-amber-400" />
+                  <MessageCircleQuestion className="w-3.5 h-3.5 text-purple-500" />
                 </div>
               </div>
             ) : activityState === 'awaiting_approval' ? (
               <div className="w-4 shrink-0 flex items-center justify-center">
                 <div className="session-awaiting-approval-indicator">
-                  <ClipboardCheck className="w-3.5 h-3.5 text-blue-400" />
+                  <ClipboardCheck className="w-3.5 h-3.5 text-blue-500" />
                 </div>
               </div>
             ) : (

--- a/src/components/shared/smart-launcher/RecentSessionItem.tsx
+++ b/src/components/shared/smart-launcher/RecentSessionItem.tsx
@@ -62,14 +62,14 @@ export function RecentSessionItem({ session, workspace, workspaceColors }: Recen
       {activityState === 'awaiting_input' && (
         <div className="w-4 shrink-0 flex items-center justify-center">
           <div className="session-awaiting-input-indicator">
-            <MessageCircleQuestion className="w-3.5 h-3.5 text-amber-400" />
+            <MessageCircleQuestion className="w-3.5 h-3.5 text-purple-500" />
           </div>
         </div>
       )}
       {activityState === 'awaiting_approval' && (
         <div className="w-4 shrink-0 flex items-center justify-center">
           <div className="session-awaiting-approval-indicator">
-            <ClipboardCheck className="w-3.5 h-3.5 text-blue-400" />
+            <ClipboardCheck className="w-3.5 h-3.5 text-blue-500" />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Change awaiting-input (AskUserQuestion) icon color from `amber-400` to `purple-500` for better visibility
- Change awaiting-approval (plan approval) icon color from `blue-400` to `blue-500` to reduce muting through the opacity pulse animation

## Test plan
- [ ] Trigger an AskUserQuestion tool call and verify the sidebar icon appears in purple
- [ ] Trigger a plan approval and verify the sidebar icon appears in a more vibrant blue
- [ ] Check the Smart Launcher recent sessions list shows the same updated colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)