### PR TITLE
Change user bubble to purple in dark mode

### DIFF
--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -133,7 +133,7 @@ export const MessageBlock = memo(function MessageBlock({
   if (message.role === 'user') {
     return (
       <div className={cn('py-2 flex justify-end', !isFirst && 'pt-3')}>
-        <div className="bg-surface-2 dark:bg-[#090909] rounded-lg px-4 py-2.5">
+        <div className="bg-surface-2 dark:bg-[#2D1B4E] rounded-lg px-4 py-2.5">
           {message.attachments && message.attachments.length > 0 && (
             <>
               <AttachmentGrid

--- a/src/components/conversation/QueuedMessageBubble.tsx
+++ b/src/components/conversation/QueuedMessageBubble.tsx
@@ -16,7 +16,7 @@ export function QueuedMessageBubble({ message }: QueuedMessageBubbleProps) {
 
   return (
     <div className="py-2 flex justify-end">
-      <div className="bg-surface-2 dark:bg-[#090909] rounded-lg px-4 py-2.5 opacity-70">
+      <div className="bg-surface-2 dark:bg-[#2D1B4E] rounded-lg px-4 py-2.5 opacity-70">
         {message.attachments && message.attachments.length > 0 && (
           <>
             <AttachmentGrid


### PR DESCRIPTION
## Summary
- The user message bubble in dark mode used `#090909` (near-black), making it barely visible against the dark background (`#0f1111`)
- Changed dark mode background to `#2D1B4E` (dark purple) for better contrast
- Light mode styling remains unchanged

## Test plan
- [ ] Open the app in dark mode and verify user message bubbles are visibly purple
- [ ] Switch to light mode and verify bubbles remain unchanged
- [ ] Send a queued message and verify it also shows the purple background in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)