### PR TITLE
Fix GitHub Repos dialog scrolling overflow

### DIFF
--- a/src/components/dialogs/GitHubReposDialog.tsx
+++ b/src/components/dialogs/GitHubReposDialog.tsx
@@ -343,9 +343,9 @@ export function GitHubReposDialog({
           </div>
         ) : (
           // Authenticated state
-          <>
+          <div className="flex-1 min-h-0 flex flex-col gap-4 overflow-hidden">
             {/* Search + Org filter */}
-            <div className="flex gap-2">
+            <div className="flex gap-2 shrink-0">
               <div className="relative flex-1">
                 <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
                 <Input
@@ -452,7 +452,7 @@ export function GitHubReposDialog({
             </ScrollArea>
 
             {/* Clone location */}
-            <div className="space-y-2 pt-1">
+            <div className="space-y-2 pt-1 shrink-0">
               <label htmlFor="gh-clone-location" className="text-sm font-medium">
                 Clone to
               </label>
@@ -477,9 +477,9 @@ export function GitHubReposDialog({
             </div>
 
             {cloneError && (
-              <p className="text-sm text-destructive">{cloneError}</p>
+              <p className="text-sm text-destructive shrink-0">{cloneError}</p>
             )}
-          </>
+          </div>
         )}
 
         <DialogFooter>


### PR DESCRIPTION
## Summary
- Fixed the GitHub Repositories dialog where the repo list overflowed past the dialog bounds, pushing the "Clone to" section and footer buttons out of view
- Replaced the React fragment (`<>`) wrapper with a proper flex container `<div>` so the `ScrollArea` gets a constrained height and scrolls internally
- Added `shrink-0` to fixed-height elements (search bar, clone location, error message) to prevent them from being compressed

## Test plan
- [ ] Open the GitHub Repositories dialog
- [ ] Verify the repo list scrolls within the dialog bounds
- [ ] Verify the "Clone to" section and Cancel/Clone buttons remain visible at the bottom
- [ ] Verify the search bar stays fixed at the top
- [ ] Test "Load more" pagination within the scroll area

🤖 Generated with [Claude Code](https://claude.com/claude-code)