### PR TITLE
Harden clone-from-URL with error classification and abort support

### DIFF
--- a/backend/git/clone.go
+++ b/backend/git/clone.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -63,6 +64,12 @@ func (rm *RepoManager) CloneRepo(ctx context.Context, url, parentDir, dirName st
 	defer cancel()
 
 	cmd := exec.CommandContext(cloneCtx, "git", "clone", url, targetPath)
+	// Prevent git from hanging on interactive credential/passphrase prompts.
+	// Without these, git clone can block indefinitely in a headless sidecar process.
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new",
+	)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -76,8 +83,29 @@ func (rm *RepoManager) CloneRepo(ctx context.Context, url, parentDir, dirName st
 		if ctx.Err() != nil {
 			return "", fmt.Errorf("git clone cancelled: %w", ctx.Err())
 		}
-		return "", fmt.Errorf("git clone failed: %s", stderr.String())
+
+		stderrStr := stderr.String()
+		return "", classifyCloneError(stderrStr)
 	}
 
 	return targetPath, nil
+}
+
+// classifyCloneError maps common git stderr messages to user-friendly error messages.
+func classifyCloneError(stderr string) error {
+	lower := strings.ToLower(stderr)
+	switch {
+	case strings.Contains(lower, "authentication failed") ||
+		strings.Contains(lower, "could not read username") ||
+		strings.Contains(lower, "terminal prompts disabled"):
+		return fmt.Errorf("authentication failed: the repository may be private or require credentials")
+	case strings.Contains(lower, "permission denied") ||
+		strings.Contains(lower, "host key verification failed"):
+		return fmt.Errorf("SSH authentication failed: check your SSH key configuration")
+	case strings.Contains(lower, "repository not found") ||
+		strings.Contains(lower, "not found"):
+		return fmt.Errorf("repository not found: check that the URL is correct and you have access")
+	default:
+		return fmt.Errorf("git clone failed: %s", stderr)
+	}
 }

--- a/backend/git/clone_test.go
+++ b/backend/git/clone_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -219,4 +220,76 @@ func TestCloneRepo_ParentIsFile(t *testing.T) {
 	_, err := rm.CloneRepo(context.Background(), "https://github.com/user/repo.git", filePath, "test")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestCloneRepo_FailsFastWithoutHanging(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network-dependent test in short mode")
+	}
+	// This test verifies that cloning a nonexistent repo fails quickly
+	// (within 30s) instead of hanging for 5 minutes waiting for credentials.
+	// The GIT_TERMINAL_PROMPT=0 and SSH BatchMode=yes settings should prevent hangs.
+	parentDir := t.TempDir()
+	rm := NewRepoManager()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := rm.CloneRepo(ctx, "https://github.com/nonexistent-user-zzzzz/nonexistent-repo-zzzzz.git", parentDir, "fast-fail-test")
+	require.Error(t, err)
+
+	// Should complete within the 30-second test timeout, not hang for 5 minutes.
+	// The error should NOT be a timeout error.
+	assert.NotContains(t, err.Error(), "timed out")
+}
+
+func TestClassifyCloneError(t *testing.T) {
+	tests := []struct {
+		name     string
+		stderr   string
+		contains string
+	}{
+		{
+			name:     "authentication failed",
+			stderr:   "fatal: Authentication failed for 'https://github.com/user/repo.git'",
+			contains: "authentication failed",
+		},
+		{
+			name:     "terminal prompts disabled",
+			stderr:   "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+			contains: "authentication failed",
+		},
+		{
+			name:     "could not read username",
+			stderr:   "fatal: could not read Username for 'https://github.com': No such device or address",
+			contains: "authentication failed",
+		},
+		{
+			name:     "permission denied ssh",
+			stderr:   "git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.",
+			contains: "SSH authentication failed",
+		},
+		{
+			name:     "host key verification",
+			stderr:   "Host key verification failed.\nfatal: Could not read from remote repository.",
+			contains: "SSH authentication failed",
+		},
+		{
+			name:     "repository not found",
+			stderr:   "fatal: repository 'https://github.com/user/repo.git/' not found",
+			contains: "repository not found",
+		},
+		{
+			name:     "generic error",
+			stderr:   "fatal: some unexpected error occurred",
+			contains: "git clone failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := classifyCloneError(tt.stderr)
+			assert.Contains(t, err.Error(), tt.contains)
+		})
+	}
 }

--- a/backend/server/clone_handler.go
+++ b/backend/server/clone_handler.go
@@ -76,11 +76,23 @@ func (h *Handlers) CloneRepo(w http.ResponseWriter, r *http.Request) {
 	clonedPath, err := h.repoManager.CloneRepo(ctx, req.URL, req.Path, req.DirName)
 	if err != nil {
 		errMsg := err.Error()
-		if strings.Contains(errMsg, "directory already exists") {
+		switch {
+		case strings.Contains(errMsg, "directory already exists"):
 			writeConflict(w, "directory already exists")
+		case strings.Contains(errMsg, "authentication failed"):
+			writeUnauthorized(w, errMsg)
+		case strings.Contains(errMsg, "SSH authentication failed"):
+			writeUnauthorized(w, errMsg)
+		case strings.Contains(errMsg, "repository not found"):
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, errMsg, nil)
+		case strings.Contains(errMsg, "timed out"):
+			writeError(w, http.StatusGatewayTimeout, "GATEWAY_TIMEOUT", errMsg, err)
+		case strings.Contains(errMsg, "cancelled"):
+			// Client cancelled — connection is likely already closed
 			return
+		default:
+			writeBadGateway(w, "git clone failed", err)
 		}
-		writeBadGateway(w, "git clone failed", err)
 		return
 	}
 

--- a/backend/server/clone_handler_test.go
+++ b/backend/server/clone_handler_test.go
@@ -253,13 +253,16 @@ func TestCloneRepo_Handler_URLValidation(t *testing.T) {
 		name       string
 		url        string
 		expectCode int
+		anyError   bool // when true, accept any error status (>= 400) instead of exact match
 	}{
-		{"valid https", "https://github.com/user/repo.git", http.StatusBadGateway}, // Valid URL but clone fails (no real repo)
-		{"valid ssh", "git@github.com:user/repo.git", http.StatusBadGateway},       // Valid URL but clone fails
-		{"invalid empty", "", http.StatusBadRequest},
-		{"invalid garbage", "not-a-url", http.StatusBadRequest},
-		{"invalid ftp", "ftp://example.com/repo", http.StatusBadRequest},
-		{"invalid local path", "/some/local/path", http.StatusBadRequest},
+		// Valid URLs pass validation but clone fails — the exact HTTP status depends on
+		// git's error message (401 for auth failure, 404 for not found, 502 for other).
+		{"valid https", "https://github.com/user/repo.git", 0, true},
+		{"valid ssh", "git@github.com:user/repo.git", 0, true},
+		{"invalid empty", "", http.StatusBadRequest, false},
+		{"invalid garbage", "not-a-url", http.StatusBadRequest, false},
+		{"invalid ftp", "ftp://example.com/repo", http.StatusBadRequest, false},
+		{"invalid local path", "/some/local/path", http.StatusBadRequest, false},
 	}
 
 	for _, tt := range tests {
@@ -275,7 +278,11 @@ func TestCloneRepo_Handler_URLValidation(t *testing.T) {
 
 			h.CloneRepo(rr, req)
 
-			assert.Equal(t, tt.expectCode, rr.Code, "url=%s", tt.url)
+			if tt.anyError {
+				assert.GreaterOrEqual(t, rr.Code, 400, "url=%s should return an error status", tt.url)
+			} else {
+				assert.Equal(t, tt.expectCode, rr.Code, "url=%s", tt.url)
+			}
 		})
 	}
 }
@@ -299,6 +306,36 @@ func TestCloneRepo_Handler_WhitespaceTrimmming(t *testing.T) {
 	var apiErr APIError
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&apiErr))
 	assert.Contains(t, apiErr.Error, "url is required")
+}
+
+func TestCloneRepo_Handler_ContextCancellation(t *testing.T) {
+	// Verify the handler doesn't panic or produce unexpected results
+	// when the request context is cancelled (simulating client disconnect).
+	h, _ := setupTestHandlers(t)
+	bareRepo := createBareTestRepoForClone(t)
+	parentDir := t.TempDir()
+
+	body, _ := json.Marshal(CloneRepoRequest{
+		URL:     bareRepo,
+		Path:    parentDir,
+		DirName: "cancel-test",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately to simulate client disconnect
+
+	req := httptest.NewRequest(http.MethodPost, "/api/clone", bytes.NewReader(body))
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	// Should not panic
+	assert.NotPanics(t, func() {
+		h.CloneRepo(rr, req)
+	})
+
+	// Note: With file:// URLs, local clones may complete before the cancellation
+	// takes effect, so we don't assert on the status code. The important thing is
+	// the handler handles cancellation gracefully without panicking.
 }
 
 // Verify that the store.GetRepoByPath function exists and works correctly

--- a/src/components/dialogs/CloneFromUrlDialog.tsx
+++ b/src/components/dialogs/CloneFromUrlDialog.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge';
 import { openFolderDialog, getHomeDir } from '@/lib/tauri';
 import { cloneRepo, resolveGitHubRepo, type GitHubRepoDTO, type RepoDTO } from '@/lib/api';
 import { parseGitHubUrl, extractRepoName } from '@/lib/github-url';
+import { classifyCloneError } from '@/lib/clone-errors';
 import { Loader2, Star, Lock, Globe2 } from 'lucide-react';
 
 interface CloneFromUrlDialogProps {
@@ -40,6 +41,7 @@ export function CloneFromUrlDialog({ isOpen, onClose, onCloned }: CloneFromUrlDi
   const hasInitializedLocation = useRef(false);
   const previewAbortRef = useRef<AbortController | null>(null);
   const previewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cloneAbortRef = useRef<AbortController | null>(null);
 
   // Fetch home directory once for default location
   useEffect(() => {
@@ -53,19 +55,27 @@ export function CloneFromUrlDialog({ isOpen, onClose, onCloned }: CloneFromUrlDi
     }
   }, []);
 
+  // Abort clone on unmount to prevent orphaned operations
+  useEffect(() => {
+    return () => {
+      if (cloneAbortRef.current) cloneAbortRef.current.abort();
+    };
+  }, []);
+
   const handleClose = useCallback(() => {
-    if (isCloning) return; // Don't close while cloning
+    // Abort in-progress clone if any
+    if (cloneAbortRef.current) cloneAbortRef.current.abort();
+    if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
+    if (previewAbortRef.current) previewAbortRef.current.abort();
     setGitUrl('');
     setDirName('');
     setUrlError(null);
     setCloneError(null);
     setRepoPreview(null);
     setIsLoadingPreview(false);
-    if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
-    if (previewAbortRef.current) previewAbortRef.current.abort();
     // Intentionally preserve cloneLocation — users often clone to the same directory
     onClose();
-  }, [isCloning, onClose]);
+  }, [onClose]);
 
   // Debounced GitHub URL detection and preview
   const fetchPreview = useCallback((url: string) => {
@@ -132,20 +142,22 @@ export function CloneFromUrlDialog({ isOpen, onClose, onCloned }: CloneFromUrlDi
     setIsCloning(true);
     setCloneError(null);
 
+    const controller = new AbortController();
+    cloneAbortRef.current = controller;
+
+    // Frontend timeout: 6 minutes (backend has 5-min timeout for git clone).
+    // Pass a reason string so we can distinguish timeout aborts from user cancels.
+    const timeoutId = setTimeout(() => controller.abort('clone_timeout'), 6 * 60 * 1000);
+
     try {
-      const result = await cloneRepo(trimmedUrl, trimmedLocation, trimmedDirName);
+      const result = await cloneRepo(trimmedUrl, trimmedLocation, trimmedDirName, controller.signal);
       onCloned?.(result.repo);
       handleClose();
     } catch (error) {
-      const msg = error instanceof Error ? error.message : 'Clone failed';
-      if (msg.includes('already exists')) {
-        setCloneError('A directory with this name already exists at the selected location.');
-      } else if (msg.includes('clone failed') || msg.includes('BAD_GATEWAY')) {
-        setCloneError('Git clone failed. Please check the URL and try again.');
-      } else {
-        setCloneError(msg);
-      }
+      setCloneError(classifyCloneError(error, controller.signal));
     } finally {
+      clearTimeout(timeoutId);
+      cloneAbortRef.current = null;
       setIsCloning(false);
     }
   };
@@ -260,8 +272,8 @@ export function CloneFromUrlDialog({ isOpen, onClose, onCloned }: CloneFromUrlDi
           </div>
 
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={handleClose} disabled={isCloning}>
-              Cancel
+            <Button type="button" variant={isCloning ? "destructive" : "outline"} onClick={handleClose}>
+              {isCloning ? 'Cancel clone' : 'Cancel'}
             </Button>
             <Button type="submit" disabled={!gitUrl.trim() || !cloneLocation.trim() || !dirName.trim() || isCloning}>
               {isCloning ? (

--- a/src/components/dialogs/GitHubReposDialog.tsx
+++ b/src/components/dialogs/GitHubReposDialog.tsx
@@ -32,6 +32,7 @@ import {
   type GitHubOrgDTO,
   type RepoDTO,
 } from '@/lib/api';
+import { classifyCloneError } from '@/lib/clone-errors';
 import { useAuthStore } from '@/stores/authStore';
 import { startOAuthFlow } from '@/lib/auth';
 import { getLanguageColor } from '@/lib/languageColors';
@@ -231,6 +232,7 @@ export function GitHubReposDialog({
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const cloneAbortRef = useRef<AbortController | null>(null);
 
   // Fetch home directory once for default clone location
   useEffect(() => {
@@ -240,6 +242,13 @@ export function GitHubReposDialog({
         if (home) setCloneLocation(home);
       });
     }
+  }, []);
+
+  // Abort clone on unmount to prevent orphaned operations
+  useEffect(() => {
+    return () => {
+      if (cloneAbortRef.current) cloneAbortRef.current.abort();
+    };
   }, []);
 
   const fetchRepos = useCallback(
@@ -305,7 +314,8 @@ export function GitHubReposDialog({
   }, [isOpen, isAuthenticated, fetchRepos]);
 
   const handleClose = useCallback(() => {
-    if (isCloning) return;
+    // Abort in-progress clone if any
+    if (cloneAbortRef.current) cloneAbortRef.current.abort();
     setRepos([]);
     setOrgs([]);
     setSelectedRepo(null);
@@ -320,7 +330,7 @@ export function GitHubReposDialog({
     if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
     if (abortRef.current) abortRef.current.abort();
     onClose();
-  }, [isCloning, onClose]);
+  }, [onClose]);
 
   const handleSearchChange = (value: string) => {
     setSearch(value);
@@ -364,26 +374,27 @@ export function GitHubReposDialog({
     setIsCloning(true);
     setCloneError(null);
 
+    const controller = new AbortController();
+    cloneAbortRef.current = controller;
+
+    // Frontend timeout: 6 minutes (backend has 5-min timeout for git clone).
+    // Pass a reason string so we can distinguish timeout aborts from user cancels.
+    const timeoutId = setTimeout(() => controller.abort('clone_timeout'), 6 * 60 * 1000);
+
     try {
       const result = await cloneRepo(
         selectedRepo.cloneUrl,
         cloneLocation.trim(),
-        selectedRepo.name
+        selectedRepo.name,
+        controller.signal
       );
       onCloned?.(result.repo);
       handleClose();
     } catch (error) {
-      const msg = error instanceof Error ? error.message : 'Clone failed';
-      if (msg.includes('already exists')) {
-        setCloneError(
-          `Directory "${selectedRepo.name}" already exists at this location.`
-        );
-      } else if (msg.includes('clone failed') || msg.includes('BAD_GATEWAY')) {
-        setCloneError('Git clone failed. Check your access and try again.');
-      } else {
-        setCloneError(msg);
-      }
+      setCloneError(classifyCloneError(error, controller.signal));
     } finally {
+      clearTimeout(timeoutId);
+      cloneAbortRef.current = null;
       setIsCloning(false);
     }
   };
@@ -613,12 +624,11 @@ export function GitHubReposDialog({
 
           <div className="flex items-center gap-2 shrink-0">
             <Button
-              variant="ghost"
+              variant={isCloning ? "destructive" : "ghost"}
               size="sm"
               onClick={handleClose}
-              disabled={isCloning}
             >
-              Cancel
+              {isCloning ? 'Cancel clone' : 'Cancel'}
             </Button>
             {isAuthenticated && (
               <Button

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2105,11 +2105,12 @@ export async function resolveGitHubRepo(url: string, signal?: AbortSignal): Prom
   return handleResponse<GitHubRepoDTO>(res);
 }
 
-export async function cloneRepo(url: string, path: string, dirName: string): Promise<CloneRepoResponse> {
+export async function cloneRepo(url: string, path: string, dirName: string, signal?: AbortSignal): Promise<CloneRepoResponse> {
   const res = await fetchWithAuth(`${getApiBase()}/api/clone`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ url, path, dirName }),
+    ...(signal && { signal }),
   });
   return handleResponse<CloneRepoResponse>(res);
 }

--- a/src/lib/clone-errors.ts
+++ b/src/lib/clone-errors.ts
@@ -1,0 +1,33 @@
+/**
+ * Classifies a clone error message into a user-friendly string.
+ * Used by both CloneFromUrlDialog and GitHubReposDialog.
+ */
+export function classifyCloneError(error: unknown, signal?: AbortSignal): string {
+  if (signal?.aborted) {
+    // Distinguish timeout aborts from user-initiated cancels.
+    // setTimeout-based aborts pass a reason string; user cancels do not.
+    if (signal.reason === 'clone_timeout') {
+      return 'Clone timed out. The repository may be too large or the server is unreachable.';
+    }
+    return 'Clone was cancelled.';
+  }
+
+  const msg = error instanceof Error ? error.message : 'Clone failed';
+
+  if (msg.includes('already exists')) {
+    return 'A directory with this name already exists at the selected location.';
+  }
+  if (msg.includes('authentication failed') || msg.includes('SSH authentication')) {
+    return 'Authentication failed. Please check your credentials or SSH key setup.';
+  }
+  if (msg.includes('not found')) {
+    return 'Repository not found. Please check the URL and your access permissions.';
+  }
+  if (msg.includes('timed out')) {
+    return 'Clone timed out. The repository may be too large or the server is unreachable.';
+  }
+  if (msg.includes('clone failed') || msg.includes('BAD_GATEWAY')) {
+    return 'Git clone failed. Please check the URL and try again.';
+  }
+  return msg;
+}


### PR DESCRIPTION
## Summary
- Prevent `git clone` from hanging on credential/passphrase prompts by setting `GIT_TERMINAL_PROMPT=0` and `SSH BatchMode=yes`
- Classify git stderr into user-friendly error messages (auth failure, SSH errors, repo not found) with proper HTTP status codes (401, 404, 504 instead of blanket 502)
- Add frontend abort/cancel support with a 6-minute timeout, distinguishing timeout aborts from user-initiated cancels
- Extract shared `classifyCloneError` helper to deduplicate error handling between `CloneFromUrlDialog` and `GitHubReposDialog`
- Fix `writeNotFound` producing doubled "not found" suffix in error messages
- Gate network-dependent test with `testing.Short()` skip for CI reliability

## Test plan
- [x] Go backend builds cleanly (`go build ./...`)
- [x] Clone-related Go tests pass (`go test -short -run 'TestClone|TestClassify' ./git/ ./server/`)
- [ ] Manual: clone a public repo via URL dialog
- [ ] Manual: attempt to clone a nonexistent repo — verify user-friendly error
- [ ] Manual: cancel a clone in progress — verify "Clone was cancelled" message
- [ ] Manual: clone via GitHub repos dialog with same scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)