### PR TITLE
Remove bold formatting from PR titles

### DIFF
--- a/src/components/dashboards/PRDashboard.tsx
+++ b/src/components/dashboards/PRDashboard.tsx
@@ -71,7 +71,7 @@ function TitleCell({ pr }: { pr: PRWithStatus }) {
 
   return (
     <div className="flex items-center gap-2 min-w-0">
-      <span className="font-medium text-base truncate" title={pr.title}>
+      <span className="text-base truncate" title={pr.title}>
         {pr.title}
       </span>
       {pr.labels?.map((label) => {

--- a/src/components/pr-dashboard/PRCard.tsx
+++ b/src/components/pr-dashboard/PRCard.tsx
@@ -193,7 +193,7 @@ export function PRCard({ pr, onJumpToSession, onSendMessage, isSendingMessage }:
           <StatusIcon className={cn('h-4 w-4 mt-0.5 shrink-0', statusInfo.color)} />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="font-medium text-base truncate">{pr.title}</span>
+              <span className="text-base truncate">{pr.title}</span>
               <span className="text-sm text-muted-foreground shrink-0">#{pr.number}</span>
               {pr.sessionName && (
                 <span className="text-xs bg-surface-2 px-1.5 py-0.5 rounded shrink-0">


### PR DESCRIPTION
## Summary
- Removed `font-medium` class from PR title spans in both the table view (`PRDashboard`) and card view (`PRCard`)
- PR titles now render with normal font weight instead of medium/bold

## Test plan
- [ ] Open the PR dashboard and verify titles are no longer bold
- [ ] Check both table view and card view

🤖 Generated with [Claude Code](https://claude.com/claude-code)