### PR TITLE
Disable browser-like behaviors in production builds

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1020,10 +1020,20 @@ export default function Home() {
   // and shortcuts that need special terminal/focus handling.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Cmd+R to reload the app
+      // Block browser zoom in production (Cmd+= Cmd+- Cmd+0)
+      if (process.env.NODE_ENV !== 'development') {
+        if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey &&
+            (e.key === '=' || e.key === '+' || e.key === '-' || e.key === '0')) {
+          e.preventDefault();
+          return;
+        }
+      }
+      // Cmd+R to reload the app (development only)
       if (e.key === 'r' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        window.location.reload();
+        if (process.env.NODE_ENV === 'development') {
+          window.location.reload();
+        }
       }
       // Cmd+K for command palette - allow terminal to handle it for clear
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
@@ -1115,6 +1125,14 @@ export default function Home() {
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [sessions, toggleBottomTerminal, selectNextTab, selectPreviousTab, setZenMode]);
+
+  // Disable default browser context menu in production
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') return;
+    const handler = (e: MouseEvent) => e.preventDefault();
+    document.addEventListener('contextmenu', handler);
+    return () => document.removeEventListener('contextmenu', handler);
+  }, []);
 
   // Handle Tauri menu events
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Block **Cmd+R** from reloading the webview in production (still calls `preventDefault` to suppress browser default)
- Block **zoom shortcuts** (Cmd+=, Cmd+-, Cmd+0) in production to prevent accidental UI scaling
- Disable the **default browser context menu** in production (custom Radix UI context menus are unaffected)
- All behaviors remain fully available in development builds via `process.env.NODE_ENV` checks

## Test plan
- [ ] `npm run tauri:dev` — verify Cmd+R reloads, right-click shows browser menu, zoom shortcuts work
- [ ] `npm run tauri:build` + launch release binary — verify:
  - Cmd+R does nothing
  - Cmd+=, Cmd+-, Cmd+0 do nothing
  - Right-click on empty areas shows no context menu
  - Right-click on sidebar items, tabs, etc. still shows custom context menus
  - Cmd+Shift+R still resets panel layouts (unchanged)
  - Cmd+Option+I / F12 do not open DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)