### PR TITLE
Make CI check external link icons smaller and more muted

### DIFF
--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -452,7 +452,7 @@ function PRHeaderSection({
       <Button
         variant="ghost"
         size="icon"
-        className="h-5 w-5 shrink-0"
+        className="h-5 w-5 shrink-0 text-muted-foreground/50 hover:text-muted-foreground"
         onClick={() => window.open(pr.htmlUrl, '_blank')}
         title="View on GitHub"
       >
@@ -654,11 +654,11 @@ function CIChecksSection({
             <Button
               variant="ghost"
               size="icon"
-              className="h-5 w-5"
+              className="h-4 w-4 text-muted-foreground/50 hover:text-muted-foreground"
               onClick={() => window.open(latestRun.htmlUrl, '_blank')}
               title="View on GitHub"
             >
-              <ExternalLink className="h-2.5 w-2.5" />
+              <ExternalLink className="h-2 w-2" />
             </Button>
           </div>
         )}
@@ -713,10 +713,10 @@ function CIChecksSection({
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-5 w-5 shrink-0"
+                        className="h-4 w-4 shrink-0 text-muted-foreground/50 hover:text-muted-foreground"
                         onClick={() => window.open(job.htmlUrl, '_blank')}
                       >
-                        <ExternalLink className="h-2.5 w-2.5" />
+                        <ExternalLink className="h-2 w-2" />
                       </Button>
                     </div>
                   );


### PR DESCRIPTION
## Summary
- Reduced CI check external link icon button size from `h-5 w-5` to `h-4 w-4` and icon size from `h-2.5 w-2.5` to `h-2 w-2`
- Added `text-muted-foreground/50` to make icons subtle by default
- Added `hover:text-muted-foreground` so icons become visible on hover
- Applied to individual job links, CI checks header link, and PR header link

## Test plan
- [ ] Open the Checks panel with a PR that has CI checks
- [ ] Verify external link icons are smaller and visually muted
- [ ] Hover over each icon and confirm it becomes more visible
- [ ] Click each icon to confirm it still opens the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)