### PR TITLE
Auto-scroll to Propose Plan block on plan approval

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -390,6 +390,25 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     }
   }, [clampedMatchIndex, searchQuery, searchMatches.total]);
 
+  // Scroll to the "Propose Plan" (ExitPlanMode) block when plan approval activates
+  const hasScrolledForPlanApprovalRef = useRef(false);
+
+  useEffect(() => {
+    if (selectedStreaming?.pendingPlanApproval) {
+      if (hasScrolledForPlanApprovalRef.current) return;
+      hasScrolledForPlanApprovalRef.current = true;
+
+      requestAnimationFrame(() => {
+        const el = document.querySelector('[data-tool-id="exit-plan-mode"]');
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      });
+    } else {
+      hasScrolledForPlanApprovalRef.current = false;
+    }
+  }, [selectedStreaming?.pendingPlanApproval]);
+
 // Filter tabs for current session only (strict session isolation)
   // All tabs are now session-scoped - no more workspace-level tabs
   const { visibleTabs, sessionTabs } = useMemo(() => {

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -366,6 +366,25 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
                   worktreePath={worktreePath}
                 />
               );
+            } else if (item.tool === 'ExitPlanMode') {
+              return (
+                <div key={item.id} data-tool-id="exit-plan-mode">
+                  <ToolUsageBlock
+                    id={item.id}
+                    tool={item.tool}
+                    params={item.params}
+                    worktreePath={worktreePath}
+                    isActive={!item.endTime}
+                    success={item.success}
+                    summary={item.summary}
+                    duration={item.endTime ? item.endTime - item.startTime : undefined}
+                    stdout={item.stdout}
+                    stderr={item.stderr}
+                    elapsedSeconds={item.elapsedSeconds}
+                    metadata={item.metadata}
+                  />
+                </div>
+              );
             } else {
               return (
                 <ToolUsageBlock


### PR DESCRIPTION
## Summary
- When the agent proposes a plan (ExitPlanMode), the conversation area now auto-scrolls so the "Propose Plan" tool block appears at the top of the viewport
- Adds a `data-tool-id="exit-plan-mode"` DOM anchor to the ExitPlanMode tool block in `StreamingMessage`
- Adds a `useEffect` in `ConversationArea` that triggers `scrollIntoView` when `pendingPlanApproval` activates, following the existing search-match scroll pattern

## Test plan
- [ ] Start a conversation in plan mode
- [ ] Let the agent work until it calls ExitPlanMode (proposes a plan)
- [ ] Verify the conversation area scrolls so the "Propose Plan" block is at the top of the viewport
- [ ] Verify plan content is visible below and the approval bar appears at the bottom
- [ ] Test with a long plan that extends beyond the viewport
- [ ] Approve or reject and verify no stale scroll on the next proposal cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)