### PR TITLE
Fix plan approval scroll targeting wrong element

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -399,7 +399,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
       hasScrolledForPlanApprovalRef.current = true;
 
       requestAnimationFrame(() => {
-        const el = document.querySelector('[data-tool-id="exit-plan-mode"]');
+        const el = document.querySelector('[data-plan-id="pending-plan"]');
         if (el) {
           el.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -337,7 +337,7 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
             } else if (item.type === 'plan') {
               const isPending = item.id === 'pending-plan';
               return isPending ? (
-                <div key={item.id} className={PROSE_CLASSES}>
+                <div key={item.id} data-plan-id="pending-plan" className={PROSE_CLASSES}>
                   <CachedMarkdown
                     cacheKey={`plan:${item.id}`}
                     content={item.content}


### PR DESCRIPTION
## Summary
- Adds a `data-plan-id="pending-plan"` attribute to the pending plan div in `StreamingMessage`
- Updates `ConversationArea` to query this attribute instead of `data-tool-id="exit-plan-mode"`, which may not exist in the DOM
- Ensures auto-scroll reliably targets the plan content block when plan approval activates

## Test plan
- [ ] Trigger a plan approval flow and verify the view auto-scrolls to the plan content at the top of the viewport
- [ ] Verify non-pending (approved) plans are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)