### PR TITLE
Fix snapshot/live event race causing duplicate tools and text on reconnect

### DIFF
--- a/src/components/conversation/VirtualizedMessageList.tsx
+++ b/src/components/conversation/VirtualizedMessageList.tsx
@@ -170,6 +170,7 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
         data={messages}
         firstItemIndex={firstItemIndex ?? INITIAL_FIRST_ITEM_INDEX}
         initialTopMostItemIndex={resolvedInitialIndex}
+        computeItemKey={(index, message) => message.id}
         itemContent={itemContent}
         followOutput={followOutput}
         alignToBottom

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -19,6 +19,38 @@ import { useSlashCommandStore } from '@/stores/slashCommandStore';
 import { notifyDesktop, getConversationLabel } from '@/hooks/useDesktopNotifications';
 import { playSound } from '@/lib/sounds';
 
+// Ref-counted map of conversations currently being reconciled from a streaming snapshot.
+// Content events for these conversations are dropped to prevent the snapshot + live event
+// race condition that causes duplicate tools and text.
+// Uses a counter (not a Set) so concurrent reconnects don't prematurely clear the flag
+// when the first reconciliation finishes while the second is still in-flight.
+const reconcilingConversations = new Map<string, number>();
+
+function startReconciling(convId: string) {
+  reconcilingConversations.set(convId, (reconcilingConversations.get(convId) ?? 0) + 1);
+}
+
+function stopReconciling(convId: string) {
+  const count = (reconcilingConversations.get(convId) ?? 1) - 1;
+  if (count <= 0) {
+    reconcilingConversations.delete(convId);
+  } else {
+    reconcilingConversations.set(convId, count);
+  }
+}
+
+function isReconciling(convId: string): boolean {
+  return (reconcilingConversations.get(convId) ?? 0) > 0;
+}
+
+// Content event types that should be suppressed during reconciliation.
+// Lifecycle events (result, turn_complete, complete, conversation_status) are NOT suppressed.
+const RECONCILIATION_SUPPRESSED_EVENTS = new Set([
+  'assistant_text', 'tool_start', 'tool_end', 'thinking_start', 'thinking_delta',
+  'thinking', 'subagent_started', 'subagent_stopped', 'subagent_output',
+  'ghost_text', 'todo_update', 'tool_progress',
+]);
+
 // Conversations that recently exited plan mode. Maps conversationId → exit timestamp.
 // Used to suppress stale SDK status messages that try to re-activate plan mode after
 // ExitPlanMode approval (SDK bug #15755). A timestamp-based cooldown ensures multiple
@@ -207,6 +239,14 @@ export function useWebSocket(enabled: boolean = true) {
   const handleConversationEvent = useCallback((data: WSEvent) => {
     const conversationId = data.conversationId;
     if (!conversationId) return;
+
+    // Drop content events for conversations being reconciled from a snapshot.
+    // This prevents the race where live events overlap with snapshot data, causing
+    // duplicate tools and text. Lifecycle events are always processed.
+    if (isReconciling(conversationId) && RECONCILIATION_SUPPRESSED_EVENTS.has(data.type)) {
+      return;
+    }
+
     const store = getStore();
 
     // Handle conversation_status separately - it uses a string payload
@@ -1027,10 +1067,8 @@ export function useWebSocket(enabled: boolean = true) {
           }
         } else {
           // Agent still active — restore streaming view from snapshot.
-          // Note: the snapshot may be up to 500ms stale (debounce interval). Text
-          // emitted between the last flush and the disconnect is lost. New WebSocket
-          // events after reconnect append from where the backend left off, so there's
-          // no duplication — just a small gap.
+          // Suppress live content events during snapshot fetch to prevent duplicates.
+          startReconciling(convId);
           try {
             const snapshot = await getStreamingSnapshot(convId);
             if (snapshot && snapshot.text) {
@@ -1048,6 +1086,8 @@ export function useWebSocket(enabled: boolean = true) {
             }
           } catch (err) {
             console.warn(`Failed to fetch streaming snapshot for ${convId}:`, err);
+          } finally {
+            stopReconciling(convId);
           }
         }
       }
@@ -1091,7 +1131,9 @@ export function useWebSocket(enabled: boolean = true) {
         // Restore conversation status (was reset to 'idle' during load)
         store.updateConversation(convId, { status: 'active' });
 
-        // Try to restore streaming content from snapshot
+        // Try to restore streaming content from snapshot.
+        // Suppress live content events during fetch to prevent duplicates.
+        startReconciling(convId);
         try {
           const snapshot = await getStreamingSnapshot(convId);
           if (snapshot && snapshot.text) {
@@ -1103,6 +1145,8 @@ export function useWebSocket(enabled: boolean = true) {
         } catch (err) {
           console.warn(`Failed to fetch initial streaming snapshot for ${convId}:`, err);
           store.setStreaming(convId, true);
+        } finally {
+          stopReconciling(convId);
         }
       }
     } catch (err) {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1384,36 +1384,45 @@ updateFileTabContent: (id, content) => set((state) => ({
     }),
   })),
   addActiveTool: (conversationId, tool, opts) => {
-    // Set up timeout to force-complete orphaned tools (skip for synthetic entries that will be completed immediately)
-    if (!opts?.skipTimeout) {
-      const timeoutKey = `${conversationId}:${tool.id}`;
-      const existing = toolTimeouts.get(timeoutKey);
-      if (existing) clearTimeout(existing);
+    return set((state) => {
+      const existing = state.activeTools[conversationId] || [];
+      // Dedup: skip if a tool with this id is already tracked (snapshot + live event race)
+      if (existing.some(t => t.id === tool.id)) {
+        return {};
+      }
 
-      const timeout = setTimeout(() => {
-        toolTimeouts.delete(timeoutKey);
-        const current = useAppStore.getState().activeTools[conversationId] || [];
-        const stillActive = current.find(t => t.id === tool.id && !t.endTime);
-        if (stillActive) {
-          console.warn(`[Store] Tool timeout: ${tool.tool} (${tool.id}) - forcing completion after ${TOOL_TIMEOUT_MS}ms`);
-          useAppStore.getState().completeActiveTool(
-            conversationId, tool.id, false, 'Tool timed out', undefined, undefined
-          );
-        }
-      }, TOOL_TIMEOUT_MS);
-      toolTimeouts.set(timeoutKey, timeout);
-    }
+      // Set up timeout to force-complete orphaned tools (skip for synthetic entries that will be completed immediately).
+      // Registered after dedup check so a duplicate call doesn't orphan the original tool's timeout.
+      if (!opts?.skipTimeout) {
+        const timeoutKey = `${conversationId}:${tool.id}`;
+        const existingTimeout = toolTimeouts.get(timeoutKey);
+        if (existingTimeout) clearTimeout(existingTimeout);
 
-    return set((state) => ({
-      activeTools: {
-        ...state.activeTools,
-        [conversationId]: [...(state.activeTools[conversationId] || []), tool],
-      },
-      // Seal current text segment so next text creates a new segment after this tool
-      streamingState: updateStreamingConv(state.streamingState, conversationId, {
-        currentSegmentId: null,
-      }),
-    }));
+        const timeout = setTimeout(() => {
+          toolTimeouts.delete(timeoutKey);
+          const current = useAppStore.getState().activeTools[conversationId] || [];
+          const stillActive = current.find(t => t.id === tool.id && !t.endTime);
+          if (stillActive) {
+            console.warn(`[Store] Tool timeout: ${tool.tool} (${tool.id}) - forcing completion after ${TOOL_TIMEOUT_MS}ms`);
+            useAppStore.getState().completeActiveTool(
+              conversationId, tool.id, false, 'Tool timed out', undefined, undefined
+            );
+          }
+        }, TOOL_TIMEOUT_MS);
+        toolTimeouts.set(timeoutKey, timeout);
+      }
+
+      return {
+        activeTools: {
+          ...state.activeTools,
+          [conversationId]: [...existing, tool],
+        },
+        // Seal current text segment so next text creates a new segment after this tool
+        streamingState: updateStreamingConv(state.streamingState, conversationId, {
+          currentSegmentId: null,
+        }),
+      };
+    });
   },
   completeActiveTool: (conversationId, toolId, success, summary, stdout, stderr, metadata) => {
     // Clear the timeout for this tool
@@ -1470,12 +1479,19 @@ updateFileTabContent: (id, content) => set((state) => ({
   },
 
   // Sub-agent actions
-  addSubAgent: (conversationId, agent) => set((state) => ({
-    subAgents: {
-      ...state.subAgents,
-      [conversationId]: [...(state.subAgents[conversationId] || []), agent],
-    },
-  })),
+  addSubAgent: (conversationId, agent) => set((state) => {
+    const existing = state.subAgents[conversationId] || [];
+    // Dedup: skip if a sub-agent with this id is already tracked (snapshot + live event race)
+    if (existing.some(a => a.agentId === agent.agentId)) {
+      return {};
+    }
+    return {
+      subAgents: {
+        ...state.subAgents,
+        [conversationId]: [...existing, agent],
+      },
+    };
+  }),
   completeSubAgent: (conversationId, agentId) => set((state) => ({
     subAgents: {
       ...state.subAgents,
@@ -1484,14 +1500,26 @@ updateFileTabContent: (id, content) => set((state) => ({
       ),
     },
   })),
-  addSubAgentTool: (conversationId, agentId, tool) => set((state) => ({
-    subAgents: {
-      ...state.subAgents,
-      [conversationId]: (state.subAgents[conversationId] || []).map((a) =>
-        a.agentId === agentId ? { ...a, tools: [...a.tools, tool] } : a
-      ),
-    },
-  })),
+  addSubAgentTool: (conversationId, agentId, tool) => set((state) => {
+    const agents = state.subAgents[conversationId] || [];
+    const agent = agents.find(a => a.agentId === agentId);
+    if (!agent) {
+      console.warn(`[Store] addSubAgentTool: sub-agent ${agentId} not found for conversation ${conversationId}, dropping tool ${tool.id}`);
+      return {};
+    }
+    // Dedup: skip if tool already exists in sub-agent's tool list (snapshot + live event race)
+    if (agent.tools.some(t => t.id === tool.id)) {
+      return {};
+    }
+    return {
+      subAgents: {
+        ...state.subAgents,
+        [conversationId]: agents.map((a) =>
+          a.agentId === agentId ? { ...a, tools: [...a.tools, tool] } : a
+        ),
+      },
+    };
+  }),
   completeSubAgentTool: (conversationId, agentId, toolId, success, summary, stdout, stderr) => set((state) => ({
     subAgents: {
       ...state.subAgents,


### PR DESCRIPTION
## Summary

- **Suppress content events during snapshot reconciliation** using a ref-counted `Map` to prevent duplicate tools and text when live WebSocket events overlap with snapshot data during reconnect
- **Move tool timeout registration after dedup check** in `addActiveTool` to fix a bug where duplicate calls would orphan the original tool's timeout
- **Add dedup guards** to `addActiveTool`, `addSubAgent`, and `addSubAgentTool` to silently skip duplicates from snapshot + live event races
- **Use stable `message.id` keys** in `VirtualizedMessageList` to prevent DOM recycling issues
- **Add `console.warn`** when `addSubAgentTool` drops a tool for an unknown sub-agent, aiding debugging

## Test plan

- [ ] Verify no duplicate tool cards appear during WebSocket reconnect while an agent is streaming
- [ ] Verify tool timeouts still fire correctly for legitimately orphaned tools
- [ ] Verify virtualized message list renders correctly with no flickering on message updates
- [ ] Run `npm run lint` — no new warnings
- [ ] Run `npm run build` — TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)