### PR TITLE
Fix recurring Maximum update depth exceeded in MainToolbar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -442,7 +442,7 @@ export default function Home() {
   const selectNextTab = useAppStore((s) => s.selectNextTab);
   const selectPreviousTab = useAppStore((s) => s.selectPreviousTab);
 
-  const { expandWorkspace } = useSettingsStore();
+  const expandWorkspace = useSettingsStore((s) => s.expandWorkspace);
   const { showWizard, showGuidedTour, completeWizard, completeTour, skipAll } = useOnboarding();
 
   // Centralized window size management for onboarding ↔ app transitions.

--- a/src/components/shared/PrimaryActionButton/index.tsx
+++ b/src/components/shared/PrimaryActionButton/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useGitStatus } from '@/hooks/useGitStatus';
 import { usePRStatus } from '@/hooks/usePRStatus';
 import { useActionState } from './useActionState';
@@ -67,7 +67,10 @@ export function PrimaryActionButton({
   // Guard: only sync when the session actually has a PR and the prDetails
   // belongs to this session (matching PR number) to avoid cross-contamination
   // when switching between sessions.
+  // Uses a ref to track what was last synced, preventing cascading re-render loops
+  // where updateSession → sessions change → Home re-renders → new config → repeat.
   const updateSession = useAppStore((s) => s.updateSession);
+  const lastSyncedRef = useRef<string | null>(null);
   useEffect(() => {
     if (!session?.id || !prDetails) return;
     if (!session.prNumber || prDetails.number !== session.prNumber) return;
@@ -87,6 +90,10 @@ export function PrimaryActionButton({
     }
 
     if (Object.keys(updates).length > 0) {
+      // Deduplicate: skip if we already synced this exact update for this session
+      const syncKey = `${session.id}:${JSON.stringify(updates)}`;
+      if (lastSyncedRef.current === syncKey) return;
+      lastSyncedRef.current = syncKey;
       updateSession(session.id, updates);
     }
   }, [session?.id, session?.prNumber, session?.prStatus, session?.checkStatus, prDetails, updateSession]);


### PR DESCRIPTION
## Summary
- Replace bare `useSettingsStore()` in `Home` with a targeted selector for `expandWorkspace`, preventing Home from re-rendering on every unrelated settings store mutation
- Add deduplication ref to `PrimaryActionButton`'s PR/check status sync effect to prevent cascading `updateSession` calls that propagate through sessions → Home → SessionToolbarContent → setToolbarConfig → MainToolbar

## Context
The previous fix (#616) addressed bare `useSettingsStore()` in the `useShallow` block but missed a second bare call at line 445. This caused `Home` to subscribe to the entire settings store, amplifying render cascades through the toolbar config chain and hitting React's 50-update depth limit.

## Test plan
- [ ] Verify no "Maximum update depth exceeded" console errors during normal usage
- [ ] Verify no errors when streaming agent responses
- [ ] Verify toolbar content updates correctly when switching sessions
- [ ] Verify PR status badge updates correctly when PR state changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)