### PR TITLE
Add Alt+M keyboard shortcut to cycle models

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -737,6 +737,14 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         e.preventDefault();
         plateInputRef.current?.focus();
       }
+      // Alt+M to cycle models
+      if (e.code === 'KeyM' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+        e.preventDefault();
+        setSelectedModel(prev => {
+          const idx = MODELS.findIndex(m => m.id === prev.id);
+          return MODELS[(idx + 1) % MODELS.length];
+        });
+      }
       // Alt+T to cycle thinking levels
       if (e.code === 'KeyT' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
@@ -1244,7 +1252,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           {/* Model Selector */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-7 gap-1.5 text-xs">
+              <Button variant="ghost" size="sm" className="h-7 gap-1.5 text-xs" title={`Model: ${selectedModel.name} (⌥M to cycle)`}>
                 <selectedModel.icon className="h-3.5 w-3.5" />
                 {selectedModel.name}
                 <ChevronDown className="h-3 w-3" />

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -182,6 +182,13 @@ export const SHORTCUTS: Shortcut[] = [
     category: 'Chat',
   },
   {
+    id: 'cycleModel',
+    key: 'm',
+    modifiers: ['alt'],
+    label: 'Cycle model',
+    category: 'Chat',
+  },
+  {
     id: 'togglePlanMode',
     key: 'Tab',
     modifiers: ['shift'],


### PR DESCRIPTION
## Summary
- Adds ⌥M (Alt+M) keyboard shortcut to cycle through available models in the chat input
- Registers the shortcut in the centralized shortcuts registry (`src/lib/shortcuts.ts`)
- Adds a tooltip to the model selector button showing the current model and shortcut hint

## Test plan
- [ ] Press ⌥M in the chat input — model selector should cycle through available models
- [ ] Verify the shortcut appears in the keyboard shortcuts dialog (⌘/)
- [ ] Hover over the model selector button — tooltip should show model name and ⌥M hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)