### PR TITLE
Include local branches in branch cache store

### DIFF
--- a/src/stores/__tests__/branchCacheStore.test.ts
+++ b/src/stores/__tests__/branchCacheStore.test.ts
@@ -58,7 +58,7 @@ describe('fetchBranches', () => {
     expect(result).toEqual(branches);
   });
 
-  it('filters out non-remote branches', async () => {
+  it('includes both local and remote branches', async () => {
     mockListBranches.mockResolvedValue({
       sessionBranches: [
         makeBranch({ name: 'origin/remote', isRemote: true }),
@@ -68,8 +68,8 @@ describe('fetchBranches', () => {
     });
 
     const result = await useBranchCacheStore.getState().fetchBranches('ws-1');
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe('origin/remote');
+    expect(result).toHaveLength(2);
+    expect(result.map((b) => b.name)).toEqual(['origin/remote', 'local-only']);
   });
 
   it('returns cached data on second call within TTL', async () => {

--- a/src/stores/branchCacheStore.ts
+++ b/src/stores/branchCacheStore.ts
@@ -12,7 +12,7 @@ interface BranchCacheEntry {
 interface BranchCacheState {
   cache: Record<string, BranchCacheEntry>;
 
-  /** Fetch remote branches for a workspace, returning cached data if fresh. */
+  /** Fetch branches for a workspace, returning cached data if fresh. */
   fetchBranches: (workspaceId: string, force?: boolean) => Promise<BranchDTO[]>;
 
   /** Mark all caches stale so the next access triggers a re-fetch. */
@@ -69,16 +69,16 @@ async function doFetch(
       sortBy: 'date',
       limit: 100,
     });
-    const remoteBranches = [...res.sessionBranches, ...res.otherBranches].filter((b) => b.isRemote);
+    const branches = [...res.sessionBranches, ...res.otherBranches];
 
     set((state) => ({
       cache: {
         ...state.cache,
-        [workspaceId]: { branches: remoteBranches, timestamp: Date.now(), isLoading: false },
+        [workspaceId]: { branches, timestamp: Date.now(), isLoading: false },
       },
     }));
 
-    return remoteBranches;
+    return branches;
   } catch (error) {
     set((state) => ({
       cache: {


### PR DESCRIPTION
## Summary
- Removed the `isRemote` filter from `branchCacheStore`'s `doFetch` so both local and remote branches are cached
- Consumers like `TargetBranchSelector` and `CreateFromPRModal` already filter by `isRemote` at the component level, so this is safe
- Allows `BranchesDashboard` and `BranchCard` to display local-only branches

## Test plan
- [ ] Verify local branches appear in the branches dashboard
- [ ] Verify target branch selector still only shows remote branches
- [ ] Verify CreateFromPR modal still filters to remote branches
- [ ] Run `npm run test` — updated test confirms both local and remote branches are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)