### PR TITLE
Fix new session appearing in wrong group before jumping to In Progress

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -224,7 +224,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
       worktreePath: '',
       status: 'idle',
       priority: 0,
-      taskStatus: 'backlog',
+      taskStatus: 'in_progress',
       createdAt: now,
       updatedAt: now,
     });


### PR DESCRIPTION
## Summary
- The optimistic placeholder session was created with `taskStatus: 'backlog'`, but the backend always creates sessions with `taskStatus: 'in_progress'`
- This mismatch caused newly created sessions to briefly appear in the Backlog group, then immediately jump to In Progress once the API responded
- Fixed by setting the placeholder's `taskStatus` to `'in_progress'` to match the backend

## Test plan
- [ ] Create a new session from the sidebar with grouping set to "status"
- [ ] Verify the session appears directly in the "In Progress" group with no visual jump
- [ ] Verify the placeholder text "Creating session..." displays correctly in the In Progress group
- [ ] Verify the session stays in place when the backend response arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)