### PR TITLE
Fix unread dot positioning to prevent content shift in sidebar

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1396,19 +1396,17 @@ function SessionRow({
       <ContextMenuTrigger asChild>
         <div
           className={cn(
-            'group flex flex-row items-center py-2 rounded-md cursor-pointer my-0.5',
-            isSessionUnread && !isSessionSelected ? 'pl-1 pr-2' : 'px-2',
+            'group relative flex flex-row items-center py-2 rounded-md cursor-pointer my-0.5',
+            'px-2',
             isSessionSelected
               ? 'bg-surface-2 hover:bg-surface-3'
               : 'hover:bg-surface-1'
           )}
           onClick={(e) => onSelectSession(session.id, e)}
         >
-          {/* Unread indicator on the left edge */}
+          {/* Unread indicator dot — absolutely positioned in left padding area */}
           {isSessionUnread && !isSessionSelected && (
-            <div className="w-2 shrink-0 flex items-center justify-center mr-1">
-              <div className="w-1.5 h-1.5 rounded-full bg-primary" />
-            </div>
+            <div className="absolute left-0.5 top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full bg-primary" />
           )}
           {/* Content column */}
           <div className="flex flex-col flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- Position the unread indicator dot absolutely within the session cell's left padding area instead of as an inline flex child
- Remove conditional padding (`pl-1 pr-2` vs `px-2`) that caused layout shift when the dot appeared/disappeared
- Content now stays in the exact same position whether the dot is visible or not

## Test plan
- [ ] Trigger unread state on a background session (let an agent complete while viewing a different session)
- [ ] Verify the blue dot appears in the left padding area of the unread session row
- [ ] Click the unread session — dot disappears, content remains in the exact same position (no shift)
- [ ] Verify the dot is vertically centered relative to the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)