### PR TITLE
Increase secondary sidebar tab tooltip delay to 500ms

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -842,7 +842,7 @@ const SortableTabButton = memo(function SortableTabButton({
   if (!shortcutDisplay) return button;
 
   return (
-    <Tooltip delayDuration={150}>
+    <Tooltip delayDuration={500}>
       <TooltipTrigger asChild>
         {button}
       </TooltipTrigger>


### PR DESCRIPTION
## Summary
- Increased tooltip `delayDuration` from 150ms to 500ms on the secondary sidebar tab buttons (Changes, Todos, etc.)
- The previous 150ms delay was too short, causing tooltips to appear too eagerly on hover

## Test plan
- [ ] Hover over secondary sidebar top tabs and verify tooltip appears after ~500ms
- [ ] Confirm tooltip still shows the correct keyboard shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)