### PR TITLE
Fix session history popover content overflow

### DIFF
--- a/src/components/navigation/NavigationHistoryPopover.tsx
+++ b/src/components/navigation/NavigationHistoryPopover.tsx
@@ -5,7 +5,7 @@ import { useAppStore } from '@/stores/appStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { buildNavigationLabel, goToBackEntry, goToForwardEntry } from '@/lib/navigation';
-import { ScrollArea } from '@/components/ui/scroll-area';
+
 import {
   MessageSquare,
 
@@ -137,7 +137,7 @@ export function NavigationHistoryPopover({ onClose }: { onClose?: () => void }) 
   const reversedBack = [...backStack].reverse();
 
   return (
-    <ScrollArea className="max-h-80">
+    <div className="max-h-80 overflow-y-auto">
       <div className="py-1">
         {/* Forward entries (where you can go forward to) — oldest at top, newest near current */}
         {forwardStack.map((entry, i) => (
@@ -163,6 +163,6 @@ export function NavigationHistoryPopover({ onClose }: { onClose?: () => void }) 
           />
         ))}
       </div>
-    </ScrollArea>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced Radix `ScrollArea` with a native `div` using `max-h-80 overflow-y-auto` in the navigation history popover
- Radix ScrollArea's Viewport uses `height: 100%` which doesn't resolve against a parent's `max-height`, so scroll detection never engaged and content overflowed the popover bounds
- The native scroll approach matches the existing pattern used by `FileMentionMenu`

## Test plan
- [ ] Open the app and navigate between several views to build up history entries
- [ ] Click the History button (clock icon) in the sidebar toolbar
- [ ] Verify the popover is contained within its bounds and scrolls when content exceeds 320px
- [ ] Verify clicking history entries still navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)