### PR TITLE
Hide Scripts tab from sidebar until feature is ready

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -15,7 +15,8 @@ import { ChecksPanel, type ChecksPanelHandle } from '@/components/panels/ChecksP
 import { McpServersPanel } from '@/components/panels/McpServersPanel';
 import { ReviewPanel } from '@/components/panels/ReviewPanel';
 import { FileHistoryPanel } from '@/components/panels/FileHistoryPanel';
-import { ScriptsPanel } from '@/components/panels/ScriptsPanel';
+// TODO: Re-import ScriptsPanel when the Scripts tab is reintroduced
+// import { ScriptsPanel } from '@/components/panels/ScriptsPanel';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -737,11 +738,7 @@ export function ChangesPanel() {
                   <FileHistoryPanel />
                 </ErrorBoundary>
               )}
-              {bottomTab === 'scripts' && (
-                <ErrorBoundary section="Scripts" fallback={<InlineErrorFallback message="Unable to display scripts" />}>
-                  <ScriptsPanel />
-                </ErrorBoundary>
-              )}
+              {/* TODO: Re-enable Scripts tab when the feature is reintroduced (see ScriptsPanel.tsx) */}
             </div>
           </div>
         </ResizablePanel>
@@ -765,7 +762,7 @@ const BOTTOM_TABS_CONFIG: Record<AllBottomPanelTab, { label: string; alwaysVisib
   'file-history': { label: 'File History' },
   budget: { label: 'Usage' },
   mcp: { label: 'MCP' },
-  scripts: { label: 'Scripts' },
+  // TODO: Re-add scripts tab when the feature is reintroduced: scripts: { label: 'Scripts' },
 };
 
 // Sortable tab button component

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -5,13 +5,14 @@ import { useAuthStore } from '@/stores/authStore';
 import type { ThinkingLevel } from '@/lib/thinkingLevels';
 
 // Bottom panel tab IDs that can be toggled (Tasks is always visible)
-export type BottomPanelTab = 'history' | 'budget' | 'mcp' | 'file-history' | 'scripts';
+// TODO: Re-add 'scripts' to BottomPanelTab when the Scripts feature is reintroduced (see ScriptsPanel.tsx)
+export type BottomPanelTab = 'history' | 'budget' | 'mcp' | 'file-history';
 
 // All bottom panel tabs including the always-visible Tasks
 export type AllBottomPanelTab = 'todos' | BottomPanelTab;
 
 // Default tab order
-export const DEFAULT_BOTTOM_TAB_ORDER: AllBottomPanelTab[] = ['todos', 'scripts', 'history', 'file-history', 'budget', 'mcp'];
+export const DEFAULT_BOTTOM_TAB_ORDER: AllBottomPanelTab[] = ['todos', 'history', 'file-history', 'budget', 'mcp'];
 
 // Top panel (right sidebar) tab IDs - Changes is always visible
 export type TopPanelTab = 'review' | 'checks' | 'files';


### PR DESCRIPTION
## Summary
- Hides the Scripts tab from the bottom panel in the right sidebar — it will be reintroduced in a later release
- Removes the `'scripts'` type, config entry, and rendering block while keeping `ScriptsPanel.tsx` and `ScriptLogViewer.tsx` intact
- Adds TODO comments at each removal point so the feature is easy to restore

## Test plan
- [ ] Verify the Scripts tab no longer appears in the bottom panel tabs
- [ ] Verify no runtime errors when switching between remaining bottom panel tabs
- [ ] Search for `TODO` + "Scripts" to confirm breadcrumbs are in place for re-enablement

🤖 Generated with [Claude Code](https://claude.com/claude-code)