### PR TITLE
Add markdown support to code review and fix review UX issues

### DIFF
--- a/src/components/comments/CommentThread.tsx
+++ b/src/components/comments/CommentThread.tsx
@@ -13,6 +13,7 @@
 import { memo, useCallback } from 'react';
 import { AlertCircle, AlertTriangle, Info, Lightbulb, CheckCircle2, Circle, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
 import { cn } from '@/lib/utils';
 import type { ReviewComment } from '@/lib/types';
 
@@ -156,9 +157,9 @@ export const CommentThread = memo(function CommentThread({
         </div>
       </div>
 
-      {/* Content - simple text rendering (could add markdown support later) */}
-      <div className="text-foreground/90 whitespace-pre-wrap break-words">
-        {comment.content}
+      {/* Content - rendered as markdown */}
+      <div className="prose prose-sm dark:prose-invert max-w-none text-sm text-foreground/90 break-words [&_pre]:my-1 [&_pre]:bg-muted/50 [&_pre]:text-xs [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1">
+        <CachedMarkdown cacheKey={`review-comment:${comment.id}`} content={comment.content} />
       </div>
     </div>
   );

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -595,6 +595,24 @@ export function ChangesPanel() {
     }
   }, [fetchChanges, fetchBranchData]);
 
+  // Auto-switch to a tab when requested by other components (e.g., WebSocket comment_added).
+  // Debounced so rapid-fire events (many comments in a review) only switch once.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab: string }>).detail;
+      if (detail?.tab) {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => handleTabSelect(detail.tab), 300);
+      }
+    };
+    window.addEventListener('select-sidebar-tab', handler);
+    return () => {
+      window.removeEventListener('select-sidebar-tab', handler);
+      if (timer) clearTimeout(timer);
+    };
+  }, [handleTabSelect]);
+
   // Keyboard shortcuts for switching sidebar tabs
   const tabShortcuts = useMemo(() => ({
     sidebarFilesTab: () => handleTabSelect('files'),

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -15,9 +15,10 @@ import {
   ChevronDown,
   Check,
   Loader2,
-  ExternalLink,
+  List,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatTimeAgo } from '@/lib/format';
 import { useAppStore } from '@/stores/appStore';
 import {
   listReviewComments,
@@ -49,8 +50,8 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
   const [filter, setFilter] = useState<CommentSeverity | 'all'>('all');
   const [loading, setLoading] = useState(false);
   const [fetchSession, setFetchSession] = useState<string | null>(null);
-  const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set());
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
+  const [groupByFile, setGroupByFile] = useState(true);
 
   const comments = useAppStore((s) =>
     sessionId ? s.reviewComments[sessionId] || EMPTY : EMPTY
@@ -158,18 +159,6 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
     [workspaceId, sessionId, updateReviewComment]
   );
 
-  const toggleCardExpanded = useCallback((commentId: string) => {
-    setExpandedCards((prev) => {
-      const next = new Set(prev);
-      if (next.has(commentId)) {
-        next.delete(commentId);
-      } else {
-        next.add(commentId);
-      }
-      return next;
-    });
-  }, []);
-
   const toggleFileCollapsed = useCallback((filePath: string) => {
     setCollapsedFiles((prev) => {
       const next = new Set(prev);
@@ -244,6 +233,19 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
           <MessageSquare className="h-3 w-3 mr-0.5" />
           {counts.suggestion > 0 && counts.suggestion}
         </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-5 text-xs px-1.5 text-muted-foreground ml-auto"
+          onClick={() => setGroupByFile((prev) => !prev)}
+          title={groupByFile ? 'Switch to flat list' : 'Switch to group by file'}
+        >
+          {groupByFile ? (
+            <List className="h-3 w-3" />
+          ) : (
+            <FileCode className="h-3 w-3" />
+          )}
+        </Button>
       </div>
 
       {/* Comments list */}
@@ -272,55 +274,66 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
       ) : (
         <ScrollArea className="flex-1 min-h-0">
           <div className="p-1.5 space-y-1">
-            {Array.from(groupedComments.entries()).map(([filePath, fileComments]) => {
-              const fileName = filePath.split('/').pop() || filePath;
-              const dirPath = filePath.split('/').slice(0, -1).join('/');
-              const unresolvedCount = fileComments.filter((c) => !c.resolved).length;
-              const isCollapsed = collapsedFiles.has(filePath);
+            {groupByFile ? (
+              Array.from(groupedComments.entries()).map(([filePath, fileComments]) => {
+                const fileName = filePath.split('/').pop() || filePath;
+                const dirPath = filePath.split('/').slice(0, -1).join('/');
+                const unresolvedCount = fileComments.filter((c) => !c.resolved).length;
+                const isCollapsed = collapsedFiles.has(filePath);
 
-              return (
-                <div key={filePath}>
-                  {/* File group header */}
-                  <button
-                    className="flex items-center gap-1.5 w-full px-1.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-surface-2 rounded transition-colors"
-                    onClick={() => toggleFileCollapsed(filePath)}
-                  >
-                    {isCollapsed ? (
-                      <ChevronRight className="h-3 w-3 shrink-0" />
-                    ) : (
-                      <ChevronDown className="h-3 w-3 shrink-0" />
-                    )}
-                    <FileCode className="h-3 w-3 shrink-0" />
-                    <span className="truncate text-left" title={filePath}>
-                      {dirPath && <span className="opacity-60">{dirPath}/</span>}
-                      <span className="text-foreground">{fileName}</span>
-                    </span>
-                    {unresolvedCount > 0 && (
-                      <span className="ml-auto shrink-0 bg-muted text-muted-foreground rounded-full px-1.5 py-0 text-2xs font-medium">
-                        {unresolvedCount}
+                return (
+                  <div key={filePath}>
+                    {/* File group header */}
+                    <button
+                      className="flex items-center gap-1.5 w-full px-1.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-surface-2 rounded transition-colors"
+                      onClick={() => toggleFileCollapsed(filePath)}
+                    >
+                      {isCollapsed ? (
+                        <ChevronRight className="h-3 w-3 shrink-0" />
+                      ) : (
+                        <ChevronDown className="h-3 w-3 shrink-0" />
+                      )}
+                      <FileCode className="h-3 w-3 shrink-0" />
+                      <span className="truncate text-left" title={filePath}>
+                        {dirPath && <span className="opacity-60">{dirPath}/</span>}
+                        <span className="text-foreground">{fileName}</span>
                       </span>
-                    )}
-                  </button>
+                      {unresolvedCount > 0 && (
+                        <span className="ml-auto shrink-0 bg-muted text-muted-foreground rounded-full px-1.5 py-0 text-2xs font-medium">
+                          {unresolvedCount}
+                        </span>
+                      )}
+                    </button>
 
-                  {/* File comments */}
-                  {!isCollapsed && (
-                    <div className="ml-2 space-y-1 mt-0.5">
-                      {fileComments.map((comment) => (
-                        <ReviewCommentCard
-                          key={comment.id}
-                          comment={comment}
-                          isExpanded={expandedCards.has(comment.id)}
-                          onToggleExpand={() => toggleCardExpanded(comment.id)}
-                          onNavigate={() => onFileSelect?.(comment.filePath, comment.lineNumber)}
-                          onResolve={() => handleResolve(comment.id)}
-                          isResolved={comment.resolved}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
+                    {/* File comments */}
+                    {!isCollapsed && (
+                      <div className="ml-2 space-y-1 mt-0.5">
+                        {fileComments.map((comment) => (
+                          <ReviewCommentCard
+                            key={comment.id}
+                            comment={comment}
+                            onNavigate={() => onFileSelect?.(comment.filePath, comment.lineNumber)}
+                            onResolve={() => handleResolve(comment.id)}
+                            isResolved={comment.resolved}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            ) : (
+              filteredComments.map((comment) => (
+                <ReviewCommentCard
+                  key={comment.id}
+                  comment={comment}
+                  onNavigate={() => onFileSelect?.(comment.filePath, comment.lineNumber)}
+                  onResolve={() => handleResolve(comment.id)}
+                  isResolved={comment.resolved}
+                  showFilePath
+                />
+              ))
+            )}
           </div>
         </ScrollArea>
       )}
@@ -344,24 +357,25 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
 
 function ReviewCommentCard({
   comment,
-  isExpanded,
-  onToggleExpand,
   onNavigate,
   onResolve,
   isResolved,
+  showFilePath,
 }: {
   comment: ReviewComment;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
   onNavigate: () => void;
   onResolve?: () => void;
   isResolved?: boolean;
+  showFilePath?: boolean;
 }) {
-  // Use title field if available, otherwise extract first line of content
   const title = comment.title || comment.content.split('\n')[0];
-  const description = comment.title
-    ? comment.content
-    : comment.content.split('\n').slice(1).join('\n').trim();
+
+  // Refresh relative timestamps every 60s
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
 
   const severity = comment.severity || 'info';
 
@@ -379,31 +393,16 @@ function ReviewCommentCard({
     suggestion: 'text-purple-500 bg-purple-500/10 border-purple-500/20',
   }[severity];
 
-  const formatTimeAgo = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / (1000 * 60));
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    return `${diffDays}d ago`;
-  };
-
   return (
     <div
       className={cn(
-        'rounded-lg border p-2 transition-colors',
+        'rounded-lg border p-2 transition-colors cursor-pointer',
         isResolved ? 'opacity-50 border-border bg-surface-1' : severityColor
       )}
+      onClick={onNavigate}
     >
-      {/* Header row - click to expand/collapse */}
-      <div
-        className="flex items-start gap-2 cursor-pointer"
-        onClick={onToggleExpand}
-      >
+      {/* Header row */}
+      <div className="flex items-start gap-2">
         {isResolved ? (
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0 mt-0.5 text-green-500" />
         ) : (
@@ -411,11 +410,6 @@ function ReviewCommentCard({
         )}
         <div className="flex-1 min-w-0">
           <div className={cn('font-medium text-xs leading-tight', isResolved && 'line-through')}>{title}</div>
-          {description && !isExpanded && (
-            <p className="text-2xs text-muted-foreground mt-0.5 line-clamp-1">
-              {description}
-            </p>
-          )}
         </div>
         <div className="flex items-center gap-0.5 shrink-0">
           {!isResolved && (
@@ -432,34 +426,23 @@ function ReviewCommentCard({
               <Check className="h-3 w-3" />
             </Button>
           )}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-5 w-5 p-0 hover:bg-accent"
-            onClick={(e) => {
-              e.stopPropagation();
-              onNavigate();
-            }}
-            title="Open in diff view"
-          >
-            <ExternalLink className="h-3 w-3 text-muted-foreground" />
-          </Button>
         </div>
       </div>
 
-      {/* Expanded content */}
-      {isExpanded && description && (
-        <div className="mt-1.5 ml-5.5 text-xs text-foreground/80 whitespace-pre-wrap break-words border-t border-border/50 pt-1.5">
-          {description}
-        </div>
-      )}
-
-      {/* Footer row - line number and time */}
+      {/* Footer row - location and time */}
       <div className="flex items-center gap-2 mt-1 ml-5.5 text-2xs text-muted-foreground">
         {comment.lineNumber > 0 && (
-          <span>L{comment.lineNumber}</span>
+          <span
+            className="truncate"
+            title={showFilePath ? `${comment.filePath}:${comment.lineNumber}` : undefined}
+          >
+            {showFilePath
+              ? `${comment.filePath}:${comment.lineNumber}`
+              : `L${comment.lineNumber}`
+            }
+          </span>
         )}
-        <span className="ml-auto flex items-center gap-0.5">
+        <span className="ml-auto flex items-center gap-0.5 shrink-0">
           <Clock className="h-2.5 w-2.5" />
           {formatTimeAgo(comment.createdAt)}
         </span>

--- a/src/components/panels/__tests__/ReviewPanel.test.tsx
+++ b/src/components/panels/__tests__/ReviewPanel.test.tsx
@@ -240,7 +240,7 @@ describe('ReviewPanel', () => {
       expect(screen.getByText('src/deep/nested/')).toBeInTheDocument();
     });
 
-    it('uses title for card heading, content for description', async () => {
+    it('uses title for card heading (content not shown in card)', async () => {
       setupMswListComments([
         makeComment({
           title: 'Short title',
@@ -253,7 +253,8 @@ describe('ReviewPanel', () => {
       await waitFor(() => {
         expect(screen.getByText('Short title')).toBeInTheDocument();
       });
-      expect(screen.getByText('This is a longer description explaining the issue in detail.')).toBeInTheDocument();
+      // Content is not rendered in the card (only visible in the diff editor)
+      expect(screen.queryByText('This is a longer description explaining the issue in detail.')).not.toBeInTheDocument();
     });
 
     it('falls back to first line of content when no title', async () => {
@@ -269,7 +270,8 @@ describe('ReviewPanel', () => {
       await waitFor(() => {
         expect(screen.getByText('First line used as title')).toBeInTheDocument();
       });
-      expect(screen.getByText('Second line is the description.')).toBeInTheDocument();
+      // Only the first line (used as title) is shown; rest is not rendered in the card
+      expect(screen.queryByText('Second line is the description.')).not.toBeInTheDocument();
     });
   });
 
@@ -403,7 +405,7 @@ describe('ReviewPanel', () => {
   // ── onFileSelect callback ────────────────────────────────────────────
 
   describe('onFileSelect callback', () => {
-    it('calls onFileSelect with file path and line number when navigate button is clicked', async () => {
+    it('calls onFileSelect with file path and line number when card is clicked', async () => {
       const user = userEvent.setup();
       const onFileSelect = vi.fn();
 
@@ -423,8 +425,8 @@ describe('ReviewPanel', () => {
         expect(screen.getByText('Click me')).toBeInTheDocument();
       });
 
-      // Click the "Open in diff view" button
-      await user.click(screen.getByTitle('Open in diff view'));
+      // Click the comment card to navigate to the file
+      await user.click(screen.getByText('Click me'));
 
       expect(onFileSelect).toHaveBeenCalledWith('src/index.ts', 33);
     });

--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -8,19 +8,22 @@ import {
 import { useSelectedIds } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
 
+const MARKDOWN_INSTRUCTION =
+  '\nWhen writing comment content, use Markdown formatting for detailed comments that include code examples, lists, or structured explanations (use fenced code blocks for code, bullet lists for multiple points, **bold** for emphasis). Keep simple one-sentence comments as plain text.';
+
 const REVIEW_PROMPTS: Record<string, string> = {
   quick:
-    'Review the changes in this session. Use get_workspace_diff to see what changed, then use add_review_comment to leave inline comments. Focus on bugs, errors, and obvious issues. Be concise.',
+    'Review the changes in this session. Use get_workspace_diff to see what changed, then use add_review_comment to leave inline comments. Focus on bugs, errors, and obvious issues. Be concise.' + MARKDOWN_INSTRUCTION,
   deep:
-    'Do a thorough code review of all changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each issue found. Check for bugs, performance problems, security issues, error handling gaps, and code quality. Be detailed and specific.',
+    'Do a thorough code review of all changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each issue found. Check for bugs, performance problems, security issues, error handling gaps, and code quality. Be detailed and specific.' + MARKDOWN_INSTRUCTION,
   security:
-    'Perform a security audit on the changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each security concern. Look for injection vulnerabilities, authentication/authorization issues, data exposure, insecure defaults, and other OWASP top 10 risks.',
+    'Perform a security audit on the changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each security concern. Look for injection vulnerabilities, authentication/authorization issues, data exposure, insecure defaults, and other OWASP top 10 risks.' + MARKDOWN_INSTRUCTION,
   performance:
-    'Review the changes in this session for performance issues. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each concern. Look for unnecessary re-renders, memory leaks, expensive computations in hot paths, missing memoization, N+1 queries, and blocking operations. Call get_review_comment_stats at the end to summarize.',
+    'Review the changes in this session for performance issues. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each concern. Look for unnecessary re-renders, memory leaks, expensive computations in hot paths, missing memoization, N+1 queries, and blocking operations. Call get_review_comment_stats at the end to summarize.' + MARKDOWN_INSTRUCTION,
   architecture:
-    'Review the changes in this session for architectural quality. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each concern. Evaluate separation of concerns, coupling between modules, adherence to existing patterns in the codebase, SOLID principles, and appropriate abstractions. Call get_review_comment_stats at the end to summarize.',
+    'Review the changes in this session for architectural quality. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each concern. Evaluate separation of concerns, coupling between modules, adherence to existing patterns in the codebase, SOLID principles, and appropriate abstractions. Call get_review_comment_stats at the end to summarize.' + MARKDOWN_INSTRUCTION,
   premerge:
-    'Perform a final pre-merge check on the changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each issue. Check for leftover TODOs, console.logs, debug code, commented-out code, missing error handling, incomplete implementations, and anything that should not be merged. Call get_review_comment_stats at the end to summarize.',
+    'Perform a final pre-merge check on the changes in this session. Use get_workspace_diff to see the full diff, then use add_review_comment to leave inline comments for each issue. Check for leftover TODOs, console.logs, debug code, commented-out code, missing error handling, incomplete implementations, and anything that should not be merged. Call get_review_comment_stats at the end to summarize.' + MARKDOWN_INSTRUCTION,
 };
 
 const REVIEW_TYPE_META: { key: string; label: string; placeholder: string }[] = [

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1394,6 +1394,10 @@ export function useWebSocket(enabled: boolean = true) {
           const payload = data.payload as ReviewComment | undefined;
           if (payload?.id) {
             getStore().addReviewComment(data.sessionId, payload);
+            // Auto-switch sidebar to Code Review tab when a new comment arrives for the active session
+            if (data.sessionId === getStore().selectedSessionId) {
+              window.dispatchEvent(new CustomEvent('select-sidebar-tab', { detail: { tab: 'review' } }));
+            }
           }
           return;
         }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -24,6 +24,24 @@ export function formatCost(usd: number): string {
 }
 
 // ---------------------------------------------------------------------------
+// Relative time formatting
+// ---------------------------------------------------------------------------
+
+/** Format a date string as a relative time ago label (e.g. "5m ago", "2h ago"). */
+export function formatTimeAgo(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+// ---------------------------------------------------------------------------
 // Tool duration formatting
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Render review comment content as markdown (code blocks, lists, bold) using `CachedMarkdown`
- Add group-by-file / flat-list toggle in the Review panel
- Simplify comment cards: remove expand/collapse, entire card is clickable to navigate
- Fix sidebar tab auto-switch firing for comments from **any** session (now guarded to active session only)
- Debounce rapid-fire `select-sidebar-tab` events so reviews with many comments don't repeatedly yank the sidebar
- Extract `formatTimeAgo` to shared `src/lib/format.ts` utility with 60s auto-refresh so timestamps stay current
- Fix leading space in `MARKDOWN_INSTRUCTION` prompt constant (now uses `\n` separator)

## Test plan
- [x] All 27 ReviewPanel tests pass
- [x] ESLint: no new warnings
- [ ] Manual: trigger a code review, verify comments render markdown (code blocks, bold, lists)
- [ ] Manual: toggle between group-by-file and flat list views
- [ ] Manual: click a comment card → navigates to file/line in diff view
- [ ] Manual: verify sidebar only switches to Review tab for the active session's comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)