### PR TITLE
Replace ESC with Cmd+Shift+Delete to stop agent

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, approvePlan } from '@/lib/api';
 import { markPlanModeExited } from '@/hooks/useWebSocket';
+import { useShortcut } from '@/hooks/useShortcut';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -758,6 +759,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     }
   }, [selectedConversationId, isStreaming, commitQueuedMessage, finalizeStreamingMessage, addMessage, setStreaming, updateConversation, clearActiveTools, showError]);
 
+  useShortcut('stopAgent', handleStop, { enabled: isStreaming });
+
   // Global keyboard shortcuts
 
   useEffect(() => {
@@ -796,14 +799,6 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         e.preventDefault();
         handleOpenFilePicker();
       }
-      // Escape to stop agent (only when streaming, no dialog/combobox open)
-      if (e.key === 'Escape' && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
-        const hasOpenOverlay = document.querySelector('[role="listbox"], [role="dialog"]');
-        if (!hasOpenOverlay && isStreaming) {
-          e.preventDefault();
-          handleStop();
-        }
-      }
       // Note: Cmd+Shift+Enter for plan approval is handled in handleKeyDown on the textarea
     };
 
@@ -830,7 +825,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       window.removeEventListener('toggle-thinking', handleToggleThinking);
       window.removeEventListener('toggle-plan-mode', handleTogglePlanMode);
     };
-  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel, isStreaming, handleStop]);
+  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel]);
 
   const handleSubmit = async () => {
     const { text: content, mentionedFiles } = plateInputRef.current?.getContent() ?? { text: '', mentionedFiles: [] };
@@ -1466,12 +1461,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                   variant="destructive"
                   className="h-8 w-8 rounded-lg"
                   onClick={handleStop}
-                  aria-label="Stop agent (Escape)"
+                  aria-label="Stop agent (⌘⇧⌫)"
                 >
                   <Square className="h-4 w-4" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent side="top">Stop agent (Esc)</TooltipContent>
+              <TooltipContent side="top">Stop agent (⌘⇧⌫)</TooltipContent>
             </Tooltip>
           ) : buttonMode === 'queue' ? (
             <Tooltip>

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -230,6 +230,13 @@ export const SHORTCUTS: Shortcut[] = [
     label: 'Previous search match',
     category: 'Chat',
   },
+  {
+    id: 'stopAgent',
+    key: 'Backspace',
+    modifiers: ['meta', 'shift'],
+    label: 'Stop agent',
+    category: 'Chat',
+  },
 
   // Terminal shortcuts are handled directly by xterm.js and are listed here
   // for documentation purposes only. They are not registered via useShortcut


### PR DESCRIPTION
## Summary
- Replaces the bare ESC key shortcut for stopping the agent with **Cmd+Shift+Delete** (⌘⇧⌫) to prevent accidental cancellation
- Registers the new `stopAgent` shortcut in the centralized shortcuts registry (`shortcuts.ts`)
- Uses the `useShortcut` hook for consistent keyboard handling instead of a raw `keydown` listener
- Updates the stop button tooltip and aria-label to reflect the new shortcut

## Test plan
- [ ] While the agent is streaming, press ESC — should do nothing
- [ ] Press Cmd+Shift+Delete — agent should stop
- [ ] Hover the stop button — tooltip should show "Stop agent (⌘⇧⌫)"
- [ ] Open keyboard shortcuts dialog (Cmd+/) — "Stop agent" should appear under Chat category
- [ ] Click the stop button — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)