### PR TITLE
Default word wrap to on in diff editor

### DIFF
--- a/src/components/files/PierreDiffEditor.tsx
+++ b/src/components/files/PierreDiffEditor.tsx
@@ -50,7 +50,7 @@ export const PierreDiffEditor = memo(function PierreDiffEditor({
   const themeType = useResolvedThemeType();
   const [activeCommentLine, setActiveCommentLine] = useState<number | null>(null);
   const [diffViewMode, setDiffViewMode] = useState<'split' | 'unified'>('unified');
-  const [wordWrap, setWordWrap] = useState(false);
+  const [wordWrap, setWordWrap] = useState(true);
 
   const getNewContent = useCallback(() => newContent, [newContent]);
 


### PR DESCRIPTION
## Summary
- Default the PierreDiffEditor word wrap to **on** so long lines wrap instead of requiring horizontal scrolling
- The toggle button in the header still allows switching back to scroll mode

## Test plan
- [ ] Open a file diff (e.g. via Changes panel or code review)
- [ ] Verify long lines wrap by default
- [ ] Toggle the wrap button off and confirm horizontal scrolling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)