### PR TITLE
Fix auto-scroll during plan approval and markdown rendering

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -390,23 +390,50 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     }
   }, [clampedMatchIndex, searchQuery, searchMatches.total]);
 
-  // Scroll to the "Propose Plan" (ExitPlanMode) block when plan approval activates
+  // Scroll to the plan content when plan approval activates.
+  // Uses Virtuoso's own scroll container (via getScrollerElement) instead of native
+  // scrollIntoView to avoid desyncing Virtuoso's internal scroll tracking, which
+  // causes blank rendering areas. Also suppresses followOutput via pendingPlanApproval
+  // prop to prevent auto-scroll-to-bottom from fighting the plan scroll.
   const hasScrolledForPlanApprovalRef = useRef(false);
 
   useEffect(() => {
+    let outerRaf: number | undefined;
+    let innerRaf: number | undefined;
+
     if (selectedStreaming?.pendingPlanApproval) {
       if (hasScrolledForPlanApprovalRef.current) return;
       hasScrolledForPlanApprovalRef.current = true;
 
-      requestAnimationFrame(() => {
-        const el = document.querySelector('[data-plan-id="pending-plan"]');
-        if (el) {
-          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
+      // Double rAF: first lets React commit the DOM, second lets Virtuoso
+      // measure and lay out the footer content.
+      outerRaf = requestAnimationFrame(() => {
+        innerRaf = requestAnimationFrame(() => {
+          const scrollerEl = messageListRef.current?.getScrollerElement();
+          if (!scrollerEl) return;
+
+          const planEl = scrollerEl.querySelector('[data-plan-id="pending-plan"]');
+          if (!planEl) return;
+
+          const OFFSET_PX = 16;
+          const planRect = planEl.getBoundingClientRect();
+          const scrollerRect = scrollerEl.getBoundingClientRect();
+          const planTopInScroller = planRect.top - scrollerRect.top + scrollerEl.scrollTop;
+
+          scrollerEl.scrollTo({
+            top: planTopInScroller - OFFSET_PX,
+            behavior: 'smooth',
+          });
+        });
       });
     } else {
       hasScrolledForPlanApprovalRef.current = false;
     }
+
+    return () => {
+      if (outerRaf !== undefined) cancelAnimationFrame(outerRaf);
+      if (innerRaf !== undefined) cancelAnimationFrame(innerRaf);
+    };
   }, [selectedStreaming?.pendingPlanApproval]);
 
 // Filter tabs for current session only (strict session isolation)
@@ -1120,6 +1147,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
             }
             footer={messageListFooter}
             isStreaming={selectedStreaming?.isStreaming ?? false}
+            pendingPlanApproval={!!selectedStreaming?.pendingPlanApproval}
           />
           {/* Fade overlay at bottom of messages */}
           <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-chat-background to-transparent pointer-events-none z-10" />

--- a/src/components/conversation/VirtualizedMessageList.tsx
+++ b/src/components/conversation/VirtualizedMessageList.tsx
@@ -13,6 +13,7 @@ const INITIAL_FIRST_ITEM_INDEX = 100_000;
 export interface VirtualizedMessageListHandle {
   scrollToIndex: (index: number, options?: { align?: 'start' | 'center' | 'end'; behavior?: 'smooth' | 'auto' }) => void;
   scrollToBottom: (behavior?: 'smooth' | 'auto') => void;
+  getScrollerElement: () => HTMLElement | null;
 }
 
 interface VirtualizedMessageListProps {
@@ -34,6 +35,8 @@ interface VirtualizedMessageListProps {
   initialTopMostItemIndex?: number | { index: number | 'LAST'; align?: 'start' | 'center' | 'end' };
   /** Called when the visible range changes — use to track scroll position for persistence */
   onRangeChanged?: (range: ListRange) => void;
+  /** When true, suppress followOutput to prevent auto-scroll-to-bottom from fighting plan scroll */
+  pendingPlanApproval?: boolean;
 }
 
 export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, VirtualizedMessageListProps>(
@@ -54,10 +57,16 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
       isStreaming,
       initialTopMostItemIndex,
       onRangeChanged,
+      pendingPlanApproval,
     },
     ref
   ) {
     const virtuosoRef = useRef<VirtuosoHandle>(null);
+    const scrollerElRef = useRef<HTMLElement | null>(null);
+
+    const scrollerRefCallback = useCallback((el: HTMLElement | Window | null) => {
+      scrollerElRef.current = el instanceof HTMLElement ? el : null;
+    }, []);
 
     useImperativeHandle(ref, () => ({
       scrollToIndex(index, options) {
@@ -73,6 +82,9 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
           align: 'end',
           behavior,
         });
+      },
+      getScrollerElement() {
+        return scrollerElRef.current;
       },
     }));
 
@@ -101,12 +113,15 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
     // Determine follow output behavior: auto-scroll when at bottom.
     // During streaming, use instant scroll to prevent bounce caused by
     // smooth scrolling + rapid dynamic height changes (react-virtuoso #317).
+    // When plan approval is pending, suppress auto-scroll so it doesn't fight
+    // the plan-top scroll position.
     const followOutput = useCallback(
       (isAtBottom: boolean) => {
+        if (pendingPlanApproval) return false as const;
         if (isAtBottom) return isStreaming ? true as const : 'smooth' as const;
         return false as const;
       },
-      [isStreaming]
+      [isStreaming, pendingPlanApproval]
     );
 
     // Footer component: streaming message + padding
@@ -151,6 +166,7 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
     return (
       <Virtuoso
         ref={virtuosoRef}
+        scrollerRef={scrollerRefCallback}
         data={messages}
         firstItemIndex={firstItemIndex ?? INITIAL_FIRST_ITEM_INDEX}
         initialTopMostItemIndex={resolvedInitialIndex}


### PR DESCRIPTION
## Summary
- Use Virtuoso's own scroll container (`getScrollerElement`) instead of native `scrollIntoView` to prevent desyncing Virtuoso's internal scroll tracking, which causes blank rendering areas
- Suppress `followOutput` during plan approval so auto-scroll-to-bottom doesn't fight the plan scroll position
- Add proper `cancelAnimationFrame` cleanup to prevent stale callbacks on unmount or rapid toggling

## Test plan
- [ ] Trigger plan approval in the UI — verify it scrolls to the plan block smoothly
- [ ] Rapidly approve/reject a plan to exercise the cleanup path
- [ ] Verify normal streaming auto-scroll still works when no plan is pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)