### PR TITLE
Add test suites for hooks, lib utilities, and stores

### DIFF
--- a/src/hooks/__tests__/useBranchSync.test.ts
+++ b/src/hooks/__tests__/useBranchSync.test.ts
@@ -1,0 +1,763 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBranchSync } from '../useBranchSync';
+import { useAppStore } from '@/stores/appStore';
+import type { BranchSyncStatusDTO, BranchSyncResultDTO } from '@/lib/api';
+
+// vi.mock is hoisted above imports by Vitest's transform, so the import
+// below always receives the mocked module regardless of source order.
+vi.mock('@/lib/api', () => ({
+  getBranchSyncStatus: vi.fn(),
+  syncBranch: vi.fn(),
+  abortBranchSync: vi.fn(),
+}));
+
+import { getBranchSyncStatus, syncBranch, abortBranchSync } from '@/lib/api';
+
+const mockedGetBranchSyncStatus = vi.mocked(getBranchSyncStatus);
+const mockedSyncBranch = vi.mocked(syncBranch);
+const mockedAbortBranchSync = vi.mocked(abortBranchSync);
+
+// --- Helpers ---
+
+function makeSyncStatus(overrides: Partial<BranchSyncStatusDTO> = {}): BranchSyncStatusDTO {
+  return {
+    behindBy: 3,
+    commits: [
+      { sha: 'abc123', message: 'fix: something', author: 'dev', date: '2026-01-01T00:00:00Z' },
+    ],
+    baseBranch: 'origin/main',
+    lastChecked: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeSyncResult(overrides: Partial<BranchSyncResultDTO> = {}): BranchSyncResultDTO {
+  return {
+    success: true,
+    ...overrides,
+  };
+}
+
+/**
+ * Flush microtasks and advance fake timers so resolved promises and
+ * React state updates (including deferred effects) can complete.
+ */
+async function flushAndAdvance(ms = 0) {
+  await act(async () => {
+    await Promise.resolve();
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+}
+
+// --- Test suite ---
+
+describe('useBranchSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    // Reset the store slices used by the hook
+    useAppStore.setState({
+      branchSyncStatus: {},
+      branchSyncLoading: {},
+      branchSyncDismissed: {},
+      branchSyncCompletedAt: {},
+    });
+
+    // Default: API returns a status behind by 3 commits
+    mockedGetBranchSyncStatus.mockResolvedValue(makeSyncStatus());
+    mockedSyncBranch.mockResolvedValue(makeSyncResult());
+    mockedAbortBranchSync.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // =====================================================
+  // Initial state & deferred fetch
+  // =====================================================
+
+  it('returns null/false defaults before any fetch', () => {
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+    expect(result.current.status).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.syncing).toBe(false);
+    expect(result.current.aborting).toBe(false);
+    expect(result.current.dismissed).toBe(false);
+    expect(result.current.conflictFiles).toEqual([]);
+    expect(result.current.lastOperation).toBeNull();
+  });
+
+  it('defers initial status check via setTimeout fallback (jsdom has no requestIdleCallback)', async () => {
+    renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+    // Before the 2000ms timeout fires, no fetch should have happened
+    await flushAndAdvance(500);
+    expect(mockedGetBranchSyncStatus).not.toHaveBeenCalled();
+
+    // After 2000ms the deferred check fires
+    await flushAndAdvance(1600);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledWith('ws-1', 'session-1');
+  });
+
+  it('does not fetch when workspaceId or sessionId is null', async () => {
+    const { result } = renderHook(() => useBranchSync(null, null));
+    await flushAndAdvance(3000);
+
+    expect(mockedGetBranchSyncStatus).not.toHaveBeenCalled();
+    expect(result.current.status).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('does not fetch when workspaceId is null', async () => {
+    renderHook(() => useBranchSync(null, 'session-1'));
+    await flushAndAdvance(3000);
+
+    expect(mockedGetBranchSyncStatus).not.toHaveBeenCalled();
+  });
+
+  it('stores status in the app store after successful fetch', async () => {
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    expect(result.current.status).not.toBeNull();
+    expect(result.current.status!.behindBy).toBe(3);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('clears dismissed state when behind by > 0 commits', async () => {
+    // Pre-dismiss the session
+    useAppStore.setState({
+      branchSyncDismissed: { 'session-1': true },
+    });
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    expect(result.current.dismissed).toBe(true);
+
+    // Trigger the deferred fetch which returns behindBy: 3
+    await flushAndAdvance(2100);
+
+    expect(result.current.dismissed).toBe(false);
+  });
+
+  // =====================================================
+  // Cache TTL (30 seconds per session)
+  // =====================================================
+
+  it('forceCheck (public checkStatus) always calls API regardless of cache TTL', async () => {
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+    // Fire initial deferred check
+    await flushAndAdvance(2100);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(1);
+
+    // The public checkStatus is forceCheck which bypasses cache.
+    // Verify it always calls the API even within the 30s TTL window.
+    await act(async () => {
+      await result.current.checkStatus();
+      await Promise.resolve();
+    });
+
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-fetches when session changes', async () => {
+    const { rerender, result } = renderHook(
+      ({ wsId, sessId }) => useBranchSync(wsId, sessId),
+      { initialProps: { wsId: 'ws-1', sessId: 'session-1' } }
+    );
+
+    await flushAndAdvance(2100);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(1);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledWith('ws-1', 'session-1');
+
+    // Switch to a different session
+    rerender({ wsId: 'ws-1', sessId: 'session-2' });
+    await flushAndAdvance(2100);
+
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(2);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledWith('ws-1', 'session-2');
+
+    // The returned status should reflect the new session (null until fetched,
+    // but since the mock resolves instantly it should be populated)
+    expect(result.current.status).not.toBeNull();
+  });
+
+  // =====================================================
+  // Rebase
+  // =====================================================
+
+  it('performs rebase and updates state on success', async () => {
+    mockedSyncBranch.mockResolvedValue(makeSyncResult({ success: true }));
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    let rebaseResult: BranchSyncResultDTO | null = null;
+    await act(async () => {
+      rebaseResult = await result.current.rebase();
+    });
+
+    expect(mockedSyncBranch).toHaveBeenCalledWith('ws-1', 'session-1', 'rebase');
+    expect(rebaseResult).not.toBeNull();
+    expect(rebaseResult!.success).toBe(true);
+    expect(result.current.syncing).toBe(false);
+    expect(result.current.dismissed).toBe(true);
+
+    // Status should be reset to behindBy: 0
+    const storeStatus = useAppStore.getState().branchSyncStatus['session-1'];
+    expect(storeStatus).not.toBeNull();
+    expect(storeStatus!.behindBy).toBe(0);
+
+    // completedAt timestamp should have been set
+    const completedAt = useAppStore.getState().branchSyncCompletedAt['session-1'];
+    expect(completedAt).toBeGreaterThan(0);
+  });
+
+  it('sets conflictFiles on rebase conflict', async () => {
+    mockedSyncBranch.mockResolvedValue(
+      makeSyncResult({
+        success: false,
+        conflictFiles: ['src/a.ts', 'src/b.ts'],
+      })
+    );
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    await act(async () => {
+      await result.current.rebase();
+    });
+
+    expect(result.current.conflictFiles).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(result.current.lastOperation).toBe('rebase');
+    expect(result.current.syncing).toBe(false);
+  });
+
+  it('returns null and keeps syncing=false when rebase throws', async () => {
+    mockedSyncBranch.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    let rebaseResult: BranchSyncResultDTO | null = null;
+    await act(async () => {
+      rebaseResult = await result.current.rebase();
+    });
+
+    expect(rebaseResult).toBeNull();
+    expect(result.current.syncing).toBe(false);
+  });
+
+  it('returns null when rebase called without session', async () => {
+    const { result } = renderHook(() => useBranchSync(null, null));
+
+    let rebaseResult: BranchSyncResultDTO | null = null;
+    await act(async () => {
+      rebaseResult = await result.current.rebase();
+    });
+
+    expect(rebaseResult).toBeNull();
+    expect(mockedSyncBranch).not.toHaveBeenCalled();
+  });
+
+  // =====================================================
+  // Merge
+  // =====================================================
+
+  it('performs merge and updates state on success', async () => {
+    mockedSyncBranch.mockResolvedValue(makeSyncResult({ success: true }));
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    let mergeResult: BranchSyncResultDTO | null = null;
+    await act(async () => {
+      mergeResult = await result.current.merge();
+    });
+
+    expect(mockedSyncBranch).toHaveBeenCalledWith('ws-1', 'session-1', 'merge');
+    expect(mergeResult).not.toBeNull();
+    expect(mergeResult!.success).toBe(true);
+    expect(result.current.syncing).toBe(false);
+    expect(result.current.dismissed).toBe(true);
+  });
+
+  it('sets conflictFiles on merge conflict', async () => {
+    mockedSyncBranch.mockResolvedValue(
+      makeSyncResult({
+        success: false,
+        conflictFiles: ['package.json'],
+      })
+    );
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    await act(async () => {
+      await result.current.merge();
+    });
+
+    expect(result.current.conflictFiles).toEqual(['package.json']);
+    expect(result.current.lastOperation).toBe('merge');
+  });
+
+  it('returns null when merge throws', async () => {
+    mockedSyncBranch.mockRejectedValue(new Error('server 500'));
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    let mergeResult: BranchSyncResultDTO | null = null;
+    await act(async () => {
+      mergeResult = await result.current.merge();
+    });
+
+    expect(mergeResult).toBeNull();
+    expect(result.current.syncing).toBe(false);
+  });
+
+  // =====================================================
+  // "Just synced" flag prevents re-fetch
+  // =====================================================
+
+  it('skips auto-refresh after a successful rebase (justSynced flag)', async () => {
+    mockedSyncBranch.mockResolvedValue(makeSyncResult({ success: true }));
+
+    const { result, rerender } = renderHook(
+      ({ wsId, sessId }) => useBranchSync(wsId, sessId),
+      { initialProps: { wsId: 'ws-1', sessId: 'session-1' } }
+    );
+
+    // Let the initial deferred check fire
+    await flushAndAdvance(2100);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(1);
+
+    // Perform a successful rebase -- this sets the justSynced flag
+    await act(async () => {
+      await result.current.rebase();
+    });
+
+    // Clear call count to isolate next check
+    mockedGetBranchSyncStatus.mockClear();
+
+    // Simulate a re-mount / session switch that causes the deferred effect to re-fire
+    // by switching away and back to the same session.
+    rerender({ wsId: 'ws-1', sessId: 'session-2' });
+    await flushAndAdvance(2100);
+
+    // session-2 should get a fetch
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(1);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledWith('ws-1', 'session-2');
+
+    mockedGetBranchSyncStatus.mockClear();
+
+    // Switch back to session-1. The justSynced flag was set for session-1,
+    // so the deferred check should be skipped.
+    rerender({ wsId: 'ws-1', sessId: 'session-1' });
+    await flushAndAdvance(2100);
+
+    // The justSynced flag consumes itself on first check, so the fetch is skipped
+    expect(mockedGetBranchSyncStatus).not.toHaveBeenCalled();
+  });
+
+  it('skips auto-refresh after a successful merge (justSynced flag)', async () => {
+    mockedSyncBranch.mockResolvedValue(makeSyncResult({ success: true }));
+
+    const { result, rerender } = renderHook(
+      ({ wsId, sessId }) => useBranchSync(wsId, sessId),
+      { initialProps: { wsId: 'ws-1', sessId: 'session-1' } }
+    );
+
+    await flushAndAdvance(2100);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.merge();
+    });
+
+    mockedGetBranchSyncStatus.mockClear();
+
+    // Switch away and back
+    rerender({ wsId: 'ws-1', sessId: 'session-2' });
+    await flushAndAdvance(2100);
+    mockedGetBranchSyncStatus.mockClear();
+
+    rerender({ wsId: 'ws-1', sessId: 'session-1' });
+    await flushAndAdvance(2100);
+
+    expect(mockedGetBranchSyncStatus).not.toHaveBeenCalled();
+  });
+
+  // =====================================================
+  // Abort
+  // =====================================================
+
+  it('aborts in-progress operation and refreshes status', async () => {
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    // Simulate a conflict so there is something to abort
+    mockedSyncBranch.mockResolvedValue(
+      makeSyncResult({ success: false, conflictFiles: ['file.ts'] })
+    );
+    await act(async () => {
+      await result.current.rebase();
+    });
+    expect(result.current.conflictFiles).toEqual(['file.ts']);
+
+    mockedGetBranchSyncStatus.mockClear();
+
+    // Now abort
+    await act(async () => {
+      await result.current.abort();
+    });
+
+    expect(mockedAbortBranchSync).toHaveBeenCalledWith('ws-1', 'session-1');
+    expect(result.current.conflictFiles).toEqual([]);
+    expect(result.current.lastOperation).toBeNull();
+    expect(result.current.aborting).toBe(false);
+
+    // abort calls forceCheck, which should have re-fetched
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles abort failure gracefully', async () => {
+    mockedAbortBranchSync.mockRejectedValue(new Error('abort failed'));
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    await act(async () => {
+      await result.current.abort();
+    });
+
+    // Should not throw; aborting should be reset
+    expect(result.current.aborting).toBe(false);
+  });
+
+  it('does not call abort API when session is null', async () => {
+    const { result } = renderHook(() => useBranchSync(null, null));
+
+    await act(async () => {
+      await result.current.abort();
+    });
+
+    expect(mockedAbortBranchSync).not.toHaveBeenCalled();
+  });
+
+  // =====================================================
+  // Dismiss & clearConflicts
+  // =====================================================
+
+  it('dismiss sets dismissed state in store', async () => {
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+    expect(result.current.dismissed).toBe(false);
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.dismissed).toBe(true);
+    expect(useAppStore.getState().branchSyncDismissed['session-1']).toBe(true);
+  });
+
+  it('dismiss is a no-op when sessionId is null', () => {
+    const { result } = renderHook(() => useBranchSync('ws-1', null));
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    // No crash, dismissed remains false
+    expect(result.current.dismissed).toBe(false);
+  });
+
+  it('clearConflicts resets conflict state', async () => {
+    mockedSyncBranch.mockResolvedValue(
+      makeSyncResult({ success: false, conflictFiles: ['a.ts'] })
+    );
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    await act(async () => {
+      await result.current.rebase();
+    });
+
+    expect(result.current.conflictFiles).toEqual(['a.ts']);
+    expect(result.current.lastOperation).toBe('rebase');
+
+    act(() => {
+      result.current.clearConflicts();
+    });
+
+    expect(result.current.conflictFiles).toEqual([]);
+    expect(result.current.lastOperation).toBeNull();
+  });
+
+  // =====================================================
+  // Mount / unmount lifecycle
+  // =====================================================
+
+  it('does not update state after unmount', async () => {
+    let resolveDeferred!: (value: BranchSyncStatusDTO) => void;
+    const deferred = new Promise<BranchSyncStatusDTO>((resolve) => {
+      resolveDeferred = resolve;
+    });
+    mockedGetBranchSyncStatus.mockReturnValue(deferred);
+
+    const { result, unmount } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+    // Trigger the deferred setTimeout
+    await flushAndAdvance(2100);
+
+    // The API was called but hasn't resolved yet
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(1);
+
+    // Unmount before the deferred fetch resolves
+    unmount();
+
+    // Now resolve -- state should NOT update because isMountedRef is false
+    await act(async () => {
+      resolveDeferred(makeSyncStatus({ behindBy: 5 }));
+      await Promise.resolve();
+    });
+
+    // Status should remain null in the store for this session because the
+    // isMountedRef guard prevented the update
+    const storeStatus = useAppStore.getState().branchSyncStatus['session-1'];
+    expect(storeStatus).toBeUndefined();
+  });
+
+  it('cleans up deferred setTimeout on unmount', async () => {
+    const { unmount } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+    // Unmount before the 2000ms deferred check fires
+    unmount();
+
+    // Advance past the deferred timeout -- should NOT trigger a fetch
+    await flushAndAdvance(3000);
+
+    expect(mockedGetBranchSyncStatus).not.toHaveBeenCalled();
+  });
+
+  // =====================================================
+  // Error handling
+  // =====================================================
+
+  it('handles getBranchSyncStatus failure gracefully', async () => {
+    mockedGetBranchSyncStatus.mockRejectedValue(new Error('API error'));
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    // Should not crash; loading should be reset to false
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBeNull();
+  });
+
+  // =====================================================
+  // forceCheck (public checkStatus)
+  // =====================================================
+
+  it('forceCheck bypasses cache TTL', async () => {
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+    // Let the initial deferred check fire
+    await flushAndAdvance(2100);
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(1);
+
+    // Immediately call forceCheck (well within 30s TTL)
+    await act(async () => {
+      await result.current.checkStatus();
+    });
+
+    // Should have been called again because force=true bypasses the cache
+    expect(mockedGetBranchSyncStatus).toHaveBeenCalledTimes(2);
+  });
+
+  // =====================================================
+  // requestIdleCallback path
+  // =====================================================
+
+  it('uses requestIdleCallback when available', async () => {
+    const mockIdleCallback = vi.fn((cb: IdleRequestCallback) => {
+      // Execute the callback synchronously for testing
+      cb({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+      return 1;
+    });
+    const mockCancelIdleCallback = vi.fn();
+
+    // Install the polyfill
+    globalThis.requestIdleCallback = mockIdleCallback;
+    globalThis.cancelIdleCallback = mockCancelIdleCallback;
+
+    try {
+      const { unmount } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+      // The hook should have used requestIdleCallback
+      await flushAndAdvance(0);
+
+      expect(mockIdleCallback).toHaveBeenCalled();
+      expect(mockedGetBranchSyncStatus).toHaveBeenCalledWith('ws-1', 'session-1');
+
+      // Unmount while polyfill is still installed so cleanup can call cancelIdleCallback
+      unmount();
+    } finally {
+      // Clean up -- remove the polyfill
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).requestIdleCallback;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).cancelIdleCallback;
+    }
+  });
+
+  it('cancels requestIdleCallback on unmount', async () => {
+    const mockCancelIdleCallback = vi.fn();
+    globalThis.requestIdleCallback = vi.fn(() => 42);
+    globalThis.cancelIdleCallback = mockCancelIdleCallback;
+
+    try {
+      const { unmount } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+      unmount();
+
+      expect(mockCancelIdleCallback).toHaveBeenCalledWith(42);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).requestIdleCallback;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).cancelIdleCallback;
+    }
+  });
+
+  // =====================================================
+  // Loading state transitions
+  // =====================================================
+
+  it('sets loading=true while fetching and false after', async () => {
+    let resolveDeferred!: (value: BranchSyncStatusDTO) => void;
+    mockedGetBranchSyncStatus.mockImplementation(
+      () =>
+        new Promise<BranchSyncStatusDTO>((resolve) => {
+          resolveDeferred = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+
+    // Trigger the deferred check
+    await flushAndAdvance(2100);
+
+    // Loading should be true while the API call is pending
+    expect(result.current.loading).toBe(true);
+
+    // Resolve the fetch
+    await act(async () => {
+      resolveDeferred(makeSyncStatus());
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  // =====================================================
+  // Syncing state transitions
+  // =====================================================
+
+  it('sets syncing=true during rebase and false after', async () => {
+    let resolveSync!: (value: BranchSyncResultDTO) => void;
+    mockedSyncBranch.mockImplementation(
+      () =>
+        new Promise<BranchSyncResultDTO>((resolve) => {
+          resolveSync = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    // Start rebase (don't await yet)
+    let rebasePromise: Promise<BranchSyncResultDTO | null>;
+    act(() => {
+      rebasePromise = result.current.rebase();
+    });
+
+    // syncing should be true while the operation is in progress
+    expect(result.current.syncing).toBe(true);
+    expect(result.current.lastOperation).toBe('rebase');
+
+    // Resolve the sync
+    await act(async () => {
+      resolveSync(makeSyncResult());
+      await rebasePromise!;
+    });
+
+    expect(result.current.syncing).toBe(false);
+  });
+
+  it('sets syncing=true during merge and false after', async () => {
+    let resolveSync!: (value: BranchSyncResultDTO) => void;
+    mockedSyncBranch.mockImplementation(
+      () =>
+        new Promise<BranchSyncResultDTO>((resolve) => {
+          resolveSync = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    let mergePromise: Promise<BranchSyncResultDTO | null>;
+    act(() => {
+      mergePromise = result.current.merge();
+    });
+
+    expect(result.current.syncing).toBe(true);
+    expect(result.current.lastOperation).toBe('merge');
+
+    await act(async () => {
+      resolveSync(makeSyncResult());
+      await mergePromise!;
+    });
+
+    expect(result.current.syncing).toBe(false);
+  });
+
+  // =====================================================
+  // Aborting state transitions
+  // =====================================================
+
+  it('sets aborting=true during abort and false after', async () => {
+    let resolveAbort!: () => void;
+    mockedAbortBranchSync.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAbort = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useBranchSync('ws-1', 'session-1'));
+    await flushAndAdvance(2100);
+
+    let abortPromise: Promise<void>;
+    act(() => {
+      abortPromise = result.current.abort();
+    });
+
+    expect(result.current.aborting).toBe(true);
+
+    await act(async () => {
+      resolveAbort();
+      await abortPromise;
+    });
+
+    expect(result.current.aborting).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useCIRuns.test.ts
+++ b/src/hooks/__tests__/useCIRuns.test.ts
@@ -1,0 +1,735 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCIRuns } from '../useCIRuns';
+
+// vi.mock is hoisted above imports by Vitest's transform, so the import
+// below always receives the mocked module regardless of source order.
+vi.mock('@/lib/api', () => ({
+  getCIRuns: vi.fn(),
+  getCIJobs: vi.fn(),
+  getCIJobLogs: vi.fn(),
+  rerunCI: vi.fn(),
+  analyzeCIFailure: vi.fn(),
+  ApiError: class ApiError extends Error {
+    constructor(
+      message: string,
+      public status: number,
+      public response?: string
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  },
+}));
+
+import {
+  getCIRuns,
+  getCIJobs,
+  getCIJobLogs,
+  rerunCI,
+  analyzeCIFailure,
+  ApiError,
+} from '@/lib/api';
+import type {
+  WorkflowRunDTO,
+  WorkflowJobDTO,
+  CIAnalysisResult,
+} from '@/lib/api';
+
+const mockedGetCIRuns = vi.mocked(getCIRuns);
+const mockedGetCIJobs = vi.mocked(getCIJobs);
+const mockedGetCIJobLogs = vi.mocked(getCIJobLogs);
+const mockedRerunCI = vi.mocked(rerunCI);
+const mockedAnalyzeCIFailure = vi.mocked(analyzeCIFailure);
+
+function makeRun(overrides: Partial<WorkflowRunDTO> = {}): WorkflowRunDTO {
+  return {
+    id: 1,
+    name: 'CI',
+    status: 'completed',
+    conclusion: 'success',
+    headSha: 'abc123',
+    headBranch: 'main',
+    htmlUrl: 'https://github.com/repo/actions/runs/1',
+    jobsUrl: 'https://api.github.com/repos/owner/repo/actions/runs/1/jobs',
+    logsUrl: 'https://api.github.com/repos/owner/repo/actions/runs/1/logs',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:01:00Z',
+    ...overrides,
+  };
+}
+
+function makeJob(overrides: Partial<WorkflowJobDTO> = {}): WorkflowJobDTO {
+  return {
+    id: 100,
+    runId: 1,
+    name: 'build',
+    status: 'completed',
+    conclusion: 'success',
+    startedAt: '2026-01-01T00:00:00Z',
+    completedAt: '2026-01-01T00:01:00Z',
+    htmlUrl: 'https://github.com/repo/actions/runs/1/jobs/100',
+    steps: [],
+    ...overrides,
+  };
+}
+
+function makeAnalysis(
+  overrides: Partial<CIAnalysisResult> = {}
+): CIAnalysisResult {
+  return {
+    errorType: 'build_failure',
+    summary: 'TypeScript compilation failed',
+    rootCause: 'Missing import in file.ts',
+    affectedFiles: ['src/file.ts'],
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
+// Helper: flush microtasks + advance timers so resolved promises and React
+// state updates can complete.
+async function flushAndAdvance(ms = 0) {
+  await act(async () => {
+    await Promise.resolve();
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+}
+
+describe('useCIRuns', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockedGetCIRuns.mockResolvedValue([makeRun()]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Initial fetch
+  // ---------------------------------------------------------------------------
+
+  describe('initial fetch', () => {
+    it('fetches CI runs on mount when workspaceId and sessionId are provided', async () => {
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).toHaveBeenCalledWith('ws-1', 'session-1');
+      expect(result.current.runs).toHaveLength(1);
+      expect(result.current.runs[0].id).toBe(1);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('sets loading to true during fetch', async () => {
+      let resolveDeferred: (value: WorkflowRunDTO[]) => void;
+      const deferred = new Promise<WorkflowRunDTO[]>((resolve) => {
+        resolveDeferred = resolve;
+      });
+      mockedGetCIRuns.mockReturnValue(deferred);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      // Should be loading before fetch resolves
+      expect(result.current.loading).toBe(true);
+      expect(result.current.runs).toHaveLength(0);
+
+      // Resolve the fetch
+      await act(async () => {
+        resolveDeferred!([makeRun()]);
+        await Promise.resolve();
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.runs).toHaveLength(1);
+    });
+
+    it('does not fetch when workspaceId is null', async () => {
+      const { result } = renderHook(() =>
+        useCIRuns(null, 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).not.toHaveBeenCalled();
+      expect(result.current.runs).toHaveLength(0);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('does not fetch when sessionId is null', async () => {
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', null)
+      );
+
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).not.toHaveBeenCalled();
+      expect(result.current.runs).toHaveLength(0);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('clears runs when workspaceId becomes null', async () => {
+      const { result, rerender } = renderHook(
+        ({ wsId, sessId }: { wsId: string | null; sessId: string | null }) =>
+          useCIRuns(wsId, sessId),
+        { initialProps: { wsId: 'ws-1', sessId: 'session-1' } }
+      );
+
+      await flushAndAdvance();
+      expect(result.current.runs).toHaveLength(1);
+
+      rerender({ wsId: null, sessId: 'session-1' });
+      await flushAndAdvance();
+
+      expect(result.current.runs).toHaveLength(0);
+    });
+
+    it('refetches when sessionId changes', async () => {
+      const { rerender } = renderHook(
+        ({ wsId, sessId }: { wsId: string | null; sessId: string | null }) =>
+          useCIRuns(wsId, sessId),
+        { initialProps: { wsId: 'ws-1', sessId: 'session-1' } }
+      );
+
+      await flushAndAdvance();
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+      expect(mockedGetCIRuns).toHaveBeenCalledWith('ws-1', 'session-1');
+
+      rerender({ wsId: 'ws-1', sessId: 'session-2' });
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+      expect(mockedGetCIRuns).toHaveBeenLastCalledWith('ws-1', 'session-2');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Polling
+  // ---------------------------------------------------------------------------
+
+  describe('polling', () => {
+    it('polls every 30s when runs are in-progress', async () => {
+      mockedGetCIRuns.mockResolvedValue([
+        makeRun({ status: 'in_progress', conclusion: '' }),
+      ]);
+
+      renderHook(() => useCIRuns('ws-1', 'session-1'));
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      // Advance past one poll interval (30s)
+      await flushAndAdvance(30_000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+
+      // Advance past another poll interval
+      await flushAndAdvance(30_000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(3);
+    });
+
+    it('polls when runs are queued', async () => {
+      mockedGetCIRuns.mockResolvedValue([
+        makeRun({ status: 'queued', conclusion: '' }),
+      ]);
+
+      renderHook(() => useCIRuns('ws-1', 'session-1'));
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      await flushAndAdvance(30_000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not poll when all runs are completed', async () => {
+      mockedGetCIRuns.mockResolvedValue([
+        makeRun({ status: 'completed', conclusion: 'success' }),
+      ]);
+
+      renderHook(() => useCIRuns('ws-1', 'session-1'));
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      // Advance past two poll intervals — no additional calls expected
+      await flushAndAdvance(60_000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops polling when in-progress runs complete', async () => {
+      // First fetch returns in-progress, second returns completed
+      mockedGetCIRuns
+        .mockResolvedValueOnce([makeRun({ status: 'in_progress', conclusion: '' })])
+        .mockResolvedValueOnce([makeRun({ status: 'completed', conclusion: 'success' })]);
+
+      renderHook(() => useCIRuns('ws-1', 'session-1'));
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      // First poll fires — returns completed
+      await flushAndAdvance(30_000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+
+      // Next interval — polling should have stopped
+      await flushAndAdvance(30_000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not poll when active is false', async () => {
+      mockedGetCIRuns.mockResolvedValue([
+        makeRun({ status: 'in_progress', conclusion: '' }),
+      ]);
+
+      renderHook(() => useCIRuns('ws-1', 'session-1', false));
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      await flushAndAdvance(30_000);
+      // No additional poll because active=false
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not poll when workspaceId or sessionId is null', async () => {
+      mockedGetCIRuns.mockResolvedValue([
+        makeRun({ status: 'in_progress', conclusion: '' }),
+      ]);
+
+      renderHook(() => useCIRuns(null, null));
+      await flushAndAdvance();
+
+      expect(mockedGetCIRuns).not.toHaveBeenCalled();
+
+      await flushAndAdvance(30_000);
+      expect(mockedGetCIRuns).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  describe('error handling', () => {
+    it('sets error state on generic failure', async () => {
+      mockedGetCIRuns.mockRejectedValue(new Error('Network failure'));
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      expect(result.current.error).toBe('Network failure');
+      expect(result.current.runs).toHaveLength(0);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('sets fallback error message for non-Error objects', async () => {
+      mockedGetCIRuns.mockRejectedValue('string error');
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      expect(result.current.error).toBe('Failed to fetch CI runs');
+    });
+
+    it('clears error on successful subsequent fetch', async () => {
+      mockedGetCIRuns
+        .mockRejectedValueOnce(new Error('Temporary failure'))
+        .mockResolvedValueOnce([makeRun()]);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+      expect(result.current.error).toBe('Temporary failure');
+
+      // Trigger refetch
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.runs).toHaveLength(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auth retry on 401
+  // ---------------------------------------------------------------------------
+
+  describe('auth retry on 401', () => {
+    it('retries after 3s delay when getCIRuns returns 401', async () => {
+      const apiError = new ApiError('Unauthorized', 401);
+      mockedGetCIRuns
+        .mockRejectedValueOnce(apiError)
+        .mockResolvedValueOnce([makeRun()]);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      // First call fails with 401
+      await flushAndAdvance();
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+      // Error should NOT be set for 401 (silent retry)
+      expect(result.current.error).toBeNull();
+
+      // Advance past the 3s auth retry delay
+      await flushAndAdvance(3000);
+
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+      expect(result.current.runs).toHaveLength(1);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('does not retry 401 if aborted before delay fires', async () => {
+      const apiError = new ApiError('Unauthorized', 401);
+      mockedGetCIRuns.mockRejectedValue(apiError);
+
+      const { unmount } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      // Unmount before the 3s retry fires
+      unmount();
+      await flushAndAdvance(3000);
+
+      // Should NOT have retried because the effect was cleaned up (abort signal)
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+    });
+
+    // NOTE: The hook currently has no max retry limit for 401s. If a limit
+    // is added in the future, this test should be updated to respect it.
+    it('retries multiple 401s until auth succeeds', async () => {
+      const apiError = new ApiError('Unauthorized', 401);
+      mockedGetCIRuns
+        .mockRejectedValueOnce(apiError)
+        .mockRejectedValueOnce(apiError)
+        .mockResolvedValueOnce([makeRun()]);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      // First 401
+      await flushAndAdvance();
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      // Retry after 3s — second 401
+      await flushAndAdvance(3000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+
+      // Retry after another 3s — success
+      await flushAndAdvance(3000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(3);
+      expect(result.current.runs).toHaveLength(1);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('does not treat non-401 ApiError as auth retry', async () => {
+      const apiError = new ApiError('Internal Server Error', 500);
+      mockedGetCIRuns.mockRejectedValue(apiError);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+      expect(result.current.error).toBe('Internal Server Error');
+
+      // Advance past the retry delay — should NOT retry
+      await flushAndAdvance(3000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Abort signal handling
+  // ---------------------------------------------------------------------------
+
+  describe('abort signal handling', () => {
+    it('does not update state after unmount (abort signal)', async () => {
+      let resolveDeferred: (value: WorkflowRunDTO[]) => void;
+      const deferred = new Promise<WorkflowRunDTO[]>((resolve) => {
+        resolveDeferred = resolve;
+      });
+      mockedGetCIRuns.mockReturnValue(deferred);
+
+      const { result, unmount } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      expect(result.current.loading).toBe(true);
+
+      // Unmount before the fetch resolves
+      unmount();
+
+      // Resolve the deferred fetch — state should NOT update
+      await act(async () => {
+        resolveDeferred!([makeRun()]);
+        await Promise.resolve();
+      });
+
+      // Last captured state should still be loading with empty runs
+      expect(result.current.loading).toBe(true);
+      expect(result.current.runs).toHaveLength(0);
+    });
+
+    it('aborts previous fetch when session changes', async () => {
+      let resolveFirst: (value: WorkflowRunDTO[]) => void;
+      const firstDeferred = new Promise<WorkflowRunDTO[]>((resolve) => {
+        resolveFirst = resolve;
+      });
+
+      const secondRuns = [makeRun({ id: 2, name: 'CI-2' })];
+
+      mockedGetCIRuns
+        .mockReturnValueOnce(firstDeferred)
+        .mockResolvedValueOnce(secondRuns);
+
+      const { result, rerender } = renderHook(
+        ({ wsId, sessId }: { wsId: string | null; sessId: string | null }) =>
+          useCIRuns(wsId, sessId),
+        { initialProps: { wsId: 'ws-1', sessId: 'session-1' } }
+      );
+
+      // Switch to a different session before first fetch resolves
+      rerender({ wsId: 'ws-1', sessId: 'session-2' });
+      await flushAndAdvance();
+
+      // Now resolve the first deferred — its result should be ignored (aborted)
+      await act(async () => {
+        resolveFirst!([makeRun({ id: 1, name: 'CI-1' })]);
+        await Promise.resolve();
+      });
+
+      // Should have the second session's data, not the first
+      expect(result.current.runs).toHaveLength(1);
+      expect(result.current.runs[0].id).toBe(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // refetch
+  // ---------------------------------------------------------------------------
+
+  describe('refetch', () => {
+    it('manually triggers a fetch and sets loading', async () => {
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      const newRuns = [makeRun({ id: 5 })];
+      mockedGetCIRuns.mockResolvedValueOnce(newRuns);
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+      expect(result.current.runs[0].id).toBe(5);
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getJobs
+  // ---------------------------------------------------------------------------
+
+  describe('getJobs', () => {
+    it('returns jobs for a given run', async () => {
+      const jobs = [makeJob({ id: 100 }), makeJob({ id: 101, name: 'test' })];
+      mockedGetCIJobs.mockResolvedValue(jobs);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      let returnedJobs: WorkflowJobDTO[];
+      await act(async () => {
+        returnedJobs = await result.current.getJobs(1);
+      });
+
+      expect(mockedGetCIJobs).toHaveBeenCalledWith('ws-1', 'session-1', 1);
+      expect(returnedJobs!).toHaveLength(2);
+      expect(returnedJobs![0].id).toBe(100);
+    });
+
+    it('throws when workspaceId or sessionId is null', async () => {
+      const { result } = renderHook(() =>
+        useCIRuns(null, null)
+      );
+
+      await flushAndAdvance();
+
+      await expect(
+        act(async () => {
+          await result.current.getJobs(1);
+        })
+      ).rejects.toThrow('No active session');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getJobLogs
+  // ---------------------------------------------------------------------------
+
+  describe('getJobLogs', () => {
+    it('returns logs for a given job', async () => {
+      mockedGetCIJobLogs.mockResolvedValue({
+        jobId: 100,
+        logs: 'Build succeeded!\nAll tests passed.',
+      });
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      let logs: string;
+      await act(async () => {
+        logs = await result.current.getJobLogs(100);
+      });
+
+      expect(mockedGetCIJobLogs).toHaveBeenCalledWith('ws-1', 'session-1', 100);
+      expect(logs!).toBe('Build succeeded!\nAll tests passed.');
+    });
+
+    it('throws when workspaceId or sessionId is null', async () => {
+      const { result } = renderHook(() =>
+        useCIRuns(null, null)
+      );
+
+      await flushAndAdvance();
+
+      await expect(
+        act(async () => {
+          await result.current.getJobLogs(100);
+        })
+      ).rejects.toThrow('No active session');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // rerunWorkflow
+  // ---------------------------------------------------------------------------
+
+  describe('rerunWorkflow', () => {
+    it('calls rerunCI and refetches runs', async () => {
+      mockedRerunCI.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await result.current.rerunWorkflow(1);
+      });
+
+      expect(mockedRerunCI).toHaveBeenCalledWith('ws-1', 'session-1', 1, false);
+      // Should have refetched runs after rerun
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes failedOnly flag to rerunCI', async () => {
+      mockedRerunCI.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      await act(async () => {
+        await result.current.rerunWorkflow(1, true);
+      });
+
+      expect(mockedRerunCI).toHaveBeenCalledWith('ws-1', 'session-1', 1, true);
+    });
+
+    it('throws when workspaceId or sessionId is null', async () => {
+      const { result } = renderHook(() =>
+        useCIRuns(null, null)
+      );
+
+      await flushAndAdvance();
+
+      await expect(
+        act(async () => {
+          await result.current.rerunWorkflow(1);
+        })
+      ).rejects.toThrow('No active session');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // analyzeFailure
+  // ---------------------------------------------------------------------------
+
+  describe('analyzeFailure', () => {
+    it('returns analysis result for a failed run/job', async () => {
+      const analysis = makeAnalysis();
+      mockedAnalyzeCIFailure.mockResolvedValue(analysis);
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      let returnedAnalysis: CIAnalysisResult;
+      await act(async () => {
+        returnedAnalysis = await result.current.analyzeFailure(1, 100);
+      });
+
+      expect(mockedAnalyzeCIFailure).toHaveBeenCalledWith(
+        'ws-1',
+        'session-1',
+        1,
+        100
+      );
+      expect(returnedAnalysis!.errorType).toBe('build_failure');
+      expect(returnedAnalysis!.rootCause).toBe('Missing import in file.ts');
+    });
+
+    it('throws when workspaceId or sessionId is null', async () => {
+      const { result } = renderHook(() =>
+        useCIRuns(null, null)
+      );
+
+      await flushAndAdvance();
+
+      await expect(
+        act(async () => {
+          await result.current.analyzeFailure(1, 100);
+        })
+      ).rejects.toThrow('No active session');
+    });
+  });
+});

--- a/src/hooks/__tests__/useFileMentions.test.ts
+++ b/src/hooks/__tests__/useFileMentions.test.ts
@@ -1,0 +1,1020 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { FileNodeDTO } from '@/lib/api';
+import type { FlatFile } from '../useFileMentions';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/api', () => ({
+  listSessionFiles: vi.fn(),
+}));
+
+import { listSessionFiles } from '@/lib/api';
+import { useFileMentions } from '../useFileMentions';
+
+const mockedListSessionFiles = vi.mocked(listSessionFiles);
+
+// ── Test data ──────────────────────────────────────────────────────────
+
+function makeFileTree(): FileNodeDTO[] {
+  return [
+    {
+      name: 'src',
+      path: 'src',
+      isDir: true,
+      children: [
+        {
+          name: 'index.ts',
+          path: 'src/index.ts',
+          isDir: false,
+        },
+        {
+          name: 'utils',
+          path: 'src/utils',
+          isDir: true,
+          children: [
+            {
+              name: 'helpers.ts',
+              path: 'src/utils/helpers.ts',
+              isDir: false,
+            },
+            {
+              name: 'format.ts',
+              path: 'src/utils/format.ts',
+              isDir: false,
+            },
+          ],
+        },
+        {
+          name: 'components',
+          path: 'src/components',
+          isDir: true,
+          children: [
+            {
+              name: 'Button.tsx',
+              path: 'src/components/Button.tsx',
+              isDir: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'package.json',
+      path: 'package.json',
+      isDir: false,
+    },
+    {
+      name: 'README.md',
+      path: 'README.md',
+      isDir: false,
+    },
+  ];
+}
+
+const defaultOptions = {
+  workspaceId: 'ws-1',
+  sessionId: 'session-1',
+  onSelectFile: vi.fn(),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function makeKeyboardEvent(key: string): React.KeyboardEvent {
+  return {
+    key,
+    preventDefault: vi.fn(),
+  } as unknown as React.KeyboardEvent;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+/** Flush microtasks so resolved promises and React state updates can complete. */
+async function flushPromises() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+describe('useFileMentions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockedListSessionFiles.mockResolvedValue(makeFileTree());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── detectAtTrigger (tested through handleTextChange) ──────────────
+
+  describe('@ trigger detection', () => {
+    it('detects @ at the start of text', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+      expect(result.current.query).toBe('');
+    });
+
+    it('detects @ after a space', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('hello @', 7);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+      expect(result.current.query).toBe('');
+    });
+
+    it('captures query text after @', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@src', 4);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+      expect(result.current.query).toBe('src');
+    });
+
+    it('captures multi-character query after @', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('fix @helpers.ts', 15);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+      expect(result.current.query).toBe('helpers.ts');
+    });
+
+    it('does not trigger on email addresses', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('user@example.com', 16);
+      });
+
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('does not trigger when @ is preceded by alphanumeric', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('test@file', 9);
+      });
+
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('does not trigger when query contains space', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      // First activate the trigger
+      await act(async () => {
+        result.current.handleTextChange('@src file', 9);
+      });
+
+      // The query "src file" contains a space so it should dismiss
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('does not trigger with empty text', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('', 0);
+      });
+
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('does not trigger with cursor at position 0', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@test', 0);
+      });
+
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('dismisses when @ trigger is no longer active', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      // Open the mention popup
+      await act(async () => {
+        result.current.handleTextChange('@src', 4);
+      });
+      expect(result.current.isOpen).toBe(true);
+
+      // Type text that invalidates the trigger (adds space)
+      await act(async () => {
+        result.current.handleTextChange('@src file', 9);
+      });
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('detects @ after newline-like whitespace', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('line1\n@test', 11);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+      expect(result.current.query).toBe('test');
+    });
+  });
+
+  // ── flattenFileTree (tested through hook loading) ──────────────────
+
+  describe('file tree flattening', () => {
+    it('flattens nested file tree into flat list', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const paths = result.current.files.map((f) => f.path);
+      expect(paths).toContain('src/index.ts');
+      expect(paths).toContain('src/utils/helpers.ts');
+      expect(paths).toContain('src/utils/format.ts');
+      expect(paths).toContain('src/components/Button.tsx');
+      expect(paths).toContain('package.json');
+      expect(paths).toContain('README.md');
+    });
+
+    it('excludes directories from flat list', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const paths = result.current.files.map((f) => f.path);
+      expect(paths).not.toContain('src');
+      expect(paths).not.toContain('src/utils');
+      expect(paths).not.toContain('src/components');
+    });
+
+    it('sets correct directory for nested files', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const helpers = result.current.files.find(
+        (f) => f.path === 'src/utils/helpers.ts'
+      );
+      expect(helpers).toBeDefined();
+      expect(helpers!.directory).toBe('src/utils');
+    });
+
+    it('sets correct name for files', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const indexFile = result.current.files.find(
+        (f) => f.path === 'src/index.ts'
+      );
+      expect(indexFile).toBeDefined();
+      expect(indexFile!.name).toBe('index.ts');
+    });
+
+    it('handles empty file tree', async () => {
+      mockedListSessionFiles.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(0);
+    });
+
+    it('handles directory with no children', async () => {
+      mockedListSessionFiles.mockResolvedValue([
+        { name: 'empty', path: 'empty', isDir: true },
+      ]);
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(0);
+    });
+  });
+
+  // ── filterFiles (tested through hook query) ────────────────────────
+
+  describe('file filtering', () => {
+    it('shows all files (up to max) when query is empty', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // All 6 files from the test tree
+      expect(result.current.files).toHaveLength(6);
+    });
+
+    it('filters files by name', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@helpers', 8);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(1);
+      expect(result.current.files[0].name).toBe('helpers.ts');
+    });
+
+    it('filters files by path', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@utils/', 7);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const paths = result.current.files.map((f) => f.path);
+      expect(paths).toContain('src/utils/helpers.ts');
+      expect(paths).toContain('src/utils/format.ts');
+      expect(paths).toHaveLength(2);
+    });
+
+    it('performs case-insensitive filtering', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@BUTTON', 7);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(1);
+      expect(result.current.files[0].name).toBe('Button.tsx');
+    });
+
+    it('returns empty results when query matches nothing', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@zzzznonexistent', 16);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(0);
+    });
+
+    it('limits results to MAX_FILE_RESULTS (50)', async () => {
+      // Generate a tree with more than 50 files
+      const manyFiles: FileNodeDTO[] = Array.from({ length: 60 }, (_, i) => ({
+        name: `file${i}.ts`,
+        path: `src/file${i}.ts`,
+        isDir: false,
+      }));
+      mockedListSessionFiles.mockResolvedValue(manyFiles);
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(50);
+    });
+
+    it('limits filtered results to 50', async () => {
+      const manyFiles: FileNodeDTO[] = Array.from({ length: 60 }, (_, i) => ({
+        name: `component${i}.ts`,
+        path: `src/component${i}.ts`,
+        isDir: false,
+      }));
+      mockedListSessionFiles.mockResolvedValue(manyFiles);
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@component', 10);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(50);
+    });
+
+    it('matches partial file extensions', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@.tsx', 5);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(1);
+      expect(result.current.files[0].name).toBe('Button.tsx');
+    });
+  });
+
+  // ── Loading state ──────────────────────────────────────────────────
+
+  describe('loading state', () => {
+    it('sets isLoading while files are being fetched', async () => {
+      let resolveFiles!: (value: FileNodeDTO[]) => void;
+      mockedListSessionFiles.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFiles = resolve;
+        })
+      );
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      // Trigger file loading
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      // Resolve the file loading
+      await act(async () => {
+        resolveFiles(makeFileTree());
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('sets isLoading to false on error', async () => {
+      mockedListSessionFiles.mockRejectedValue(new Error('Network error'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.files).toHaveLength(0);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('does not load files when workspaceId is null', async () => {
+      const options = { ...defaultOptions, workspaceId: null };
+
+      const { result } = renderHook(() => useFileMentions(options));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockedListSessionFiles).not.toHaveBeenCalled();
+    });
+
+    it('does not load files when sessionId is null', async () => {
+      const options = { ...defaultOptions, sessionId: null };
+
+      const { result } = renderHook(() => useFileMentions(options));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockedListSessionFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Caching ────────────────────────────────────────────────────────
+
+  describe('file caching', () => {
+    it('only fetches files once per session', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      // First trigger
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Dismiss
+      act(() => {
+        result.current.dismiss();
+      });
+
+      // Second trigger
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockedListSessionFiles).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears cache when sessionId changes', async () => {
+      const { result, rerender } = renderHook(
+        (props) => useFileMentions(props),
+        { initialProps: defaultOptions }
+      );
+
+      // First trigger
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockedListSessionFiles).toHaveBeenCalledTimes(1);
+
+      // Dismiss and change session
+      act(() => {
+        result.current.dismiss();
+      });
+
+      rerender({ ...defaultOptions, sessionId: 'session-2' });
+
+      // Trigger again with new session
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockedListSessionFiles).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears cache when workspaceId changes', async () => {
+      const { result, rerender } = renderHook(
+        (props) => useFileMentions(props),
+        { initialProps: defaultOptions }
+      );
+
+      // First trigger
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockedListSessionFiles).toHaveBeenCalledTimes(1);
+
+      // Dismiss and change workspace
+      act(() => {
+        result.current.dismiss();
+      });
+
+      rerender({ ...defaultOptions, workspaceId: 'ws-2' });
+
+      // Trigger again
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockedListSessionFiles).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Keyboard navigation ────────────────────────────────────────────
+
+  describe('keyboard navigation', () => {
+    async function openWithFiles() {
+      const hookResult = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        hookResult.result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      return hookResult;
+    }
+
+    it('returns false when menu is not open', () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      const handled = result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+      expect(handled).toBe(false);
+    });
+
+    it('moves selection down with ArrowDown', async () => {
+      const { result } = await openWithFiles();
+      expect(result.current.selectedIndex).toBe(0);
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+      });
+
+      expect(result.current.selectedIndex).toBe(1);
+    });
+
+    it('wraps selection from last to first with ArrowDown', async () => {
+      const { result } = await openWithFiles();
+      const fileCount = result.current.files.length;
+
+      // Move to the last item
+      for (let i = 0; i < fileCount - 1; i++) {
+        act(() => {
+          result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+        });
+      }
+      expect(result.current.selectedIndex).toBe(fileCount - 1);
+
+      // One more should wrap to 0
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+      });
+      expect(result.current.selectedIndex).toBe(0);
+    });
+
+    it('moves selection up with ArrowUp', async () => {
+      const { result } = await openWithFiles();
+
+      // Move down first
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+      });
+      expect(result.current.selectedIndex).toBe(2);
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowUp'));
+      });
+      expect(result.current.selectedIndex).toBe(1);
+    });
+
+    it('wraps selection from first to last with ArrowUp', async () => {
+      const { result } = await openWithFiles();
+      const fileCount = result.current.files.length;
+      expect(result.current.selectedIndex).toBe(0);
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowUp'));
+      });
+
+      expect(result.current.selectedIndex).toBe(fileCount - 1);
+    });
+
+    it('selects file on Enter', async () => {
+      const onSelectFile = vi.fn();
+      const { result } = renderHook(() =>
+        useFileMentions({ ...defaultOptions, onSelectFile })
+      );
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const selectedFile = result.current.files[0];
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('Enter'));
+      });
+
+      expect(onSelectFile).toHaveBeenCalledWith(selectedFile, 0);
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('selects file on Tab', async () => {
+      const onSelectFile = vi.fn();
+      const { result } = renderHook(() =>
+        useFileMentions({ ...defaultOptions, onSelectFile })
+      );
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const selectedFile = result.current.files[0];
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('Tab'));
+      });
+
+      expect(onSelectFile).toHaveBeenCalledWith(selectedFile, 0);
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('dismisses on Escape', async () => {
+      const { result } = await openWithFiles();
+      expect(result.current.isOpen).toBe(true);
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('Escape'));
+      });
+
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('returns true for handled keys (consumed)', async () => {
+      const { result } = await openWithFiles();
+
+      const handledKeys = ['ArrowDown', 'ArrowUp', 'Enter', 'Tab', 'Escape'];
+      for (const key of handledKeys) {
+        // Reopen if dismissed
+        if (!result.current.isOpen) {
+          await act(async () => {
+            result.current.handleTextChange('@', 1);
+            await vi.advanceTimersByTimeAsync(0);
+          });
+        }
+
+        let handled = false;
+        act(() => {
+          handled = result.current.handleKeyDown(makeKeyboardEvent(key));
+        });
+        expect(handled).toBe(true);
+      }
+    });
+
+    it('returns false for unhandled keys', async () => {
+      const { result } = await openWithFiles();
+
+      let handled = false;
+      act(() => {
+        handled = result.current.handleKeyDown(makeKeyboardEvent('a'));
+      });
+      expect(handled).toBe(false);
+    });
+
+    it('calls preventDefault on handled keys', async () => {
+      const { result } = await openWithFiles();
+
+      const event = makeKeyboardEvent('ArrowDown');
+
+      act(() => {
+        result.current.handleKeyDown(event);
+      });
+
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('returns false when open but no files match', async () => {
+      mockedListSessionFiles.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      let handled = false;
+      act(() => {
+        handled = result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+      });
+      expect(handled).toBe(false);
+    });
+
+    it('resets selectedIndex when query changes', async () => {
+      const { result } = await openWithFiles();
+
+      // Move selection down
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+      });
+      expect(result.current.selectedIndex).toBe(2);
+
+      // Change query - should reset index
+      await act(async () => {
+        result.current.handleTextChange('@h', 2);
+      });
+
+      expect(result.current.selectedIndex).toBe(0);
+    });
+  });
+
+  // ── selectFile ─────────────────────────────────────────────────────
+
+  describe('selectFile', () => {
+    it('calls onSelectFile with file and trigger position', async () => {
+      const onSelectFile = vi.fn();
+      const { result } = renderHook(() =>
+        useFileMentions({ ...defaultOptions, onSelectFile })
+      );
+
+      await act(async () => {
+        result.current.handleTextChange('check @', 7);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const file = result.current.files[0];
+
+      act(() => {
+        result.current.selectFile(file);
+      });
+
+      // triggerPos should be 6 (index of @)
+      expect(onSelectFile).toHaveBeenCalledWith(file, 6);
+    });
+
+    it('closes the menu after selecting', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+
+      act(() => {
+        result.current.selectFile(result.current.files[0]);
+      });
+
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('resets query and selectedIndex after selecting', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@src', 4);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+      });
+
+      expect(result.current.query).toBe('src');
+      expect(result.current.selectedIndex).toBe(1);
+
+      act(() => {
+        result.current.selectFile(result.current.files[1]);
+      });
+
+      expect(result.current.query).toBe('');
+      expect(result.current.selectedIndex).toBe(0);
+    });
+  });
+
+  // ── dismiss ────────────────────────────────────────────────────────
+
+  describe('dismiss', () => {
+    it('closes the menu', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+
+      act(() => {
+        result.current.dismiss();
+      });
+
+      expect(result.current.isOpen).toBe(false);
+    });
+
+    it('resets query', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@test', 5);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      act(() => {
+        result.current.dismiss();
+      });
+
+      expect(result.current.query).toBe('');
+    });
+
+    it('resets selectedIndex', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyboardEvent('ArrowDown'));
+      });
+
+      act(() => {
+        result.current.dismiss();
+      });
+
+      expect(result.current.selectedIndex).toBe(0);
+    });
+  });
+
+  // ── API integration ────────────────────────────────────────────────
+
+  describe('API integration', () => {
+    it('calls listSessionFiles with correct arguments', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockedListSessionFiles).toHaveBeenCalledWith('ws-1', 'session-1', 'all');
+    });
+
+    it('handles API error gracefully', async () => {
+      mockedListSessionFiles.mockRejectedValue(new Error('Server error'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to load files for mentions:',
+        expect.any(Error)
+      );
+      expect(result.current.files).toHaveLength(0);
+      expect(result.current.isLoading).toBe(false);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('allows retry after API failure', async () => {
+      mockedListSessionFiles
+        .mockRejectedValueOnce(new Error('Server error'))
+        .mockResolvedValueOnce(makeFileTree());
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      // First trigger fails
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files).toHaveLength(0);
+
+      // Dismiss and try again
+      act(() => {
+        result.current.dismiss();
+      });
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current.files.length).toBeGreaterThan(0);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── setSelectedIndex ───────────────────────────────────────────────
+
+  describe('setSelectedIndex', () => {
+    it('allows manual index setting', async () => {
+      const { result } = renderHook(() => useFileMentions(defaultOptions));
+
+      await act(async () => {
+        result.current.handleTextChange('@', 1);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      act(() => {
+        result.current.setSelectedIndex(3);
+      });
+
+      expect(result.current.selectedIndex).toBe(3);
+    });
+  });
+});

--- a/src/hooks/__tests__/useMessagePrefetch.test.ts
+++ b/src/hooks/__tests__/useMessagePrefetch.test.ts
@@ -1,0 +1,967 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { useAppStore } from '@/stores/appStore';
+import type { Conversation, Message, WorktreeSession } from '@/lib/types';
+
+// ---- Mocks ----
+
+const mockGetConversationMessages = vi.fn();
+const mockToStoreMessage = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  getConversationMessages: (...args: unknown[]) => mockGetConversationMessages(...args),
+  toStoreMessage: (...args: unknown[]) => mockToStoreMessage(...args),
+}));
+
+// ---- Helpers ----
+
+let nextMsgId = 1;
+
+function makeSession(overrides: Partial<WorktreeSession> = {}): WorktreeSession {
+  return {
+    id: `session-${overrides.id ?? '1'}`,
+    workspaceId: 'ws-1',
+    name: 'test-session',
+    branch: 'test-branch',
+    worktreePath: '/tmp/test',
+    status: 'active',
+    priority: 0,
+    taskStatus: 'in_progress',
+    ...overrides,
+  };
+}
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: `conv-${overrides.id ?? '1'}`,
+    sessionId: 'session-1',
+    type: 'task',
+    name: 'Test Conversation',
+    status: 'active',
+    messages: [],
+    toolSummary: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeMessage(conversationId: string, overrides: Partial<Message> = {}): Message {
+  const id = `msg-${nextMsgId++}`;
+  return {
+    id,
+    conversationId,
+    role: 'user',
+    content: 'hello',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makePageResponse(convId: string, count = 2) {
+  const dtos = Array.from({ length: count }, (_, i) => ({
+    id: `dto-${convId}-${i}`,
+    role: 'user' as const,
+    content: `Message ${i}`,
+    timestamp: new Date().toISOString(),
+  }));
+  return {
+    messages: dtos,
+    hasMore: false,
+    totalCount: count,
+    oldestPosition: 0,
+  };
+}
+
+function setupStore(overrides: Record<string, unknown> = {}) {
+  useAppStore.setState({
+    selectedConversationId: 'conv-initial',
+    selectedWorkspaceId: 'ws-1',
+    sessions: [makeSession()],
+    conversations: [],
+    messages: [],
+    messagePagination: {},
+    ...overrides,
+  });
+}
+
+/**
+ * Timer constants matching the hook's internal timing.
+ * Keep in sync with useMessagePrefetch.ts.
+ */
+const DRAIN_TICK_MS = 10;
+const DEFAULT_DRAIN_ROUNDS = 30; // 30 × 10ms = 300ms — enough for idle callback + single batch
+const MULTI_BATCH_DRAIN_ROUNDS = 50; // 50 × 10ms = 500ms — enough for multiple batches with yields
+
+/**
+ * Flush microtasks and pending timers in a loop until all are drained.
+ * The hook chains promises with setTimeout/requestIdleCallback, so we need
+ * to interleave timer advancement (to fire the setTimeout callbacks) with
+ * microtask flushing (to resolve the promises they wrap).
+ */
+async function drainTimers(rounds = DEFAULT_DRAIN_ROUNDS) {
+  for (let i = 0; i < rounds; i++) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DRAIN_TICK_MS);
+    });
+  }
+}
+
+/**
+ * Install a requestIdleCallback polyfill that delegates to setTimeout
+ * so fake timers can control it.
+ */
+function installIdleCallbackPolyfill() {
+  globalThis.requestIdleCallback = ((cb: IdleRequestCallback) => {
+    return setTimeout(
+      () => cb({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline),
+      0
+    ) as unknown as number;
+  }) as typeof globalThis.requestIdleCallback;
+
+  globalThis.cancelIdleCallback = ((id: number) => {
+    clearTimeout(id);
+  }) as typeof globalThis.cancelIdleCallback;
+}
+
+// ---- Tests ----
+
+describe('useMessagePrefetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    nextMsgId = 1;
+
+    // Always install the polyfill. Tests that need to test the fallback path
+    // will override it locally and restore afterward.
+    installIdleCallbackPolyfill();
+
+    // Default mock: return a simple page
+    mockGetConversationMessages.mockImplementation((convId: string) =>
+      Promise.resolve(makePageResponse(convId))
+    );
+    mockToStoreMessage.mockImplementation(
+      (dto: { id: string; role: string; content: string; timestamp: string }, convId: string) => ({
+        id: dto.id,
+        conversationId: convId,
+        role: dto.role,
+        content: dto.content,
+        timestamp: dto.timestamp,
+      })
+    );
+
+    // Reset store
+    useAppStore.setState({
+      selectedConversationId: null,
+      selectedWorkspaceId: null,
+      sessions: [],
+      conversations: [],
+      messages: [],
+      messagePagination: {},
+    });
+  });
+
+  afterEach(() => {
+    // Ensure React component tree is torn down while polyfill is still installed
+    cleanup();
+
+    // Now safe to restore timers
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // Dynamic import defers loading until mocks are established.
+  // vi.resetModules() is intentionally NOT used here — it would break the
+  // vi.mock() wiring. Module-level state is safe because each test renders
+  // a fresh hook instance with its own refs/closures.
+  async function importHook() {
+    const mod = await import('../useMessagePrefetch');
+    return mod.useMessagePrefetch;
+  }
+
+  // ── Enabled / disabled ────────────────────────────────────────────────
+
+  it('does nothing when disabled', async () => {
+    const useMessagePrefetch = await importHook();
+
+    setupStore({
+      conversations: [makeConversation({ id: 'conv-1' })],
+    });
+
+    renderHook(() => useMessagePrefetch(false));
+
+    await drainTimers();
+
+    expect(mockGetConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it('re-enables prefetch when enabled changes from false to true', async () => {
+    const useMessagePrefetch = await importHook();
+
+    const conv1 = makeConversation({ id: 'conv-toggle', sessionId: 'session-1' });
+
+    setupStore({
+      selectedConversationId: null,
+      conversations: [conv1],
+      messagePagination: {},
+    });
+
+    const { rerender } = renderHook(
+      ({ enabled }) => useMessagePrefetch(enabled),
+      { initialProps: { enabled: false } }
+    );
+
+    await drainTimers();
+    expect(mockGetConversationMessages).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await drainTimers();
+
+    expect(mockGetConversationMessages).toHaveBeenCalledWith('conv-toggle', { limit: 50 });
+  });
+
+  // ── Initial load polling ──────────────────────────────────────────────
+
+  describe('initial load polling', () => {
+    it('waits for initial conversation messages to load before prefetching', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-1', sessionId: 'session-1' });
+      const convTarget = makeConversation({ id: 'conv-target', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: 'conv-1',
+        conversations: [conv1, convTarget],
+        messagePagination: {}, // conv-1 not yet loaded
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      // Fire the requestIdleCallback (setTimeout 0)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // The hook should be polling at 200ms waiting for initial conv pagination
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+
+      // Advance past one 200ms poll - still not loaded
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+
+      // Now set the pagination for the initial conv (simulates ConversationArea loading it)
+      useAppStore.setState({
+        messagePagination: {
+          'conv-1': { hasMore: false, oldestPosition: 0, isLoadingMore: false },
+        },
+      });
+
+      // Next poll at 200ms resolves the wait, then fetches begin
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      await drainTimers();
+
+      expect(mockGetConversationMessages).toHaveBeenCalledWith('conv-target', { limit: 50 });
+    });
+
+    it('polls at 200ms intervals until initial conversation is loaded', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const initialConv = makeConversation({ id: 'conv-init', sessionId: 'session-1' });
+      const otherConv = makeConversation({ id: 'conv-other', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: 'conv-init',
+        conversations: [initialConv, otherConv],
+        messagePagination: {},
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      // Fire requestIdleCallback
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // After first 200ms poll - still not loaded
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+
+      // After second 200ms poll - still not loaded
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+
+      // Now load it
+      useAppStore.setState({
+        messagePagination: {
+          'conv-init': { hasMore: false, oldestPosition: 0, isLoadingMore: false },
+        },
+      });
+
+      // Next poll resolves the wait
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      await drainTimers();
+
+      expect(mockGetConversationMessages).toHaveBeenCalledWith('conv-other', { limit: 50 });
+    });
+
+    it('skips polling when no initial conversation is selected', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-no-init', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [conv1],
+        messagePagination: {},
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers();
+
+      expect(mockGetConversationMessages).toHaveBeenCalledWith('conv-no-init', { limit: 50 });
+    });
+
+    it('skips polling when initial conversation already has pagination', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-ready', sessionId: 'session-1' });
+      const conv2 = makeConversation({ id: 'conv-needs-fetch', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: 'conv-ready',
+        conversations: [conv1, conv2],
+        messagePagination: {
+          'conv-ready': { hasMore: false, oldestPosition: 0, isLoadingMore: false },
+        },
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers();
+
+      expect(mockGetConversationMessages).toHaveBeenCalledWith('conv-needs-fetch', { limit: 50 });
+    });
+
+    it('aborts polling on unmount', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-poll-abort', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: 'conv-poll-abort',
+        conversations: [conv1],
+        messagePagination: {}, // not loaded yet so polling starts
+      });
+
+      const { unmount } = renderHook(() => useMessagePrefetch(true));
+
+      // Fire idle callback to start prefetch (enters the polling loop)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Unmount while polling
+      unmount();
+
+      // Advance well past what polling would need
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+
+      // Should never fetch because abortRef was set
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Filtering ─────────────────────────────────────────────────────────
+
+  describe('filtering', () => {
+    it('skips conversations that already have pagination data', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-1', sessionId: 'session-1' });
+      const conv2 = makeConversation({ id: 'conv-2', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: 'conv-1',
+        conversations: [conv1, conv2],
+        messagePagination: {
+          'conv-1': { hasMore: false, oldestPosition: 0, isLoadingMore: false },
+          'conv-2': { hasMore: false, oldestPosition: 0, isLoadingMore: false },
+        },
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers();
+
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+    });
+
+    it('skips conversations whose session is archived', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const archivedSession = makeSession({ id: 'archived-session', archived: true });
+      const conv1 = makeConversation({ id: 'conv-archived', sessionId: 'archived-session' });
+
+      setupStore({
+        selectedConversationId: null,
+        sessions: [makeSession(), archivedSession],
+        conversations: [conv1],
+        messagePagination: {},
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers();
+
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+    });
+
+    it('skips conversations that already have messages in the store', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-with-msgs', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [conv1],
+        messages: [makeMessage('conv-with-msgs')],
+        messagePagination: {},
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers();
+
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Batch processing ──────────────────────────────────────────────────
+
+  describe('batch processing', () => {
+    it('processes conversations in batches of 3', async () => {
+      const useMessagePrefetch = await importHook();
+
+      // Create 5 conversations that need fetching
+      const convs = Array.from({ length: 5 }, (_, i) =>
+        makeConversation({ id: `conv-${i}`, sessionId: 'session-1' })
+      );
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: convs,
+        messagePagination: {},
+      });
+
+      const callOrder: string[] = [];
+      mockGetConversationMessages.mockImplementation((convId: string) => {
+        callOrder.push(convId);
+        return Promise.resolve(makePageResponse(convId));
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      expect(mockGetConversationMessages).toHaveBeenCalledTimes(5);
+
+      // First batch: conv-0, conv-1, conv-2
+      expect(callOrder.slice(0, 3)).toEqual(['conv-0', 'conv-1', 'conv-2']);
+      // Second batch: conv-3, conv-4
+      expect(callOrder.slice(3)).toEqual(['conv-3', 'conv-4']);
+    });
+
+    it('yields to main thread between batches via requestIdleCallback', async () => {
+      const useMessagePrefetch = await importHook();
+
+      let ricCallCount = 0;
+      globalThis.requestIdleCallback = ((cb: IdleRequestCallback) => {
+        ricCallCount++;
+        return setTimeout(
+          () => cb({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline),
+          0
+        ) as unknown as number;
+      }) as typeof globalThis.requestIdleCallback;
+
+      // 4 conversations = 2 batches, 1 yield between them + 1 initial defer = 2 rIC calls
+      const convs = Array.from({ length: 4 }, (_, i) =>
+        makeConversation({ id: `conv-${i}`, sessionId: 'session-1' })
+      );
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: convs,
+        messagePagination: {},
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      // 1 for initial defer + 1 for yield between batch 1 and batch 2
+      expect(ricCallCount).toBe(2);
+    });
+  });
+
+  // ── Workspace prioritization ──────────────────────────────────────────
+
+  describe('workspace prioritization', () => {
+    it('fetches same-workspace conversations before other workspaces', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const sessionWs1 = makeSession({ id: 'session-ws1', workspaceId: 'ws-1' });
+      const sessionWs2 = makeSession({ id: 'session-ws2', workspaceId: 'ws-2' });
+
+      // Mix: deliberately interleave other-workspace and same-workspace conversations
+      const convOther1 = makeConversation({ id: 'conv-other-1', sessionId: 'session-ws2' });
+      const convSame1 = makeConversation({ id: 'conv-same-1', sessionId: 'session-ws1' });
+      const convOther2 = makeConversation({ id: 'conv-other-2', sessionId: 'session-ws2' });
+      const convSame2 = makeConversation({ id: 'conv-same-2', sessionId: 'session-ws1' });
+
+      setupStore({
+        selectedConversationId: null,
+        selectedWorkspaceId: 'ws-1',
+        sessions: [sessionWs1, sessionWs2],
+        conversations: [convOther1, convSame1, convOther2, convSame2],
+        messagePagination: {},
+      });
+
+      const callOrder: string[] = [];
+      mockGetConversationMessages.mockImplementation((convId: string) => {
+        callOrder.push(convId);
+        return Promise.resolve(makePageResponse(convId));
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      expect(callOrder).toHaveLength(4);
+
+      // Same-workspace conversations should come first
+      expect(callOrder[0]).toBe('conv-same-1');
+      expect(callOrder[1]).toBe('conv-same-2');
+      // Other-workspace conversations after
+      expect(callOrder[2]).toBe('conv-other-1');
+      expect(callOrder[3]).toBe('conv-other-2');
+    });
+  });
+
+  // ── Duplication prevention ────────────────────────────────────────────
+
+  describe('duplication prevention', () => {
+    it('re-checks messagePagination before each fetch in a batch', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-recheck', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [conv1],
+        messagePagination: {},
+      });
+
+      // Override requestIdleCallback: set pagination before firing the callback,
+      // so the re-check inside the batch map skips the fetch.
+      globalThis.requestIdleCallback = ((cb: IdleRequestCallback) => {
+        return setTimeout(() => {
+          // Simulate another component loading this conversation's messages
+          useAppStore.setState({
+            messagePagination: {
+              'conv-recheck': { hasMore: false, oldestPosition: 0, isLoadingMore: false },
+            },
+          });
+          cb({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+        }, 0) as unknown as number;
+      }) as typeof globalThis.requestIdleCallback;
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+
+      // Restore polyfill for cleanup
+      installIdleCallbackPolyfill();
+    });
+
+    it('does not re-fetch a conversation that was loaded by another component mid-batch', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-dup', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [conv1],
+        messagePagination: {},
+      });
+
+      mockGetConversationMessages.mockImplementation((convId: string) => {
+        // Simulate race: another component sets pagination before this resolves
+        useAppStore.setState((state) => ({
+          messagePagination: {
+            ...state.messagePagination,
+            [convId]: { hasMore: false, oldestPosition: 0, isLoadingMore: false },
+          },
+        }));
+        return Promise.resolve(makePageResponse(convId));
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      expect(mockGetConversationMessages).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Store updates ─────────────────────────────────────────────────────
+
+  describe('store updates', () => {
+    it('stores fetched messages via setMessagePage', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-store', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [conv1],
+        messagePagination: {},
+      });
+
+      const pageResponse = {
+        messages: [
+          { id: 'dto-1', role: 'user' as const, content: 'Hello', timestamp: '2024-01-01T00:00:00Z' },
+        ],
+        hasMore: true,
+        totalCount: 10,
+        oldestPosition: 5,
+      };
+      mockGetConversationMessages.mockResolvedValue(pageResponse);
+      mockToStoreMessage.mockImplementation((dto: { id: string }, convId: string) => ({
+        id: dto.id,
+        conversationId: convId,
+        role: 'user',
+        content: 'Hello',
+        timestamp: '2024-01-01T00:00:00Z',
+      }));
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      // Verify messages ended up in the store
+      const state = useAppStore.getState();
+      const storedMessages = state.messages.filter((m) => m.conversationId === 'conv-store');
+      expect(storedMessages).toHaveLength(1);
+      expect(storedMessages[0].id).toBe('dto-1');
+
+      // Verify pagination was set
+      const pagination = state.messagePagination['conv-store'];
+      expect(pagination).toBeDefined();
+      expect(pagination.hasMore).toBe(true);
+    });
+
+    it('uses 0 as fallback when oldestPosition is undefined', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-no-pos', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [conv1],
+        messagePagination: {},
+      });
+
+      mockGetConversationMessages.mockResolvedValue({
+        messages: [],
+        hasMore: false,
+        totalCount: 0,
+        oldestPosition: undefined,
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      const pagination = useAppStore.getState().messagePagination['conv-no-pos'];
+      expect(pagination).toBeDefined();
+      expect(pagination.oldestPosition).toBe(0);
+    });
+  });
+
+  // ── Error handling ────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('silently ignores fetch errors and continues with remaining conversations', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const conv1 = makeConversation({ id: 'conv-err', sessionId: 'session-1' });
+      const conv2 = makeConversation({ id: 'conv-ok', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [conv1, conv2],
+        messagePagination: {},
+      });
+
+      mockGetConversationMessages.mockImplementation((convId: string) => {
+        if (convId === 'conv-err') {
+          return Promise.reject(new Error('Network error'));
+        }
+        return Promise.resolve(makePageResponse(convId));
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      // conv-ok should still have been fetched despite conv-err failing
+      expect(mockGetConversationMessages).toHaveBeenCalledWith('conv-ok', { limit: 50 });
+
+      // conv-ok should be in the store, conv-err should not
+      const pagination = useAppStore.getState().messagePagination;
+      expect(pagination['conv-ok']).toBeDefined();
+      expect(pagination['conv-err']).toBeUndefined();
+    });
+  });
+
+  // ── Cleanup on unmount ────────────────────────────────────────────────
+
+  describe('cleanup on unmount', () => {
+    it('aborts on unmount and does not apply pending results', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const convs = Array.from({ length: 7 }, (_, i) =>
+        makeConversation({ id: `conv-${i}`, sessionId: 'session-1' })
+      );
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: convs,
+        messagePagination: {},
+      });
+
+      // Make fetches slow so we can unmount mid-flight
+      mockGetConversationMessages.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(makePageResponse('x')), 500))
+      );
+
+      const { unmount } = renderHook(() => useMessagePrefetch(true));
+
+      // Fire requestIdleCallback
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Unmount before fetches complete
+      unmount();
+
+      // Advance past the slow fetch timeouts
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      // Results should not have been applied to the store
+      const pagination = useAppStore.getState().messagePagination;
+      expect(Object.keys(pagination)).toHaveLength(0);
+    });
+
+    it('cancels requestIdleCallback handle on unmount', async () => {
+      const useMessagePrefetch = await importHook();
+
+      const cancelSpy = vi.fn();
+
+      globalThis.requestIdleCallback = ((_cb: IdleRequestCallback) => {
+        // Do NOT fire the callback so it stays pending
+        return 42;
+      }) as typeof globalThis.requestIdleCallback;
+      globalThis.cancelIdleCallback = cancelSpy;
+
+      setupStore({
+        conversations: [makeConversation({ id: 'conv-cleanup', sessionId: 'session-1' })],
+      });
+
+      const { unmount } = renderHook(() => useMessagePrefetch(true));
+
+      unmount();
+
+      expect(cancelSpy).toHaveBeenCalledWith(42);
+
+      // Restore polyfill for cleanup
+      installIdleCallbackPolyfill();
+    });
+
+    it('clears setTimeout handle on unmount when requestIdleCallback is unavailable', async () => {
+      const useMessagePrefetch = await importHook();
+
+      // Remove requestIdleCallback to trigger the setTimeout fallback path.
+      // Use a typeof-safe approach: set to non-function so typeof check fails.
+      const savedRIC = globalThis.requestIdleCallback;
+      const savedCIC = globalThis.cancelIdleCallback;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).requestIdleCallback = undefined;
+
+      setupStore({
+        conversations: [makeConversation({ id: 'conv-cleanup-fb', sessionId: 'session-1' })],
+      });
+
+      const { unmount } = renderHook(() => useMessagePrefetch(true));
+
+      // Restore before unmount so cleanup doesn't error
+      globalThis.requestIdleCallback = savedRIC;
+      globalThis.cancelIdleCallback = savedCIC;
+
+      // Unmount before the 2000ms timeout fires
+      unmount();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      // The fetch should never have been called since we unmounted first
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+
+      installIdleCallbackPolyfill();
+    });
+  });
+
+  // ── requestIdleCallback fallback ──────────────────────────────────────
+
+  describe('requestIdleCallback fallback', () => {
+    it('uses setTimeout(2000) when requestIdleCallback is unavailable for initial defer', async () => {
+      const useMessagePrefetch = await importHook();
+
+      // Remove requestIdleCallback to trigger fallback
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).requestIdleCallback = undefined;
+
+      const conv1 = makeConversation({ id: 'conv-fallback', sessionId: 'session-1' });
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [conv1],
+        messagePagination: {},
+      });
+
+      const { unmount } = renderHook(() => useMessagePrefetch(true));
+
+      // At 1999ms, nothing should have fired yet
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1999);
+      });
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+
+      // At 2000ms the fallback setTimeout fires
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      await drainTimers();
+
+      expect(mockGetConversationMessages).toHaveBeenCalledWith('conv-fallback', { limit: 50 });
+
+      // Restore polyfill before unmount
+      installIdleCallbackPolyfill();
+      unmount();
+    });
+
+    it('uses setTimeout(100) between batches when requestIdleCallback is unavailable', async () => {
+      const useMessagePrefetch = await importHook();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).requestIdleCallback = undefined;
+
+      // 4 conversations = 2 batches (3 + 1), needs a yield between them
+      const convs = Array.from({ length: 4 }, (_, i) =>
+        makeConversation({ id: `conv-fb-${i}`, sessionId: 'session-1' })
+      );
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: convs,
+        messagePagination: {},
+      });
+
+      const callOrder: string[] = [];
+      mockGetConversationMessages.mockImplementation((convId: string) => {
+        callOrder.push(convId);
+        return Promise.resolve(makePageResponse(convId));
+      });
+
+      const { unmount } = renderHook(() => useMessagePrefetch(true));
+
+      // Wait for the initial 2000ms fallback setTimeout
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      // Drain timers for the 100ms yield between batches + microtasks
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      // All 4 should have been fetched across 2 batches
+      expect(callOrder).toHaveLength(4);
+      expect(callOrder.slice(0, 3)).toEqual(['conv-fb-0', 'conv-fb-1', 'conv-fb-2']);
+      expect(callOrder[3]).toBe('conv-fb-3');
+
+      // Restore polyfill before unmount
+      installIdleCallbackPolyfill();
+      unmount();
+    });
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles empty conversation list gracefully', async () => {
+      const useMessagePrefetch = await importHook();
+
+      setupStore({
+        selectedConversationId: null,
+        conversations: [],
+        messagePagination: {},
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers();
+
+      expect(mockGetConversationMessages).not.toHaveBeenCalled();
+    });
+
+    it('handles conversations with missing session gracefully', async () => {
+      const useMessagePrefetch = await importHook();
+
+      // Conversation references a session that does not exist in the store
+      const orphanConv = makeConversation({ id: 'conv-orphan', sessionId: 'nonexistent-session' });
+
+      setupStore({
+        selectedConversationId: null,
+        sessions: [makeSession()],
+        conversations: [orphanConv],
+        messagePagination: {},
+      });
+
+      renderHook(() => useMessagePrefetch(true));
+
+      await drainTimers(MULTI_BATCH_DRAIN_ROUNDS);
+
+      // Orphan conversation: its session is not in archivedSessionIds (only matching IDs
+      // that have archived=true go there), so it passes the filter. The session lookup
+      // returns undefined so it goes to otherWorkspaces.
+      expect(mockGetConversationMessages).toHaveBeenCalledWith('conv-orphan', { limit: 50 });
+    });
+  });
+});

--- a/src/hooks/__tests__/useTabPersistence.test.ts
+++ b/src/hooks/__tests__/useTabPersistence.test.ts
@@ -1,0 +1,682 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAppStore } from '@/stores/appStore';
+import type { FileTab } from '@/lib/types';
+
+// ---- Mocks ----
+
+vi.mock('@/lib/api', () => ({
+  listFileTabs: vi.fn(),
+  saveFileTabs: vi.fn(),
+  getApiBase: vi.fn().mockReturnValue('http://localhost:9876'),
+}));
+
+import { listFileTabs, saveFileTabs, getApiBase } from '@/lib/api';
+import type { FileTabDTO } from '@/lib/api';
+
+const mockedListFileTabs = vi.mocked(listFileTabs);
+const mockedSaveFileTabs = vi.mocked(saveFileTabs);
+const mockedGetApiBase = vi.mocked(getApiBase);
+
+// ---- Test data factories ----
+
+function makeFileTab(overrides: Partial<FileTab> = {}): FileTab {
+  return {
+    id: 'tab-1',
+    workspaceId: 'ws-1',
+    sessionId: 'session-1',
+    path: 'src/file.ts',
+    name: 'file.ts',
+    isLoading: false,
+    viewMode: 'file',
+    isPinned: false,
+    openedAt: '2026-01-01T00:00:00.000Z',
+    lastAccessedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeFileTabDTO(overrides: Partial<FileTabDTO> = {}): FileTabDTO {
+  return {
+    id: 'tab-1',
+    workspaceId: 'ws-1',
+    sessionId: 'session-1',
+    path: 'src/file.ts',
+    viewMode: 'file',
+    isPinned: false,
+    position: 0,
+    openedAt: '2026-01-01T00:00:00.000Z',
+    lastAccessedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// Helper: flush microtasks + advance timers so resolved promises and React
+// state updates (including effects) can complete.
+async function flushAndAdvance(ms = 0) {
+  await act(async () => {
+    await Promise.resolve();
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+}
+
+// ---- Tests ----
+
+describe('useTabPersistence', () => {
+  // Track sendBeacon mock and beforeunload listeners
+  let mockSendBeacon: ReturnType<typeof vi.fn>;
+  let beforeUnloadHandlers: Array<() => void>;
+  const originalAddEventListener = window.addEventListener;
+  const originalRemoveEventListener = window.removeEventListener;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    // Reset store to clean state
+    useAppStore.setState({
+      selectedWorkspaceId: 'ws-1',
+      selectedSessionId: 'session-1',
+      selectedFileTabId: null,
+      fileTabs: [],
+    });
+
+    // Default mock implementations
+    mockedListFileTabs.mockResolvedValue([]);
+    mockedSaveFileTabs.mockResolvedValue(undefined);
+    mockedGetApiBase.mockReturnValue('http://localhost:9876');
+
+    // Mock navigator.sendBeacon
+    mockSendBeacon = vi.fn().mockReturnValue(true);
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: mockSendBeacon,
+      writable: true,
+      configurable: true,
+    });
+
+    // Track beforeunload event listeners manually.
+    // This wraps addEventListener globally to intercept 'beforeunload' registrations
+    // while delegating all events (including non-beforeunload) to the original handler.
+    beforeUnloadHandlers = [];
+    window.addEventListener = vi.fn((event: string, handler: unknown) => {
+      if (event === 'beforeunload') {
+        beforeUnloadHandlers.push(handler as () => void);
+      }
+      originalAddEventListener.call(window, event, handler as EventListenerOrEventListenerObject);
+    });
+    window.removeEventListener = vi.fn((event: string, handler: unknown) => {
+      if (event === 'beforeunload') {
+        beforeUnloadHandlers = beforeUnloadHandlers.filter((h) => h !== handler);
+      }
+      originalRemoveEventListener.call(window, event, handler as EventListenerOrEventListenerObject);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    window.addEventListener = originalAddEventListener;
+    window.removeEventListener = originalRemoveEventListener;
+  });
+
+  // Dynamically import the hook so mocks are established first
+  async function importAndRender() {
+    // Clear the module cache to pick up fresh mocks
+    const mod = await import('../useTabPersistence');
+    return renderHook(() => mod.useTabPersistence());
+  }
+
+  // ===================================================================
+  // Tab loading when workspace/session changes
+  // ===================================================================
+
+  describe('loading tabs on workspace/session change', () => {
+    it('loads tabs from the API when workspace and session are set', async () => {
+      const dto = makeFileTabDTO({ id: 'tab-1', sessionId: 'session-1' });
+      mockedListFileTabs.mockResolvedValue([dto]);
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      expect(mockedListFileTabs).toHaveBeenCalledWith('ws-1');
+
+      // Tabs should be set in the store
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].id).toBe('tab-1');
+      expect(tabs[0].path).toBe('src/file.ts');
+      expect(tabs[0].name).toBe('file.ts');
+      expect(tabs[0].isLoading).toBe(false);
+
+      unmount();
+    });
+
+    it('does not load when workspaceId is missing', async () => {
+      useAppStore.setState({ selectedWorkspaceId: null });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      expect(mockedListFileTabs).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('does not load when sessionId is missing', async () => {
+      useAppStore.setState({ selectedSessionId: null });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      expect(mockedListFileTabs).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('filters loaded tabs to only the current session', async () => {
+      const currentSessionTab = makeFileTabDTO({ id: 'tab-current', sessionId: 'session-1' });
+      const otherSessionTab = makeFileTabDTO({ id: 'tab-other', sessionId: 'session-2' });
+      const noSessionTab = makeFileTabDTO({ id: 'tab-none', sessionId: undefined });
+      mockedListFileTabs.mockResolvedValue([currentSessionTab, otherSessionTab, noSessionTab]);
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      // Only session-1 tabs should appear in the store
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].id).toBe('tab-current');
+
+      unmount();
+    });
+
+    it('auto-selects the first tab if no tab is currently selected', async () => {
+      const dto = makeFileTabDTO({ id: 'tab-first', sessionId: 'session-1' });
+      mockedListFileTabs.mockResolvedValue([dto]);
+
+      useAppStore.setState({ selectedFileTabId: null });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      expect(useAppStore.getState().selectedFileTabId).toBe('tab-first');
+
+      unmount();
+    });
+
+    it('does not auto-select if a tab is already selected', async () => {
+      const dto = makeFileTabDTO({ id: 'tab-new', sessionId: 'session-1' });
+      mockedListFileTabs.mockResolvedValue([dto]);
+
+      useAppStore.setState({ selectedFileTabId: 'already-selected' });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      expect(useAppStore.getState().selectedFileTabId).toBe('already-selected');
+
+      unmount();
+    });
+
+    it('handles API errors gracefully during load', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockedListFileTabs.mockRejectedValue(new Error('Network error'));
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to load tabs:', expect.any(Error));
+      // Store should remain empty (not crash)
+      expect(useAppStore.getState().fileTabs).toHaveLength(0);
+
+      consoleSpy.mockRestore();
+      unmount();
+    });
+
+    it('skips fetch if store already has tabs for the current session', async () => {
+      // Pre-populate store with a tab for the current session
+      const existingTab = makeFileTab({ id: 'existing', workspaceId: 'ws-1', sessionId: 'session-1' });
+      useAppStore.setState({ fileTabs: [existingTab] });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      // Should not call listFileTabs since tabs already exist
+      expect(mockedListFileTabs).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    it('derives the tab name from the last path segment', async () => {
+      const dto = makeFileTabDTO({
+        id: 'tab-deep',
+        sessionId: 'session-1',
+        path: 'src/components/deep/MyComponent.tsx',
+      });
+      mockedListFileTabs.mockResolvedValue([dto]);
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs[0].name).toBe('MyComponent.tsx');
+
+      unmount();
+    });
+  });
+
+  // ===================================================================
+  // Multi-session tab preservation
+  // ===================================================================
+
+  describe('multi-session tab preservation', () => {
+    it('preserves tabs from other sessions when loading new session tabs', async () => {
+      // Pre-populate store with a tab from another session (session-2)
+      const otherSessionTab = makeFileTab({
+        id: 'other-tab',
+        workspaceId: 'ws-1',
+        sessionId: 'session-2',
+        path: 'src/other.ts',
+        name: 'other.ts',
+      });
+      // Make sure the existing tab doesn't match the current session so we don't skip
+      useAppStore.setState({ fileTabs: [otherSessionTab] });
+
+      const newSessionDTO = makeFileTabDTO({
+        id: 'new-tab',
+        sessionId: 'session-1',
+        path: 'src/new.ts',
+      });
+      mockedListFileTabs.mockResolvedValue([newSessionDTO]);
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      const tabs = useAppStore.getState().fileTabs;
+      // Should have both: the other session tab AND the newly loaded session tab
+      expect(tabs).toHaveLength(2);
+      expect(tabs.find((t) => t.id === 'other-tab')).toBeTruthy();
+      expect(tabs.find((t) => t.id === 'new-tab')).toBeTruthy();
+
+      unmount();
+    });
+  });
+
+  // ===================================================================
+  // Debounced saves (2 second delay)
+  // ===================================================================
+
+  describe('debounced save', () => {
+    it('saves tabs after the 2s debounce delay', async () => {
+      const tab = makeFileTab();
+      useAppStore.setState({ fileTabs: [tab] });
+
+      const { unmount } = await importAndRender();
+      // Let the load effect run (will find existing tabs for session so skips fetch,
+      // but the save effect will schedule)
+      await flushAndAdvance();
+
+      // The save debounce hasn't fired yet
+      expect(mockedSaveFileTabs).not.toHaveBeenCalled();
+
+      // Advance past the 2s debounce
+      await flushAndAdvance(2100);
+
+      expect(mockedSaveFileTabs).toHaveBeenCalledWith('ws-1', expect.any(Array));
+
+      unmount();
+    });
+
+    it('debounces rapid tab changes into a single save', async () => {
+      const tab1 = makeFileTab({ id: 'tab-1' });
+      useAppStore.setState({ fileTabs: [tab1] });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      // Add tabs rapidly (within 2s window)
+      for (let i = 2; i <= 4; i++) {
+        act(() => {
+          const current = useAppStore.getState().fileTabs;
+          useAppStore.setState({
+            fileTabs: [
+              ...current,
+              makeFileTab({ id: `tab-${i}`, path: `src/file${i}.ts`, name: `file${i}.ts` }),
+            ],
+          });
+        });
+        // Small gap, well within the 2s debounce window
+        await flushAndAdvance(200);
+      }
+
+      // At this point the final timer was set ~200ms ago. Advance to trigger it.
+      await flushAndAdvance(2100);
+
+      // saveFileTabs should only have been called once (the debounced call)
+      // Note: there may be one call from the initial render cycle too
+      const callCount = mockedSaveFileTabs.mock.calls.length;
+      expect(callCount).toBeGreaterThanOrEqual(1);
+      // The final call should include all 4 tabs
+      const lastCallTabs = mockedSaveFileTabs.mock.calls[callCount - 1][1] as FileTabDTO[];
+      expect(lastCallTabs.length).toBe(4);
+
+      unmount();
+    });
+
+    it('does not save when workspaceId is missing', async () => {
+      useAppStore.setState({
+        selectedWorkspaceId: null,
+        fileTabs: [makeFileTab()],
+      });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance(3000);
+
+      expect(mockedSaveFileTabs).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    it('handles save API errors gracefully', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockedSaveFileTabs.mockRejectedValue(new Error('Save failed'));
+
+      const tab = makeFileTab();
+      useAppStore.setState({ fileTabs: [tab] });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance(3000);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to save tabs:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+      unmount();
+    });
+  });
+
+  // ===================================================================
+  // Save skip if no changes (JSON comparison)
+  // ===================================================================
+
+  describe('skip save when no changes', () => {
+    it('does not save if tabs have not changed since last save', async () => {
+      const dto = makeFileTabDTO({ id: 'tab-1', sessionId: 'session-1' });
+      mockedListFileTabs.mockResolvedValue([dto]);
+
+      // Pre-select a tab so auto-select doesn't fire (which would mutate
+      // lastAccessedAt and create a mismatch with the saved JSON)
+      useAppStore.setState({ selectedFileTabId: 'tab-1' });
+
+      const { unmount } = await importAndRender();
+
+      // Let load complete - this sets lastSavedRef from loaded data
+      await flushAndAdvance();
+
+      // The loaded tabs should match what was saved, so no save should fire
+      mockedSaveFileTabs.mockClear();
+
+      // Advance well past debounce
+      await flushAndAdvance(3000);
+
+      expect(mockedSaveFileTabs).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    it('saves when tabs have changed from last saved state', async () => {
+      const dto = makeFileTabDTO({ id: 'tab-1', sessionId: 'session-1' });
+      mockedListFileTabs.mockResolvedValue([dto]);
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+      mockedSaveFileTabs.mockClear();
+
+      // Add a new tab to the store (represents a change)
+      act(() => {
+        const current = useAppStore.getState().fileTabs;
+        useAppStore.setState({
+          fileTabs: [
+            ...current,
+            makeFileTab({ id: 'tab-2', path: 'src/new.ts', name: 'new.ts' }),
+          ],
+        });
+      });
+
+      // Advance past debounce
+      await flushAndAdvance(3000);
+
+      expect(mockedSaveFileTabs).toHaveBeenCalled();
+
+      unmount();
+    });
+  });
+
+  // ===================================================================
+  // DTO conversion with defaults
+  // ===================================================================
+
+  describe('DTO conversion', () => {
+    it('converts FileTab to FileTabDTO with correct field mapping', async () => {
+      const tab = makeFileTab({
+        id: 'dto-test',
+        workspaceId: 'ws-1',
+        sessionId: 'session-1',
+        path: 'src/component.tsx',
+        viewMode: 'diff',
+        isPinned: true,
+        openedAt: '2026-02-01T12:00:00.000Z',
+        lastAccessedAt: '2026-02-01T13:00:00.000Z',
+      });
+
+      useAppStore.setState({ fileTabs: [tab] });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance(3000);
+
+      expect(mockedSaveFileTabs).toHaveBeenCalled();
+      const savedTabs = mockedSaveFileTabs.mock.calls[0][1] as FileTabDTO[];
+      expect(savedTabs).toHaveLength(1);
+
+      const savedDTO = savedTabs[0];
+      expect(savedDTO.id).toBe('dto-test');
+      expect(savedDTO.workspaceId).toBe('ws-1');
+      expect(savedDTO.sessionId).toBe('session-1');
+      expect(savedDTO.path).toBe('src/component.tsx');
+      expect(savedDTO.viewMode).toBe('diff');
+      expect(savedDTO.isPinned).toBe(true);
+      expect(savedDTO.position).toBe(0);
+      expect(savedDTO.openedAt).toBe('2026-02-01T12:00:00.000Z');
+      expect(savedDTO.lastAccessedAt).toBe('2026-02-01T13:00:00.000Z');
+
+      unmount();
+    });
+
+    it('provides defaults for optional FileTab fields in DTO', async () => {
+      // Create a tab with no viewMode, isPinned, openedAt, lastAccessedAt
+      const tab: FileTab = {
+        id: 'minimal-tab',
+        workspaceId: 'ws-1',
+        sessionId: 'session-1',
+        path: 'src/minimal.ts',
+        name: 'minimal.ts',
+        isLoading: false,
+        // viewMode, isPinned, openedAt, lastAccessedAt intentionally omitted
+      };
+
+      useAppStore.setState({ fileTabs: [tab] });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance(3000);
+
+      expect(mockedSaveFileTabs).toHaveBeenCalled();
+      const savedTabs = mockedSaveFileTabs.mock.calls[0][1] as FileTabDTO[];
+      const savedDTO = savedTabs[0];
+
+      // tabToDTO should provide defaults
+      expect(savedDTO.viewMode).toBe('file');
+      expect(savedDTO.isPinned).toBe(false);
+      expect(savedDTO.position).toBe(0);
+      // openedAt and lastAccessedAt should get new Date().toISOString() defaults
+      expect(savedDTO.openedAt).toBeTruthy();
+      expect(savedDTO.lastAccessedAt).toBeTruthy();
+
+      unmount();
+    });
+
+    it('only saves tabs belonging to the current workspace', async () => {
+      const wsTab = makeFileTab({ id: 'ws-tab', workspaceId: 'ws-1' });
+      const otherWsTab = makeFileTab({ id: 'other-ws-tab', workspaceId: 'ws-other' });
+
+      useAppStore.setState({ fileTabs: [wsTab, otherWsTab] });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance(3000);
+
+      expect(mockedSaveFileTabs).toHaveBeenCalledWith('ws-1', expect.any(Array));
+      const savedTabs = mockedSaveFileTabs.mock.calls[0][1] as FileTabDTO[];
+      // Only ws-1 tab should be saved
+      expect(savedTabs).toHaveLength(1);
+      expect(savedTabs[0].id).toBe('ws-tab');
+
+      unmount();
+    });
+  });
+
+  // ===================================================================
+  // beforeunload sync save with navigator.sendBeacon
+  // ===================================================================
+
+  describe('beforeunload and sendBeacon', () => {
+    it('registers a beforeunload event listener', async () => {
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      expect(window.addEventListener).toHaveBeenCalledWith(
+        'beforeunload',
+        expect.any(Function)
+      );
+
+      unmount();
+    });
+
+    it('calls sendBeacon with correct URL and data on beforeunload', async () => {
+      const tab = makeFileTab({ id: 'beacon-tab', workspaceId: 'ws-1' });
+      useAppStore.setState({ fileTabs: [tab] });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      // Simulate the beforeunload event
+      expect(beforeUnloadHandlers.length).toBeGreaterThan(0);
+      // Fire the latest handler
+      beforeUnloadHandlers[beforeUnloadHandlers.length - 1]();
+
+      expect(mockSendBeacon).toHaveBeenCalledWith(
+        'http://localhost:9876/api/repos/ws-1/tabs',
+        expect.any(String)
+      );
+
+      // Verify the beacon payload contains the tab DTOs
+      const payload = JSON.parse(mockSendBeacon.mock.calls[0][1] as string);
+      expect(payload.tabs).toBeDefined();
+      expect(payload.tabs).toHaveLength(1);
+      expect(payload.tabs[0].id).toBe('beacon-tab');
+
+      unmount();
+    });
+
+    it('does not send beacon when workspaceId is missing', async () => {
+      useAppStore.setState({
+        selectedWorkspaceId: null,
+        fileTabs: [makeFileTab()],
+      });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      // Trigger beforeunload if any handler was registered
+      if (beforeUnloadHandlers.length > 0) {
+        beforeUnloadHandlers[beforeUnloadHandlers.length - 1]();
+      }
+
+      expect(mockSendBeacon).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    it('removes beforeunload listener on unmount', async () => {
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      unmount();
+
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        'beforeunload',
+        expect.any(Function)
+      );
+    });
+
+    it('fires a final save on cleanup when there is a pending timeout', async () => {
+      const tab = makeFileTab({ id: 'cleanup-tab' });
+      useAppStore.setState({ fileTabs: [tab] });
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      // At this point a debounced save timeout is pending (from the fileTabs effect).
+      // Unmounting should clear the timeout and trigger an immediate saveTabs().
+      mockedSaveFileTabs.mockClear();
+
+      unmount();
+
+      // The cleanup calls saveTabs() synchronously (fire-and-forget)
+      await flushAndAdvance();
+
+      // The cleanup save should have been called since the tab is new
+      // (not matching lastSavedRef which was set from an empty load).
+      expect(mockedSaveFileTabs).toHaveBeenCalledWith('ws-1', expect.any(Array));
+      // Verify the beforeunload listener was also cleaned up
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        'beforeunload',
+        expect.any(Function),
+      );
+    });
+  });
+
+  // ===================================================================
+  // Edge cases
+  // ===================================================================
+
+  describe('edge cases', () => {
+    it('handles an empty path gracefully (falls back to full path as name)', async () => {
+      const dto = makeFileTabDTO({
+        id: 'empty-path-tab',
+        sessionId: 'session-1',
+        path: '',
+      });
+      mockedListFileTabs.mockResolvedValue([dto]);
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs).toHaveLength(1);
+      // When path is empty, .split('/').pop() returns '' so it falls back to path itself
+      expect(tabs[0].name).toBe('');
+
+      unmount();
+    });
+
+    it('handles loading when API returns no tabs for session', async () => {
+      mockedListFileTabs.mockResolvedValue([]);
+
+      const { unmount } = await importAndRender();
+      await flushAndAdvance();
+
+      expect(useAppStore.getState().fileTabs).toHaveLength(0);
+      // Should not select any tab
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+
+      unmount();
+    });
+  });
+});

--- a/src/lib/__tests__/attachments.test.ts
+++ b/src/lib/__tests__/attachments.test.ts
@@ -1,0 +1,611 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getFileExtension,
+  getFileName,
+  isFileSupported,
+  getMimeType,
+  getFileCategory,
+  isImage,
+  generateAttachmentId,
+  formatFileSize,
+  validateFile,
+  validateAttachments,
+  processDroppedFiles,
+  loadAttachmentContent,
+  loadAllAttachmentContents,
+  getAttachmentSubtitle,
+  ATTACHMENT_LIMITS,
+  SUPPORTED_EXTENSIONS,
+} from '../attachments';
+import type { Attachment } from '../types';
+
+// Mock the tauri module
+vi.mock('../tauri', () => ({
+  readFileMetadata: vi.fn(),
+  readFileAsBase64: vi.fn(),
+  countFileLines: vi.fn(),
+  getImageDimensions: vi.fn(),
+}));
+
+import { readFileMetadata, readFileAsBase64, countFileLines, getImageDimensions } from '../tauri';
+
+const mockReadFileMetadata = vi.mocked(readFileMetadata);
+const mockReadFileAsBase64 = vi.mocked(readFileAsBase64);
+const mockCountFileLines = vi.mocked(countFileLines);
+const mockGetImageDimensions = vi.mocked(getImageDimensions);
+
+function makeAttachment(overrides: Partial<Attachment> = {}): Attachment {
+  return {
+    id: 'att-123',
+    type: 'file',
+    name: 'test.ts',
+    mimeType: 'text/typescript',
+    size: 1024,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ============================================================================
+// getFileExtension
+// ============================================================================
+
+describe('getFileExtension', () => {
+  it('returns lowercase extension with dot', () => {
+    expect(getFileExtension('foo.ts')).toBe('.ts');
+  });
+
+  it('handles uppercase extensions', () => {
+    expect(getFileExtension('image.PNG')).toBe('.png');
+  });
+
+  it('returns last extension for double extensions', () => {
+    expect(getFileExtension('archive.tar.gz')).toBe('.gz');
+  });
+
+  it('returns empty string for files without extension', () => {
+    expect(getFileExtension('Makefile')).toBe('');
+  });
+
+  it('handles paths with directories', () => {
+    expect(getFileExtension('/home/user/project/index.tsx')).toBe('.tsx');
+  });
+
+  it('handles dotfiles', () => {
+    // path.extname treats the entire dotfile name as the extension
+    // (e.g. ".gitignore" → ".gitignore") since there's nothing before the dot.
+    expect(getFileExtension('.gitignore')).toBe('.gitignore');
+  });
+});
+
+// ============================================================================
+// getFileName
+// ============================================================================
+
+describe('getFileName', () => {
+  it('extracts filename from unix path', () => {
+    expect(getFileName('/home/user/file.ts')).toBe('file.ts');
+  });
+
+  it('extracts filename from windows path', () => {
+    expect(getFileName('C:\\Users\\user\\file.ts')).toBe('file.ts');
+  });
+
+  it('returns the string itself if no path separator', () => {
+    expect(getFileName('file.ts')).toBe('file.ts');
+  });
+
+  it('handles trailing slash', () => {
+    expect(getFileName('/foo/bar/')).toBe('');
+  });
+});
+
+// ============================================================================
+// isFileSupported
+// ============================================================================
+
+describe('isFileSupported', () => {
+  it('returns true for supported code files', () => {
+    expect(isFileSupported('app.ts')).toBe(true);
+    expect(isFileSupported('app.tsx')).toBe(true);
+    expect(isFileSupported('main.go')).toBe(true);
+    expect(isFileSupported('script.py')).toBe(true);
+  });
+
+  it('returns true for supported image files', () => {
+    expect(isFileSupported('photo.png')).toBe(true);
+    expect(isFileSupported('icon.svg')).toBe(true);
+  });
+
+  it('returns true for config files', () => {
+    expect(isFileSupported('package.json')).toBe(true);
+    expect(isFileSupported('config.yaml')).toBe(true);
+  });
+
+  it('returns false for unsupported file types', () => {
+    expect(isFileSupported('archive.zip')).toBe(false);
+    expect(isFileSupported('binary.exe')).toBe(false);
+    expect(isFileSupported('video.mp4')).toBe(false);
+  });
+
+  it('returns false for files without extension', () => {
+    expect(isFileSupported('Makefile')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isFileSupported('IMAGE.PNG')).toBe(true);
+    expect(isFileSupported('File.JSON')).toBe(true);
+  });
+});
+
+// ============================================================================
+// getMimeType
+// ============================================================================
+
+describe('getMimeType', () => {
+  it('returns correct MIME for images', () => {
+    expect(getMimeType('photo.png')).toBe('image/png');
+    expect(getMimeType('photo.jpg')).toBe('image/jpeg');
+    expect(getMimeType('photo.jpeg')).toBe('image/jpeg');
+    expect(getMimeType('icon.svg')).toBe('image/svg+xml');
+  });
+
+  it('returns correct MIME for code files', () => {
+    expect(getMimeType('app.ts')).toBe('text/typescript');
+    expect(getMimeType('app.js')).toBe('text/javascript');
+    expect(getMimeType('main.py')).toBe('text/x-python');
+    expect(getMimeType('main.go')).toBe('text/x-go');
+  });
+
+  it('returns correct MIME for config files', () => {
+    expect(getMimeType('config.json')).toBe('application/json');
+    expect(getMimeType('config.yaml')).toBe('text/yaml');
+  });
+
+  it('returns octet-stream for unknown extensions', () => {
+    expect(getMimeType('file.xyz')).toBe('application/octet-stream');
+  });
+
+  it('returns octet-stream for files without extension', () => {
+    expect(getMimeType('Makefile')).toBe('application/octet-stream');
+  });
+});
+
+// ============================================================================
+// getFileCategory
+// ============================================================================
+
+describe('getFileCategory', () => {
+  it('categorizes image files', () => {
+    expect(getFileCategory('photo.png')).toBe('image');
+    expect(getFileCategory('icon.svg')).toBe('image');
+  });
+
+  it('categorizes code files', () => {
+    expect(getFileCategory('app.ts')).toBe('code');
+    expect(getFileCategory('main.go')).toBe('code');
+    expect(getFileCategory('lib.rs')).toBe('code');
+  });
+
+  it('categorizes text files', () => {
+    expect(getFileCategory('readme.md')).toBe('text');
+    expect(getFileCategory('notes.txt')).toBe('text');
+  });
+
+  it('categorizes config files', () => {
+    expect(getFileCategory('package.json')).toBe('config');
+    expect(getFileCategory('docker.dockerfile')).toBe('config');
+  });
+
+  it('categorizes shell files', () => {
+    expect(getFileCategory('build.sh')).toBe('shell');
+    expect(getFileCategory('setup.ps1')).toBe('shell');
+  });
+
+  it('categorizes markup files', () => {
+    expect(getFileCategory('index.html')).toBe('markup');
+    expect(getFileCategory('style.css')).toBe('markup');
+  });
+
+  it('categorizes data files', () => {
+    expect(getFileCategory('schema.sql')).toBe('data');
+    expect(getFileCategory('query.graphql')).toBe('data');
+  });
+
+  it('categorizes document files', () => {
+    expect(getFileCategory('report.pdf')).toBe('documents');
+  });
+
+  it('returns unknown for unsupported files', () => {
+    expect(getFileCategory('archive.zip')).toBe('unknown');
+    expect(getFileCategory('Makefile')).toBe('unknown');
+  });
+});
+
+// ============================================================================
+// isImage
+// ============================================================================
+
+describe('isImage', () => {
+  it('returns true for image extensions', () => {
+    expect(isImage('photo.png')).toBe(true);
+    expect(isImage('photo.jpg')).toBe(true);
+    expect(isImage('photo.gif')).toBe(true);
+    expect(isImage('photo.webp')).toBe(true);
+  });
+
+  it('returns false for non-image files', () => {
+    expect(isImage('code.ts')).toBe(false);
+    expect(isImage('doc.pdf')).toBe(false);
+  });
+});
+
+// ============================================================================
+// generateAttachmentId
+// ============================================================================
+
+describe('generateAttachmentId', () => {
+  it('starts with att- prefix', () => {
+    expect(generateAttachmentId()).toMatch(/^att-/);
+  });
+
+  it('generates unique IDs', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateAttachmentId()));
+    expect(ids.size).toBe(100);
+  });
+});
+
+// ============================================================================
+// formatFileSize
+// ============================================================================
+
+describe('formatFileSize', () => {
+  it('formats bytes', () => {
+    expect(formatFileSize(500)).toBe('500 B');
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  it('formats kilobytes', () => {
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+    expect(formatFileSize(1536)).toBe('1.5 KB');
+  });
+
+  it('formats megabytes', () => {
+    expect(formatFileSize(1024 * 1024)).toBe('1.0 MB');
+    expect(formatFileSize(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+
+  it('handles boundary at 1024', () => {
+    expect(formatFileSize(1023)).toBe('1023 B');
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+  });
+
+  it('handles boundary at 1MB', () => {
+    expect(formatFileSize(1024 * 1024 - 1)).toMatch(/KB$/);
+    expect(formatFileSize(1024 * 1024)).toBe('1.0 MB');
+  });
+});
+
+// ============================================================================
+// validateFile
+// ============================================================================
+
+describe('validateFile', () => {
+  it('accepts valid file with supported extension and size', () => {
+    expect(validateFile('app.ts', 1024)).toEqual({ valid: true });
+  });
+
+  it('rejects unsupported extension', () => {
+    const result = validateFile('archive.zip', 1024);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unsupported file type');
+    expect(result.error).toContain('.zip');
+  });
+
+  it('rejects file exceeding max size', () => {
+    const result = validateFile('app.ts', ATTACHMENT_LIMITS.MAX_FILE_SIZE + 1);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('File too large');
+  });
+
+  it('accepts file at exactly max size', () => {
+    expect(validateFile('app.ts', ATTACHMENT_LIMITS.MAX_FILE_SIZE)).toEqual({ valid: true });
+  });
+
+  it('checks extension before size', () => {
+    const result = validateFile('archive.zip', ATTACHMENT_LIMITS.MAX_FILE_SIZE + 1);
+    expect(result.error).toContain('Unsupported file type');
+  });
+});
+
+// ============================================================================
+// validateAttachments
+// ============================================================================
+
+describe('validateAttachments', () => {
+  it('accepts valid set of attachments', () => {
+    const attachments = [makeAttachment({ size: 1024 })];
+    expect(validateAttachments(attachments)).toEqual({ valid: true });
+  });
+
+  it('rejects when too many attachments', () => {
+    const attachments = Array.from({ length: ATTACHMENT_LIMITS.MAX_ATTACHMENTS + 1 }, () =>
+      makeAttachment({ size: 100 })
+    );
+    const result = validateAttachments(attachments);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Too many attachments');
+  });
+
+  it('accepts exactly max number of attachments', () => {
+    const attachments = Array.from({ length: ATTACHMENT_LIMITS.MAX_ATTACHMENTS }, () =>
+      makeAttachment({ size: 100 })
+    );
+    expect(validateAttachments(attachments)).toEqual({ valid: true });
+  });
+
+  it('rejects when total size exceeds limit', () => {
+    const attachments = [
+      makeAttachment({ size: ATTACHMENT_LIMITS.MAX_TOTAL_SIZE }),
+      makeAttachment({ size: 1 }),
+    ];
+    const result = validateAttachments(attachments);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Total attachment size');
+  });
+
+  it('accepts empty attachment list', () => {
+    expect(validateAttachments([])).toEqual({ valid: true });
+  });
+});
+
+// ============================================================================
+// processDroppedFiles
+// ============================================================================
+
+describe('processDroppedFiles', () => {
+  it('processes valid text file', async () => {
+    mockReadFileMetadata.mockResolvedValue({ size: 500, isDirectory: false });
+    mockCountFileLines.mockResolvedValue(42);
+
+    const result = await processDroppedFiles(['/home/user/code.ts']);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+    expect(result.attachments[0]).toMatchObject({
+      type: 'file',
+      name: 'code.ts',
+      mimeType: 'text/typescript',
+      size: 500,
+      lineCount: 42,
+    });
+  });
+
+  it('processes valid image file with dimensions', async () => {
+    mockReadFileMetadata.mockResolvedValue({ size: 2048, isDirectory: false });
+    mockGetImageDimensions.mockResolvedValue({ width: 800, height: 600 });
+
+    const result = await processDroppedFiles(['/home/user/photo.png']);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0]).toMatchObject({
+      type: 'image',
+      name: 'photo.png',
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it('returns error for directory', async () => {
+    mockReadFileMetadata.mockResolvedValue({ size: 0, isDirectory: true });
+
+    const result = await processDroppedFiles(['/home/user/src']);
+
+    expect(result.attachments).toHaveLength(0);
+    expect(result.errors).toContain('Folders cannot be attached');
+  });
+
+  it('returns error when metadata read fails', async () => {
+    mockReadFileMetadata.mockResolvedValue(null);
+
+    const result = await processDroppedFiles(['/home/user/file.ts']);
+
+    expect(result.attachments).toHaveLength(0);
+    expect(result.errors[0]).toContain('Failed to read file');
+  });
+
+  it('returns error for unsupported file type', async () => {
+    mockReadFileMetadata.mockResolvedValue({ size: 100, isDirectory: false });
+
+    const result = await processDroppedFiles(['/home/user/archive.zip']);
+
+    expect(result.attachments).toHaveLength(0);
+    expect(result.errors[0]).toContain('Unsupported file type');
+  });
+
+  it('returns error for oversized file', async () => {
+    mockReadFileMetadata.mockResolvedValue({
+      size: ATTACHMENT_LIMITS.MAX_FILE_SIZE + 1,
+      isDirectory: false,
+    });
+
+    const result = await processDroppedFiles(['/home/user/big.ts']);
+
+    expect(result.attachments).toHaveLength(0);
+    expect(result.errors[0]).toContain('File too large');
+  });
+
+  it('processes multiple files in parallel', async () => {
+    mockReadFileMetadata.mockResolvedValue({ size: 100, isDirectory: false });
+    mockCountFileLines.mockResolvedValue(10);
+
+    const result = await processDroppedFiles(['/a.ts', '/b.js', '/c.py']);
+
+    expect(result.attachments).toHaveLength(3);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('handles mix of valid and invalid files', async () => {
+    mockReadFileMetadata
+      .mockResolvedValueOnce({ size: 100, isDirectory: false }) // valid .ts
+      .mockResolvedValueOnce({ size: 100, isDirectory: false }); // .zip fails validation
+    mockCountFileLines.mockResolvedValue(10);
+
+    const result = await processDroppedFiles(['/valid.ts', '/invalid.zip']);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('catches thrown errors gracefully', async () => {
+    mockReadFileMetadata.mockRejectedValue(new Error('disk error'));
+
+    const result = await processDroppedFiles(['/broken.ts']);
+
+    expect(result.attachments).toHaveLength(0);
+    expect(result.errors[0]).toContain('disk error');
+  });
+
+  it('does not count lines for PDF files', async () => {
+    mockReadFileMetadata.mockResolvedValue({ size: 5000, isDirectory: false });
+
+    const result = await processDroppedFiles(['/doc.pdf']);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(mockCountFileLines).not.toHaveBeenCalled();
+    expect(result.attachments[0].lineCount).toBeUndefined();
+  });
+
+  it('handles image without dimensions gracefully', async () => {
+    mockReadFileMetadata.mockResolvedValue({ size: 2048, isDirectory: false });
+    mockGetImageDimensions.mockResolvedValue(null);
+
+    const result = await processDroppedFiles(['/photo.png']);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].width).toBeUndefined();
+    expect(result.attachments[0].height).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// loadAttachmentContent
+// ============================================================================
+
+describe('loadAttachmentContent', () => {
+  it('returns attachment as-is if base64Data already loaded', async () => {
+    const att = makeAttachment({ base64Data: 'abc123', path: '/file.ts' });
+    const result = await loadAttachmentContent(att);
+    expect(result).toBe(att);
+    expect(mockReadFileAsBase64).not.toHaveBeenCalled();
+  });
+
+  it('loads base64 content from file path', async () => {
+    mockReadFileAsBase64.mockResolvedValue('ZmlsZWNvbnRlbnQ=');
+    const att = makeAttachment({ path: '/file.ts' });
+
+    const result = await loadAttachmentContent(att);
+
+    expect(result.base64Data).toBe('ZmlsZWNvbnRlbnQ=');
+    expect(mockReadFileAsBase64).toHaveBeenCalledWith('/file.ts');
+  });
+
+  it('throws if attachment has no path', async () => {
+    const att = makeAttachment({ path: undefined });
+    await expect(loadAttachmentContent(att)).rejects.toThrow('has no path');
+  });
+
+  it('throws if reading file content fails', async () => {
+    mockReadFileAsBase64.mockResolvedValue(null);
+    const att = makeAttachment({ path: '/missing.ts' });
+    await expect(loadAttachmentContent(att)).rejects.toThrow('Failed to read file content');
+  });
+});
+
+// ============================================================================
+// loadAllAttachmentContents
+// ============================================================================
+
+describe('loadAllAttachmentContents', () => {
+  it('loads content for all attachments', async () => {
+    mockReadFileAsBase64.mockResolvedValue('base64data');
+    const attachments = [
+      makeAttachment({ path: '/a.ts' }),
+      makeAttachment({ path: '/b.ts' }),
+    ];
+
+    const result = await loadAllAttachmentContents(attachments);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].base64Data).toBe('base64data');
+    expect(result[1].base64Data).toBe('base64data');
+  });
+
+  it('returns empty array for empty input', async () => {
+    const result = await loadAllAttachmentContents([]);
+    expect(result).toEqual([]);
+  });
+});
+
+// ============================================================================
+// getAttachmentSubtitle
+// ============================================================================
+
+describe('getAttachmentSubtitle', () => {
+  it('shows dimensions for images', () => {
+    const att = makeAttachment({ type: 'image', width: 1920, height: 1080 });
+    expect(getAttachmentSubtitle(att)).toBe('1920\u00D71080');
+  });
+
+  it('shows line count for text files with plural', () => {
+    const att = makeAttachment({ lineCount: 42 });
+    expect(getAttachmentSubtitle(att)).toBe('42 lines');
+  });
+
+  it('shows line count singular for 1 line', () => {
+    const att = makeAttachment({ lineCount: 1 });
+    expect(getAttachmentSubtitle(att)).toBe('1 line');
+  });
+
+  it('falls back to file size when no other metadata', () => {
+    const att = makeAttachment({ size: 2048 });
+    expect(getAttachmentSubtitle(att)).toBe('2.0 KB');
+  });
+
+  it('falls back to file size when lineCount is 0', () => {
+    const att = makeAttachment({ lineCount: 0, size: 512 });
+    expect(getAttachmentSubtitle(att)).toBe('512 B');
+  });
+
+  it('prefers dimensions over lineCount for images', () => {
+    const att = makeAttachment({ type: 'image', width: 100, height: 100, lineCount: 10 });
+    expect(getAttachmentSubtitle(att)).toBe('100\u00D7100');
+  });
+});
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+describe('ATTACHMENT_LIMITS', () => {
+  it('has expected limits', () => {
+    expect(ATTACHMENT_LIMITS.MAX_FILE_SIZE).toBe(5 * 1024 * 1024);
+    expect(ATTACHMENT_LIMITS.MAX_TOTAL_SIZE).toBe(20 * 1024 * 1024);
+    expect(ATTACHMENT_LIMITS.MAX_ATTACHMENTS).toBe(10);
+  });
+});
+
+describe('SUPPORTED_EXTENSIONS', () => {
+  it('includes all expected categories', () => {
+    expect(Object.keys(SUPPORTED_EXTENSIONS)).toEqual(
+      expect.arrayContaining(['image', 'text', 'code', 'config', 'shell', 'markup', 'data', 'documents'])
+    );
+  });
+
+  it('includes PDF in documents', () => {
+    expect(SUPPORTED_EXTENSIONS.documents).toContain('.pdf');
+  });
+});

--- a/src/lib/__tests__/auth-token.test.ts
+++ b/src/lib/__tests__/auth-token.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The vitest setup defines window.__TAURI__ as writable but not configurable,
+// so we use simple assignment to toggle Tauri environment.
+const win = window as Window & { __TAURI__?: unknown };
+
+describe('auth-token', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    win.__TAURI__ = undefined;
+  });
+
+  afterEach(() => {
+    win.__TAURI__ = undefined;
+  });
+
+  // After resetModules, we need to get the mock invoke from the freshly imported module
+  async function setup() {
+    const tauriCore = await import('@tauri-apps/api/core');
+    const authToken = await import('../auth-token');
+    const mockInvoke = vi.mocked(tauriCore.invoke);
+    return { ...authToken, mockInvoke };
+  }
+
+  describe('getAuthToken', () => {
+    it('returns null when window is undefined', async () => {
+      const originalWindow = globalThis.window;
+      // @ts-expect-error - testing SSR case
+      delete globalThis.window;
+      try {
+        const { getAuthToken } = await setup();
+        const result = await getAuthToken();
+        expect(result).toBeNull();
+      } finally {
+        globalThis.window = originalWindow;
+      }
+    });
+
+    it('returns null when __TAURI__ is not present', async () => {
+      const { getAuthToken, mockInvoke } = await setup();
+      const result = await getAuthToken();
+      expect(result).toBeNull();
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('invokes get_auth_token when in Tauri environment', async () => {
+      win.__TAURI__ = {};
+      const { getAuthToken, mockInvoke } = await setup();
+      mockInvoke.mockResolvedValue('test-token-123');
+
+      const result = await getAuthToken();
+      expect(result).toBe('test-token-123');
+      expect(mockInvoke).toHaveBeenCalledWith('get_auth_token');
+    });
+
+    it('caches the token on subsequent calls', async () => {
+      win.__TAURI__ = {};
+      const { getAuthToken, mockInvoke } = await setup();
+      mockInvoke.mockResolvedValue('cached-token');
+
+      const first = await getAuthToken();
+      const second = await getAuthToken();
+
+      expect(first).toBe('cached-token');
+      expect(second).toBe('cached-token');
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null and logs error when invoke fails', async () => {
+      win.__TAURI__ = {};
+      const { getAuthToken, mockInvoke } = await setup();
+      mockInvoke.mockRejectedValue(new Error('IPC error'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        const result = await getAuthToken();
+        expect(result).toBeNull();
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to get auth token:', expect.any(Error));
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('getCachedAuthToken', () => {
+    it('returns null before any token is fetched', async () => {
+      const { getCachedAuthToken } = await setup();
+      expect(getCachedAuthToken()).toBeNull();
+    });
+
+    it('returns the token after getAuthToken has been called', async () => {
+      win.__TAURI__ = {};
+      const { getAuthToken, getCachedAuthToken, mockInvoke } = await setup();
+      mockInvoke.mockResolvedValue('my-token');
+
+      await getAuthToken();
+      expect(getCachedAuthToken()).toBe('my-token');
+    });
+  });
+
+  describe('initAuthToken', () => {
+    it('calls getAuthToken to prime the cache', async () => {
+      win.__TAURI__ = {};
+      const { initAuthToken, getCachedAuthToken, mockInvoke } = await setup();
+      mockInvoke.mockResolvedValue('init-token');
+
+      await initAuthToken();
+      expect(getCachedAuthToken()).toBe('init-token');
+    });
+  });
+
+  describe('clearAuthTokenCache', () => {
+    it('clears the cached token', async () => {
+      win.__TAURI__ = {};
+      const { getAuthToken, getCachedAuthToken, clearAuthTokenCache, mockInvoke } = await setup();
+      mockInvoke.mockResolvedValue('will-be-cleared');
+
+      await getAuthToken();
+      expect(getCachedAuthToken()).toBe('will-be-cleared');
+
+      clearAuthTokenCache();
+      expect(getCachedAuthToken()).toBeNull();
+    });
+
+    it('forces re-fetch on next getAuthToken call', async () => {
+      win.__TAURI__ = {};
+      const { getAuthToken, clearAuthTokenCache, mockInvoke } = await setup();
+      mockInvoke
+        .mockResolvedValueOnce('token-v1')
+        .mockResolvedValueOnce('token-v2');
+
+      const first = await getAuthToken();
+      expect(first).toBe('token-v1');
+
+      clearAuthTokenCache();
+      const second = await getAuthToken();
+      expect(second).toBe('token-v2');
+      expect(mockInvoke).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,933 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { server } from '@/__mocks__/server';
+import { http, HttpResponse } from 'msw';
+
+const API_BASE = 'http://localhost:9876';
+
+// Mock dependencies (these are hoisted before module evaluation)
+vi.mock('@/lib/tauri', () => ({
+  isTauri: vi.fn(() => false),
+  safeListen: vi.fn(async () => vi.fn()),
+  safeInvoke: vi.fn(async () => null),
+}));
+
+vi.mock('@/lib/backend-port', () => ({
+  getBackendPortSync: vi.fn(() => 9876),
+}));
+
+vi.mock('@/lib/pkce', () => ({
+  generateRandomString: vi.fn(() => 'mock-random-string'),
+  generateCodeChallenge: vi.fn(async () => 'mock-challenge'),
+}));
+
+vi.mock('@/lib/linearAuth', () => ({
+  LINEAR_STATE_PREFIX: 'linear:',
+  handleLinearOAuthCallback: vi.fn(),
+}));
+
+/**
+ * Re-apply vi.doMock() calls after vi.resetModules() and import fresh modules.
+ * The auth module reads from sessionStorage on load, so resetModules is required
+ * to get a fresh module with clean state for each test.
+ */
+function applyDoMocks() {
+  vi.doMock('@/lib/tauri', () => ({
+    isTauri: vi.fn(() => false),
+    safeListen: vi.fn(async () => vi.fn()),
+    safeInvoke: vi.fn(async () => null),
+  }));
+  vi.doMock('@/lib/backend-port', () => ({
+    getBackendPortSync: vi.fn(() => 9876),
+  }));
+  vi.doMock('@/lib/pkce', () => ({
+    generateRandomString: vi.fn(() => 'mock-random-string'),
+    generateCodeChallenge: vi.fn(async () => 'mock-challenge'),
+  }));
+  vi.doMock('@/lib/linearAuth', () => ({
+    LINEAR_STATE_PREFIX: 'linear:',
+    handleLinearOAuthCallback: vi.fn(),
+  }));
+}
+
+async function importFreshModules() {
+  const tauriMod = await import('@/lib/tauri');
+  const pkceMod = await import('@/lib/pkce');
+  const linearAuthMod = await import('@/lib/linearAuth');
+  const authMod = await import('../auth');
+
+  return {
+    ...authMod,
+    mockIsTauri: vi.mocked(tauriMod.isTauri),
+    mockSafeListen: vi.mocked(tauriMod.safeListen),
+    mockSafeInvoke: vi.mocked(tauriMod.safeInvoke),
+    mockGenerateRandomString: vi.mocked(pkceMod.generateRandomString),
+    mockGenerateCodeChallenge: vi.mocked(pkceMod.generateCodeChallenge),
+    mockHandleLinearOAuthCallback: vi.mocked(linearAuthMod.handleLinearOAuthCallback),
+  };
+}
+
+async function setup() {
+  vi.resetModules();
+  sessionStorage.clear();
+  localStorage.clear();
+  applyDoMocks();
+  return importFreshModules();
+}
+
+// Helper to set up sessionStorage state before module loads
+// (the module reads from sessionStorage on import)
+async function setupWithSessionState(state: string, verifier: string) {
+  vi.resetModules();
+  sessionStorage.clear();
+  localStorage.clear();
+  sessionStorage.setItem('oauth_state', state);
+  sessionStorage.setItem('oauth_code_verifier', verifier);
+  applyDoMocks();
+  return importFreshModules();
+}
+
+const mockUser = {
+  login: 'testuser',
+  name: 'Test User',
+  avatar_url: 'https://example.com/avatar.png',
+};
+
+describe('auth', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.restoreAllMocks();
+    server.resetHandlers();
+  });
+
+  // =========================================================
+  // getOAuthErrorMessage (tested indirectly via handleOAuthCallback)
+  // =========================================================
+  describe('getOAuthErrorMessage (via handleOAuthCallback)', () => {
+    it('maps access_denied to user-friendly message', async () => {
+      const { handleOAuthCallback } = await setup();
+      const url = 'chatml://oauth/callback?error=access_denied';
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'You declined to authorize ChatML',
+      );
+    });
+
+    it('maps redirect_uri_mismatch to config error', async () => {
+      const { handleOAuthCallback } = await setup();
+      const url = 'chatml://oauth/callback?error=redirect_uri_mismatch';
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'redirect URL is not registered',
+      );
+    });
+
+    it('maps application_suspended to suspended message', async () => {
+      const { handleOAuthCallback } = await setup();
+      const url = 'chatml://oauth/callback?error=application_suspended';
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'application has been suspended',
+      );
+    });
+
+    it('maps incorrect_client_credentials to contact support', async () => {
+      const { handleOAuthCallback } = await setup();
+      const url = 'chatml://oauth/callback?error=incorrect_client_credentials';
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'Please contact support',
+      );
+    });
+
+    it('uses error_description for unknown errors when provided', async () => {
+      const { handleOAuthCallback } = await setup();
+      const url = 'chatml://oauth/callback?error=unknown_error&error_description=Something+went+wrong';
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'Something went wrong',
+      );
+    });
+
+    it('uses generic message for unknown errors without description', async () => {
+      const { handleOAuthCallback } = await setup();
+      const url = 'chatml://oauth/callback?error=unknown_error';
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'GitHub authorization failed: unknown_error',
+      );
+    });
+  });
+
+  // =========================================================
+  // isOAuthPending / cancelOAuthFlow
+  // =========================================================
+  describe('isOAuthPending', () => {
+    it('returns false initially (no pending state)', async () => {
+      const { isOAuthPending } = await setup();
+      expect(isOAuthPending()).toBe(false);
+    });
+
+    it('returns true after startOAuthFlow', async () => {
+      const { isOAuthPending, startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await startOAuthFlow();
+      expect(isOAuthPending()).toBe(true);
+      openSpy.mockRestore();
+    });
+
+    it('returns true when sessionStorage has state on module load', async () => {
+      const { isOAuthPending } = await setupWithSessionState(
+        'restored-state',
+        'restored-verifier',
+      );
+      expect(isOAuthPending()).toBe(true);
+    });
+  });
+
+  describe('cancelOAuthFlow', () => {
+    it('clears pending state and sessionStorage', async () => {
+      const { isOAuthPending, cancelOAuthFlow, startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      await startOAuthFlow();
+      expect(isOAuthPending()).toBe(true);
+      expect(sessionStorage.getItem('oauth_state')).not.toBeNull();
+      expect(sessionStorage.getItem('oauth_code_verifier')).not.toBeNull();
+
+      cancelOAuthFlow();
+      expect(isOAuthPending()).toBe(false);
+      expect(sessionStorage.getItem('oauth_state')).toBeNull();
+      expect(sessionStorage.getItem('oauth_code_verifier')).toBeNull();
+
+      openSpy.mockRestore();
+    });
+  });
+
+  // =========================================================
+  // startOAuthFlow
+  // =========================================================
+  describe('startOAuthFlow', () => {
+    it('generates PKCE state and verifier', async () => {
+      const { startOAuthFlow, mockGenerateRandomString } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      await startOAuthFlow();
+
+      // generateRandomString is called twice: once for state, once for verifier
+      expect(mockGenerateRandomString).toHaveBeenCalledTimes(2);
+      expect(mockGenerateRandomString).toHaveBeenCalledWith(32);
+
+      openSpy.mockRestore();
+    });
+
+    it('stores state and verifier in sessionStorage', async () => {
+      const { startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      await startOAuthFlow();
+
+      expect(sessionStorage.getItem('oauth_state')).toBe('mock-random-string');
+      expect(sessionStorage.getItem('oauth_code_verifier')).toBe('mock-random-string');
+
+      openSpy.mockRestore();
+    });
+
+    it('opens correct GitHub auth URL with proper params in non-Tauri', async () => {
+      const { startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      await startOAuthFlow();
+
+      expect(openSpy).toHaveBeenCalledOnce();
+      const url = new URL(openSpy.mock.calls[0][0] as string);
+
+      expect(url.origin + url.pathname).toBe('https://github.com/login/oauth/authorize');
+      expect(url.searchParams.get('redirect_uri')).toBe('chatml://oauth/callback');
+      expect(url.searchParams.get('scope')).toBe('repo,read:user');
+      expect(url.searchParams.get('state')).toBe('mock-random-string');
+      expect(url.searchParams.get('code_challenge')).toBe('mock-challenge');
+      expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(openSpy.mock.calls[0][1]).toBe('_blank');
+
+      openSpy.mockRestore();
+    });
+
+    it('calls generateCodeChallenge with the verifier', async () => {
+      const { startOAuthFlow, mockGenerateCodeChallenge } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      await startOAuthFlow();
+
+      expect(mockGenerateCodeChallenge).toHaveBeenCalledWith('mock-random-string');
+
+      openSpy.mockRestore();
+    });
+
+    it('in Tauri env: calls shell.open instead of window.open', async () => {
+      const { startOAuthFlow, mockIsTauri } = await setup();
+      mockIsTauri.mockReturnValue(true);
+
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      // The mock for @tauri-apps/plugin-shell is already set up by vitest.config.ts alias
+      const shellMod = await import('@tauri-apps/plugin-shell');
+      const shellOpen = vi.mocked(shellMod.open);
+      shellOpen.mockClear();
+
+      await startOAuthFlow();
+
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(shellOpen).toHaveBeenCalledOnce();
+
+      // Verify the URL structure
+      const authUrl = shellOpen.mock.calls[0][0];
+      expect(authUrl).toContain('https://github.com/login/oauth/authorize');
+      expect(authUrl).toContain('code_challenge=mock-challenge');
+
+      openSpy.mockRestore();
+    });
+  });
+
+  // =========================================================
+  // handleOAuthCallback
+  // =========================================================
+  describe('handleOAuthCallback', () => {
+    it('exchanges code for token successfully', async () => {
+      const { handleOAuthCallback, startOAuthFlow, isOAuthPending } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      await startOAuthFlow();
+
+      const state = sessionStorage.getItem('oauth_state')!;
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/github/callback`, async ({ request }) => {
+          const body = await request.json() as Record<string, unknown>;
+          expect(body.code).toBe('test-code');
+          expect(body.code_verifier).toBe('mock-random-string');
+          return HttpResponse.json({ token: 'gh-token-123', user: mockUser });
+        }),
+      );
+
+      const result = await handleOAuthCallback(
+        `chatml://oauth/callback?code=test-code&state=${encodeURIComponent(state)}`,
+      );
+
+      expect(result.token).toBe('gh-token-123');
+      expect(result.user).toEqual(mockUser);
+      // State should be cleared after success
+      expect(isOAuthPending()).toBe(false);
+      expect(sessionStorage.getItem('oauth_state')).toBeNull();
+      expect(sessionStorage.getItem('oauth_code_verifier')).toBeNull();
+
+      openSpy.mockRestore();
+    });
+
+    it('throws on GitHub error response (access_denied)', async () => {
+      const { handleOAuthCallback, startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await startOAuthFlow();
+
+      const url = 'chatml://oauth/callback?error=access_denied&error_description=User+denied+access';
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'You declined to authorize ChatML',
+      );
+
+      openSpy.mockRestore();
+    });
+
+    it('throws on missing authorization code', async () => {
+      const { handleOAuthCallback, startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await startOAuthFlow();
+
+      const state = sessionStorage.getItem('oauth_state')!;
+      const url = `chatml://oauth/callback?state=${encodeURIComponent(state)}`;
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'No authorization code received from GitHub',
+      );
+
+      openSpy.mockRestore();
+    });
+
+    it('throws on state mismatch (CRITICAL SECURITY)', async () => {
+      const { handleOAuthCallback, startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await startOAuthFlow();
+
+      const url = 'chatml://oauth/callback?code=test-code&state=wrong-state-value';
+      await expect(handleOAuthCallback(url)).rejects.toThrow(
+        'Security error: state mismatch',
+      );
+
+      openSpy.mockRestore();
+    });
+
+    it('validates state against sessionStorage when module state lost', async () => {
+      // Simulate module reload: set sessionStorage, then import fresh module.
+      // The module reads from sessionStorage on load.
+      const { handleOAuthCallback } = await setupWithSessionState(
+        'stored-state-value',
+        'stored-verifier-value',
+      );
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/github/callback`, async ({ request }) => {
+          const body = await request.json() as Record<string, unknown>;
+          expect(body.code_verifier).toBe('stored-verifier-value');
+          return HttpResponse.json({ token: 'gh-token', user: mockUser });
+        }),
+      );
+
+      const result = await handleOAuthCallback(
+        'chatml://oauth/callback?code=test-code&state=stored-state-value',
+      );
+      expect(result.token).toBe('gh-token');
+    });
+
+    it('clears state after successful exchange', async () => {
+      const { handleOAuthCallback, startOAuthFlow, isOAuthPending } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await startOAuthFlow();
+      const state = sessionStorage.getItem('oauth_state')!;
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/github/callback`, () => {
+          return HttpResponse.json({ token: 'tok', user: mockUser });
+        }),
+      );
+
+      await handleOAuthCallback(
+        `chatml://oauth/callback?code=c&state=${encodeURIComponent(state)}`,
+      );
+
+      expect(isOAuthPending()).toBe(false);
+      expect(sessionStorage.getItem('oauth_state')).toBeNull();
+      expect(sessionStorage.getItem('oauth_code_verifier')).toBeNull();
+
+      openSpy.mockRestore();
+    });
+
+    it('sends code_verifier in the exchange request', async () => {
+      const { handleOAuthCallback, startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await startOAuthFlow();
+      const state = sessionStorage.getItem('oauth_state')!;
+
+      let capturedVerifier: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/auth/github/callback`, async ({ request }) => {
+          const body = await request.json() as Record<string, unknown>;
+          capturedVerifier = body.code_verifier;
+          return HttpResponse.json({ token: 'tok', user: mockUser });
+        }),
+      );
+
+      await handleOAuthCallback(
+        `chatml://oauth/callback?code=c&state=${encodeURIComponent(state)}`,
+      );
+
+      expect(capturedVerifier).toBe('mock-random-string');
+
+      openSpy.mockRestore();
+    });
+
+    it('throws when backend exchange returns non-OK', async () => {
+      const { handleOAuthCallback, startOAuthFlow } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await startOAuthFlow();
+      const state = sessionStorage.getItem('oauth_state')!;
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/github/callback`, () => {
+          return new HttpResponse('Bad Request', { status: 400 });
+        }),
+      );
+
+      await expect(
+        handleOAuthCallback(
+          `chatml://oauth/callback?code=c&state=${encodeURIComponent(state)}`,
+        ),
+      ).rejects.toThrow('Failed to complete authentication');
+
+      openSpy.mockRestore();
+    });
+  });
+
+  // =========================================================
+  // Token storage: storeToken / loadToken / clearToken
+  // =========================================================
+  describe('storeToken / loadToken / clearToken', () => {
+    describe('non-Tauri (localStorage)', () => {
+      it('storeToken saves to localStorage', async () => {
+        const { storeToken } = await setup();
+        await storeToken('my-token');
+        expect(localStorage.getItem('github_token')).toBe('my-token');
+      });
+
+      it('loadToken reads from localStorage', async () => {
+        const { loadToken } = await setup();
+        localStorage.setItem('github_token', 'stored-token');
+        const token = await loadToken();
+        expect(token).toBe('stored-token');
+      });
+
+      it('loadToken returns null when no token', async () => {
+        const { loadToken } = await setup();
+        const token = await loadToken();
+        expect(token).toBeNull();
+      });
+
+      it('clearToken removes from localStorage', async () => {
+        const { clearToken } = await setup();
+        localStorage.setItem('github_token', 'to-clear');
+        await clearToken();
+        expect(localStorage.getItem('github_token')).toBeNull();
+      });
+    });
+
+    describe('Tauri (Stronghold with localStorage fallback)', () => {
+      it('storeToken falls back to localStorage when Stronghold is unavailable', async () => {
+        const { storeToken, mockIsTauri } = await setup();
+        mockIsTauri.mockReturnValue(true);
+
+        // In tests, the Stronghold mock doesn't fully implement
+        // getStrongholdStore (appDataDir is missing), so storeToken
+        // falls back to localStorage.
+        await storeToken('stronghold-token');
+
+        expect(localStorage.getItem('github_token')).toBe('stronghold-token');
+      });
+
+      it('clearToken clears both localStorage and attempts Stronghold', async () => {
+        const { clearToken, mockIsTauri } = await setup();
+        mockIsTauri.mockReturnValue(true);
+        localStorage.setItem('github_token', 'legacy');
+
+        await clearToken();
+        expect(localStorage.getItem('github_token')).toBeNull();
+      });
+    });
+  });
+
+  // =========================================================
+  // sendTokenToBackend
+  // =========================================================
+  describe('sendTokenToBackend', () => {
+    it('sends token with POST and returns user info', async () => {
+      const { sendTokenToBackend } = await setup();
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/token`, async ({ request }) => {
+          const body = await request.json() as Record<string, unknown>;
+          expect(body.token).toBe('my-token');
+          return HttpResponse.json({ user: mockUser });
+        }),
+      );
+
+      const result = await sendTokenToBackend('my-token');
+      expect(result).toEqual({ user: mockUser });
+    });
+
+    it('returns null on non-OK response', async () => {
+      const { sendTokenToBackend } = await setup();
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/token`, () => {
+          return new HttpResponse('Unauthorized', { status: 401 });
+        }),
+      );
+
+      const result = await sendTokenToBackend('bad-token');
+      expect(result).toBeNull();
+    });
+
+    it('returns null on network error', async () => {
+      const { sendTokenToBackend } = await setup();
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/token`, () => {
+          return HttpResponse.error();
+        }),
+      );
+
+      const result = await sendTokenToBackend('any-token');
+      expect(result).toBeNull();
+    });
+  });
+
+  // =========================================================
+  // getAuthStatus
+  // =========================================================
+  describe('getAuthStatus', () => {
+    it('returns auth status from backend', async () => {
+      const { getAuthStatus } = await setup();
+
+      server.use(
+        http.get(`${API_BASE}/api/auth/status`, () => {
+          return HttpResponse.json({ authenticated: true, user: mockUser });
+        }),
+      );
+
+      const status = await getAuthStatus();
+      expect(status.authenticated).toBe(true);
+      expect(status.user).toEqual(mockUser);
+    });
+
+    it('returns unauthenticated status', async () => {
+      const { getAuthStatus } = await setup();
+
+      server.use(
+        http.get(`${API_BASE}/api/auth/status`, () => {
+          return HttpResponse.json({ authenticated: false });
+        }),
+      );
+
+      const status = await getAuthStatus();
+      expect(status.authenticated).toBe(false);
+    });
+  });
+
+  // =========================================================
+  // logout
+  // =========================================================
+  describe('logout', () => {
+    it('clears token and calls backend logout', async () => {
+      const { logout } = await setup();
+      localStorage.setItem('github_token', 'tok');
+
+      let logoutCalled = false;
+      server.use(
+        http.post(`${API_BASE}/api/auth/logout`, () => {
+          logoutCalled = true;
+          return HttpResponse.json({});
+        }),
+      );
+
+      await logout();
+      expect(localStorage.getItem('github_token')).toBeNull();
+      expect(logoutCalled).toBe(true);
+    });
+  });
+
+  // =========================================================
+  // initAuth
+  // =========================================================
+  describe('initAuth', () => {
+    it('returns authenticated:false when no token', async () => {
+      const { initAuth } = await setup();
+
+      const status = await initAuth();
+      expect(status).toEqual({ authenticated: false });
+    });
+
+    it('returns authenticated:true when token exists in localStorage', async () => {
+      const { initAuth } = await setup();
+      localStorage.setItem('github_token', 'existing-token');
+
+      const status = await initAuth();
+      expect(status).toEqual({ authenticated: true });
+    });
+  });
+
+  // =========================================================
+  // validateStoredToken
+  // =========================================================
+  describe('validateStoredToken', () => {
+    it('returns user from backend if already authenticated', async () => {
+      const { validateStoredToken } = await setup();
+
+      server.use(
+        http.get(`${API_BASE}/api/auth/status`, () => {
+          return HttpResponse.json({ authenticated: true, user: mockUser });
+        }),
+      );
+
+      const user = await validateStoredToken();
+      expect(user).toEqual(mockUser);
+    });
+
+    it('falls back to stored token if backend not authenticated', async () => {
+      const { validateStoredToken } = await setup();
+      localStorage.setItem('github_token', 'stored-token');
+
+      server.use(
+        http.get(`${API_BASE}/api/auth/status`, () => {
+          return HttpResponse.json({ authenticated: false });
+        }),
+        http.post(`${API_BASE}/api/auth/token`, () => {
+          return HttpResponse.json({ user: mockUser });
+        }),
+      );
+
+      const user = await validateStoredToken();
+      expect(user).toEqual(mockUser);
+    });
+
+    it('clears token if validation fails', async () => {
+      const { validateStoredToken } = await setup();
+      localStorage.setItem('github_token', 'invalid-token');
+
+      server.use(
+        http.get(`${API_BASE}/api/auth/status`, () => {
+          return HttpResponse.json({ authenticated: false });
+        }),
+        http.post(`${API_BASE}/api/auth/token`, () => {
+          return new HttpResponse('Unauthorized', { status: 401 });
+        }),
+      );
+
+      const user = await validateStoredToken();
+      expect(user).toBeNull();
+      expect(localStorage.getItem('github_token')).toBeNull();
+    });
+
+    it('returns null if no token stored', async () => {
+      const { validateStoredToken } = await setup();
+
+      server.use(
+        http.get(`${API_BASE}/api/auth/status`, () => {
+          return HttpResponse.json({ authenticated: false });
+        }),
+      );
+
+      const user = await validateStoredToken();
+      expect(user).toBeNull();
+    });
+
+    it('falls back to token path when getAuthStatus throws', async () => {
+      const { validateStoredToken } = await setup();
+      localStorage.setItem('github_token', 'my-token');
+
+      server.use(
+        http.get(`${API_BASE}/api/auth/status`, () => {
+          return HttpResponse.error();
+        }),
+        http.post(`${API_BASE}/api/auth/token`, () => {
+          return HttpResponse.json({ user: mockUser });
+        }),
+      );
+
+      const user = await validateStoredToken();
+      expect(user).toEqual(mockUser);
+    });
+  });
+
+  // =========================================================
+  // listenForOAuthCallback
+  // =========================================================
+  describe('listenForOAuthCallback', () => {
+    it('sets up Tauri event listener via safeListen', async () => {
+      const { listenForOAuthCallback, mockSafeListen } = await setup();
+
+      const githubCb = vi.fn();
+      const githubErr = vi.fn();
+      await listenForOAuthCallback(githubCb, githubErr);
+
+      expect(mockSafeListen).toHaveBeenCalledWith(
+        'oauth-callback',
+        expect.any(Function),
+      );
+    });
+
+    it('sets up DOM custom event listener', async () => {
+      const { listenForOAuthCallback } = await setup();
+      const addSpy = vi.spyOn(window, 'addEventListener');
+
+      const githubCb = vi.fn();
+      const githubErr = vi.fn();
+      await listenForOAuthCallback(githubCb, githubErr);
+
+      const domListenerCalls = addSpy.mock.calls.filter(
+        (c) => c[0] === 'tauri-oauth-callback',
+      );
+      expect(domListenerCalls.length).toBe(1);
+
+      addSpy.mockRestore();
+    });
+
+    it('sets up focus poll listener', async () => {
+      const { listenForOAuthCallback } = await setup();
+      const addSpy = vi.spyOn(window, 'addEventListener');
+
+      const githubCb = vi.fn();
+      const githubErr = vi.fn();
+      await listenForOAuthCallback(githubCb, githubErr);
+
+      const focusListenerCalls = addSpy.mock.calls.filter(
+        (c) => c[0] === 'focus',
+      );
+      expect(focusListenerCalls.length).toBe(1);
+
+      addSpy.mockRestore();
+    });
+
+    it('returns cleanup function that removes all listeners', async () => {
+      const { listenForOAuthCallback, mockSafeListen } = await setup();
+      const unlistenTauri = vi.fn();
+      mockSafeListen.mockResolvedValue(unlistenTauri);
+
+      const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+      const cleanup = await listenForOAuthCallback(vi.fn(), vi.fn());
+      cleanup();
+
+      expect(unlistenTauri).toHaveBeenCalled();
+
+      const removedEvents = removeSpy.mock.calls.map((c) => c[0]);
+      expect(removedEvents).toContain('tauri-oauth-callback');
+      expect(removedEvents).toContain('focus');
+
+      removeSpy.mockRestore();
+    });
+
+    it('routes GitHub callbacks to github handler', async () => {
+      const { listenForOAuthCallback, startOAuthFlow, mockSafeListen } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      await startOAuthFlow();
+      const state = sessionStorage.getItem('oauth_state')!;
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/github/callback`, () => {
+          return HttpResponse.json({ token: 'tok', user: mockUser });
+        }),
+      );
+
+      // Capture the event handler
+      let tauriHandler: ((url: string) => Promise<void>) | undefined;
+      mockSafeListen.mockImplementation(async (_event, handler) => {
+        tauriHandler = handler as (url: string) => Promise<void>;
+        return vi.fn();
+      });
+
+      const githubCb = vi.fn();
+      const githubErr = vi.fn();
+      await listenForOAuthCallback(githubCb, githubErr);
+
+      // Simulate Tauri event with GitHub callback
+      await tauriHandler!(
+        `chatml://oauth/callback?code=test-code&state=${encodeURIComponent(state)}`,
+      );
+
+      expect(githubCb).toHaveBeenCalledWith(
+        expect.objectContaining({ token: 'tok', user: mockUser }),
+      );
+
+      openSpy.mockRestore();
+    });
+
+    it('routes Linear callbacks to linear handler', async () => {
+      const { listenForOAuthCallback, mockSafeListen, mockHandleLinearOAuthCallback } = await setup();
+
+      const linearUser = { id: 'l1', name: 'Lin', email: 'l@example.com', displayName: 'Lin', avatarUrl: '' };
+      mockHandleLinearOAuthCallback.mockResolvedValue({ user: linearUser });
+
+      let tauriHandler: ((url: string) => Promise<void>) | undefined;
+      mockSafeListen.mockImplementation(async (_event, handler) => {
+        tauriHandler = handler as (url: string) => Promise<void>;
+        return vi.fn();
+      });
+
+      const githubCb = vi.fn();
+      const githubErr = vi.fn();
+      const linearCb = vi.fn();
+      const linearErr = vi.fn();
+      await listenForOAuthCallback(githubCb, githubErr, linearCb, linearErr);
+
+      // Simulate Tauri event with Linear callback (state starts with "linear:")
+      await tauriHandler!(
+        'chatml://oauth/callback?code=lin-code&state=linear:some-state',
+      );
+
+      expect(linearCb).toHaveBeenCalledWith({ user: linearUser });
+      expect(githubCb).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates callbacks (processed flag)', async () => {
+      const { listenForOAuthCallback, startOAuthFlow, mockSafeListen } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await startOAuthFlow();
+      const state = sessionStorage.getItem('oauth_state')!;
+
+      server.use(
+        http.post(`${API_BASE}/api/auth/github/callback`, () => {
+          return HttpResponse.json({ token: 'tok', user: mockUser });
+        }),
+      );
+
+      let tauriHandler: ((url: string) => Promise<void>) | undefined;
+      mockSafeListen.mockImplementation(async (_event, handler) => {
+        tauriHandler = handler as (url: string) => Promise<void>;
+        return vi.fn();
+      });
+
+      const githubCb = vi.fn();
+      await listenForOAuthCallback(githubCb, vi.fn());
+
+      const url = `chatml://oauth/callback?code=test-code&state=${encodeURIComponent(state)}`;
+      await tauriHandler!(url);
+      await tauriHandler!(url); // Second call should be skipped
+
+      expect(githubCb).toHaveBeenCalledTimes(1);
+
+      openSpy.mockRestore();
+    });
+
+    it('retries on error (resets processed flag)', async () => {
+      const { listenForOAuthCallback, startOAuthFlow, mockSafeListen, mockGenerateRandomString } = await setup();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      // First flow
+      await startOAuthFlow();
+      const state1 = sessionStorage.getItem('oauth_state')!;
+
+      let callCount = 0;
+      server.use(
+        http.post(`${API_BASE}/api/auth/github/callback`, () => {
+          callCount++;
+          if (callCount === 1) {
+            return new HttpResponse('Server Error', { status: 500 });
+          }
+          return HttpResponse.json({ token: 'tok', user: mockUser });
+        }),
+      );
+
+      let tauriHandler: ((url: string) => Promise<void>) | undefined;
+      mockSafeListen.mockImplementation(async (_event, handler) => {
+        tauriHandler = handler as (url: string) => Promise<void>;
+        return vi.fn();
+      });
+
+      const githubCb = vi.fn();
+      const githubErr = vi.fn();
+      await listenForOAuthCallback(githubCb, githubErr);
+
+      // First attempt: will fail (state is cleared by handleOAuthCallback on error-free path,
+      // but this path has a state match then a backend 500)
+      const url1 = `chatml://oauth/callback?code=c&state=${encodeURIComponent(state1)}`;
+      await tauriHandler!(url1);
+
+      // Error callback should have been called
+      expect(githubErr).toHaveBeenCalledTimes(1);
+      expect(githubCb).not.toHaveBeenCalled();
+
+      // Start a new flow for retry (state was consumed)
+      mockGenerateRandomString.mockReturnValue('retry-random-string');
+      await startOAuthFlow();
+      const state2 = sessionStorage.getItem('oauth_state')!;
+
+      // Second attempt: should succeed because processed was reset on error
+      const url2 = `chatml://oauth/callback?code=c2&state=${encodeURIComponent(state2)}`;
+      await tauriHandler!(url2);
+
+      expect(githubCb).toHaveBeenCalledTimes(1);
+
+      openSpy.mockRestore();
+    });
+  });
+
+  // =========================================================
+  // OAUTH_TIMEOUT_MS export
+  // =========================================================
+  describe('OAUTH_TIMEOUT_MS', () => {
+    it('is 120000 (2 minutes)', async () => {
+      const { OAUTH_TIMEOUT_MS } = await setup();
+      expect(OAUTH_TIMEOUT_MS).toBe(120000);
+    });
+  });
+});

--- a/src/lib/__tests__/check-utils.test.ts
+++ b/src/lib/__tests__/check-utils.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getCheckStatusInfo,
+  formatDuration,
+  computeJobDuration,
+  formatCIFailureMessage,
+} from '../check-utils';
+import type { CIFailureContextDTO } from '@/lib/api';
+
+// ============================================================================
+// getCheckStatusInfo
+// ============================================================================
+
+describe('getCheckStatusInfo', () => {
+  describe('in_progress status', () => {
+    it('returns Running with yellow color', () => {
+      const info = getCheckStatusInfo('in_progress', '');
+      expect(info.label).toBe('Running');
+      expect(info.color).toBe('text-yellow-500');
+    });
+  });
+
+  describe('queued/waiting/pending statuses', () => {
+    it.each(['queued', 'waiting', 'pending'])('returns Queued for status "%s"', (status) => {
+      const info = getCheckStatusInfo(status, '');
+      expect(info.label).toBe('Queued');
+      expect(info.color).toBe('text-muted-foreground');
+    });
+  });
+
+  describe('completed status', () => {
+    it('returns Passed for success conclusion', () => {
+      const info = getCheckStatusInfo('completed', 'success');
+      expect(info.label).toBe('Passed');
+      expect(info.color).toBe('text-green-500');
+    });
+
+    it('returns Failed for failure conclusion', () => {
+      const info = getCheckStatusInfo('completed', 'failure');
+      expect(info.label).toBe('Failed');
+      expect(info.color).toBe('text-red-500');
+    });
+
+    it('returns Timed out for timed_out conclusion', () => {
+      const info = getCheckStatusInfo('completed', 'timed_out');
+      expect(info.label).toBe('Timed out');
+      expect(info.color).toBe('text-red-500');
+    });
+
+    it('returns Cancelled for cancelled conclusion', () => {
+      const info = getCheckStatusInfo('completed', 'cancelled');
+      expect(info.label).toBe('Cancelled');
+      expect(info.color).toBe('text-muted-foreground');
+    });
+
+    it('returns Skipped for skipped conclusion', () => {
+      const info = getCheckStatusInfo('completed', 'skipped');
+      expect(info.label).toBe('Skipped');
+      expect(info.color).toBe('text-muted-foreground');
+    });
+
+    it('returns Neutral for neutral conclusion', () => {
+      const info = getCheckStatusInfo('completed', 'neutral');
+      expect(info.label).toBe('Neutral');
+      expect(info.color).toBe('text-muted-foreground');
+    });
+
+    it('returns Action required for action_required conclusion', () => {
+      const info = getCheckStatusInfo('completed', 'action_required');
+      expect(info.label).toBe('Action required');
+      expect(info.color).toBe('text-red-500');
+    });
+
+    it('falls back to conclusion string for unknown conclusion', () => {
+      const info = getCheckStatusInfo('completed', 'stale');
+      expect(info.label).toBe('stale');
+      expect(info.color).toBe('text-muted-foreground');
+    });
+
+    it('falls back to "Done" for empty conclusion', () => {
+      const info = getCheckStatusInfo('completed', '');
+      expect(info.label).toBe('Done');
+    });
+  });
+
+  describe('unknown status', () => {
+    it('falls back to status string as label', () => {
+      const info = getCheckStatusInfo('requested', '');
+      expect(info.label).toBe('requested');
+      expect(info.color).toBe('text-muted-foreground');
+    });
+  });
+});
+
+// ============================================================================
+// formatDuration
+// ============================================================================
+
+describe('formatDuration', () => {
+  it('formats seconds under a minute', () => {
+    expect(formatDuration(0)).toBe('0s');
+    expect(formatDuration(30)).toBe('30s');
+    expect(formatDuration(59)).toBe('59s');
+  });
+
+  it('formats exact minutes', () => {
+    expect(formatDuration(60)).toBe('1m');
+    expect(formatDuration(120)).toBe('2m');
+  });
+
+  it('formats minutes with remaining seconds', () => {
+    expect(formatDuration(90)).toBe('1m 30s');
+    expect(formatDuration(125)).toBe('2m 5s');
+  });
+
+  it('formats exact hours', () => {
+    expect(formatDuration(3600)).toBe('1h');
+    expect(formatDuration(7200)).toBe('2h');
+  });
+
+  it('formats hours with remaining minutes', () => {
+    expect(formatDuration(3660)).toBe('1h 1m');
+    expect(formatDuration(5400)).toBe('1h 30m');
+  });
+
+  it('drops remaining seconds in hour range', () => {
+    // 1h 1m 30s -> 1h 1m (seconds dropped)
+    expect(formatDuration(3690)).toBe('1h 1m');
+  });
+});
+
+// ============================================================================
+// computeJobDuration
+// ============================================================================
+
+describe('computeJobDuration', () => {
+  it('computes duration in seconds from ISO timestamps', () => {
+    const result = computeJobDuration({
+      startedAt: '2025-01-01T00:00:00Z',
+      completedAt: '2025-01-01T00:01:30Z',
+    });
+    expect(result).toBe(90);
+  });
+
+  it('returns 0 for same start and end time', () => {
+    const result = computeJobDuration({
+      startedAt: '2025-01-01T00:00:00Z',
+      completedAt: '2025-01-01T00:00:00Z',
+    });
+    expect(result).toBe(0);
+  });
+
+  it('returns undefined for invalid start date', () => {
+    const result = computeJobDuration({
+      startedAt: 'not-a-date',
+      completedAt: '2025-01-01T00:00:00Z',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for invalid end date', () => {
+    const result = computeJobDuration({
+      startedAt: '2025-01-01T00:00:00Z',
+      completedAt: 'invalid',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('clamps negative durations to 0', () => {
+    const result = computeJobDuration({
+      startedAt: '2025-01-01T00:01:00Z',
+      completedAt: '2025-01-01T00:00:00Z',
+    });
+    expect(result).toBe(0);
+  });
+
+  it('rounds to nearest second', () => {
+    const result = computeJobDuration({
+      startedAt: '2025-01-01T00:00:00.000Z',
+      completedAt: '2025-01-01T00:00:01.600Z',
+    });
+    expect(result).toBe(2);
+  });
+});
+
+// ============================================================================
+// formatCIFailureMessage
+// ============================================================================
+
+describe('formatCIFailureMessage', () => {
+  it('formats a single failed run with a single failed job', () => {
+    const context: CIFailureContextDTO = {
+      branch: 'main',
+      failedRuns: [{
+        runId: 1,
+        runName: 'CI',
+        runUrl: 'https://github.com/run/1',
+        failedJobs: [{
+          jobId: 10,
+          jobName: 'test',
+          jobUrl: 'https://github.com/job/10',
+          failedSteps: ['Run tests'],
+          logs: 'Error: test failed',
+          logLines: 1,
+          truncated: false,
+        }],
+      }],
+      totalFailed: 1,
+      truncated: false,
+    };
+
+    const msg = formatCIFailureMessage(context);
+    expect(msg).toContain('Fix the failing CI checks');
+    expect(msg).toContain('## Workflow: "CI"');
+    expect(msg).toContain('### Job: "test" - FAILED');
+    expect(msg).toContain('Failed steps: Run tests');
+    expect(msg).toContain('<logs>');
+    expect(msg).toContain('Error: test failed');
+    expect(msg).toContain('</logs>');
+  });
+
+  it('shows truncation notice for log output', () => {
+    const context: CIFailureContextDTO = {
+      branch: 'main',
+      failedRuns: [{
+        runId: 1,
+        runName: 'CI',
+        runUrl: 'https://github.com/run/1',
+        failedJobs: [{
+          jobId: 10,
+          jobName: 'build',
+          jobUrl: 'https://github.com/job/10',
+          failedSteps: [],
+          logs: 'truncated log output',
+          logLines: 500,
+          truncated: true,
+        }],
+      }],
+      totalFailed: 1,
+      truncated: false,
+    };
+
+    const msg = formatCIFailureMessage(context);
+    expect(msg).toContain('log truncated, showing tail of 500 total lines');
+  });
+
+  it('shows unavailable message when logs are missing', () => {
+    const context: CIFailureContextDTO = {
+      branch: 'main',
+      failedRuns: [{
+        runId: 1,
+        runName: 'CI',
+        runUrl: 'https://github.com/run/1',
+        failedJobs: [{
+          jobId: 10,
+          jobName: 'deploy',
+          jobUrl: 'https://github.com/job/10',
+          failedSteps: [],
+          logs: '(logs unavailable)',
+          logLines: 0,
+          truncated: false,
+        }],
+      }],
+      totalFailed: 1,
+      truncated: false,
+    };
+
+    const msg = formatCIFailureMessage(context);
+    expect(msg).toContain('(logs unavailable)');
+    expect(msg).not.toContain('<logs>');
+  });
+
+  it('shows truncation note when total failures are truncated', () => {
+    const context: CIFailureContextDTO = {
+      branch: 'main',
+      failedRuns: [{
+        runId: 1,
+        runName: 'CI',
+        runUrl: 'https://github.com/run/1',
+        failedJobs: [{
+          jobId: 10,
+          jobName: 'test',
+          jobUrl: 'https://github.com/job/10',
+          failedSteps: [],
+          logs: 'error',
+          logLines: 1,
+          truncated: false,
+        }],
+      }],
+      totalFailed: 12,
+      truncated: true,
+    };
+
+    const msg = formatCIFailureMessage(context);
+    expect(msg).toContain('12 total jobs failed');
+    expect(msg).toContain('Only the first 5 are shown');
+  });
+
+  it('handles multiple failed steps', () => {
+    const context: CIFailureContextDTO = {
+      branch: 'main',
+      failedRuns: [{
+        runId: 1,
+        runName: 'CI',
+        runUrl: 'https://github.com/run/1',
+        failedJobs: [{
+          jobId: 10,
+          jobName: 'test',
+          jobUrl: 'https://github.com/job/10',
+          failedSteps: ['Lint', 'Build', 'Test'],
+          logs: 'errors',
+          logLines: 1,
+          truncated: false,
+        }],
+      }],
+      totalFailed: 1,
+      truncated: false,
+    };
+
+    const msg = formatCIFailureMessage(context);
+    expect(msg).toContain('Failed steps: Lint, Build, Test');
+  });
+
+  it('omits failed steps line when no steps provided', () => {
+    const context: CIFailureContextDTO = {
+      branch: 'main',
+      failedRuns: [{
+        runId: 1,
+        runName: 'CI',
+        runUrl: 'https://github.com/run/1',
+        failedJobs: [{
+          jobId: 10,
+          jobName: 'test',
+          jobUrl: 'https://github.com/job/10',
+          failedSteps: [],
+          logs: 'error',
+          logLines: 1,
+          truncated: false,
+        }],
+      }],
+      totalFailed: 1,
+      truncated: false,
+    };
+
+    const msg = formatCIFailureMessage(context);
+    expect(msg).not.toContain('Failed steps:');
+  });
+});

--- a/src/lib/__tests__/pr-utils.test.ts
+++ b/src/lib/__tests__/pr-utils.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { computePRStatus, STATUS_ORDER, STATUS_LABELS } from '../pr-utils';
+import type { PRDashboardItem } from '@/lib/api';
+
+function makePR(overrides: Partial<PRDashboardItem> = {}): PRDashboardItem {
+  return {
+    number: 1,
+    title: 'Test PR',
+    state: 'open',
+    htmlUrl: 'https://github.com/org/repo/pull/1',
+    isDraft: false,
+    mergeable: true,
+    mergeableState: 'clean',
+    checkStatus: 'success',
+    checkDetails: [],
+    labels: [],
+    branch: 'feature',
+    baseBranch: 'main',
+    workspaceId: 'ws-1',
+    workspaceName: 'project',
+    repoOwner: 'org',
+    repoName: 'repo',
+    checksTotal: 3,
+    checksPassed: 3,
+    checksFailed: 0,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// computePRStatus
+// ============================================================================
+
+describe('computePRStatus', () => {
+  describe('ready status', () => {
+    it('returns ready when all checks pass and no conflicts', () => {
+      const result = computePRStatus(makePR());
+      expect(result.statusCategory).toBe('ready');
+      expect(result.allPassed).toBe(true);
+      expect(result.hasConflicts).toBe(false);
+      expect(result.pendingCount).toBe(0);
+    });
+
+    it('returns ready when there are no checks', () => {
+      const result = computePRStatus(makePR({
+        checksTotal: 0,
+        checksPassed: 0,
+        checksFailed: 0,
+      }));
+      expect(result.statusCategory).toBe('ready');
+      // allPassed is false when there are no checks
+      expect(result.allPassed).toBe(false);
+    });
+  });
+
+  describe('draft status', () => {
+    it('returns draft for draft PRs', () => {
+      const result = computePRStatus(makePR({ isDraft: true }));
+      expect(result.statusCategory).toBe('draft');
+    });
+
+    it('draft takes priority over conflicts', () => {
+      const result = computePRStatus(makePR({
+        isDraft: true,
+        mergeableState: 'dirty',
+      }));
+      expect(result.statusCategory).toBe('draft');
+    });
+
+    it('draft takes priority over failures', () => {
+      const result = computePRStatus(makePR({
+        isDraft: true,
+        checksFailed: 1,
+      }));
+      expect(result.statusCategory).toBe('draft');
+    });
+  });
+
+  describe('conflicts status', () => {
+    it('returns conflicts for dirty mergeable state', () => {
+      const result = computePRStatus(makePR({ mergeableState: 'dirty' }));
+      expect(result.statusCategory).toBe('conflicts');
+      expect(result.hasConflicts).toBe(true);
+    });
+
+    it('returns conflicts when mergeable is false', () => {
+      const result = computePRStatus(makePR({ mergeable: false }));
+      expect(result.statusCategory).toBe('conflicts');
+      expect(result.hasConflicts).toBe(true);
+    });
+
+    it('conflicts takes priority over failures', () => {
+      const result = computePRStatus(makePR({
+        mergeableState: 'dirty',
+        checksFailed: 2,
+      }));
+      expect(result.statusCategory).toBe('conflicts');
+    });
+  });
+
+  describe('failures status', () => {
+    it('returns failures when checks have failed', () => {
+      const result = computePRStatus(makePR({
+        checksTotal: 5,
+        checksPassed: 3,
+        checksFailed: 2,
+      }));
+      expect(result.statusCategory).toBe('failures');
+    });
+
+    it('failures takes priority over pending', () => {
+      const result = computePRStatus(makePR({
+        checksTotal: 5,
+        checksPassed: 2,
+        checksFailed: 1,
+        // pending = 5 - 2 - 1 = 2
+      }));
+      expect(result.statusCategory).toBe('failures');
+    });
+  });
+
+  describe('pending status', () => {
+    it('returns pending when checks are still running', () => {
+      const result = computePRStatus(makePR({
+        checksTotal: 5,
+        checksPassed: 3,
+        checksFailed: 0,
+      }));
+      expect(result.statusCategory).toBe('pending');
+      expect(result.pendingCount).toBe(2);
+    });
+  });
+
+  describe('computed fields', () => {
+    it('computes pendingCount correctly', () => {
+      const result = computePRStatus(makePR({
+        checksTotal: 10,
+        checksPassed: 6,
+        checksFailed: 1,
+      }));
+      expect(result.pendingCount).toBe(3);
+    });
+
+    it('preserves all original PR fields', () => {
+      const pr = makePR({ title: 'My PR', number: 42 });
+      const result = computePRStatus(pr);
+      expect(result.title).toBe('My PR');
+      expect(result.number).toBe(42);
+    });
+
+    it('allPassed is true only when checks exist and all pass', () => {
+      const allPass = computePRStatus(makePR({
+        checksTotal: 3, checksPassed: 3, checksFailed: 0,
+      }));
+      expect(allPass.allPassed).toBe(true);
+
+      const someFail = computePRStatus(makePR({
+        checksTotal: 3, checksPassed: 2, checksFailed: 1,
+      }));
+      expect(someFail.allPassed).toBe(false);
+
+      const somePending = computePRStatus(makePR({
+        checksTotal: 3, checksPassed: 2, checksFailed: 0,
+      }));
+      expect(somePending.allPassed).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+describe('STATUS_ORDER', () => {
+  it('lists statuses in display order', () => {
+    expect(STATUS_ORDER).toEqual(['ready', 'failures', 'conflicts', 'pending', 'draft']);
+  });
+});
+
+describe('STATUS_LABELS', () => {
+  it('has labels for all status categories', () => {
+    expect(STATUS_LABELS.ready).toBe('Ready to Merge');
+    expect(STATUS_LABELS.pending).toBe('Checks Pending');
+    expect(STATUS_LABELS.failures).toBe('Check Failures');
+    expect(STATUS_LABELS.conflicts).toBe('Merge Conflicts');
+    expect(STATUS_LABELS.draft).toBe('Draft');
+  });
+});

--- a/src/stores/__tests__/branchCacheStore.test.ts
+++ b/src/stores/__tests__/branchCacheStore.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useBranchCacheStore } from '../branchCacheStore';
+import type { BranchDTO } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  listBranches: vi.fn(),
+}));
+
+function makeBranch(overrides: Partial<BranchDTO> = {}): BranchDTO {
+  return {
+    name: 'origin/main',
+    isRemote: true,
+    isHead: false,
+    lastCommitSha: 'abc123',
+    lastCommitDate: '2025-01-01',
+    lastCommitSubject: 'test commit',
+    lastAuthor: 'dev',
+    aheadMain: 0,
+    behindMain: 0,
+    ...overrides,
+  };
+}
+
+let mockListBranches: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  const api = await import('@/lib/api');
+  mockListBranches = vi.mocked(api.listBranches);
+  mockListBranches.mockReset();
+
+  // Reset the store state
+  useBranchCacheStore.setState({ cache: {} });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ============================================================================
+// fetchBranches
+// ============================================================================
+
+describe('fetchBranches', () => {
+  it('fetches branches from API on first call', async () => {
+    const branches = [makeBranch({ name: 'origin/feature' })];
+    mockListBranches.mockResolvedValue({
+      sessionBranches: branches,
+      otherBranches: [],
+    });
+
+    const result = await useBranchCacheStore.getState().fetchBranches('ws-1');
+
+    expect(mockListBranches).toHaveBeenCalledWith('ws-1', {
+      includeRemote: true,
+      sortBy: 'date',
+      limit: 100,
+    });
+    expect(result).toEqual(branches);
+  });
+
+  it('filters out non-remote branches', async () => {
+    mockListBranches.mockResolvedValue({
+      sessionBranches: [
+        makeBranch({ name: 'origin/remote', isRemote: true }),
+        makeBranch({ name: 'local-only', isRemote: false }),
+      ],
+      otherBranches: [],
+    });
+
+    const result = await useBranchCacheStore.getState().fetchBranches('ws-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('origin/remote');
+  });
+
+  it('returns cached data on second call within TTL', async () => {
+    vi.useFakeTimers();
+    const branches = [makeBranch()];
+    mockListBranches.mockResolvedValue({
+      sessionBranches: branches,
+      otherBranches: [],
+    });
+
+    const first = await useBranchCacheStore.getState().fetchBranches('ws-1');
+    mockListBranches.mockClear();
+
+    // Advance less than TTL (5 min)
+    vi.advanceTimersByTime(2 * 60 * 1000);
+
+    const second = await useBranchCacheStore.getState().fetchBranches('ws-1');
+    expect(mockListBranches).not.toHaveBeenCalled();
+    expect(second).toBe(first);
+  });
+
+  it('refetches when cache expires after TTL', async () => {
+    vi.useFakeTimers();
+    const oldBranches = [makeBranch({ name: 'origin/old' })];
+    const newBranches = [makeBranch({ name: 'origin/new' })];
+
+    mockListBranches.mockResolvedValueOnce({
+      sessionBranches: oldBranches,
+      otherBranches: [],
+    });
+
+    await useBranchCacheStore.getState().fetchBranches('ws-1');
+
+    // Advance past TTL
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    mockListBranches.mockResolvedValueOnce({
+      sessionBranches: newBranches,
+      otherBranches: [],
+    });
+
+    // Stale data exists, so it returns stale and refreshes in background
+    const result = await useBranchCacheStore.getState().fetchBranches('ws-1');
+    expect(result).toEqual(oldBranches); // Returns stale data
+    expect(mockListBranches).toHaveBeenCalled(); // But triggers background refresh
+  });
+
+  it('force fetch bypasses cache', async () => {
+    vi.useFakeTimers();
+    const branches = [makeBranch()];
+    mockListBranches.mockResolvedValue({
+      sessionBranches: branches,
+      otherBranches: [],
+    });
+
+    await useBranchCacheStore.getState().fetchBranches('ws-1');
+    mockListBranches.mockClear();
+
+    mockListBranches.mockResolvedValue({
+      sessionBranches: [makeBranch({ name: 'origin/forced' })],
+      otherBranches: [],
+    });
+
+    const result = await useBranchCacheStore.getState().fetchBranches('ws-1', true);
+    expect(mockListBranches).toHaveBeenCalled();
+    expect(result[0].name).toBe('origin/forced');
+  });
+
+  it('handles API errors gracefully', async () => {
+    mockListBranches.mockRejectedValue(new Error('network error'));
+
+    await expect(
+      useBranchCacheStore.getState().fetchBranches('ws-1')
+    ).rejects.toThrow('network error');
+
+    // Loading state should be cleared
+    const entry = useBranchCacheStore.getState().cache['ws-1'];
+    expect(entry?.isLoading).toBe(false);
+  });
+
+  it('caches per workspace independently', async () => {
+    mockListBranches
+      .mockResolvedValueOnce({
+        sessionBranches: [makeBranch({ name: 'origin/ws1-branch' })],
+        otherBranches: [],
+      })
+      .mockResolvedValueOnce({
+        sessionBranches: [makeBranch({ name: 'origin/ws2-branch' })],
+        otherBranches: [],
+      });
+
+    const ws1 = await useBranchCacheStore.getState().fetchBranches('ws-1');
+    const ws2 = await useBranchCacheStore.getState().fetchBranches('ws-2');
+
+    expect(ws1[0].name).toBe('origin/ws1-branch');
+    expect(ws2[0].name).toBe('origin/ws2-branch');
+  });
+
+  it('combines sessionBranches and otherBranches', async () => {
+    mockListBranches.mockResolvedValue({
+      sessionBranches: [makeBranch({ name: 'origin/session-br' })],
+      otherBranches: [makeBranch({ name: 'origin/other-br' })],
+    });
+
+    const result = await useBranchCacheStore.getState().fetchBranches('ws-1');
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ============================================================================
+// invalidateAll
+// ============================================================================
+
+describe('invalidateAll', () => {
+  it('resets timestamps to 0 for all cached workspaces', async () => {
+    mockListBranches.mockResolvedValue({
+      sessionBranches: [makeBranch()],
+      otherBranches: [],
+    });
+
+    await useBranchCacheStore.getState().fetchBranches('ws-1');
+    await useBranchCacheStore.getState().fetchBranches('ws-2');
+
+    useBranchCacheStore.getState().invalidateAll();
+
+    const cache = useBranchCacheStore.getState().cache;
+    expect(cache['ws-1'].timestamp).toBe(0);
+    expect(cache['ws-2'].timestamp).toBe(0);
+  });
+
+  it('preserves branch data after invalidation', async () => {
+    mockListBranches.mockResolvedValue({
+      sessionBranches: [makeBranch({ name: 'origin/keep-me' })],
+      otherBranches: [],
+    });
+
+    await useBranchCacheStore.getState().fetchBranches('ws-1');
+    useBranchCacheStore.getState().invalidateAll();
+
+    const entry = useBranchCacheStore.getState().cache['ws-1'];
+    expect(entry.branches[0].name).toBe('origin/keep-me');
+  });
+
+  it('handles empty cache gracefully', () => {
+    useBranchCacheStore.getState().invalidateAll();
+    expect(useBranchCacheStore.getState().cache).toEqual({});
+  });
+});

--- a/src/stores/__tests__/slashCommandStore.test.ts
+++ b/src/stores/__tests__/slashCommandStore.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useSlashCommandStore } from '../slashCommandStore';
+import type { SkillDTO } from '@/lib/api';
+import type { UserCommandFile, SdkCommandInfo, SlashCommandAvailability } from '../slashCommandStore';
+
+vi.mock('@/lib/api', () => ({
+  listUserCommands: vi.fn(),
+}));
+
+function makeSkill(overrides: Partial<SkillDTO> = {}): SkillDTO {
+  return {
+    id: 'test-skill',
+    name: 'Test Skill',
+    description: 'A test skill',
+    category: 'productivity' as SkillDTO['category'],
+    author: 'test',
+    version: '1.0.0',
+    preview: '',
+    skillPath: '/path',
+    createdAt: '2025-01-01',
+    updatedAt: '2025-01-01',
+    ...overrides,
+  };
+}
+
+function makeUserCommand(overrides: Partial<UserCommandFile> = {}): UserCommandFile {
+  return {
+    name: 'my-command',
+    description: 'A user command',
+    filePath: '/commands/my-command.md',
+    content: 'Do something',
+    ...overrides,
+  };
+}
+
+const withSession: SlashCommandAvailability = { hasSession: true };
+const noSession: SlashCommandAvailability = { hasSession: false };
+
+beforeEach(() => {
+  useSlashCommandStore.setState({
+    installedSkills: [],
+    userCommands: [],
+    sdkCommands: [],
+    sdkCommandMeta: {},
+  });
+});
+
+// ============================================================================
+// getAllCommands
+// ============================================================================
+
+describe('getAllCommands', () => {
+  it('returns built-in commands when no session and no extras', () => {
+    const commands = useSlashCommandStore.getState().getAllCommands(noSession);
+    // Built-in commands without requiresSession: help, refactor, explain, plan, think
+    const triggers = commands.map((c) => c.trigger);
+    expect(triggers).toContain('help');
+    expect(triggers).toContain('plan');
+    expect(triggers).toContain('think');
+    // Session-required commands should be filtered out
+    expect(triggers).not.toContain('sync');
+    expect(triggers).not.toContain('deep-review');
+    expect(triggers).not.toContain('security');
+  });
+
+  it('returns all built-in commands when session is active', () => {
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const triggers = commands.map((c) => c.trigger);
+    expect(triggers).toContain('help');
+    expect(triggers).toContain('sync');
+    expect(triggers).toContain('deep-review');
+    expect(triggers).toContain('security');
+    expect(triggers).toContain('plan');
+    expect(triggers).toContain('think');
+  });
+
+  it('includes installed skills', () => {
+    useSlashCommandStore.getState().setInstalledSkills([
+      makeSkill({ id: 'commit', name: 'Auto Commit' }),
+    ]);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const skill = commands.find((c) => c.trigger === 'commit');
+    expect(skill).toBeDefined();
+    expect(skill!.source).toBe('skill');
+    expect(skill!.label).toBe('Auto Commit');
+  });
+
+  it('includes user commands', () => {
+    useSlashCommandStore.getState().setUserCommands([
+      makeUserCommand({ name: 'deploy', description: 'Deploy to prod' }),
+    ]);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const cmd = commands.find((c) => c.trigger === 'deploy');
+    expect(cmd).toBeDefined();
+    expect(cmd!.source).toBe('user');
+  });
+
+  it('includes SDK commands', () => {
+    useSlashCommandStore.getState().setSdkCommands(['lint', 'format']);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    expect(commands.find((c) => c.trigger === 'lint')).toBeDefined();
+    expect(commands.find((c) => c.trigger === 'format')).toBeDefined();
+  });
+
+  it('deduplicates: built-in wins over skill with same trigger', () => {
+    useSlashCommandStore.getState().setInstalledSkills([
+      makeSkill({ id: 'help', name: 'Custom Help' }),
+    ]);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const helpCmds = commands.filter((c) => c.trigger === 'help');
+    expect(helpCmds).toHaveLength(1);
+    expect(helpCmds[0].source).toBe('builtin');
+  });
+
+  it('deduplicates: skill wins over SDK with same trigger', () => {
+    useSlashCommandStore.getState().setInstalledSkills([
+      makeSkill({ id: 'lint', name: 'Lint Skill' }),
+    ]);
+    useSlashCommandStore.getState().setSdkCommands(['lint']);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const lintCmds = commands.filter((c) => c.trigger === 'lint');
+    expect(lintCmds).toHaveLength(1);
+    expect(lintCmds[0].source).toBe('skill');
+  });
+
+  it('sorts commands alphabetically by trigger', () => {
+    useSlashCommandStore.getState().setSdkCommands(['zoo', 'alpha', 'mid']);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const triggers = commands.map((c) => c.trigger);
+    const sorted = [...triggers].sort();
+    expect(triggers).toEqual(sorted);
+  });
+
+  it('filters skills/user/sdk by requiresSession', () => {
+    useSlashCommandStore.getState().setInstalledSkills([
+      makeSkill({ id: 'my-skill', name: 'My Skill' }),
+    ]);
+    useSlashCommandStore.getState().setUserCommands([
+      makeUserCommand({ name: 'my-cmd' }),
+    ]);
+    useSlashCommandStore.getState().setSdkCommands(['sdk-cmd']);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(noSession);
+    expect(commands.find((c) => c.trigger === 'my-skill')).toBeUndefined();
+    expect(commands.find((c) => c.trigger === 'my-cmd')).toBeUndefined();
+    expect(commands.find((c) => c.trigger === 'sdk-cmd')).toBeUndefined();
+  });
+
+  it('uses rich SDK metadata description when available', () => {
+    const richMeta: SdkCommandInfo[] = [
+      { name: 'deploy', description: 'Deploy to production server' },
+    ];
+    useSlashCommandStore.getState().setSdkCommandsRich(richMeta);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const deploy = commands.find((c) => c.trigger === 'deploy');
+    expect(deploy).toBeDefined();
+    expect(deploy!.description).toBe('Deploy to production server');
+  });
+
+  it('falls back to generic description for SDK commands without metadata', () => {
+    useSlashCommandStore.getState().setSdkCommands(['unknown-cmd']);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const cmd = commands.find((c) => c.trigger === 'unknown-cmd');
+    expect(cmd!.description).toBe('Plugin command: unknown-cmd');
+  });
+});
+
+// ============================================================================
+// Cache behavior
+// ============================================================================
+
+describe('command cache', () => {
+  it('returns same reference on repeated calls with unchanged sources', () => {
+    const first = useSlashCommandStore.getState().getAllCommands(withSession);
+    const second = useSlashCommandStore.getState().getAllCommands(withSession);
+    expect(first).toBe(second);
+  });
+
+  it('invalidates cache when skills change', () => {
+    const first = useSlashCommandStore.getState().getAllCommands(withSession);
+    useSlashCommandStore.getState().setInstalledSkills([makeSkill()]);
+    const second = useSlashCommandStore.getState().getAllCommands(withSession);
+    expect(first).not.toBe(second);
+  });
+
+  it('invalidates cache when user commands change', () => {
+    const first = useSlashCommandStore.getState().getAllCommands(withSession);
+    useSlashCommandStore.getState().setUserCommands([makeUserCommand()]);
+    const second = useSlashCommandStore.getState().getAllCommands(withSession);
+    expect(first).not.toBe(second);
+  });
+
+  it('invalidates cache when SDK commands change', () => {
+    const first = useSlashCommandStore.getState().getAllCommands(withSession);
+    useSlashCommandStore.getState().setSdkCommands(['new-cmd']);
+    const second = useSlashCommandStore.getState().getAllCommands(withSession);
+    expect(first).not.toBe(second);
+  });
+
+  it('invalidates cache when availability changes', () => {
+    const first = useSlashCommandStore.getState().getAllCommands(noSession);
+    const second = useSlashCommandStore.getState().getAllCommands(withSession);
+    expect(first).not.toBe(second);
+  });
+});
+
+// ============================================================================
+// User command execution types
+// ============================================================================
+
+describe('user command execution', () => {
+  it('sets execution type to prompt when content has $ARGUMENTS', () => {
+    useSlashCommandStore.getState().setUserCommands([
+      makeUserCommand({ name: 'search', content: 'Search for $ARGUMENTS' }),
+    ]);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const cmd = commands.find((c) => c.trigger === 'search');
+    expect(cmd!.executionType).toBe('prompt');
+  });
+
+  it('sets execution type to skill when content has no $ARGUMENTS', () => {
+    useSlashCommandStore.getState().setUserCommands([
+      makeUserCommand({ name: 'run-tests', content: 'Run all tests' }),
+    ]);
+
+    const commands = useSlashCommandStore.getState().getAllCommands(withSession);
+    const cmd = commands.find((c) => c.trigger === 'run-tests');
+    expect(cmd!.executionType).toBe('skill');
+  });
+});
+
+// ============================================================================
+// setSdkCommandsRich
+// ============================================================================
+
+describe('setSdkCommandsRich', () => {
+  it('populates both sdkCommands and sdkCommandMeta', () => {
+    const commands: SdkCommandInfo[] = [
+      { name: 'build', description: 'Build project' },
+      { name: 'test', description: 'Run tests', argumentHint: '<pattern>' },
+    ];
+
+    useSlashCommandStore.getState().setSdkCommandsRich(commands);
+    const state = useSlashCommandStore.getState();
+
+    expect(state.sdkCommands).toEqual(['build', 'test']);
+    expect(state.sdkCommandMeta['build']).toEqual({ name: 'build', description: 'Build project' });
+    expect(state.sdkCommandMeta['test']).toEqual({
+      name: 'test',
+      description: 'Run tests',
+      argumentHint: '<pattern>',
+    });
+  });
+});
+
+// ============================================================================
+// fetchUserCommands
+// ============================================================================
+
+describe('fetchUserCommands', () => {
+  it('fetches and stores user commands from API', async () => {
+    const { listUserCommands } = await import('@/lib/api');
+    vi.mocked(listUserCommands).mockResolvedValue([
+      { name: 'deploy', description: 'Deploy', filePath: '/deploy.md', content: 'deploy it' },
+    ]);
+
+    await useSlashCommandStore.getState().fetchUserCommands('ws-1', 'session-1');
+
+    const state = useSlashCommandStore.getState();
+    expect(state.userCommands).toHaveLength(1);
+    expect(state.userCommands[0].name).toBe('deploy');
+  });
+
+  it('silently fails on API error', async () => {
+    const { listUserCommands } = await import('@/lib/api');
+    vi.mocked(listUserCommands).mockRejectedValue(new Error('network'));
+
+    // Should not throw
+    await useSlashCommandStore.getState().fetchUserCommands('ws-1', 'session-1');
+    expect(useSlashCommandStore.getState().userCommands).toEqual([]);
+  });
+});

--- a/src/stores/__tests__/updateStore.test.ts
+++ b/src/stores/__tests__/updateStore.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// The store checks for __TAURI_INTERNALS__ in window
+const win = window as Window & { __TAURI_INTERNALS__?: unknown };
+
+describe('updateStore', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  /** Create a fake update object matching the shape returned by the updater plugin. */
+  function makeFakeUpdate(overrides: { version?: string; downloadAndInstall?: ReturnType<typeof vi.fn> } = {}) {
+    return {
+      version: overrides.version ?? '2.0.0',
+      downloadAndInstall: overrides.downloadAndInstall ?? vi.fn(),
+    };
+  }
+
+  // Get fresh store + fresh mocks after each resetModules
+  async function setup() {
+    vi.resetModules();
+    win.__TAURI_INTERNALS__ = {};
+    const updaterMod = await import('@tauri-apps/plugin-updater');
+    const processMod = await import('@tauri-apps/plugin-process');
+    const { useUpdateStore } = await import('../updateStore');
+    return {
+      store: useUpdateStore,
+      mockCheck: vi.mocked(updaterMod.check),
+      mockRelaunch: vi.mocked(processMod.relaunch),
+    };
+  }
+
+  describe('checkForUpdates', () => {
+    it('sets status to available when update found', async () => {
+      const { store, mockCheck } = await setup();
+      const fakeUpdate = makeFakeUpdate();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockCheck.mockResolvedValueOnce(fakeUpdate as any);
+
+      await store.getState().checkForUpdates();
+
+      expect(store.getState().status).toBe('available');
+      expect(store.getState().version).toBe('2.0.0');
+    });
+
+    it('resets to idle when no update available', async () => {
+      const { store, mockCheck } = await setup();
+      mockCheck.mockResolvedValueOnce(null);
+
+      await store.getState().checkForUpdates();
+
+      expect(store.getState().status).toBe('idle');
+      expect(store.getState().version).toBeNull();
+    });
+
+    it('returns to idle on check error', async () => {
+      const { store, mockCheck } = await setup();
+      mockCheck.mockRejectedValueOnce(new Error('network'));
+      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      await store.getState().checkForUpdates();
+
+      expect(store.getState().status).toBe('idle');
+      debugSpy.mockRestore();
+    });
+
+    it('prevents concurrent check calls', async () => {
+      const { store, mockCheck } = await setup();
+      store.setState({ status: 'checking' });
+
+      await store.getState().checkForUpdates();
+
+      expect(mockCheck).not.toHaveBeenCalled();
+    });
+
+    it('prevents check during download', async () => {
+      const { store, mockCheck } = await setup();
+      store.setState({ status: 'downloading' });
+
+      await store.getState().checkForUpdates();
+
+      expect(mockCheck).not.toHaveBeenCalled();
+    });
+
+    it('clears error when starting new check', async () => {
+      const { store, mockCheck } = await setup();
+      store.setState({ status: 'error', error: 'old error' });
+      mockCheck.mockResolvedValueOnce(null);
+
+      await store.getState().checkForUpdates();
+
+      expect(store.getState().error).toBeNull();
+    });
+  });
+
+  describe('downloadAndInstall', () => {
+    it('does nothing if no pending update', async () => {
+      const { store } = await setup();
+      await store.getState().downloadAndInstall();
+      expect(store.getState().status).toBe('idle');
+    });
+
+    it('tracks download progress events', async () => {
+      const { store, mockCheck } = await setup();
+
+      const mockDownload = vi.fn(async (callback: (event: { event: string; data: Record<string, unknown> }) => void) => {
+        callback({ event: 'Started', data: { contentLength: 1000 } });
+        callback({ event: 'Progress', data: { chunkLength: 500 } });
+        callback({ event: 'Progress', data: { chunkLength: 500 } });
+        callback({ event: 'Finished', data: {} });
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockCheck.mockResolvedValueOnce(makeFakeUpdate({ downloadAndInstall: mockDownload }) as any);
+
+      await store.getState().checkForUpdates();
+      await store.getState().downloadAndInstall();
+
+      expect(store.getState().status).toBe('ready');
+      expect(store.getState().progress).toBe(100);
+    });
+
+    it('sets error state on download failure', async () => {
+      const { store, mockCheck } = await setup();
+
+      const mockDownload = vi.fn().mockRejectedValue(new Error('download failed'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockCheck.mockResolvedValueOnce(makeFakeUpdate({ downloadAndInstall: mockDownload }) as any);
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await store.getState().checkForUpdates();
+      await store.getState().downloadAndInstall();
+
+      expect(store.getState().status).toBe('error');
+      expect(store.getState().error).toBe('download failed');
+      errorSpy.mockRestore();
+    });
+
+    it('sets generic error message for non-Error throws', async () => {
+      const { store, mockCheck } = await setup();
+
+      const mockDownload = vi.fn().mockRejectedValue('string error');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockCheck.mockResolvedValueOnce(makeFakeUpdate({ downloadAndInstall: mockDownload }) as any);
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await store.getState().checkForUpdates();
+      await store.getState().downloadAndInstall();
+
+      expect(store.getState().error).toBe('Download failed');
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('relaunch', () => {
+    it('calls Tauri relaunch', async () => {
+      const { store, mockRelaunch } = await setup();
+      await store.getState().relaunch();
+      expect(mockRelaunch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 307 tests across 13 new test files covering hooks (`useBranchSync`, `useCIRuns`, `useFileMentions`, `useMessagePrefetch`, `useTabPersistence`), lib utilities (`attachments`, `auth`, `auth-token`, `check-utils`, `pr-utils`), and stores (`branchCacheStore`, `slashCommandStore`, `updateStore`)
- Includes review-driven fixes: assertion-less test fixed, misleading titles corrected, magic numbers replaced with named constants, mock setup duplication reduced via shared helpers, and documentation added for non-obvious patterns (mock hoisting, dotfile extensions, retry assumptions)

## Test plan
- [x] All 307 tests pass (`npx vitest run` on the 13 files)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)