### PR TITLE
Fix review tab not appearing when triggered during session switch

### DIFF
--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -102,8 +102,10 @@ export function useReviewTrigger() {
           model: reviewModel,
         });
 
-        if (stale) return;
-
+        // Always add the conversation and message to the store, even if the
+        // user switched sessions. The conversation exists on the backend;
+        // keeping the store in sync ensures the tab appears when the user
+        // returns to the original session.
         addConversation({
           id: conv.id,
           sessionId: conv.sessionId,
@@ -124,8 +126,15 @@ export function useReviewTrigger() {
           timestamp: new Date().toISOString(),
         });
 
-        selectConversation(conv.id);
+        // Always mark streaming so WebSocket reconnection reconciliation
+        // can discover this conversation if the connection drops mid-review.
         setStreaming(conv.id, true);
+
+        // Only navigate to the review tab if the user is still on the
+        // same session. Otherwise they'll see it when they switch back.
+        if (!stale) {
+          selectConversation(conv.id);
+        }
       } catch (err) {
         if (!stale) console.error('Failed to start review:', err);
       }


### PR DESCRIPTION
## Summary
- When a review was triggered and the user switched sessions before the async `createConversation` resolved, the early `stale` return discarded the conversation/message — the review tab never appeared when returning to the session
- Now conversation, message, and streaming state are always written to the store (syncing with the backend); only navigation (`selectConversation`) is gated on `!stale`
- Ensures WebSocket reconnection reconciliation can discover actively-streaming reviews if the connection drops mid-review

## Test plan
- [ ] Trigger a review, immediately switch to another session before the tab appears, then switch back — review tab should be visible
- [ ] Trigger a review while staying on the session — behavior unchanged, tab appears and streams normally
- [ ] Simulate a WebSocket disconnect/reconnect during an active review — streaming state should reconcile correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)