### PR TITLE
Fix context meter using cumulative token counts instead of per-call data

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -2110,21 +2110,11 @@ function handleMessage(message: SDKMessage): void {
         }
       }
 
-      // Emit reliable context_usage from the result's cumulative usage.
-      // The SDK's per-assistant-message usage may not be populated correctly
-      // during streaming, but the result's usage is always reliable.
-      const resultUsage = resultMsg.usage as { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } | undefined;
-      debug(`[context_usage] result usage: ${JSON.stringify(resultUsage)}`);
+      // NOTE: result.usage is cumulative across all API calls in the agentic loop,
+      // so we do NOT emit it as context_usage — it would overwrite the correct
+      // per-call data emitted per assistant message in the "assistant" case above.
+      debug(`[context_usage] result usage (cumulative, not emitted): ${JSON.stringify(resultMsg.usage)}`);
       debug(`[context_usage] result modelUsage: ${JSON.stringify(resultMsg.modelUsage)}`);
-      if (resultUsage?.input_tokens) {
-        emit({
-          type: "context_usage",
-          inputTokens: resultUsage.input_tokens,
-          outputTokens: resultUsage.output_tokens ?? 0,
-          cacheReadInputTokens: resultUsage.cache_read_input_tokens ?? 0,
-          cacheCreationInputTokens: resultUsage.cache_creation_input_tokens ?? 0,
-        });
-      }
 
       // Extract context window size from modelUsage for context meter
       const resultModelUsage = resultMsg.modelUsage as Record<string, { contextWindow?: number }> | undefined;

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -464,9 +464,7 @@ export function useWebSocket(enabled: boolean = true) {
                          : undefined,
           },
         });
-        // Update context meter from reliable result data.
-        // This ensures the meter is always updated at the end of each turn, even if
-        // the per-message context_usage events were unreliable during streaming.
+        // Extract context window size from the result's modelUsage.
         const resultModelUsage = event.modelUsage as Record<string, { contextWindow?: number }> | undefined;
         if (resultModelUsage) {
           for (const key of Object.keys(resultModelUsage)) {
@@ -478,15 +476,9 @@ export function useWebSocket(enabled: boolean = true) {
             }
           }
         }
-        const resultUsage = normalizeUsage(event.usage);
-        if (resultUsage && resultUsage.inputTokens > 0) {
-          freshStore.setContextUsage(conversationId, {
-            inputTokens: resultUsage.inputTokens,
-            outputTokens: resultUsage.outputTokens,
-            cacheReadInputTokens: resultUsage.cacheReadInputTokens ?? 0,
-            cacheCreationInputTokens: resultUsage.cacheCreationInputTokens ?? 0,
-          });
-        }
+        // NOTE: event.usage is cumulative across all API calls in the agentic loop,
+        // so we do NOT update context usage from it — it would overwrite the correct
+        // per-call data from context_usage events emitted per assistant message.
         // Update conversation status to completed
         freshStore.updateConversation(conversationId, { status: 'completed' });
         // Clear agent todos — tasks are no longer relevant after turn ends


### PR DESCRIPTION
## Summary
- Stop emitting `context_usage` from `result.usage` in the agent runner — it's cumulative across all API calls in the agentic loop and overwrites accurate per-message token data
- Remove the corresponding frontend handler in `useWebSocket.ts` that consumed cumulative usage from result events
- Clean up stale comments that no longer matched the updated behavior

## Test plan
- [ ] Verify context meter updates correctly during streaming (per-message emissions still work)
- [ ] Verify context meter doesn't show inflated token counts at end of turn
- [ ] Verify context window size still updates from `modelUsage` in result events

🤖 Generated with [Claude Code](https://claude.com/claude-code)