### PR TITLE
Sync agent-initiated EnterPlanMode with SDK state and frontend

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1031,6 +1031,32 @@ const postToolUseHook: HookCallback = async (input, toolUseId) => {
     lastPlanFilePath = null;
   }
 
+  // When the agent autonomously enters plan mode via EnterPlanMode, emit a dedicated
+  // event so the frontend can distinguish it from stale SDK status echoes and bypass
+  // the exit cooldown. Mirrors the ExitPlanMode pattern above.
+  if (hookInput.tool_name === "EnterPlanMode") {
+    // Clear stale-mode suppression — this is a genuine plan mode entry
+    suppressStalePlanMode = false;
+    // Track pre-plan mode so ExitPlanMode can restore it
+    if (currentPermissionMode !== "plan") {
+      prePlanPermissionMode = currentPermissionMode;
+    }
+    currentPermissionMode = "plan" as PermissionMode;
+    // Clear stale plan file path — new plan cycle starts fresh
+    lastPlanFilePath = null;
+    debug(`EnterPlanMode completed — entering plan mode, previous mode was "${prePlanPermissionMode}"`);
+    emit({ type: "permission_mode_changed", mode: "plan", source: "enter_plan_tool" });
+    // Sync SDK internal state to plan mode (mirrors ExitPlanMode's setPermissionMode call)
+    if (queryRef) {
+      try {
+        await queryRef.setPermissionMode("plan");
+        debug(`SDK permission mode confirmed set to "plan"`);
+      } catch (err: unknown) {
+        debug(`Failed to set permission mode after EnterPlanMode: ${err}`);
+      }
+    }
+  }
+
   // If this is a sub-agent tool, emit a tool_end event with agentId
   if (toolUseId) {
     const subTool = subagentActiveTools.get(toolUseId);

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -394,19 +394,29 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     && conversationHasMessages
     && !isSuggestionStale;
 
-  // Sync toggle with agent-driven plan mode changes:
-  // - ON when agent enters plan mode (e.g. EnterPlanMode tool)
-  // - OFF when agent exits plan mode without user interaction (auto-exit with no plan content)
-  // Explicit user deactivation is handled by handleApprovePlan.
+  // Sync the local planModeEnabled toggle with the store's planModeActive, and vice versa.
+  // Agent-driven changes (store → toggle) take priority during streaming.
+  // User-driven changes (toggle → store) apply when not streaming.
   useEffect(() => {
+    // Agent-driven: store says plan mode ON but toggle is OFF → sync toggle ON
     if (planModeActive && !planModeEnabled) {
       setPlanModeEnabled(true);
-    } else if (!planModeActive && planModeEnabled && isStreaming && !pendingPlanApproval) {
-      // Agent exited plan mode (auto-approved, no plan to review) — sync toggle off.
-      // Only syncs during streaming to avoid fighting with user's manual toggle.
-      setPlanModeEnabled(false);
+      return; // Store is already correct, don't push back
     }
-  }, [planModeActive, planModeEnabled, isStreaming, pendingPlanApproval]);
+    // Agent-driven: store says plan mode OFF while streaming → sync toggle OFF
+    if (!planModeActive && planModeEnabled && isStreaming && !pendingPlanApproval) {
+      setPlanModeEnabled(false);
+      return; // Store is already correct, don't push back
+    }
+    // User-driven: toggle changed while not streaming → push to store
+    if (selectedConversationId) {
+      const current = useAppStore.getState().streamingState[selectedConversationId];
+      if (current?.isStreaming) return; // Don't fight with WebSocket handler
+      if ((current?.planModeActive ?? false) !== planModeEnabled) {
+        setPlanModeActive(selectedConversationId, planModeEnabled);
+      }
+    }
+  }, [planModeActive, planModeEnabled, isStreaming, pendingPlanApproval, selectedConversationId, setPlanModeActive]);
 
   // Restore per-session toggle states when switching sessions
   const prevSessionRef = useRef<string | null>(null);
@@ -432,19 +442,6 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     setSessionToggleState(selectedSessionId, { thinkingLevel, planModeEnabled });
   }, [selectedSessionId, thinkingLevel, planModeEnabled, setSessionToggleState]);
 
-  // Keep streaming state planModeActive in sync with the local toggle.
-  // This ensures the ConversationArea banner is visible immediately when:
-  // - A new session starts with defaultPlanMode = true
-  // - Switching to a session that had planModeEnabled = true
-  // - A new conversation is created in a session with plan mode on
-  useEffect(() => {
-    if (!selectedConversationId) return;
-    const current = useAppStore.getState().streamingState[selectedConversationId];
-    if (current?.isStreaming) return; // Don't fight with WebSocket handler
-    if ((current?.planModeActive ?? false) !== planModeEnabled) {
-      setPlanModeActive(selectedConversationId, planModeEnabled);
-    }
-  }, [selectedConversationId, planModeEnabled, setPlanModeActive]);
 
   // Check if there's a pending user question
   const pendingQuestion = usePendingUserQuestion(selectedConversationId);

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -614,10 +614,16 @@ export function useWebSocket(enabled: boolean = true) {
             // User-initiated plan mode activations are always honored.
             // SDK-originated events are suppressed if within the exit cooldown
             // (guards against SDK bug #15755 stale status messages).
-            if (event.source === 'user') {
+            if (event.source === 'user' || event.source === 'enter_plan_tool') {
+              // Genuine activation (user toggle or agent EnterPlanMode tool) — always honor
+              // and clear cooldown so subsequent sdk_status events for this cycle aren't suppressed.
               recentlyExitedPlanMode.delete(conversationId);
               store.setPlanModeActive(conversationId, true);
-              notifyDesktop(conversationId, 'Plan ready for review', 'The AI needs your approval');
+              // Only notify when user explicitly toggles plan mode. Agent-initiated entry
+              // (enter_plan_tool) means the agent just started planning — no plan to review yet.
+              if (event.source === 'user') {
+                notifyDesktop(conversationId, 'Plan ready for review', 'The AI needs your approval');
+              }
             } else if (isInPlanModeExitCooldown(conversationId)) {
               // Suppress — cooldown window handles multiple stale events
             } else {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -289,7 +289,7 @@ export interface AgentEvent {
   sessionId?: string;
   resuming?: boolean;
   forking?: boolean;
-  source?: 'startup' | 'resume' | 'clear' | 'compact' | 'user' | 'exit_plan' | 'sdk_status';
+  source?: 'startup' | 'resume' | 'clear' | 'compact' | 'user' | 'exit_plan' | 'sdk_status' | 'enter_plan_tool';
   reason?: string;
 
   // Enhanced init fields


### PR DESCRIPTION
## Summary
- **SDK sync**: Added `setPermissionMode("plan")` call in the `EnterPlanMode` post-tool-use hook, mirroring the existing `ExitPlanMode` pattern to prevent SDK internal state desync
- **Notification fix**: Suppressed premature "Plan ready for review" desktop notification when the agent enters plan mode via `EnterPlanMode` — no plan exists yet to review
- **Effect consolidation**: Merged two separate plan-mode sync effects in `ChatInput` into a single effect, eliminating fragile `useRef`-based coordination that could race under rapid agent toggling
- **Type & routing**: Added `enter_plan_tool` source to the `AgentEvent` type union and WebSocket handler to bypass stale-mode exit cooldown for genuine agent-initiated plan entries

## Test plan
- [ ] Agent triggers `EnterPlanMode` → plan mode activates in UI without "Plan ready for review" notification
- [ ] Agent completes plan and `ExitPlanMode` fires → plan mode deactivates, notification fires correctly
- [ ] User manually toggles plan mode on/off → store stays in sync, banner appears/disappears
- [ ] Rapid agent plan mode on→off during streaming → no stale state or flickering
- [ ] Switch sessions with different plan mode states → toggle restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)