### PR TITLE
Improve All/Uncommitted toggle visibility in Changes panel

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -1297,7 +1297,7 @@ export function ChangesFileList({
             onClick={() => onChangesViewChange('all')}
             className={cn(
               "px-1.5 py-0.5 rounded-sm text-2xs transition-colors",
-              changesView === 'all' ? "bg-surface-3 text-foreground" : "text-muted-foreground hover:text-foreground"
+              changesView === 'all' ? "bg-accent/30 text-foreground font-medium" : "text-muted-foreground hover:text-foreground"
             )}
           >
             All
@@ -1306,7 +1306,7 @@ export function ChangesFileList({
             onClick={() => onChangesViewChange('uncommitted')}
             className={cn(
               "px-1.5 py-0.5 rounded-sm text-2xs transition-colors",
-              changesView === 'uncommitted' ? "bg-surface-3 text-foreground" : "text-muted-foreground hover:text-foreground"
+              changesView === 'uncommitted' ? "bg-accent/30 text-foreground font-medium" : "text-muted-foreground hover:text-foreground"
             )}
           >
             Uncommitted


### PR DESCRIPTION
## Summary
- Replace `bg-surface-3` with `bg-accent/30` and add `font-medium` for the selected state of the All/Uncommitted toggle
- Matches the existing `TabsTrigger` active-state pattern used elsewhere in the project
- The accent color's chrominance provides clear distinction from the neutral `surface-2` container in both light and dark mode

## Test plan
- [ ] Toggle between "All" and "Uncommitted" — selected state should show a visible tinted background
- [ ] Verify in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)