### PR TITLE
Show context utilization as percentage instead of token count

### DIFF
--- a/src/components/conversation/ContextMeter.tsx
+++ b/src/components/conversation/ContextMeter.tsx
@@ -65,7 +65,7 @@ export function ContextMeter({ conversationId }: ContextMeterProps) {
             'hover:bg-accent/50 transition-colors cursor-default',
             colorClass
           )}
-          aria-label={`Context usage: ${formatTokenCount(used)} of ${formatTokenCount(maxTokens)} tokens`}
+          aria-label={`Context usage: ${Math.round(percentage)}% (${formatTokenCount(used)} of ${formatTokenCount(maxTokens)} tokens)`}
         >
           <svg className="h-3.5 w-3.5" viewBox="0 0 18 18">
             <circle
@@ -89,7 +89,7 @@ export function ContextMeter({ conversationId }: ContextMeterProps) {
               transform="rotate(-90 9 9)"
             />
           </svg>
-          <span className="tabular-nums">{formatTokenCount(used)}</span>
+          <span className="tabular-nums">{Math.round(percentage)}%</span>
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" side="top" className="w-64 p-3">

--- a/src/components/conversation/__tests__/ContextMeter.test.tsx
+++ b/src/components/conversation/__tests__/ContextMeter.test.tsx
@@ -98,31 +98,34 @@ describe('ContextMeter', () => {
   });
 
   // ==========================================================================
-  // Token formatting
+  // Percentage display
   // ==========================================================================
 
-  it('formats large tokens with "k" notation', () => {
+  it('displays percentage for normal usage', () => {
     useAppStore.setState({
       contextUsage: { [CONV_ID]: makeContextUsage({ inputTokens: 70400 }) },
     });
     render(<ContextMeter conversationId={CONV_ID} />);
-    expect(screen.getByText('70.4k')).toBeInTheDocument();
+    // 70400/200000 = 35.2% → rounds to 35%
+    expect(screen.getByText('35%')).toBeInTheDocument();
   });
 
-  it('displays small token counts as raw numbers', () => {
+  it('displays 0% for very small usage', () => {
     useAppStore.setState({
       contextUsage: { [CONV_ID]: makeContextUsage({ inputTokens: 500 }) },
     });
     render(<ContextMeter conversationId={CONV_ID} />);
-    expect(screen.getByText('500')).toBeInTheDocument();
+    // 500/200000 = 0.25% → rounds to 0%
+    expect(screen.getByText('0%')).toBeInTheDocument();
   });
 
-  it('formats 1000 tokens as "1.0k"', () => {
+  it('rounds percentage correctly for small usage', () => {
     useAppStore.setState({
       contextUsage: { [CONV_ID]: makeContextUsage({ inputTokens: 1000 }) },
     });
     render(<ContextMeter conversationId={CONV_ID} />);
-    expect(screen.getByText('1.0k')).toBeInTheDocument();
+    // 1000/200000 = 0.5% → rounds to 1%
+    expect(screen.getByText('1%')).toBeInTheDocument();
   });
 
   // ==========================================================================
@@ -330,7 +333,7 @@ describe('ContextMeter', () => {
   // Cache-inclusive context utilization
   // ==========================================================================
 
-  it('displays sum of all input token types', () => {
+  it('caps percentage label at 100% when tokens exceed context window', () => {
     useAppStore.setState({
       contextUsage: {
         [CONV_ID]: makeContextUsage({
@@ -341,8 +344,8 @@ describe('ContextMeter', () => {
       },
     });
     render(<ContextMeter conversationId={CONV_ID} />);
-    // Total: 10 + 800000 + 3000 = 803010 -> 803.0k
-    expect(screen.getByText('803.0k')).toBeInTheDocument();
+    // Total: 10 + 800000 + 3000 = 803010, exceeds 200000 → capped at 100%
+    expect(screen.getByText('100%')).toBeInTheDocument();
   });
 
   it('shows popover header with total input tokens including cache', () => {
@@ -389,7 +392,8 @@ describe('ContextMeter', () => {
     });
     render(<ContextMeter conversationId={CONV_ID} />);
     const button = screen.getByRole('button');
-    expect(button).toHaveAttribute('aria-label', 'Context usage: 105.0k of 200.0k tokens');
+    // 105010/200000 = 52.505% → rounds to 53%
+    expect(button).toHaveAttribute('aria-label', 'Context usage: 53% (105.0k of 200.0k tokens)');
   });
 
   it('caps percentage at 100% when total tokens exceed contextWindow', () => {


### PR DESCRIPTION
## Summary
- Changed the Context Meter label in the compose toolbar from raw token count (e.g., "70.4k") to percentage (e.g., "35%") for at-a-glance feedback on context window utilization
- Updated aria-label to lead with percentage while retaining token details for accessibility
- Verified token calculation is correct per Anthropic API: `inputTokens + cacheReadInputTokens + cacheCreationInputTokens` are additive (not overlapping), and per-message usage is the right source for context size
- Color thresholds (80% amber, 95% red) confirmed appropriate for compaction warnings

## Test plan
- [x] All 28 ContextMeter tests pass with updated assertions
- [ ] Visually verify compose toolbar shows percentage (e.g., "35%") instead of token count
- [ ] Click the meter to confirm popover still shows detailed token breakdown
- [ ] Verify color transitions: default → amber at 80% → red at 95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)