### PR TITLE
Fix Cmd+N shortcut not loading conversations before navigating

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -711,20 +711,44 @@ export default function Home() {
         }
       }
 
-      // Add to store and select
+      // Add to store
       addSession(mapSessionDTO(newSession));
-      // Note: no conversationId needed — navigate() calls selectSession() which
-      // auto-selects the first conversation for the session as a side effect.
+
+      // Fetch conversations created by backend so ConversationArea can render.
+      // Without this, selectSession() finds no conversations and leaves
+      // selectedConversationId null, showing the "Preparing session" spinner.
+      let firstConvId: string | null = null;
+      try {
+        const conversations = await listConversations(selectedWorkspaceId, newSession.id);
+        conversations.forEach((conv) => {
+          if (!firstConvId) firstConvId = conv.id;
+          addConversation({
+            id: conv.id,
+            sessionId: conv.sessionId,
+            type: conv.type,
+            name: conv.name,
+            status: conv.status,
+            messages: [],
+            toolSummary: conv.toolSummary,
+            createdAt: conv.createdAt,
+            updatedAt: conv.updatedAt,
+          });
+        });
+      } catch (error) {
+        console.error('Failed to load conversations for new session:', error);
+      }
+
       navigate({
         workspaceId: newSession.workspaceId,
         sessionId: newSession.id,
+        conversationId: firstConvId ?? undefined,
         contentView: { type: 'conversation' },
       });
     } catch (error) {
       console.error('Failed to create session:', error);
       showError(error instanceof Error ? error.message : 'Failed to create session. Please try again.', 'Session Error');
     }
-  }, [selectedWorkspaceId, workspaces, addSession, showError]);
+  }, [selectedWorkspaceId, workspaces, addSession, addConversation, showError]);
 
   const handleNewConversation = useCallback(async () => {
     if (!selectedWorkspaceId || !selectedSessionId) return;


### PR DESCRIPTION
## Summary
- The `handleNewSession` in `page.tsx` (used by **Cmd+N** and the **command palette**) was creating a session via the API but never loading its conversations into the store before navigating
- This caused `selectSession()` to find zero conversations, leaving `selectedConversationId` null and showing the "Preparing session" spinner instead of the ready-to-use conversation view
- Added the same conversation-loading step that the sidebar's `handleCreateSession` already uses — call `listConversations()` and `addConversation()` before navigating, and pass `conversationId` explicitly

## Test plan
- [ ] Press **Cmd+N** → session is created → conversation view with chat input appears (not "Preparing session..." spinner)
- [ ] Click the sidebar **+** button → same result as before (no regression)
- [ ] Open command palette (**Cmd+K**) → select "New Session" → same result as Cmd+N
- [ ] If `listConversations` fails (e.g. network error), navigate still runs gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)