### PR TITLE
Improve thinking level menu UX

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1303,6 +1306,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6029,6 +6045,24 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo, Fragment } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, approvePlan } from '@/lib/api';
 import { markPlanModeExited } from '@/hooks/useWebSocket';
@@ -9,6 +9,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
@@ -44,7 +45,7 @@ import { processDroppedFiles, validateAttachments, SUPPORTED_EXTENSIONS, loadAll
 import { UserQuestionPrompt } from './UserQuestionPrompt';
 import { usePendingUserQuestion, useStreamingState } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { THINKING_LEVELS, THINKING_TOKEN_MAP, type ThinkingLevel, resolveThinkingParams, clampThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
+import { THINKING_LEVELS, type ThinkingLevel, resolveThinkingParams, clampThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
 import { useSlashCommandStore, type UnifiedSlashCommand } from '@/stores/slashCommandStore';
 import { SummaryPicker } from './SummaryPicker';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
@@ -98,6 +99,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const defaultModel = useSettingsStore((s) => s.defaultModel);
   const setDefaultModel = useSettingsStore((s) => s.setDefaultModel);
   const defaultThinkingLevel = useSettingsStore((s) => s.defaultThinkingLevel);
+  const setDefaultThinkingLevel = useSettingsStore((s) => s.setDefaultThinkingLevel);
   const [selectedModel, setSelectedModel] = useState(
     () => MODELS.find((m) => m.id === defaultModel) ?? MODELS[0]
   );
@@ -1353,48 +1355,63 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                 <ChevronDown className="h-3 w-3" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-72">
-              {THINKING_LEVELS.map((level) => {
-                const isDisabled = level.id === 'off' && !canDisableThinking(selectedModel);
-                const isSelected = level.id === thinkingLevel;
-                const tokens = THINKING_TOKEN_MAP[level.id];
-                const budgetLabel = level.id === 'off'
-                  ? null
-                  : selectedModel.supportsEffort
-                    ? 'adaptive'
-                    : tokens != null
-                      ? `${(tokens / 1000).toFixed(0)}K tokens`
-                      : null;
-                return (
-                  <DropdownMenuItem
-                    key={level.id}
-                    disabled={isDisabled}
-                    onClick={() => setThinkingLevel(level.id)}
-                    className="flex-col items-start gap-0 py-2"
-                  >
-                    <div className="flex w-full items-center gap-1.5">
-                      <span className="font-medium">{level.label}</span>
-                      {level.id === defaultThinkingLevel && (
-                        <span className="text-xs text-muted-foreground">(default)</span>
-                      )}
-                      {isDisabled && (
-                        <span className="text-xs text-muted-foreground">(Opus always thinks)</span>
-                      )}
-                      <span className="ml-auto flex items-center gap-2">
-                        {budgetLabel && (
-                          <span className="text-[11px] tabular-nums text-muted-foreground/70">
-                            {budgetLabel}
+            <DropdownMenuContent align="start" className="w-64">
+              <DropdownMenuLabel className="flex items-center justify-between text-2xs font-normal text-muted-foreground uppercase tracking-wider">
+                Extended Thinking
+                <span className="normal-case tracking-normal text-muted-foreground/60">⌥T</span>
+              </DropdownMenuLabel>
+              {THINKING_LEVELS
+                .filter((level) => level.id !== 'off' || canDisableThinking(selectedModel))
+                .map((level, index, arr) => {
+                  const isSelected = level.id === thinkingLevel;
+                  const isDefault = level.id === defaultThinkingLevel;
+                  return (
+                    <Fragment key={level.id}>
+                      {/* Separate "Off" from the thinking levels; only renders when "Off" is the first item */}
+                      {index === 1 && arr[0].id === 'off' && <DropdownMenuSeparator />}
+                      <DropdownMenuItem
+                        onClick={() => setThinkingLevel(level.id)}
+                        className="group flex-col items-start gap-0 py-2"
+                      >
+                        <div className="flex w-full items-center gap-1.5">
+                          <span className="font-medium">{level.label}</span>
+                          <span className="ml-auto flex shrink-0 items-center gap-1">
+                            {isSelected && <Check className="h-3.5 w-3.5" />}
+                            {isDefault ? (
+                              <Star className="h-3 w-3 fill-current text-amber-500" />
+                            ) : level.id !== 'off' ? (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <button
+                                    type="button"
+                                    aria-label={`Set ${level.label} as default thinking level`}
+                                    className="flex items-center justify-center rounded p-0.5 text-muted-foreground/50 opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                    onPointerDown={(e) => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                    }}
+                                    onClick={(e) => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      setDefaultThinkingLevel(level.id);
+                                      showInfo(`${level.label} set as default thinking level`);
+                                    }}
+                                  >
+                                    <Star className="h-3 w-3" />
+                                  </button>
+                                </TooltipTrigger>
+                                <TooltipContent side="right" sideOffset={8}>Set as default</TooltipContent>
+                              </Tooltip>
+                            ) : null}
                           </span>
-                        )}
-                        {isSelected && <Check className="h-3.5 w-3.5" />}
-                      </span>
-                    </div>
-                    <span className="text-xs text-muted-foreground leading-tight">
-                      {level.description}
-                    </span>
-                  </DropdownMenuItem>
-                );
-              })}
+                        </div>
+                        <span className="text-xs text-muted-foreground leading-tight">
+                          {level.description}
+                        </span>
+                      </DropdownMenuItem>
+                    </Fragment>
+                  );
+                })}
             </DropdownMenuContent>
           </DropdownMenu>
 

--- a/src/lib/thinkingLevels.ts
+++ b/src/lib/thinkingLevels.ts
@@ -10,10 +10,10 @@ export type ThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'max';
 
 export const THINKING_LEVELS: { id: ThinkingLevel; label: string; description: string }[] = [
   { id: 'off', label: 'Off', description: 'Disable extended thinking' },
-  { id: 'low', label: 'Low', description: 'Minimal reasoning, may skip on simple tasks' },
-  { id: 'medium', label: 'Medium', description: 'Balanced reasoning for moderate tasks' },
-  { id: 'high', label: 'High', description: 'Strong reasoning for most problems' },
-  { id: 'max', label: 'Max', description: 'Maximum reasoning depth and capability' },
+  { id: 'low', label: 'Low', description: 'Quick answers, may skip thinking on simple tasks' },
+  { id: 'medium', label: 'Medium', description: 'Brief reasoning before responding' },
+  { id: 'high', label: 'High', description: 'Thorough reasoning for complex tasks' },
+  { id: 'max', label: 'Max', description: 'Deepest analysis, best for hard problems' },
 ];
 
 /** Default thinking token budgets for non-effort models (Sonnet/Haiku). */


### PR DESCRIPTION
## Summary
- Redesigns the thinking level dropdown with a labeled header, `⌥T` shortcut hint, and inline "set as default" star action per level
- Fixes star button to use a native `<button>` for keyboard accessibility with proper focus-visible styles
- Fixes event propagation so clicking the star doesn't also select the thinking level or close the menu
- Filters out the "Off" option when unsupported instead of showing it disabled
- Updates thinking level descriptions to be clearer and more user-friendly

## Test plan
- [ ] Open thinking level dropdown — verify header with "⌥T" hint appears
- [ ] Click a thinking level — verify it selects and closes the menu
- [ ] Hover a non-default level and click the star icon — verify it sets the default without selecting the level or closing the menu
- [ ] Tab through the dropdown with keyboard — verify the star button is focusable and activatable
- [ ] Switch to an Opus model — verify "Off" option is hidden (not disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)