### PR TITLE
Fix session auto-rename regression in sidebar

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -2000,11 +2000,6 @@ func (m *Manager) tryAutoNameSession(ctx context.Context, sessionID, suggestedNa
 		return
 	}
 
-	// Skip if session has already been auto-named
-	if sess.AutoNamed {
-		return
-	}
-
 	// Format the name like a branch name
 	formattedName := formatSessionName(suggestedName)
 	if formattedName == "" {


### PR DESCRIPTION
## Summary

- Fixes regression from #628 where `claimAutoName()` sets `AutoNamed=true` before title generation, causing `tryAutoNameSession()` to bail out early — session name and branch rename never happen
- Tab title updated correctly (conversation name set before the bail), but sidebar stayed stuck on the original branch name
- Removes the now-redundant `AutoNamed` guard from `tryAutoNameSession` since `claimAutoName` already prevents duplicate renames

## Test plan

- [ ] Create a new session and send a message — sidebar name should update to the AI-generated title
- [ ] Tab title should also update (already worked before)
- [ ] Git branch should be renamed to match the generated name
- [ ] Verify concurrent conversations on the same session don't cause duplicate renames (the race fix from #628 is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)