### PR TITLE
Clear stale plan state on plan mode re-entry and exit

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -478,6 +478,10 @@ function setupInputQueue(): void {
             // Reset suppression and cooldown — user is explicitly entering plan mode
             suppressStalePlanMode = false;
             lastExitPlanApprovalTime = 0;
+            // Clear stale plan file path — a new plan cycle starts fresh.
+            // Without this, re-entering plan mode and calling ExitPlanMode would
+            // re-read the previously approved plan file from disk.
+            lastPlanFilePath = null;
           }
           currentPermissionMode = input.permissionMode as PermissionMode;
           void queryRef.setPermissionMode(input.permissionMode as "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk").then(() => {
@@ -1022,6 +1026,9 @@ const postToolUseHook: HookCallback = async (input, toolUseId) => {
         debug(`Failed to restore permission mode after ExitPlanMode: ${err}`);
       }
     }
+    // Clear the plan file path now that the plan cycle is complete.
+    // Defense-in-depth: also cleared on plan mode re-entry (set_permission_mode handler).
+    lastPlanFilePath = null;
   }
 
   // If this is a sub-agent tool, emit a tool_end event with agentId

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -140,6 +140,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     commitQueuedMessage,
     clearPendingPlanApproval,
     setApprovedPlanContent,
+    clearApprovedPlanContent,
     clearActiveTools,
     finalizeStreamingMessage,
     setPlanModeActive,
@@ -589,8 +590,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     // Update store state optimistically so the banner and toggle react together
     if (selectedConversationId) {
       setPlanModeActive(selectedConversationId, newValue);
-      // Suppress stale backend events that would re-activate plan mode
-      if (!newValue) {
+      if (newValue) {
+        // New plan cycle — clear stale approved plan content from the previous cycle
+        // so it doesn't render in StreamingMessage or carry into the next message.
+        clearApprovedPlanContent(selectedConversationId);
+        clearPendingPlanApproval(selectedConversationId);
+      } else {
+        // Suppress stale backend events that would re-activate plan mode
         markPlanModeExited(selectedConversationId);
       }
     }
@@ -604,7 +610,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         // plan mode will be applied when the next message starts
       }
     }
-  }, [planModeEnabled, selectedConversationId, setPlanModeActive]);
+  }, [planModeEnabled, selectedConversationId, setPlanModeActive, clearApprovedPlanContent, clearPendingPlanApproval]);
 
 
   // Handle plan approval — clear UI optimistically so the bar disappears instantly

--- a/src/stores/__tests__/appStore.planMode.test.ts
+++ b/src/stores/__tests__/appStore.planMode.test.ts
@@ -171,4 +171,74 @@ describe('appStore - Plan Mode State', () => {
       expect(state?.planModeActive).toBe(false);
     });
   });
+
+  describe('clearApprovedPlanContent', () => {
+    it('clears approvedPlanContent and approvedPlanTimestamp', () => {
+      initStreamingState(convId);
+      useAppStore.getState().setApprovedPlanContent(convId, '# My Plan');
+
+      useAppStore.getState().clearApprovedPlanContent(convId);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.approvedPlanContent).toBeUndefined();
+      expect(state?.approvedPlanTimestamp).toBeUndefined();
+    });
+
+    it('does not affect other streaming state fields', () => {
+      initStreamingState(convId);
+      useAppStore.getState().setPlanModeActive(convId, true);
+      useAppStore.getState().setPendingPlanApproval(convId, 'req-1');
+      useAppStore.getState().setApprovedPlanContent(convId, '# Plan');
+
+      useAppStore.getState().clearApprovedPlanContent(convId);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.planModeActive).toBe(true);
+      expect(state?.pendingPlanApproval).toEqual({ requestId: 'req-1' });
+      expect(state?.approvedPlanContent).toBeUndefined();
+    });
+
+    it('does not affect other conversations', () => {
+      const otherId = 'other-conv';
+      initStreamingState(convId);
+      initStreamingState(otherId);
+      useAppStore.getState().setApprovedPlanContent(convId, '# Plan A');
+      useAppStore.getState().setApprovedPlanContent(otherId, '# Plan B');
+
+      useAppStore.getState().clearApprovedPlanContent(convId);
+
+      expect(useAppStore.getState().streamingState[convId]?.approvedPlanContent).toBeUndefined();
+      expect(useAppStore.getState().streamingState[otherId]?.approvedPlanContent).toBe('# Plan B');
+    });
+
+    it('is safe to call when no approved plan exists', () => {
+      initStreamingState(convId);
+
+      // Should not throw
+      useAppStore.getState().clearApprovedPlanContent(convId);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.approvedPlanContent).toBeUndefined();
+    });
+  });
+
+  describe('plan mode re-entry clears stale state', () => {
+    it('clearing approved plan and pending approval resets for new plan cycle', () => {
+      initStreamingState(convId);
+      // Simulate: plan was approved in a previous cycle
+      useAppStore.getState().setApprovedPlanContent(convId, '# Old Plan');
+      useAppStore.getState().setPendingPlanApproval(convId, 'req-old');
+
+      // Simulate: user re-enters plan mode (what handlePlanModeToggle does)
+      useAppStore.getState().clearApprovedPlanContent(convId);
+      useAppStore.getState().clearPendingPlanApproval(convId);
+      useAppStore.getState().setPlanModeActive(convId, true);
+
+      const state = useAppStore.getState().streamingState[convId];
+      expect(state?.approvedPlanContent).toBeUndefined();
+      expect(state?.approvedPlanTimestamp).toBeUndefined();
+      expect(state?.pendingPlanApproval).toBeNull();
+      expect(state?.planModeActive).toBe(true);
+    });
+  });
 });

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -372,6 +372,7 @@ interface AppState {
   setPendingPlanApproval: (conversationId: string, requestId: string, planContent?: string) => void;
   clearPendingPlanApproval: (conversationId: string) => void;
   setApprovedPlanContent: (conversationId: string, content: string) => void;
+  clearApprovedPlanContent: (conversationId: string) => void;
   addActiveTool: (conversationId: string, tool: ActiveTool, opts?: { skipTimeout?: boolean }) => void;
   completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string, metadata?: import('@/lib/types').ToolMetadata) => void;
   updateToolProgress: (conversationId: string, toolId: string, progress: { elapsedTimeSeconds?: number; toolName?: string }) => void;
@@ -1387,6 +1388,12 @@ updateFileTabContent: (id, content) => set((state) => ({
     streamingState: updateStreamingConv(state.streamingState, conversationId, {
       approvedPlanContent: content,
       approvedPlanTimestamp: Date.now(),
+    }),
+  })),
+  clearApprovedPlanContent: (conversationId) => set((state) => ({
+    streamingState: updateStreamingConv(state.streamingState, conversationId, {
+      approvedPlanContent: undefined,
+      approvedPlanTimestamp: undefined,
     }),
   })),
   addActiveTool: (conversationId, tool, opts) => {


### PR DESCRIPTION
## Summary

- **Fix stale `lastPlanFilePath` in agent-runner**: Clear on both plan mode entry and `ExitPlanMode` completion so re-entering plan mode doesn't re-read a previously approved plan file from disk
- **Fix stale UI state in frontend**: Clear `approvedPlanContent` and `pendingPlanApproval` when toggling plan mode on, preventing the previous cycle's approved plan from rendering in `StreamingMessage` or the approval banner
- **Add `clearApprovedPlanContent` store action** with full test coverage for the new action and the re-entry scenario

## Test plan

- [ ] Enter plan mode, get a plan approved, exit plan mode
- [ ] Re-enter plan mode — verify no stale plan content or approval banner appears
- [ ] Verify `ExitPlanMode` reads the correct (new) plan file after re-entry
- [ ] Run `npm run test -- src/stores/__tests__/appStore.planMode.test.ts` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)