### PR TITLE
Add MCP tools for explicit PR lifecycle reporting

### DIFF
--- a/agent-runner/src/mcp/server.ts
+++ b/agent-runner/src/mcp/server.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { WorkspaceContext } from "./context.js";
 import { createLinearTools } from "./tools/linear.js";
 import { createCommentTools } from "./tools/comments.js";
+import { createPRTools } from "./tools/pr.js";
 import { createScriptTools } from "./tools/scripts.js";
 
 const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://localhost:9876";
@@ -275,6 +276,9 @@ export function createChatMLMcpServer(options: McpServerOptions) {
 
       // Review comment tools
       ...createCommentTools(context),
+
+      // PR lifecycle tools
+      ...createPRTools(context),
 
       // Script config tools
       ...createScriptTools(context),

--- a/agent-runner/src/mcp/tools/pr.ts
+++ b/agent-runner/src/mcp/tools/pr.ts
@@ -1,0 +1,123 @@
+// agent-runner/src/mcp/tools/pr.ts
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import type { WorkspaceContext } from "../context.js";
+
+const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://localhost:9876";
+const AUTH_TOKEN = process.env.CHATML_AUTH_TOKEN || "";
+
+// Matches GitHub PR URLs: https://github.com/owner/repo/pull/123
+const PR_URL_PATTERN = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/;
+
+function buildHeaders(json = false): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (json) headers["Content-Type"] = "application/json";
+  if (AUTH_TOKEN) headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
+  return headers;
+}
+
+export function createPRTools(context: WorkspaceContext) {
+  return [
+    tool(
+      "report_pr_created",
+      "Report that a pull request was created for this session. Call this AFTER successfully creating a PR with `gh pr create` or any other method. This ensures the PR is immediately tracked in the ChatML UI.",
+      {
+        prNumber: z.number().int().positive().describe("The PR number (e.g., 123)"),
+        prUrl: z.string().describe("The full PR URL (e.g., https://github.com/owner/repo/pull/123)"),
+      },
+      async ({ prNumber, prUrl }) => {
+        if (!PR_URL_PATTERN.test(prUrl)) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: `Invalid PR URL: expected a GitHub PR URL like https://github.com/owner/repo/pull/123, got: ${prUrl}`,
+            }],
+          };
+        }
+
+        try {
+          const response = await fetch(
+            `${BACKEND_URL}/api/repos/${context.workspaceId}/sessions/${context.sessionId}/pr/report`,
+            {
+              method: "POST",
+              headers: buildHeaders(true),
+              body: JSON.stringify({ prNumber, prUrl }),
+            }
+          );
+
+          if (!response.ok) {
+            const error = await response.text();
+            return {
+              content: [{
+                type: "text" as const,
+                text: `Failed to report PR: ${response.status} ${error}`,
+              }],
+            };
+          }
+
+          return {
+            content: [{
+              type: "text" as const,
+              text: `Reported PR #${prNumber} to ChatML. The PR badge will appear in the sidebar.`,
+            }],
+          };
+        } catch (error) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: `Error reporting PR: ${error}`,
+            }],
+          };
+        }
+      },
+      { annotations: { readOnlyHint: false } }
+    ),
+
+    tool(
+      "report_pr_merged",
+      "Report that a pull request was merged for this session. Call this AFTER successfully merging a PR with `gh pr merge` or any other method. This updates the session status in ChatML.",
+      {
+        prNumber: z.number().int().positive().optional().describe("The PR number that was merged (optional if the session already has a PR associated)"),
+      },
+      async ({ prNumber }) => {
+        try {
+          const response = await fetch(
+            `${BACKEND_URL}/api/repos/${context.workspaceId}/sessions/${context.sessionId}/pr/report-merge`,
+            {
+              method: "POST",
+              headers: buildHeaders(true),
+              body: JSON.stringify({ prNumber }),
+            }
+          );
+
+          if (!response.ok) {
+            const error = await response.text();
+            return {
+              content: [{
+                type: "text" as const,
+                text: `Failed to report PR merge: ${response.status} ${error}`,
+              }],
+            };
+          }
+
+          return {
+            content: [{
+              type: "text" as const,
+              text: prNumber
+                ? `Reported PR #${prNumber} merge to ChatML. Session status will update shortly.`
+                : `Reported PR merge to ChatML. Session status will update shortly.`,
+            }],
+          };
+        } catch (error) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: `Error reporting PR merge: ${error}`,
+            }],
+          };
+        }
+      },
+      { annotations: { readOnlyHint: false } }
+    ),
+  ];
+}

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -739,7 +739,10 @@ outer:
 						}
 
 						if prNum > 0 && m.onPRCreated != nil {
-							conv, _ := m.store.GetConversationMeta(ctx, convID)
+							conv, convErr := m.store.GetConversationMeta(ctx, convID)
+							if convErr != nil {
+								logger.Manager.Warnf("Failed to get conversation %s for PR creation detection: %v", convID, convErr)
+							}
 							if conv != nil {
 								go m.onPRCreated(conv.SessionID, prNum, prURL)
 								prDeferredRecheck = m.onPRCreated
@@ -754,7 +757,10 @@ outer:
 				// Detect PR merge from Bash tool stdout (e.g., gh pr merge)
 				if event.Tool == "Bash" && event.Success && prMergedPattern.MatchString(event.Stdout) {
 					if m.onPRMerged != nil {
-						conv, _ := m.store.GetConversationMeta(ctx, convID)
+						conv, convErr := m.store.GetConversationMeta(ctx, convID)
+						if convErr != nil {
+							logger.Manager.Warnf("Failed to get conversation %s for PR merge detection: %v", convID, convErr)
+						}
 						if conv != nil {
 							go m.onPRMerged(conv.SessionID)
 							mergeHandler := m.onPRMerged
@@ -775,7 +781,10 @@ outer:
 				// trigger an immediate PR check to pick up externally-created PRs.
 				if event.Tool == "Bash" && event.Success && gitPushCommandPattern.MatchString(bashCmd) && gitPushPattern.MatchString(event.Stderr) {
 					if m.onPRCreated != nil {
-						conv, _ := m.store.GetConversationMeta(ctx, convID)
+						conv, convErr := m.store.GetConversationMeta(ctx, convID)
+						if convErr != nil {
+							logger.Manager.Warnf("Failed to get conversation %s for git push detection: %v", convID, convErr)
+						}
 						if conv != nil {
 							sess, _ := m.store.GetSession(ctx, conv.SessionID)
 							if sess != nil && sess.PRNumber == 0 {
@@ -2288,6 +2297,12 @@ You have access to ChatML MCP tools:
 - `+"`"+`mcp__chatml__get_recent_activity`+"`"+` — recent git log
 - `+"`"+`mcp__chatml__add_review_comment`+"`"+` — leave inline code review comments visible in the ChatML UI
 - `+"`"+`mcp__chatml__list_review_comments`+"`"+` / `+"`"+`mcp__chatml__get_review_comment_stats`+"`"+` — read review comments
+- `+"`"+`mcp__chatml__report_pr_created`+"`"+` — report PR creation to update the ChatML sidebar
+- `+"`"+`mcp__chatml__report_pr_merged`+"`"+` — report PR merge to update session status
+
+**After creating a PR** (with `+"`"+`gh pr create`+"`"+` or any other method), ALWAYS call `+"`"+`mcp__chatml__report_pr_created`+"`"+` with the PR number and URL. This ensures the PR badge appears immediately in the sidebar.
+
+**After merging a PR** (with `+"`"+`gh pr merge`+"`"+` or any other method), ALWAYS call `+"`"+`mcp__chatml__report_pr_merged`+"`"+` to update the session status.
 
 Do NOT use `+"`"+`mcp__chatml__start_linear_issue`+"`"+` — it creates git branches inside the worktree, which conflicts with the session model. Use the Linear MCP server directly for Linear operations.`,
 		session.Name,

--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -162,10 +162,45 @@ func (w *PRWatcher) UpdateSessionBranch(sessionID, newBranch string) {
 	}
 }
 
+// ensureSessionWatched checks whether a session is already in the watch map.
+// If not, it auto-registers it from the database. Returns true if the session
+// is (now) watched, false if it could not be registered.
+func (w *PRWatcher) ensureSessionWatched(sessionID, caller string) bool {
+	w.mu.RLock()
+	_, exists := w.sessions[sessionID]
+	w.mu.RUnlock()
+	if exists {
+		return true
+	}
+
+	if w.store == nil {
+		logger.PRWatcher.Warnf("%s: session %s not in watch map and no store available", caller, sessionID)
+		return false
+	}
+
+	sess, err := w.store.GetSession(w.ctx, sessionID)
+	if err != nil || sess == nil {
+		logger.PRWatcher.Warnf("%s: session %s not in watch map and DB lookup failed (err=%v)", caller, sessionID, err)
+		return false
+	}
+
+	repoPath := ""
+	if repo, repoErr := w.store.GetRepo(w.ctx, sess.WorkspaceID); repoErr == nil && repo != nil {
+		repoPath = repo.Path
+	}
+	logger.PRWatcher.Infof("Auto-registering session %s in PRWatcher (%s)", sessionID, caller)
+	w.WatchSession(sessionID, sess.WorkspaceID, sess.Branch, repoPath, models.PRStatusNone, 0, "")
+	return true
+}
+
 // ForceCheckSession invalidates the PR cache for a session's repo and immediately
 // checks for PRs. Used when the agent creates a PR via bash so the UI updates
 // within seconds instead of waiting for the next poll cycle.
 func (w *PRWatcher) ForceCheckSession(sessionID string) {
+	if !w.ensureSessionWatched(sessionID, "ForceCheckSession") {
+		return
+	}
+
 	w.mu.RLock()
 	entry, exists := w.sessions[sessionID]
 	if !exists {
@@ -199,6 +234,10 @@ func (w *PRWatcher) ForceCheckSession(sessionID string) {
 // mergeable status without racing with GitHub's eventual consistency.
 func (w *PRWatcher) RegisterPRFromAgent(sessionID string, prNumber int, prURL string) {
 	if prNumber > 0 {
+		// Ensure the session is in the watch map before taking the lock.
+		// This avoids the fragile unlock-call-relock pattern.
+		w.ensureSessionWatched(sessionID, "RegisterPRFromAgent")
+
 		w.mu.Lock()
 		entry, exists := w.sessions[sessionID]
 		if exists {

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -4527,6 +4527,70 @@ func (h *Handlers) RefreshPRStatus(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
+// ReportPRCreated is called by the MCP tool when an agent creates a PR.
+// This provides a guaranteed notification path independent of bash output regex parsing.
+func (h *Handlers) ReportPRCreated(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sessionID := chi.URLParam(r, "sessionId")
+
+	var req struct {
+		PRNumber int    `json:"prNumber"`
+		PRURL    string `json:"prUrl"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+	if req.PRNumber <= 0 {
+		writeValidationError(w, "prNumber must be positive")
+		return
+	}
+
+	if h.prWatcher == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	// Verify session exists
+	session, err := h.store.GetSession(ctx, sessionID)
+	if err != nil || session == nil {
+		writeNotFound(w, "session")
+		return
+	}
+
+	// RegisterPRFromAgent handles auto-registration in the watch map (via
+	// ensureSessionWatched), DB update, and WebSocket broadcast in one call.
+	// Don't call WatchSession separately — it would set the PR number first,
+	// causing RegisterPRFromAgent to skip the DB update and broadcast.
+	h.prWatcher.RegisterPRFromAgent(sessionID, req.PRNumber, req.PRURL)
+
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// ReportPRMerged is called by the MCP tool when an agent merges a PR.
+// Triggers a force-check to verify the merge against GitHub.
+func (h *Handlers) ReportPRMerged(w http.ResponseWriter, r *http.Request) {
+	sessionID := chi.URLParam(r, "sessionId")
+
+	if h.prWatcher == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	// Read optional prNumber from body for logging (best-effort)
+	var req struct {
+		PRNumber int `json:"prNumber"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	if req.PRNumber > 0 {
+		logger.Handlers.Infof("ReportPRMerged: session %s, PR #%d", sessionID, req.PRNumber)
+	}
+
+	h.prWatcher.ForceCheckSession(sessionID)
+	w.WriteHeader(http.StatusAccepted)
+}
+
 // GeneratePRDescription uses AI to generate a PR title and body from session changes
 func (h *Handlers) GeneratePRDescription(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -115,6 +115,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Get("/{id}/sessions/{sessionId}/git-status", h.GetSessionGitStatus)
 		r.Get("/{id}/sessions/{sessionId}/pr-status", h.GetSessionPRStatus)
 		r.Post("/{id}/sessions/{sessionId}/pr-refresh", h.RefreshPRStatus)
+		r.Post("/{id}/sessions/{sessionId}/pr/report", h.ReportPRCreated)
+		r.Post("/{id}/sessions/{sessionId}/pr/report-merge", h.ReportPRMerged)
 		r.Get("/{id}/sessions/{sessionId}/pr/generate", h.GeneratePRDescription)
 		r.Post("/{id}/sessions/{sessionId}/pr/create", h.CreatePR)
 		r.Get("/{id}/settings/pr-template", h.GetPRTemplate)

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -12,7 +12,7 @@ import {
 import { getAuthToken } from '@/lib/auth-token';
 import { getBackendPort, getBackendPortSync } from '@/lib/backend-port';
 import { useConnectionStore } from '@/stores/connectionStore';
-import { getConversationDropStats, getActiveStreamingConversations, getConversationMessages, getStreamingSnapshot, toStoreMessage, updateSession as updateSessionApi } from '@/lib/api';
+import { getConversationDropStats, getActiveStreamingConversations, getConversationMessages, getStreamingSnapshot, toStoreMessage, updateSession as updateSessionApi, refreshPRStatus } from '@/lib/api';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useBranchCacheStore } from '@/stores/branchCacheStore';
 import { useSlashCommandStore } from '@/stores/slashCommandStore';
@@ -1053,6 +1053,20 @@ export function useWebSocket(enabled: boolean = true) {
       }
     } catch (err) {
       console.warn('Failed to reconcile streaming state after reconnect:', err);
+    }
+
+    // Refresh PR status for the selected session to catch events missed during disconnect.
+    // Best-effort: the result arrives via WebSocket session_pr_update event.
+    try {
+      const { selectedSessionId, sessions } = getStore();
+      if (selectedSessionId) {
+        const session = sessions.find(s => s.id === selectedSessionId);
+        if (session) {
+          refreshPRStatus(session.workspaceId, selectedSessionId).catch(() => {});
+        }
+      }
+    } catch {
+      // Silently ignore — PR status will catch up on next poll cycle
     }
   // getStore is a stable reference (useAppStore.getState), no deps needed
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -30,6 +30,21 @@ import type {
   SessionToggleState,
 } from '@/lib/types';
 import { useSettingsStore } from './settingsStore';
+import { refreshPRStatus } from '@/lib/api';
+
+// Throttle on-select PR refresh to avoid excessive API calls.
+// Entries are pruned when the map exceeds MAX_PR_REFRESH_ENTRIES to prevent unbounded growth.
+const lastPRRefreshMap = new Map<string, number>();
+const PR_REFRESH_THROTTLE_MS = 30_000; // 30 seconds
+const MAX_PR_REFRESH_ENTRIES = 100;
+
+function pruneRefreshMap() {
+  if (lastPRRefreshMap.size <= MAX_PR_REFRESH_ENTRIES) return;
+  const now = Date.now();
+  for (const [key, ts] of lastPRRefreshMap) {
+    if (now - ts > PR_REFRESH_THROTTLE_MS) lastPRRefreshMap.delete(key);
+  }
+}
 
 // Maximum number of file tabs before LRU eviction kicks in
 const MAX_FILE_TABS = 10;
@@ -750,6 +765,22 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedConversationId: targetConversation?.id || null,
       selectedFileTabId: newSelectedTabId,
     });
+
+    // Background PR refresh: catches missed WebSocket events and externally-created PRs.
+    // Throttled to max once per 30s per session. Result arrives via WebSocket.
+    if (id) {
+      const session = state.sessions.find(s => s.id === id);
+      if (session) {
+        const lastRefresh = lastPRRefreshMap.get(id) ?? 0;
+        if (Date.now() - lastRefresh > PR_REFRESH_THROTTLE_MS) {
+          lastPRRefreshMap.set(id, Date.now());
+          pruneRefreshMap();
+          refreshPRStatus(session.workspaceId, id).catch(() => {
+            // Best-effort — silently ignore errors
+          });
+        }
+      }
+    }
   },
   setSessionToggleState: (sessionId, toggleState) => set((state) => ({
     sessionToggleState: {


### PR DESCRIPTION
## Summary

- Adds explicit MCP tools (`report_pr_created`, `report_pr_merged`) that agents call after PR operations, providing a guaranteed notification path independent of bash regex parsing
- Fixes PRWatcher auto-registration bugs where sessions created after startup were silently ignored
- Adds background PR status refresh on session select (throttled 30s) and WebSocket reconnect

## Changes Made

- **`agent-runner/src/mcp/tools/pr.ts`** (new) — Two MCP tools: `report_pr_created` (with GitHub URL validation) and `report_pr_merged`, both calling new backend endpoints
- **`agent-runner/src/mcp/server.ts`** — Registers the new PR tools
- **`backend/server/handlers.go`** — `ReportPRCreated` and `ReportPRMerged` HTTP handlers
- **`backend/server/router.go`** — Routes for `/pr/report` and `/pr/report-merge`
- **`backend/branch/pr_watcher.go`** — Extracted `ensureSessionWatched()` helper to deduplicate auto-registration logic across `ForceCheckSession` and `RegisterPRFromAgent`; eliminated fragile lock-unlock-relock pattern
- **`backend/agent/manager.go`** — Added error logging for `GetConversationMeta` failures during PR detection; added MCP tool documentation to agent system prompt
- **`src/stores/appStore.ts`** — PR status refresh on session select with 30s throttle and bounded map cleanup
- **`src/hooks/useWebSocket.ts`** — PR status refresh on WebSocket reconnect

## Test Plan

- [x] `go build ./...` passes
- [x] TypeScript type-check passes (no new errors)
- [ ] Manual: create a PR via `gh pr create` in a session — PR badge should appear immediately
- [ ] Manual: merge a PR via `gh pr merge` — session status should update
- [ ] Manual: select different sessions rapidly — PR refresh should throttle to once per 30s
- [ ] Manual: disconnect/reconnect WebSocket — PR status should refresh for active session

🤖 Generated with [Claude Code](https://claude.com/claude-code)