### PR TITLE
Change code review default grouping to flat list

### DIFF
--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -246,6 +246,7 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
               size="sm"
               className="h-5 text-xs px-1.5 text-muted-foreground ml-auto"
               onClick={() => setGroupByFile((prev) => !prev)}
+              aria-label={groupByFile ? 'Switch to flat list' : 'Group by file'}
             >
               {groupByFile ? (
                 <ListTree className="h-3 w-3" />

--- a/src/components/panels/__tests__/ReviewPanel.test.tsx
+++ b/src/components/panels/__tests__/ReviewPanel.test.tsx
@@ -239,9 +239,8 @@ describe('ReviewPanel', () => {
         expect(screen.getByText('Missing error handling')).toBeInTheDocument();
       });
 
-      // Toggle to grouped view (the grouping button is the last button in the filter bar)
-      const buttons = screen.getAllByRole('button');
-      await user.click(buttons[buttons.length - 1]);
+      // Toggle to grouped view
+      await user.click(screen.getByRole('button', { name: 'Group by file' }));
 
       await waitFor(() => {
         expect(screen.getByText('file.ts')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Default the review panel to show comments as a flat list instead of grouped by file
- Users can still toggle grouping on via the icon button in the filter bar

## Test plan
- [ ] Open the Code Review panel — comments should display as a flat list by default
- [ ] Click the grouping toggle icon — should switch to grouped-by-file view
- [ ] Click again — should return to flat list

🤖 Generated with [Claude Code](https://claude.com/claude-code)