### PR TITLE
Fix raw JSON error messages shown in API error dialogs

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,6 +43,9 @@ export class ApiError extends Error {
         if (parsed.code) {
           this.code = parsed.code;
         }
+        if (parsed.error) {
+          this.message = parsed.error;
+        }
       } catch {
         // Response is not JSON, ignore
       }


### PR DESCRIPTION
## Summary
- `ApiError` constructor parsed JSON responses to extract the `code` field but never extracted the `error` field for the message
- This caused all API errors to display raw JSON (e.g. `{"error":"no commits ahead of base branch","code":"VALIDATION_ERROR"}`) instead of the human-readable message
- Added `this.message = parsed.error` to extract the error text properly

## Test plan
- [x] All 10 existing `CreatePRDialog` tests pass
- [ ] Open "New Pull Request" dialog on a branch with no commits ahead — should show "no commits ahead of base branch" instead of raw JSON
- [ ] Trigger other API errors (e.g. missing GitHub auth) — should show clean messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)