### PR TITLE
Add unresolved comment count badge to Code Review tab

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -611,6 +611,7 @@ export function ChangesPanel() {
         selectedTab={selectedTab}
         setSelectedTab={handleTabSelect}
         changesCount={branchStats?.totalFiles || changes?.length || 0}
+        reviewCount={unresolvedCount}
         menuContext={menuContext}
       />
 
@@ -975,11 +976,13 @@ function TopPanelTabs({
   selectedTab,
   setSelectedTab,
   changesCount,
+  reviewCount,
   menuContext,
 }: {
   selectedTab: string;
   setSelectedTab: (tab: string) => void;
   changesCount: number;
+  reviewCount: number;
   menuContext: TopPanelMenuContext;
 }) {
   const topTabOrder = useSettingsStore((s) => s.topTabOrder);
@@ -1033,7 +1036,11 @@ function TopPanelTabs({
                   label={TOP_TABS_CONFIG[tabId].label}
                   isActive={selectedTab === tabId}
                   onClick={() => setSelectedTab(tabId)}
-                  badge={tabId === 'changes' && changesCount > 0 ? changesCount : undefined}
+                  badge={
+                    tabId === 'changes' && changesCount > 0 ? changesCount
+                    : tabId === 'review' && reviewCount > 0 ? reviewCount
+                    : undefined
+                  }
                   shortcutId={TOP_TABS_CONFIG[tabId].shortcutId}
                 />
               ))}


### PR DESCRIPTION
## Summary
- Display the number of unresolved review comments as a badge on the Code Review tab
- Follows the existing badge pattern used by the Changes tab (file count) and Tasks tab (pending count)
- Badge updates in real-time as comments are added, resolved, or deleted via WebSocket events

## Test plan
- [ ] Open a session and trigger a code review that adds comments
- [ ] Verify the Code Review tab shows a numeric badge with the unresolved comment count
- [ ] Resolve a comment and confirm the badge count decreases
- [ ] Resolve all comments and confirm the badge disappears
- [ ] Verify the Changes tab badge still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)