### PR TITLE
Fix theme flickering in Pierre viewers on load

### DIFF
--- a/src/components/files/PierreDiffEditor.tsx
+++ b/src/components/files/PierreDiffEditor.tsx
@@ -5,7 +5,7 @@ import { FileDiff } from '@pierre/diffs/react';
 import type { FileContents, DiffLineAnnotation } from '@pierre/diffs/react';
 import type { FileDiffOptions, FileDiffMetadata, OnDiffLineClickProps } from '@pierre/diffs';
 import { parseDiffFromFile } from '@pierre/diffs';
-import { useTheme } from 'next-themes';
+import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
 import { FileCode, Rows, SplitSquareHorizontal, WrapText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -47,8 +47,7 @@ export const PierreDiffEditor = memo(function PierreDiffEditor({
   onCreateComment,
   scrollToLine,
 }: PierreDiffEditorProps) {
-  const { resolvedTheme } = useTheme();
-  const themeType = resolvedTheme === 'dark' ? 'dark' : 'light';
+  const themeType = useResolvedThemeType();
   const [activeCommentLine, setActiveCommentLine] = useState<number | null>(null);
   const [diffViewMode, setDiffViewMode] = useState<'split' | 'unified'>('unified');
   const [wordWrap, setWordWrap] = useState(false);

--- a/src/components/files/PierreEditor.tsx
+++ b/src/components/files/PierreEditor.tsx
@@ -3,7 +3,7 @@
 import { memo, useState, useMemo, useCallback } from 'react';
 import { File as PierreFile } from '@pierre/diffs/react';
 import type { FileContents, FileOptions } from '@pierre/diffs/react';
-import { useTheme } from 'next-themes';
+import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
 import { FileCode, Eye, WrapText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -45,8 +45,7 @@ export const PierreEditor = memo(function PierreEditor({
   filename,
   onToggleMarkdownView,
 }: PierreEditorProps) {
-  const { resolvedTheme } = useTheme();
-  const themeType = resolvedTheme === 'dark' ? 'dark' : 'light';
+  const themeType = useResolvedThemeType();
   const [showAll, setShowAll] = useState(false);
   const [wordWrap, setWordWrap] = useState(false);
 

--- a/src/hooks/useResolvedThemeType.ts
+++ b/src/hooks/useResolvedThemeType.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+
+/**
+ * Returns 'dark' | 'light' with a synchronous DOM fallback for the
+ * pre-hydration render where next-themes returns undefined.
+ *
+ * ThemeScript applies the 'dark' class to <html> synchronously in <head>,
+ * so document.documentElement.classList is always correct by the time
+ * any component renders.
+ */
+export function useResolvedThemeType(): 'dark' | 'light' {
+  const { resolvedTheme } = useTheme();
+
+  if (resolvedTheme === 'dark' || resolvedTheme === 'light') {
+    return resolvedTheme;
+  }
+
+  // Fallback: read the class that ThemeScript applied synchronously
+  if (typeof document !== 'undefined') {
+    return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+  }
+
+  return 'dark';
+}


### PR DESCRIPTION
## Summary
- `next-themes`' `useTheme()` returns `resolvedTheme = undefined` on the first render before hydration completes, causing Pierre to briefly render with its light theme before switching to dark — a subtle color flicker
- Added a `useResolvedThemeType` hook that falls back to reading the `dark` class from `document.documentElement` (set synchronously by `ThemeScript` in `<head>`) when `resolvedTheme` is still undefined
- Updated `PierreEditor` and `PierreDiffEditor` to use the new hook

## Test plan
- [ ] Set theme to dark, open a file viewer or diff viewer — should render dark from the first frame with no flicker
- [ ] Set theme to light, same test — no flicker
- [ ] Set theme to "system", toggle macOS appearance — Pierre should match immediately
- [ ] Verify no type errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)