### PR TITLE
Fix get_workspace_diff MCP tool exceeding max token size

### DIFF
--- a/agent-runner/src/mcp/server.ts
+++ b/agent-runner/src/mcp/server.ts
@@ -122,17 +122,38 @@ export function createChatMLMcpServer(options: McpServerOptions) {
           file: z.string().optional().describe("Get diff for a specific file path"),
         },
         async ({ detailed, file }) => {
+          const MAX_DIFF_BYTES = 120000;
+
           try {
-            // Single file diff
+            // Single file unified diff
             if (file) {
-              const res = await fetch(sessionApiUrl(context, `/diff?path=${encodeURIComponent(file)}`), { headers: buildHeaders() });
+              const res = await fetch(
+                sessionApiUrl(context, `/diff-summary?path=${encodeURIComponent(file)}&maxBytes=${MAX_DIFF_BYTES}`),
+                { headers: buildHeaders() }
+              );
               if (!res.ok) {
                 const text = await res.text();
                 throw new Error(`Backend error ${res.status}: ${text}`);
               }
-              const diff = await res.json();
+              const diff = await res.text();
               return {
-                content: [{ type: "text", text: JSON.stringify(diff, null, 2) }],
+                content: [{ type: "text", text: diff || "No changes for this file" }],
+              };
+            }
+
+            // Detailed mode: unified diff for the whole workspace
+            if (detailed) {
+              const res = await fetch(
+                sessionApiUrl(context, `/diff-summary?maxBytes=${MAX_DIFF_BYTES}`),
+                { headers: buildHeaders() }
+              );
+              if (!res.ok) {
+                const text = await res.text();
+                throw new Error(`Backend error ${res.status}: ${text}`);
+              }
+              const diff = await res.text();
+              return {
+                content: [{ type: "text", text: diff || "No changes" }],
               };
             }
 
@@ -159,40 +180,6 @@ export function createChatMLMcpServer(options: McpServerOptions) {
 
             if (!hasCommits && !hasUncommitted) {
               return { content: [{ type: "text", text: "No changes" }] };
-            }
-
-            if (detailed) {
-              // Collect all changed file paths (from both committed and uncommitted)
-              const filePaths = new Set<string>();
-              if (hasUncommitted) {
-                for (const f of uncommitted) filePaths.add(f.path);
-              }
-              if (hasCommits) {
-                for (const c of branch.commits) {
-                  for (const f of c.files) filePaths.add(f.path);
-                }
-              }
-
-              // Fetch full diffs for all files in parallel
-              const diffs = await Promise.all(
-                Array.from(filePaths).map(async (path) => {
-                  try {
-                    const res = await fetch(sessionApiUrl(context, `/diff?path=${encodeURIComponent(path)}`), { headers: buildHeaders() });
-                    if (!res.ok) {
-                      const text = await res.text();
-                      return { path, error: `Backend error ${res.status}: ${text}` };
-                    }
-                    const diff = await res.json();
-                    return { path, oldContent: diff.oldContent, newContent: diff.newContent };
-                  } catch {
-                    return { path, error: "Failed to fetch diff" };
-                  }
-                })
-              );
-
-              return {
-                content: [{ type: "text", text: JSON.stringify({ uncommitted, commits: branch.commits, branchStats: branch.branchStats, diffs }, null, 2) }],
-              };
             }
 
             // Stat mode: format a concise summary

--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -1544,7 +1544,7 @@ func (rm *RepoManager) GetDiffSummary(ctx context.Context, repoPath, baseRef str
 	var result strings.Builder
 	result.WriteString("=== Diff Stats ===\n")
 	result.Write(statOut)
-	result.WriteString("\n=== Diff (truncated) ===\n")
+	result.WriteString("\n=== Diff ===\n")
 
 	diff := string(diffOut)
 	if len(diff) > maxBytes {
@@ -1553,4 +1553,26 @@ func (rm *RepoManager) GetDiffSummary(ctx context.Context, repoPath, baseRef str
 	result.WriteString(diff)
 
 	return result.String(), nil
+}
+
+// GetFileDiffUnified returns the unified diff for a single file compared to baseRef.
+// The diff output is capped at maxBytes.
+func (rm *RepoManager) GetFileDiffUnified(ctx context.Context, repoPath, baseRef, filePath string, maxBytes int) (string, error) {
+	if err := ValidateGitRef(baseRef); err != nil {
+		return "", fmt.Errorf("invalid base ref: %w", err)
+	}
+
+	cmd, cancel := gitCmdWithContext(ctx, repoPath, "diff", baseRef, "--", filePath)
+	defer cancel()
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("diff failed for %s: %w", filePath, err)
+	}
+
+	diff := string(out)
+	if len(diff) > maxBytes {
+		diff = diff[:maxBytes] + "\n... (truncated)"
+	}
+
+	return diff, nil
 }

--- a/backend/git/repo_test.go
+++ b/backend/git/repo_test.go
@@ -633,7 +633,7 @@ func TestGetDiffSummary_WithChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, summary, "=== Diff Stats ===")
-	assert.Contains(t, summary, "=== Diff (truncated) ===")
+	assert.Contains(t, summary, "=== Diff ===")
 	assert.Contains(t, summary, "new-file.txt")
 }
 
@@ -648,7 +648,7 @@ func TestGetDiffSummary_NoChanges(t *testing.T) {
 
 	// Should still have section headers but no actual diff content
 	assert.Contains(t, summary, "=== Diff Stats ===")
-	assert.Contains(t, summary, "=== Diff (truncated) ===")
+	assert.Contains(t, summary, "=== Diff ===")
 }
 
 func TestGetDiffSummary_Truncation(t *testing.T) {

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -2591,6 +2591,60 @@ func (h *Handlers) GetSessionFileDiff(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, response)
 }
 
+// GetSessionDiffSummary returns a unified diff summary for the session's worktree.
+// Supports optional query parameters:
+//   - maxBytes: maximum diff size in bytes (default 120000)
+//   - path: if set, returns unified diff for a single file only
+func (h *Handlers) GetSessionDiffSummary(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sessionID := chi.URLParam(r, "sessionId")
+
+	session, workingPath, baseRef, err := h.getSessionAndWorkspace(ctx, sessionID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if session == nil {
+		writeNotFound(w, "session")
+		return
+	}
+	if checkWorktreePath(w, workingPath) {
+		return
+	}
+
+	maxBytes := 120000
+	if mb := r.URL.Query().Get("maxBytes"); mb != "" {
+		if parsed, err := strconv.Atoi(mb); err == nil && parsed > 0 {
+			maxBytes = parsed
+		}
+	}
+
+	filePath := r.URL.Query().Get("path")
+
+	var result string
+	if filePath != "" {
+		cleanPath, err := validatePath(workingPath, filePath)
+		if err != nil {
+			writeValidationError(w, "invalid path")
+			return
+		}
+		result, err = h.repoManager.GetFileDiffUnified(ctx, workingPath, baseRef, cleanPath, maxBytes)
+		if err != nil {
+			writeInternalError(w, "failed to get file diff", err)
+			return
+		}
+	} else {
+		result, err = h.repoManager.GetDiffSummary(ctx, workingPath, baseRef, maxBytes)
+		if err != nil {
+			writeInternalError(w, "failed to get diff summary", err)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte(result))
+}
+
 // FileHistoryResponse represents the commit history for a file
 type FileHistoryResponse struct {
 	Commits []git.FileCommit `json:"commits"`

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -125,6 +125,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Post("/{id}/sessions/{sessionId}/branch-sync", h.SyncSessionBranch)
 		r.Post("/{id}/sessions/{sessionId}/branch-sync/abort", h.AbortSessionSync)
 		r.Get("/{id}/sessions/{sessionId}/diff", h.GetSessionFileDiff)
+		r.Get("/{id}/sessions/{sessionId}/diff-summary", h.GetSessionDiffSummary)
 		r.Get("/{id}/sessions/{sessionId}/file-history", h.GetSessionFileHistory)
 		r.Get("/{id}/sessions/{sessionId}/file-at-ref", h.GetSessionFileAtRef)
 		r.Get("/{id}/sessions/{sessionId}/file", h.GetSessionFileContent)


### PR DESCRIPTION
## Summary
- The `get_workspace_diff` MCP tool with `detailed: true` was returning **665K+ characters** by fetching full old+new file contents for every changed file, exceeding the Anthropic API's tool result size limit
- Switched to returning **unified diffs** (`git diff` format) instead of full file contents — ~10-20x smaller and better for AI consumption
- Added new `/diff-summary` backend endpoint with configurable `maxBytes` truncation (default 120KB), reusing the existing `GetDiffSummary` infrastructure

## Test plan
- [ ] Verify `get_workspace_diff` with `detailed: true` returns unified diff format and stays well under 120KB
- [ ] Verify `get_workspace_diff` with `file` parameter returns single-file unified diff
- [ ] Verify `get_workspace_diff` without parameters (summary mode) is unchanged
- [ ] Run Go tests: `go test ./git/... ./server/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)