### PR TITLE
Overhaul PrimaryActionButton with three-tier color system

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -859,6 +859,28 @@ code.hljs { padding: 3px 5px; }
 .stagger-children > *:nth-child(9) { animation-delay: 400ms; }
 .stagger-children > *:nth-child(10) { animation-delay: 450ms; }
 
+/* PrimaryActionButton tier change animation */
+@keyframes action-button-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-action-enter {
+  animation: action-button-enter 150ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-action-enter {
+    animation: none;
+  }
+}
+
 /* Hover effects */
 .hover-lift {
   transition: transform 0.2s ease, box-shadow 0.2s ease;

--- a/src/components/shared/PrimaryActionButton/ActionButton.tsx
+++ b/src/components/shared/PrimaryActionButton/ActionButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -39,7 +39,22 @@ export function ActionButton({
     setPendingActionKey(actionKey);
   }, [actionKey]);
 
-  // Nothing to render if action is null (e.g., merged PR)
+  // Replay enter animation when the tier changes by removing and re-adding the class
+  const containerRef = useRef<HTMLDivElement>(null);
+  const prevTierRef = useRef(action?.tier);
+  useEffect(() => {
+    if (!action || !containerRef.current) return;
+    if (prevTierRef.current !== action.tier) {
+      const el = containerRef.current;
+      el.classList.remove('animate-action-enter');
+      // Force reflow so the browser registers the removal
+      void el.offsetWidth;
+      el.classList.add('animate-action-enter');
+    }
+    prevTierRef.current = action.tier;
+  }, [action?.tier, action]);
+
+  // Nothing to render if action is null (e.g., clean state)
   if (!action) {
     return null;
   }
@@ -98,17 +113,14 @@ export function ActionButton({
       destructive: 'border-l-red-400/40',
       success: 'border-l-emerald-400/40',
       warning: 'border-l-yellow-400/40',
-      info: 'border-l-blue-400/40',
-      purple: 'border-l-purple-400/40',
-      secondary: 'border-l-secondary-foreground/10',
     }[action.variant] || 'border-l-primary/30';
 
     return (
-      <div className={cn("inline-flex rounded-sm shadow-sm", className)}>
+      <div ref={containerRef} className={cn("inline-flex rounded-sm shadow-sm animate-action-enter", className)}>
         <Button
           variant={action.variant}
           size="sm"
-          className="h-6 text-xs gap-1 px-2 rounded-r-none rounded-l-sm border-r-0 transition-none"
+          className="h-6 text-xs gap-1 px-2 rounded-r-none rounded-l-sm border-r-0 transition-colors duration-150"
           onClick={handleClick}
           disabled={pendingAction}
         >
@@ -125,7 +137,7 @@ export function ActionButton({
               variant={action.variant}
               size="sm"
               className={cn(
-                'h-6 w-4 px-0.5 rounded-l-none rounded-r-sm transition-none border-l',
+                'h-6 w-4 px-0.5 rounded-l-none rounded-r-sm transition-colors duration-150 border-l',
                 separatorColor
               )}
               disabled={pendingAction}
@@ -165,21 +177,23 @@ export function ActionButton({
     );
   }
 
-  // Regular button - use transition-none for instant variant changes
+  // Regular button (no dropdown)
   return (
-    <Button
-      variant={action.variant}
-      size="sm"
-      className={cn("h-6 text-xs gap-1 px-2 rounded-sm transition-none", className)}
-      onClick={handleClick}
-      disabled={pendingAction}
-    >
-      {pendingAction ? (
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-      ) : (
-        <Icon className="h-3.5 w-3.5" />
-      )}
-      {pendingAction ? 'Sending...' : action.label}
-    </Button>
+    <div ref={containerRef} className={cn("animate-action-enter", className)}>
+      <Button
+        variant={action.variant}
+        size="sm"
+        className="h-6 text-xs gap-1 px-2 rounded-sm transition-colors duration-150"
+        onClick={handleClick}
+        disabled={pendingAction}
+      >
+        {pendingAction ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Icon className="h-3.5 w-3.5" />
+        )}
+        {pendingAction ? 'Sending...' : action.label}
+      </Button>
+    </div>
   );
 }

--- a/src/components/shared/PrimaryActionButton/types.ts
+++ b/src/components/shared/PrimaryActionButton/types.ts
@@ -8,14 +8,13 @@ export type PrimaryActionType =
   | 'continue-cherry-pick'
   | 'continue-revert'
   | 'sync-branch'
-  | 'commit-changes'
-  | 'push-changes'
-  | 'update-pr'
-  | 'view-pr'
   | 'create-pr'
+  | 'view-pr'
   | 'archive-session';
 
-export type ButtonVariant = 'default' | 'destructive' | 'success' | 'warning' | 'info' | 'purple' | 'secondary';
+export type ButtonVariant = 'default' | 'destructive' | 'success' | 'warning';
+
+export type ActionTier = 'alert' | 'action' | 'complete';
 
 export interface DropdownAction {
   label: string;
@@ -26,6 +25,7 @@ export interface DropdownAction {
 
 export interface PrimaryAction {
   type: PrimaryActionType;
+  tier: ActionTier;
   label: string;
   icon: LucideIcon;
   variant: ButtonVariant;

--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -10,8 +10,6 @@ import {
   FileEdit,
   GitMerge,
   Rocket,
-  Package,
-  History,
   Download,
 } from 'lucide-react';
 import type { GitStatusDTO, PRDetails } from '@/lib/api';
@@ -27,17 +25,19 @@ interface Session {
 /**
  * Hook that determines the primary action based on git status, session state, and PR details.
  *
+ * Three-tier color system:
+ *   Alert (red)    — blockers that need fixing
+ *   Action (primary) — the natural next workflow step
+ *   Complete (green) — terminal/done state
+ *
  * Priority order:
- * 1. Conflicts - "Resolve Conflicts" (destructive)
- * 2. CI failures - "Fix Issues" (destructive)
- * 3. In-progress operation - "Continue {Op}" with Abort dropdown (warning)
- * 4. Diverged - "Sync Branch" (info)
- * 5. Has changes - "Commit Changes" (default)
- * 6. Unpushed commits - "Push Changes" (default)
- * 7a. Open PR with unpushed - "Update PR" (success)
- * 7b. Open PR - "View PR" (success)
- * 8. Clean & ready - "Create PR" (success)
- * 9. PR merged - Hidden (null)
+ * 1. Conflicts        → "Resolve Conflicts"   (alert)
+ * 2. CI failures      → "Fix Issues"          (alert)
+ * 3. In-progress op   → "Continue {Op}"       (action)
+ * 4. Diverged         → "Sync Branch"         (action)
+ * 5. Work to ship     → "New Pull Request"    (action) — collapses commit/push/create-pr
+ * 6. Open PR          → "Merge PR"            (action) — includes "Push Latest" when needed
+ * 7. PR merged        → "Archive Session"     (complete)
  */
 export function useActionState(
   gitStatus: GitStatusDTO | null,
@@ -45,17 +45,17 @@ export function useActionState(
   prDetails: PRDetails | null,
 ): PrimaryAction | null {
   return useMemo(() => {
-    // Priority 9: PR is merged - show archive session button
+    // Priority 7: PR is merged — show archive session button
     // Check both the session store (updated by PRWatcher) and live prDetails
     // (fetched from GitHub) to handle the case where the PR was just merged
     // but the store hasn't been updated yet.
     if (session?.prStatus === 'merged' || prDetails?.merged) {
       return {
         type: 'archive-session',
+        tier: 'complete',
         label: 'Archive Session',
-
         icon: Archive,
-        variant: 'default',
+        variant: 'success',
         sessionId: session?.id,
       };
     }
@@ -71,8 +71,8 @@ export function useActionState(
     if (conflicts.hasConflicts) {
       return {
         type: 'resolve-conflicts',
+        tier: 'alert',
         label: 'Resolve Conflicts',
-
         icon: XCircle,
         variant: 'destructive',
         message: 'Resolve the merge conflicts',
@@ -83,6 +83,7 @@ export function useActionState(
     if (prDetails?.checkStatus === 'failure') {
       return {
         type: 'fix-issues',
+        tier: 'alert',
         label: 'Fix Issues',
         icon: XCircle,
         variant: 'destructive',
@@ -97,6 +98,7 @@ export function useActionState(
 
       return {
         type: `continue-${opType}` as PrimaryAction['type'],
+        tier: 'action',
         label: `Continue ${capitalizedOp}`,
         icon: AlertTriangle,
         variant: 'warning',
@@ -112,10 +114,10 @@ export function useActionState(
     if (sync.diverged) {
       return {
         type: 'sync-branch',
+        tier: 'action',
         label: 'Sync Branch',
-
         icon: GitBranch,
-        variant: 'info',
+        variant: 'default',
         message: `Rebase my branch on ${sync.baseBranch}`,
         dropdownActions: [
           { label: 'Merge Instead', message: `Merge ${sync.baseBranch} into my branch`, icon: GitMerge },
@@ -124,111 +126,107 @@ export function useActionState(
       };
     }
 
-    // Priority 5: Has uncommitted changes
-    if (workingDirectory.hasChanges) {
-      return {
-        type: 'commit-changes',
-        label: 'Commit Changes',
+    // Priority 5: Work to ship — uncommitted changes, unpushed commits, or commits ahead (no open PR)
+    // Collapses the old "Commit Changes", "Push Changes", and "Create PR" into one action.
+    const hasChanges = workingDirectory.hasChanges;
+    const hasUnpushed = sync.unpushedCommits > 0;
+    const hasAhead = sync.aheadBy > 0;
+    const hasOpenPR = session?.prStatus === 'open';
 
-        icon: GitCommit,
-        variant: 'purple',
-        message: 'Commit my changes',
-        dropdownActions: [
+    if ((hasChanges || hasUnpushed || hasAhead) && !hasOpenPR) {
+      // Adapt the primary message based on what work is needed
+      let message: string;
+      if (hasChanges) {
+        message = 'Commit all changes, push to remote, and create a pull request';
+      } else if (hasUnpushed) {
+        message = 'Push commits and create a pull request';
+      } else {
+        message = 'Create a pull request';
+      }
+
+      // Build contextual dropdown options
+      const dropdownActions: PrimaryAction['dropdownActions'] = [];
+
+      if (hasChanges) {
+        dropdownActions.push(
+          { label: 'Commit Only', message: 'Commit my changes', icon: GitCommit },
           { label: 'Commit & Push', message: 'Commit my changes and push to remote', icon: Rocket },
-          { label: 'Commit & Create PR', message: 'Commit my changes, push to remote, and create a pull request', icon: GitPullRequest },
-          { label: 'Stash Changes', message: 'Stash my changes for later', icon: Package },
-          { label: 'Amend Last Commit', message: 'Add these changes to my last commit', icon: History },
-        ],
-      };
-    }
+        );
+      }
+      if (hasUnpushed && !hasChanges) {
+        dropdownActions.push(
+          { label: 'Push Only', message: 'Push my commits to the remote branch', icon: Upload },
+        );
+      }
+      dropdownActions.push(
+        { label: 'Create PR in Draft', message: hasChanges
+          ? 'Commit all changes, push to remote, and create a draft pull request'
+          : hasUnpushed
+            ? 'Push commits and create a draft pull request'
+            : 'Create a draft pull request', icon: FileEdit },
+      );
 
-    // Priority 6: Has unpushed commits (no open PR)
-    if (sync.unpushedCommits > 0 && session?.prStatus !== 'open') {
       return {
-        type: 'push-changes',
-        label: 'Push Changes',
-
-        icon: Upload,
-        variant: 'default',
-        message: 'Push my commits',
-        dropdownActions: [
-          { label: 'Push & Create PR', message: 'Push my commits and create a pull request', icon: GitPullRequest },
-          { label: 'Force Push', message: 'Force push my commits to the remote branch', icon: Upload },
-        ],
-      };
-    }
-
-    // Priority 7a: Open PR with unpushed commits
-    if (session?.prStatus === 'open' && sync.unpushedCommits > 0) {
-      return {
-        type: 'update-pr',
-        label: 'Update PR',
+        type: 'create-pr',
+        tier: 'action',
+        label: 'New Pull Request',
         icon: GitPullRequest,
-        variant: 'success',
-        message: 'Push the latest changes to the PR',
-        dropdownActions: [
-          { label: 'Force Push', message: 'Force push to update the PR', icon: Upload },
-          { label: 'Squash & Push', message: 'Squash commits into one and push to the PR', icon: GitMerge },
-        ],
+        variant: 'default',
+        message,
+        dropdownActions,
       };
     }
 
-    // Priority 7b: Open PR (view only)
-    if (session?.prStatus === 'open') {
-      // Variant depends on CI check status:
-      // - checks passed or no checks → green (success)
-      // - checks pending or unknown  → neutral (default)
-      // Note: checks failed is caught by Priority 2 above
+    // Priority 6: Open PR — always show "Merge PR", with "Push Latest" in dropdown when needed
+    // Variant depends on CI check status:
+    // - checks passed or no checks → green (success) — safe to merge signal
+    // - checks pending or unknown  → neutral (default)
+    // Note: checks failed is caught by Priority 2 above
+    if (hasOpenPR) {
       const mergeVariant =
         prDetails?.checkStatus === 'success' || prDetails?.checkStatus === 'none'
           ? 'success' as const
           : 'default' as const;
 
+      const dropdownActions: PrimaryAction['dropdownActions'] = [];
+
+      // Add push option when there are unpushed commits
+      if (hasUnpushed) {
+        dropdownActions.push(
+          { label: 'Push Latest Changes', message: 'Push the latest changes to the PR', icon: Upload },
+        );
+      }
+
+      dropdownActions.push(
+        {
+          label: 'Create a merge commit',
+          message: 'Merge the pull request with a merge commit',
+          description: 'All commits from this branch will be added to the base branch via a merge commit.',
+        },
+        {
+          label: 'Squash and merge',
+          message: 'Squash and merge the pull request',
+          description: 'The commits from this branch will be combined into one commit in the base branch.',
+        },
+        {
+          label: 'Rebase and merge',
+          message: 'Rebase and merge the pull request',
+          description: 'The commits from this branch will be rebased and added to the base branch.',
+        },
+      );
+
       return {
         type: 'view-pr',
+        tier: 'action',
         label: 'Merge PR',
         icon: GitMerge,
         variant: mergeVariant,
         message: 'Squash and merge the pull request',
-        dropdownActions: [
-          {
-            label: 'Create a merge commit',
-            message: 'Merge the pull request with a merge commit',
-            description: 'All commits from this branch will be added to the base branch via a merge commit.',
-          },
-          {
-            label: 'Squash and merge',
-            message: 'Squash and merge the pull request',
-            description: 'The commits from this branch will be combined into one commit in the base branch.',
-          },
-          {
-            label: 'Rebase and merge',
-            message: 'Rebase and merge the pull request',
-            description: 'The commits from this branch will be rebased and added to the base branch.',
-          },
-        ],
+        dropdownActions,
       };
     }
 
-    // Priority 8: Clean state with commits ahead - ready to create PR
-    // Only show "Create PR" if we have commits ahead of the base branch
-    if (sync.aheadBy > 0) {
-      return {
-        type: 'create-pr',
-        label: 'New Pull Request',
-
-        icon: GitPullRequest,
-        variant: 'success',
-        message: 'Create a pull request',
-        dropdownActions: [
-          { label: 'Create PR in Draft', message: 'Create a draft pull request', icon: FileEdit },
-          { label: 'Push Changes Only', message: 'Push my commits to the remote branch', icon: Upload },
-          { label: 'Squash & Create PR', message: 'Squash my commits into one and create a pull request', icon: GitMerge },
-        ],
-      };
-    }
-
-    // Priority 9: Completely clean state - nothing to do, hide button
+    // Clean state — nothing to do, hide button
     return null;
   }, [gitStatus, session, prDetails]);
 }


### PR DESCRIPTION
## Summary
- Simplify PrimaryActionButton from 9 workflow priorities to 7 by collapsing commit/push/create-pr into a single "New Pull Request" action with contextual dropdown options
- Introduce a three-tier color system: **alert** (red) for blockers, **action** (primary/warning) for next workflow steps, **complete** (green) for terminal states
- Add enter animation on tier transitions using ref-based class replay (avoids full React remount that would close open dropdowns)
- Restore `warning` variant for in-progress git operations and CI-status-dependent green for "Merge PR" when checks pass

## Test plan
- [ ] Verify button shows red for conflicts and CI failures
- [ ] Verify button shows amber/warning for in-progress rebase/merge/cherry-pick
- [ ] Verify "New Pull Request" appears when there are uncommitted changes, unpushed commits, or commits ahead
- [ ] Verify "Merge PR" turns green when CI checks pass, stays neutral when pending
- [ ] Verify dropdown stays open during tier transitions (no remount)
- [ ] Verify enter animation plays on tier change but respects `prefers-reduced-motion`
- [ ] Verify agent working indicator conditionally renders (not always mounted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)