### PR TITLE
Add rich tool block rendering for Edit, Write, Read, and Todo tools

### DIFF
--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, memo } from 'react';
+import { useState, useMemo, memo, lazy, Suspense } from 'react';
 import {
   Collapsible,
   CollapsibleContent,
@@ -33,7 +33,13 @@ import { parseMcpToolName, formatToolDuration, stripCdPrefix } from '@/lib/forma
 import { TOOL_TARGET_TRUNCATE, TOOL_COMMAND_TRUNCATE } from '@/lib/constants';
 import { useAppStore } from '@/stores/appStore';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { TodoToolDetail } from '@/components/conversation/tool-details/TodoToolDetail';
 import type { ToolMetadata } from '@/lib/types';
+
+// Lazy-load heavy Pierre-based components (only loaded when user expands a tool block)
+const EditToolDetail = lazy(() => import('@/components/conversation/tool-details/EditToolDetail').then(m => ({ default: m.EditToolDetail })));
+const WriteToolDetail = lazy(() => import('@/components/conversation/tool-details/WriteToolDetail').then(m => ({ default: m.WriteToolDetail })));
+const ReadToolDetail = lazy(() => import('@/components/conversation/tool-details/ReadToolDetail').then(m => ({ default: m.ReadToolDetail })));
 
 interface ToolUsageBlockProps {
   id: string;
@@ -174,8 +180,12 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   // Check if this is a Bash tool
   const isBashTool = ['Bash', 'bash', 'execute_command'].includes(tool);
 
-  // Check if this is an Edit tool and calculate line stats
+  // Check tool types for specialized rendering
   const isEditTool = ['Edit', 'edit_file'].includes(tool);
+  const isWriteTool = ['Write', 'write_file'].includes(tool);
+  const isReadTool = ['Read', 'read_file'].includes(tool);
+  const isTodoTool = tool === 'TodoWrite';
+
   const editStats = useMemo(() => {
     if (!isEditTool) return null;
     return calculateEditStats(params);
@@ -479,58 +489,91 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
             }
           >
             <div className="mt-0.5 ml-4 space-y-1.5">
-              {/* Full command for Bash tools */}
-              {isBashTool && fullTarget && (
-                <div className="rounded border bg-muted p-2">
-                  <div className="text-2xs text-muted-foreground/60 mb-1">Command</div>
-                  <pre className="font-mono text-2xs text-text-success whitespace-pre-wrap break-all">
-                    $ {fullTarget}
-                  </pre>
-                </div>
+              {/* Edit tool: inline diff viewer */}
+              {isEditTool && typeof params?.old_string === 'string' && typeof params?.new_string === 'string' && fullFilePath ? (
+                <Suspense fallback={<div className="rounded border bg-muted p-2 text-2xs text-muted-foreground">Loading diff viewer...</div>}>
+                  <EditToolDetail
+                    oldString={params.old_string as string}
+                    newString={params.new_string as string}
+                    filePath={fullFilePath}
+                  />
+                </Suspense>
+              ) : isWriteTool && typeof params?.content === 'string' && fullFilePath ? (
+                /* Write tool: syntax-highlighted code viewer */
+                <Suspense fallback={<div className="rounded border bg-muted p-2 text-2xs text-muted-foreground">Loading code viewer...</div>}>
+                  <WriteToolDetail
+                    content={params.content as string}
+                    filePath={fullFilePath}
+                  />
+                </Suspense>
+              ) : isReadTool && stdout && fullFilePath ? (
+                /* Read tool: syntax-highlighted file preview */
+                <Suspense fallback={<div className="rounded border bg-muted p-2 text-2xs text-muted-foreground">Loading code viewer...</div>}>
+                  <ReadToolDetail
+                    content={stdout}
+                    filePath={fullFilePath}
+                  />
+                </Suspense>
+              ) : isTodoTool && Array.isArray(params?.todos) ? (
+                /* TodoWrite: formatted task list */
+                <TodoToolDetail todos={params.todos as Array<{ content: string; status: 'pending' | 'in_progress' | 'completed'; activeForm?: string }>} />
+              ) : (
+                /* Generic fallback for all other tools */
+                <>
+                  {/* Full command for Bash tools */}
+                  {isBashTool && fullTarget && (
+                    <div className="rounded border bg-muted p-2">
+                      <div className="text-2xs text-muted-foreground/60 mb-1">Command</div>
+                      <pre className="font-mono text-2xs text-text-success whitespace-pre-wrap break-all">
+                        $ {fullTarget}
+                      </pre>
+                    </div>
+                  )}
+
+                  {/* Summary (hidden when stdout is present since the Output box already shows the full content) */}
+                  {summary && !stdout && (
+                    <div className={cn(
+                      'text-2xs px-2 py-1 rounded',
+                      success === false ? 'text-text-error bg-text-error/10' : 'text-muted-foreground bg-muted/30'
+                    )}>
+                      {summary}
+                    </div>
+                  )}
+
+                  {/* stdout output */}
+                  {stdout && (
+                    <div className="rounded border bg-muted p-2">
+                      <div className="text-2xs text-muted-foreground/60 mb-1">Output</div>
+                      <pre className="font-mono text-2xs text-foreground/80 whitespace-pre-wrap break-all max-h-[500px] overflow-y-auto">
+                        {stdout}
+                      </pre>
+                    </div>
+                  )}
+
+                  {/* Additional parameters (structured display) */}
+                  {additionalParams.length > 0 && (
+                    <div className="rounded border bg-muted/30 p-2">
+                      <div className="text-2xs text-muted-foreground/60 mb-1">Parameters</div>
+                      <div className="space-y-0.5">
+                        {additionalParams.map(({ key, value }) => (
+                          <div key={key} className="flex gap-2 text-2xs">
+                            <span className="text-muted-foreground font-medium shrink-0">{key}:</span>
+                            <span className="text-foreground/80 font-mono break-all">{value}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
               )}
 
-              {/* Summary (hidden when stdout is present since the Output box already shows the full content) */}
-              {summary && !stdout && (
-                <div className={cn(
-                  'text-2xs px-2 py-1 rounded',
-                  success === false ? 'text-text-error bg-text-error/10' : 'text-muted-foreground bg-muted/30'
-                )}>
-                  {summary}
-                </div>
-              )}
-
-              {/* stdout output */}
-              {stdout && (
-                <div className="rounded border bg-muted p-2">
-                  <div className="text-2xs text-muted-foreground/60 mb-1">Output</div>
-                  <pre className="font-mono text-2xs text-foreground/80 whitespace-pre-wrap break-all max-h-[500px] overflow-y-auto">
-                    {stdout}
-                  </pre>
-                </div>
-              )}
-
-              {/* stderr output */}
+              {/* stderr — always shown when present, regardless of which renderer was used */}
               {stderr && (
                 <div className="rounded border border-text-error/30 bg-text-error/10 p-2">
                   <div className="text-2xs text-text-error/60 mb-1">Error Output</div>
                   <pre className="font-mono text-2xs text-text-error whitespace-pre-wrap break-all max-h-[500px] overflow-y-auto">
                     {stderr}
                   </pre>
-                </div>
-              )}
-
-              {/* Additional parameters (structured display) */}
-              {additionalParams.length > 0 && (
-                <div className="rounded border bg-muted/30 p-2">
-                  <div className="text-2xs text-muted-foreground/60 mb-1">Parameters</div>
-                  <div className="space-y-0.5">
-                    {additionalParams.map(({ key, value }) => (
-                      <div key={key} className="flex gap-2 text-2xs">
-                        <span className="text-muted-foreground font-medium shrink-0">{key}:</span>
-                        <span className="text-foreground/80 font-mono break-all">{value}</span>
-                      </div>
-                    ))}
-                  </div>
                 </div>
               )}
             </div>

--- a/src/components/conversation/tool-details/CodeViewerDetail.tsx
+++ b/src/components/conversation/tool-details/CodeViewerDetail.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { memo, useMemo, useState, useCallback } from 'react';
+import { File as PierreFile } from '@pierre/diffs/react';
+import type { FileContents, FileOptions } from '@pierre/diffs/react';
+import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
+import { FileCode, WrapText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { BlockErrorFallback } from '@/components/shared/ErrorFallbacks';
+import { CopyButton } from '@/components/shared/CopyButton';
+import { getShikiLanguage } from '@/lib/languageMapping';
+
+const PIERRE_THEMES = { dark: 'pierre-dark', light: 'pierre-light' } as const;
+
+const MAX_LINES = 5000;
+
+interface CodeViewerDetailProps {
+  content: string;
+  filePath: string;
+  /** Cache key prefix to distinguish different tool types (e.g. 'tool-read', 'tool-write') */
+  cachePrefix: string;
+}
+
+function truncateContent(content: string): { text: string; truncated: boolean; totalLines: number } {
+  const lines = content.split('\n');
+  if (lines.length <= MAX_LINES) {
+    return { text: content, truncated: false, totalLines: lines.length };
+  }
+  return { text: lines.slice(0, MAX_LINES).join('\n'), truncated: true, totalLines: lines.length };
+}
+
+export const CodeViewerDetail = memo(function CodeViewerDetail({
+  content,
+  filePath,
+  cachePrefix,
+}: CodeViewerDetailProps) {
+  const themeType = useResolvedThemeType();
+  const [wordWrap, setWordWrap] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+
+  const getContent = useCallback(() => content, [content]);
+
+  const filename = filePath.split('/').pop() || filePath;
+  const language = getShikiLanguage(filename);
+
+  const { text: displayContent, truncated, totalLines } = useMemo(
+    () => showAll ? { text: content, truncated: false, totalLines: content.split('\n').length } : truncateContent(content),
+    [content, showAll],
+  );
+
+  const renderHeaderMetadata = useCallback(() => (
+    <div className="flex items-center gap-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn('h-5 w-5 text-muted-foreground', wordWrap && 'bg-muted')}
+        onClick={() => setWordWrap(w => !w)}
+        title={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}
+      >
+        <WrapText className="w-2.5 h-2.5" />
+      </Button>
+      <CopyButton getText={getContent} />
+    </div>
+  ), [wordWrap, getContent]);
+
+  const file: FileContents = useMemo(() => ({
+    name: filename,
+    contents: displayContent,
+    lang: language as FileContents['lang'],
+    cacheKey: `${cachePrefix}:${filePath}:${displayContent.length}:${displayContent.slice(0, 64)}`,
+  }), [filename, filePath, displayContent, language, cachePrefix]);
+
+  const options: FileOptions<undefined> = useMemo(() => ({
+    theme: PIERRE_THEMES,
+    themeType,
+    overflow: wordWrap ? 'wrap' as const : 'scroll' as const,
+    tokenizeMaxLineLength: 500,
+  }), [themeType, wordWrap]);
+
+  return (
+    <ErrorBoundary
+      section="CodeViewerDetail"
+      fallback={
+        <BlockErrorFallback
+          icon={FileCode}
+          title="Code viewer failed to load"
+          description="There was an error initializing the code viewer"
+        />
+      }
+    >
+      <div className="max-h-[400px] overflow-auto overscroll-contain relative z-0 rounded border">
+        <PierreFile
+          file={file}
+          options={options}
+          renderHeaderMetadata={renderHeaderMetadata}
+        />
+        {truncated && (
+          <div className="sticky bottom-0 flex items-center justify-center gap-2 px-4 py-2 bg-muted/80 backdrop-blur-sm border-t text-xs text-muted-foreground">
+            <span>Showing {MAX_LINES.toLocaleString()} of {totalLines.toLocaleString()} lines</span>
+            <button
+              onClick={() => setShowAll(true)}
+              className="text-primary hover:underline font-medium"
+            >
+              Show all
+            </button>
+          </div>
+        )}
+      </div>
+    </ErrorBoundary>
+  );
+});

--- a/src/components/conversation/tool-details/EditToolDetail.tsx
+++ b/src/components/conversation/tool-details/EditToolDetail.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { memo, useMemo, useState, useCallback } from 'react';
+import { FileDiff } from '@pierre/diffs/react';
+import type { FileContents } from '@pierre/diffs/react';
+import type { FileDiffMetadata } from '@pierre/diffs';
+import { parseDiffFromFile } from '@pierre/diffs';
+import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
+import { FileCode, Rows, SplitSquareHorizontal, WrapText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { BlockErrorFallback } from '@/components/shared/ErrorFallbacks';
+import { CopyButton } from '@/components/shared/CopyButton';
+import { getShikiLanguage } from '@/lib/languageMapping';
+
+const PIERRE_THEMES = { dark: 'pierre-dark', light: 'pierre-light' } as const;
+
+interface EditToolDetailProps {
+  oldString: string;
+  newString: string;
+  filePath: string;
+}
+
+export const EditToolDetail = memo(function EditToolDetail({
+  oldString,
+  newString,
+  filePath,
+}: EditToolDetailProps) {
+  const themeType = useResolvedThemeType();
+  const [diffViewMode, setDiffViewMode] = useState<'split' | 'unified'>('unified');
+  const [wordWrap, setWordWrap] = useState(false);
+
+  const getNewContent = useCallback(() => newString, [newString]);
+
+  const filename = filePath.split('/').pop() || filePath;
+  const language = getShikiLanguage(filename);
+
+  const oldFile: FileContents = useMemo(() => ({
+    name: filename,
+    contents: oldString,
+    lang: language as FileContents['lang'],
+    cacheKey: `tool-edit-old:${filePath}:${oldString.length}:${oldString.slice(0, 64)}`,
+  }), [filename, filePath, oldString, language]);
+
+  const newFile: FileContents = useMemo(() => ({
+    name: filename,
+    contents: newString,
+    lang: language as FileContents['lang'],
+    cacheKey: `tool-edit-new:${filePath}:${newString.length}:${newString.slice(0, 64)}`,
+  }), [filename, filePath, newString, language]);
+
+  const fileDiff: FileDiffMetadata = useMemo(() => {
+    return parseDiffFromFile(oldFile, newFile);
+  }, [oldFile, newFile]);
+
+  const renderHeaderMetadata = useCallback(() => (
+    <div className="flex items-center gap-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn('h-5 w-5 text-muted-foreground', diffViewMode === 'unified' && 'bg-muted')}
+        onClick={() => setDiffViewMode('unified')}
+        title="Unified view"
+      >
+        <Rows className="w-2.5 h-2.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn('h-5 w-5 text-muted-foreground', diffViewMode === 'split' && 'bg-muted')}
+        onClick={() => setDiffViewMode('split')}
+        title="Split view"
+      >
+        <SplitSquareHorizontal className="w-2.5 h-2.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn('h-5 w-5 text-muted-foreground', wordWrap && 'bg-muted')}
+        onClick={() => setWordWrap(w => !w)}
+        title={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}
+      >
+        <WrapText className="w-2.5 h-2.5" />
+      </Button>
+      <CopyButton getText={getNewContent} />
+    </div>
+  ), [diffViewMode, wordWrap, getNewContent]);
+
+  const options = useMemo(() => ({
+    theme: PIERRE_THEMES,
+    themeType,
+    diffStyle: diffViewMode === 'split' ? 'split' as const : 'unified' as const,
+    overflow: wordWrap ? 'wrap' as const : 'scroll' as const,
+    diffIndicators: 'bars' as const,
+    lineDiffType: 'word' as const,
+    tokenizeMaxLineLength: 500,
+  }), [themeType, diffViewMode, wordWrap]);
+
+  return (
+    <ErrorBoundary
+      section="EditToolDetail"
+      fallback={
+        <BlockErrorFallback
+          icon={FileCode}
+          title="Diff viewer failed to load"
+          description="There was an error initializing the diff viewer"
+        />
+      }
+    >
+      <div className="max-h-[400px] overflow-auto overscroll-contain relative z-0 rounded border">
+        <FileDiff
+          fileDiff={fileDiff}
+          options={options}
+          renderHeaderMetadata={renderHeaderMetadata}
+        />
+      </div>
+    </ErrorBoundary>
+  );
+});

--- a/src/components/conversation/tool-details/ReadToolDetail.tsx
+++ b/src/components/conversation/tool-details/ReadToolDetail.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { CodeViewerDetail } from './CodeViewerDetail';
+
+interface ReadToolDetailProps {
+  content: string;
+  filePath: string;
+}
+
+export const ReadToolDetail = function ReadToolDetail({ content, filePath }: ReadToolDetailProps) {
+  return <CodeViewerDetail content={content} filePath={filePath} cachePrefix="tool-read" />;
+};

--- a/src/components/conversation/tool-details/TodoToolDetail.tsx
+++ b/src/components/conversation/tool-details/TodoToolDetail.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { memo } from 'react';
+import { CheckCircle2, Circle, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface TodoItem {
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  activeForm?: string;
+}
+
+interface TodoToolDetailProps {
+  todos: TodoItem[];
+}
+
+export const TodoToolDetail = memo(function TodoToolDetail({ todos }: TodoToolDetailProps) {
+  if (!todos || todos.length === 0) return null;
+
+  return (
+    <div className="rounded border bg-muted/30 p-2 space-y-1">
+      {todos.map((todo, index) => (
+        <div
+          key={index}
+          className={cn(
+            'flex items-start gap-2 text-2xs py-0.5',
+            todo.status === 'completed' && 'text-muted-foreground',
+          )}
+        >
+          <span className="shrink-0 mt-0.5">
+            {todo.status === 'completed' ? (
+              <CheckCircle2 className="w-3 h-3 text-text-success" />
+            ) : todo.status === 'in_progress' ? (
+              <Loader2 className="w-3 h-3 text-primary animate-spin" />
+            ) : (
+              <Circle className="w-3 h-3 text-muted-foreground/50" />
+            )}
+          </span>
+          <span className={cn(
+            todo.status === 'completed' && 'line-through',
+          )}>
+            {todo.content}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+});

--- a/src/components/conversation/tool-details/WriteToolDetail.tsx
+++ b/src/components/conversation/tool-details/WriteToolDetail.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { CodeViewerDetail } from './CodeViewerDetail';
+
+interface WriteToolDetailProps {
+  content: string;
+  filePath: string;
+}
+
+export const WriteToolDetail = function WriteToolDetail({ content, filePath }: WriteToolDetailProps) {
+  return <CodeViewerDetail content={content} filePath={filePath} cachePrefix="tool-write" />;
+};

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -483,6 +483,7 @@ export function useWebSocket(enabled: boolean = true) {
           durationMs: t.endTime && t.startTime ? t.endTime - t.startTime : undefined,
           stdout: t.stdout,
           stderr: t.stderr,
+          metadata: t.metadata,
         }));
 
         // Atomic finalization - creates message and clears streaming/activeTools in one update

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -949,6 +949,7 @@ export interface ToolUsageDTO {
   durationMs?: number;
   stdout?: string;
   stderr?: string;
+  metadata?: import('@/lib/types').ToolMetadata;
 }
 
 export interface TimelineEntryDTO {


### PR DESCRIPTION
## Summary
- Adds specialized inline renderers for tool blocks: Pierre diff viewer for Edit, syntax-highlighted code viewer for Write/Read, and formatted task list for TodoWrite
- Lazy-loads heavy Pierre-based components so they're only fetched when a user expands a tool block
- Passes tool metadata through the WebSocket DTO for richer inline summaries
- Extracts shared `CodeViewerDetail` component to deduplicate Read/Write viewers
- Fixes stderr rendering to always show when present regardless of which specialized renderer was used

## Test plan
- [ ] Expand an Edit tool block — verify inline diff viewer renders with split/unified toggle
- [ ] Expand a Write tool block — verify syntax-highlighted code viewer renders
- [ ] Expand a Read tool block — verify syntax-highlighted file preview renders
- [ ] Expand a TodoWrite tool block — verify formatted task list with status icons renders
- [ ] Trigger a tool with stderr output — verify error output appears below any specialized renderer
- [ ] Verify tool blocks that don't match specialized renderers still show generic fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)