### PR TITLE
Fix Maximum update depth exceeded error in MainToolbar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
   useMessages,
 } from '@/stores/selectors';
 import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix } from '@/stores/settingsStore';
+import { useShallow } from 'zustand/react/shallow';
 import { navigate } from '@/lib/navigation';
 import { ENABLE_BROWSER_TABS } from '@/lib/constants';
 import { useTabStore } from '@/stores/tabStore';
@@ -228,7 +229,19 @@ export default function Home() {
     layoutInner, setLayoutInner,
     layoutVertical, setLayoutVertical,
     resetLayouts,
-  } = useSettingsStore();
+  } = useSettingsStore(useShallow((s) => ({
+    showBottomTerminal: s.showBottomTerminal,
+    setShowBottomTerminal: s.setShowBottomTerminal,
+    zenMode: s.zenMode,
+    setZenMode: s.setZenMode,
+    layoutOuter: s.layoutOuter,
+    setLayoutOuter: s.setLayoutOuter,
+    layoutInner: s.layoutInner,
+    setLayoutInner: s.setLayoutInner,
+    layoutVertical: s.layoutVertical,
+    setLayoutVertical: s.setLayoutVertical,
+    resetLayouts: s.resetLayouts,
+  })));
 
   const toggleBottomTerminal = useCallback(() => {
     setShowBottomTerminal(!showBottomTerminal);

--- a/src/components/layout/MainToolbar.tsx
+++ b/src/components/layout/MainToolbar.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { PanelLeft, PanelRight, PanelBottom, Plus } from 'lucide-react';
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { useUIStore, type ToolbarSlots } from '@/stores/uiStore';
 import { useTabStore } from '@/stores/tabStore';
@@ -104,18 +104,22 @@ export function MainToolbar({
   onOpenShortcuts,
 }: MainToolbarProps) {
   const toolbarConfig = useUIStore((s) => s.toolbarConfig);
-  const setTabTitle = useUIStore((s) => s.setTabTitle);
   const activeTabId = useTabStore((s) => s.activeTabId);
   const tabCount = useTabStore((s) => s.tabOrder.length);
   const hasMultipleTabs = ENABLE_BROWSER_TABS && tabCount > 1;
 
-  // Cache the active tab's rich toolbar title whenever it changes
+  // Cache the active tab's rich toolbar title whenever toolbarConfig changes.
+  // Use a ref to track the title and only update the store when the config
+  // reference actually changes (driven by the caller's useMemo), avoiding
+  // cascading store updates from ReactNode reference instability.
   const toolbarTitle = toolbarConfig?.title;
+  const prevTitleRef = useRef<ReactNode>(null);
   useEffect(() => {
-    if (ENABLE_BROWSER_TABS && toolbarTitle && activeTabId) {
-      setTabTitle(activeTabId, toolbarTitle);
+    if (ENABLE_BROWSER_TABS && toolbarTitle && activeTabId && prevTitleRef.current !== toolbarTitle) {
+      prevTitleRef.current = toolbarTitle;
+      useUIStore.getState().setTabTitle(activeTabId, toolbarTitle);
     }
-  }, [toolbarTitle, activeTabId, setTabTitle]);
+  }, [toolbarTitle, activeTabId]);
 
   return (
     <div className="shrink-0">

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
+import { createContext, useContext, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -77,8 +77,15 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     [addToast]
   );
 
+  // Memoize the context value so consumers that only use the action functions
+  // (error, success, etc.) don't re-render when the toasts array changes.
+  const contextValue = useMemo(
+    () => ({ toasts, addToast, removeToast, error, success, info, warning }),
+    [toasts, addToast, removeToast, error, success, info, warning]
+  );
+
   return (
-    <ToastContext.Provider value={{ toasts, addToast, removeToast, error, success, info, warning }}>
+    <ToastContext.Provider value={contextValue}>
       {children}
       <Toaster />
     </ToastContext.Provider>

--- a/src/hooks/useMainToolbarContent.ts
+++ b/src/hooks/useMainToolbarContent.ts
@@ -1,9 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useUIStore, type ToolbarConfig } from '@/stores/uiStore';
 
 /**
  * Sets the MainToolbar's dynamic content (Flutter AppBar-style).
- * Config is applied on mount and cleared on unmount.
+ * Config is applied on mount / update and cleared on unmount.
  *
  * @example
  * useMainToolbarContent({
@@ -14,10 +14,20 @@ import { useUIStore, type ToolbarConfig } from '@/stores/uiStore';
  * });
  */
 export function useMainToolbarContent(config: ToolbarConfig) {
-  const setToolbarConfig = useUIStore((s) => s.setToolbarConfig);
+  const configRef = useRef(config);
 
   useEffect(() => {
-    setToolbarConfig(config);
-    return () => setToolbarConfig(null);
-  }, [config, setToolbarConfig]);
+    configRef.current = config;
+  });
+
+  // Apply on mount and clear on unmount
+  useEffect(() => {
+    useUIStore.getState().setToolbarConfig(configRef.current);
+    return () => useUIStore.getState().setToolbarConfig(null);
+  }, []);
+
+  // Sync config updates when the caller's memoized config changes
+  useEffect(() => {
+    useUIStore.getState().setToolbarConfig(config);
+  }, [config]);
 }


### PR DESCRIPTION
## Summary
- Fix "Maximum update depth exceeded" React error in MainToolbar caused by cascading Zustand store updates
- Replace bare `useSettingsStore()` in Home with `useShallow` selector to prevent unnecessary full-tree re-renders
- Guard `setTabTitle` effect and `useMainToolbarContent` hook against no-op store writes from unstable ReactNode references
- Memoize `ToastContext.Provider` value to stop all `useToast()` consumers re-rendering on parent renders

## Test plan
- [ ] Verify no "Maximum update depth exceeded" error in console on app load
- [ ] Verify toolbar content (workspace name, session name, branch) renders correctly
- [ ] Verify tab titles update when switching sessions in multi-tab mode
- [ ] Verify toast notifications still appear and disappear correctly
- [ ] Verify settings changes (zen mode, theme, bottom terminal toggle) still work
- [ ] Verify no regressions in sidebar panel toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)