### PR TITLE
Restore missing unread indicator dot in sidebar

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1396,13 +1396,20 @@ function SessionRow({
       <ContextMenuTrigger asChild>
         <div
           className={cn(
-            'group flex flex-row items-center px-2 py-2 rounded-md cursor-pointer my-0.5',
+            'group flex flex-row items-center py-2 rounded-md cursor-pointer my-0.5',
+            isSessionUnread && !isSessionSelected ? 'pl-1 pr-2' : 'px-2',
             isSessionSelected
               ? 'bg-surface-2 hover:bg-surface-3'
               : 'hover:bg-surface-1'
           )}
           onClick={(e) => onSelectSession(session.id, e)}
         >
+          {/* Unread indicator on the left edge */}
+          {isSessionUnread && !isSessionSelected && (
+            <div className="w-2 shrink-0 flex items-center justify-center mr-1">
+              <div className="w-1.5 h-1.5 rounded-full bg-primary" />
+            </div>
+          )}
           {/* Content column */}
           <div className="flex flex-col flex-1 min-w-0">
           {/* First line: status icon + branch name + stats/actions */}


### PR DESCRIPTION
## Summary
- Re-added the colored unread indicator dot on the left edge of session cells in the sidebar, which was accidentally removed in a previous commit
- Added conditional left padding so the dot fits without shifting layout

## Test plan
- [ ] Open the app with multiple sessions
- [ ] Navigate away from a session that receives new messages
- [ ] Verify the unread session shows a colored dot on the left edge and bold text
- [ ] Navigate to the unread session and verify the dot and bold text clear
- [ ] Verify selected sessions never show the dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)