### PR TITLE
Introduce AI provider abstraction and open-source release prep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,18 @@
-# GitHub OAuth Configuration
-# Create a GitHub OAuth App at: https://github.com/settings/developers
-# Set the callback URL to: chatml://oauth/callback
+# Anthropic API Key (required for AI functionality)
+# Get your API key at: https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# Backend environment variables
+# GitHub OAuth Configuration (optional — enables PR creation and CI/CD monitoring)
+# Create a GitHub OAuth App at: https://github.com/settings/developers
+# Set the Authorization callback URL to: chatml://oauth/callback
+# Note: Community contributors need their own GitHub OAuth App
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
-
-# Frontend environment variables (exposed to browser)
 NEXT_PUBLIC_GITHUB_CLIENT_ID=your_github_client_id
 
-# Linear OAuth Configuration
+# Linear OAuth Configuration (optional — enables issue tracking integration)
 # Create a Linear OAuth App at: https://linear.app/settings/api/applications
-# Set the callback URL to: chatml://oauth/callback
+# Set the Callback URL to: chatml://oauth/callback
+# Note: Community contributors need their own Linear OAuth App
 LINEAR_CLIENT_ID=your_linear_client_id
 NEXT_PUBLIC_LINEAR_CLIENT_ID=your_linear_client_id

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,14 @@ jobs:
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_CLIENT_SECRET }}
         run: |
           cd backend
-          GOOS=darwin GOARCH=arm64 go build -ldflags "\
-            -X 'github.com/chatml/chatml-backend/server.githubClientID=$GITHUB_CLIENT_ID' \
-            -X 'github.com/chatml/chatml-backend/server.githubClientSecret=$GITHUB_CLIENT_SECRET'" \
+          # Build with embedded OAuth credentials if available, otherwise plain build
+          # (plain builds fall back to environment variables at runtime)
+          LDFLAGS=""
+          if [ -n "$GITHUB_CLIENT_ID" ]; then
+            LDFLAGS="-X 'github.com/chatml/chatml-backend/server.githubClientID=$GITHUB_CLIENT_ID' \
+              -X 'github.com/chatml/chatml-backend/server.githubClientSecret=$GITHUB_CLIENT_SECRET'"
+          fi
+          GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" \
             -o ../src-tauri/binaries/chatml-backend-aarch64-apple-darwin .
 
       - name: Build Go backend (macOS x64)
@@ -96,12 +101,17 @@ jobs:
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_CLIENT_SECRET }}
         run: |
           cd backend
-          GOOS=darwin GOARCH=amd64 go build -ldflags "\
-            -X 'github.com/chatml/chatml-backend/server.githubClientID=$GITHUB_CLIENT_ID' \
-            -X 'github.com/chatml/chatml-backend/server.githubClientSecret=$GITHUB_CLIENT_SECRET'" \
+          # Build with embedded OAuth credentials if available, otherwise plain build
+          LDFLAGS=""
+          if [ -n "$GITHUB_CLIENT_ID" ]; then
+            LDFLAGS="-X 'github.com/chatml/chatml-backend/server.githubClientID=$GITHUB_CLIENT_ID' \
+              -X 'github.com/chatml/chatml-backend/server.githubClientSecret=$GITHUB_CLIENT_SECRET'"
+          fi
+          GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" \
             -o ../src-tauri/binaries/chatml-backend-x86_64-apple-darwin .
 
       - name: Sign Go backend sidecar (macOS)
+        if: env.APPLE_CERTIFICATE != ''
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,128 @@
+# Architecture
+
+ChatML is a native macOS desktop application for AI-assisted development. It uses a polyglot architecture with four distinct layers, each chosen for its strengths.
+
+## System Overview
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    Tauri Shell (Rust)                     │
+│   Window management, PTY terminals, OAuth deep links,    │
+│   Stronghold credential storage, native menus            │
+├──────────────────────────────────────────────────────────┤
+│                Next.js Frontend (React 19)                │
+│   UI components, Zustand stores, WebSocket client        │
+│   Static HTML export served by Tauri                     │
+├──────────────────────────────────────────────────────────┤
+│                  Go Backend (:9876)                       │
+│   REST API, WebSocket hub, SQLite, git/worktree ops,     │
+│   agent process management, OAuth handlers               │
+├──────────────────────────────────────────────────────────┤
+│              Agent Runner (Node.js)                       │
+│   Claude Agent SDK wrapper, MCP server, tool execution   │
+│   One process per conversation, runs in session worktree │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Data Model
+
+```
+Workspace → Session → Conversation → Message
+```
+
+- **Workspace** — A git repository on disk. Contains settings, branch prefix config, and custom instructions.
+- **Session** — An isolated git worktree for a single task. Has its own branch, priority, status, and PR tracking.
+- **Conversation** — A chat within a session. Types: `task` (full tool access), `review` (code review), `chat` (general discussion).
+- **Message** — Individual message with role (`user`, `assistant`, `system`), content blocks, tool calls, and token usage stats.
+
+## Communication Flow
+
+```
+Frontend ←──HTTP/WS──→ Go Backend ←──stdin/stdout──→ Agent Runner
+   │                       │                              │
+   │  REST: CRUD ops       │  Spawns process per          │  Claude Agent SDK
+   │  WebSocket: streaming │  conversation in the         │  query() + hooks
+   │                       │  session's worktree           │
+   │                       │                              │
+   │                       ├── SQLite (persistence)        │
+   │                       ├── Git (worktree management)   │
+   │                       └── OAuth (GitHub, Linear)      │
+```
+
+1. Frontend connects to Go backend via HTTP REST + WebSocket on localhost port 9876
+2. When a conversation starts, the backend spawns a Node.js agent-runner process
+3. The agent-runner runs inside the session's git worktree directory
+4. Agent output streams through stdout → backend → WebSocket → frontend
+5. All state is persisted in SQLite (backend/store/)
+
+## Provider Architecture
+
+ChatML uses a two-level provider abstraction:
+
+### Go Backend (`ai.Provider` interface)
+For lightweight AI tasks that don't need the full agent SDK:
+- PR description generation
+- Conversation/session summarization
+- Input suggestions
+
+The `ai.Provider` interface in `backend/ai/provider.go` can be implemented by any provider.
+
+### Agent Runner (stdin/stdout JSON protocol)
+For heavy agentic work (coding, tool use, planning):
+- The Go backend spawns an agent-runner process and communicates via JSON over stdin/stdout
+- The protocol is documented in `docs/agent-runner-protocol.md`
+- The current implementation wraps the Claude Agent SDK
+- New providers can implement their own agent-runner that speaks the same protocol
+
+### Provider Capabilities
+The backend exposes `GET /api/provider/capabilities` which returns what the current provider supports (extended thinking, plan mode, sub-agents, effort levels). The frontend uses this to conditionally show/hide features.
+
+## Directory Structure
+
+```
+chatml/
+├── src/                        # Next.js frontend
+│   ├── app/                    # App router pages
+│   ├── components/             # React components
+│   │   ├── conversation/       # Chat interface, message rendering
+│   │   ├── session/            # Session management UI
+│   │   ├── settings/           # Settings panels
+│   │   └── workspace/          # Workspace sidebar, dashboard
+│   ├── hooks/                  # Custom React hooks
+│   ├── lib/                    # API client, utilities, types
+│   └── stores/                 # Zustand state stores
+├── backend/                    # Go backend server
+│   ├── agent/                  # Agent process spawning & management
+│   ├── ai/                     # AI provider interface & Anthropic client
+│   ├── git/                    # Git & worktree operations
+│   ├── server/                 # HTTP handlers, WebSocket hub, router
+│   ├── store/                  # SQLite persistence layer
+│   └── main.go                 # Server entry point
+├── agent-runner/               # Claude Agent SDK runner
+│   └── src/
+│       ├── index.ts            # Main entry point, SDK hooks
+│       └── mcp/                # Built-in MCP server
+├── src-tauri/                  # Tauri desktop wrapper
+│   ├── src/                    # Rust source (main.rs, plugins)
+│   └── tauri.conf.json         # Tauri configuration
+├── docs/                       # Documentation
+└── public/                     # Static assets
+```
+
+## State Management
+
+- **Frontend**: Zustand stores in `src/stores/` — one store per concern (sessions, conversations, settings, etc.)
+- **Backend**: SQLite in WAL mode via pure-Go driver (no CGo) in `backend/store/`
+- **Real-time sync**: WebSocket events keep frontend state in sync with backend changes
+
+## Key Design Decisions
+
+1. **Git worktrees for isolation** — Each session gets its own worktree and branch, enabling truly parallel AI development without merge conflicts.
+
+2. **Process-per-conversation** — Each agent conversation runs in its own Node.js process, providing natural isolation and the ability to kill runaway agents.
+
+3. **Local-first** — All data stays on your machine. No cloud component except the AI provider API.
+
+4. **Stdin/stdout protocol** — The Go backend communicates with agent runners via JSON over stdin/stdout, making it straightforward to swap in different AI providers without changing the backend.
+
+5. **Static frontend export** — Next.js generates static HTML that Tauri serves directly, avoiding the need for a separate web server process.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,32 +91,6 @@ Workspace → Session → Conversation → Message
 - **Frontend**: Zustand stores in `src/stores/`
 - **Backend**: SQLite persistence in `backend/store/`
 
-## Issue Tracking (Linear)
-
-This project uses the **ChatML** team in Linear for issue tracking. Use the Linear MCP tools (e.g., `mcp__linear__list_issues`, `mcp__linear__create_issue`).
-
-### Working with Issues
-
-```bash
-# List issues
-mcp__linear__list_issues team="ChatML"
-
-# Create issue
-mcp__linear__create_issue team="ChatML" title="Description" description="..."
-
-# View issue
-mcp__linear__get_issue id="CHA-123"
-```
-
-### Priority Levels
-
-| Priority | Use For |
-|----------|---------|
-| Urgent (1) | Critical - must fix immediately |
-| High (2) | Important, blocks other work |
-| Medium (3) | Normal priority |
-| Low (4) | Nice to have |
-
 ## Git Workflow
 
 ### ⛔ CRITICAL: Never Commit to Main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to ChatML
+
+Thank you for your interest in contributing to ChatML! This guide will help you get set up and understand our development workflow.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) v20+
+- [Go](https://go.dev) 1.22+
+- [Rust](https://www.rust-lang.org/tools/install) (latest stable)
+- [Tauri CLI](https://tauri.app/start/prerequisites/) v2
+- macOS 10.15+ (ChatML is currently macOS-only)
+
+## Development Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/chatml/chatml.git
+   cd chatml
+   ```
+
+2. **Copy environment config**
+   ```bash
+   cp .env.example .env
+   ```
+   Edit `.env` with your API keys and OAuth credentials (see [OAuth Setup](#oauth-setup) below).
+
+3. **Start development**
+   ```bash
+   make dev
+   ```
+   This installs dependencies, builds the Go backend and agent-runner, and starts the Tauri dev server.
+
+## Build Commands
+
+| Command | Description |
+|---------|-------------|
+| `make dev` | Start all services (backend + frontend + Tauri) |
+| `make backend` | Build Go backend only |
+| `make agent-runner` | Build agent-runner only |
+| `make build` | Production build |
+| `make build-debug` | Debug build (no code signing required) |
+| `make test` | Run Go backend tests |
+| `make clean` | Remove all build artifacts |
+
+## Testing & Linting
+
+Before submitting a PR, run:
+
+```bash
+# Go backend
+make test                  # Run tests with race detection
+cd backend && go vet ./... # Static analysis
+
+# Frontend
+npm run lint               # ESLint
+npm run build              # TypeScript type checking + build
+```
+
+## OAuth Setup
+
+ChatML integrates with GitHub and Linear via OAuth. For development, you need your own OAuth apps.
+
+### GitHub OAuth App
+
+1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
+2. Click "New OAuth App"
+3. Set **Authorization callback URL** to: `chatml://oauth/callback`
+4. Copy the Client ID and Client Secret to your `.env` file
+
+### Linear OAuth App
+
+1. Go to [Linear API Applications](https://linear.app/settings/api/applications)
+2. Create a new application
+3. Set **Callback URL** to: `chatml://oauth/callback`
+4. Copy the Client ID to your `.env` file
+
+### Running Without OAuth
+
+GitHub and Linear OAuth are optional. ChatML works without them — you just won't have PR creation or Linear issue tracking features. The Anthropic API key is required for AI functionality.
+
+## Auto-Updater
+
+The auto-updater in `src-tauri/tauri.conf.json` is configured for the official ChatML distribution. If you're building a fork:
+
+- Update the `endpoints` URL to point to your own releases
+- Or set `"createUpdaterArtifacts": false` in the bundle config to disable it
+- Or simply ignore updater errors during development (`make build-debug` handles this)
+
+## Architecture Overview
+
+ChatML is a polyglot application with four layers:
+
+```
+Tauri (Rust) → Next.js Frontend (React) → Go Backend → Agent Runner (Node.js)
+```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for details.
+
+### Adding a New Model Provider
+
+ChatML currently supports Claude via the Anthropic Claude Agent SDK. The architecture is designed for community-contributed providers:
+
+1. **Go backend**: The `ai.Provider` interface in `backend/ai/provider.go` defines the contract for lightweight AI tasks (PR generation, summarization). Implement this interface for your provider.
+
+2. **Agent runner**: The agent runner communicates with the Go backend via a stdin/stdout JSON protocol documented in `docs/agent-runner-protocol.md`. To add a new provider, implement an agent runner that speaks this protocol.
+
+3. **Frontend**: Provider capabilities are exposed via `GET /api/provider/capabilities`. The UI conditionally shows features based on what the provider supports.
+
+## Pull Request Process
+
+1. Create a feature branch from `main`: `git checkout -b feature/description`
+2. Make your changes
+3. Run the full test/lint suite (see above)
+4. Push and open a PR against `main`
+5. Describe what you changed and why in the PR description
+
+## Code Style
+
+- **Go**: Standard `gofmt` formatting, no special linter config
+- **TypeScript/React**: ESLint config in the repo (run `npm run lint`)
+- **Rust**: Standard `rustfmt` formatting
+- Keep changes focused — one logical change per PR

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ChatML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1477,6 +1477,7 @@ async function main(): Promise<void> {
   lifecycle("main() entered");
   emit({
     type: "ready",
+    provider: "claude",
     conversationId,
     cwd,
     resuming: !!resumeSessionId,

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1653,7 +1653,7 @@ func formatSessionName(name string) string {
 // 2. ANTHROPIC_API_KEY environment variable
 // 3. Claude Code OAuth token from macOS Keychain
 // Returns nil if no credentials are available.
-func (m *Manager) newAIClient() *ai.Client {
+func (m *Manager) newAIClient() ai.Provider {
 	// Source 1: SQLite settings (explicit user-configured API key)
 	envVars, err := m.loadEnvVars(m.ctx)
 	if err != nil {

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -8,6 +8,7 @@ import (
 
 	"os"
 
+	"github.com/chatml/chatml-backend/ai"
 	"github.com/chatml/chatml-backend/crypto"
 	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/models"
@@ -1111,9 +1112,11 @@ func TestNewAIClient_Source1_SQLiteApiKey(t *testing.T) {
 		}
 	}()
 
-	client := m.newAIClient()
-	require.NotNil(t, client, "should create client from SQLite API key")
+	provider := m.newAIClient()
+	require.NotNil(t, provider, "should create client from SQLite API key")
 	// Client should use x-api-key auth (not Bearer)
+	client, ok := provider.(*ai.Client)
+	require.True(t, ok, "expected *ai.Client, got %T", provider)
 	assert.Equal(t, "x-api-key", client.AuthHeader())
 }
 
@@ -1131,8 +1134,10 @@ func TestNewAIClient_Source2_EnvVar(t *testing.T) {
 		}
 	}()
 
-	client := m.newAIClient()
-	require.NotNil(t, client, "should create client from env var")
+	provider := m.newAIClient()
+	require.NotNil(t, provider, "should create client from env var")
+	client, ok := provider.(*ai.Client)
+	require.True(t, ok, "expected *ai.Client, got %T", provider)
 	assert.Equal(t, "x-api-key", client.AuthHeader())
 }
 
@@ -1155,9 +1160,11 @@ func TestNewAIClient_Source1_TakesPriorityOverSource2(t *testing.T) {
 		}
 	}()
 
-	client := m.newAIClient()
-	require.NotNil(t, client)
+	provider := m.newAIClient()
+	require.NotNil(t, provider)
 	// Client should use SQLite key (source 1), not env var (source 2)
+	client, ok := provider.(*ai.Client)
+	require.True(t, ok, "expected *ai.Client, got %T", provider)
 	assert.Equal(t, "x-api-key", client.AuthHeader())
 	assert.Equal(t, "sk-sqlite-priority", client.AuthValue())
 }
@@ -1242,8 +1249,10 @@ func TestNewAIClient_EnvVarsWithAnthropicKey(t *testing.T) {
 		}
 	}()
 
-	client := m.newAIClient()
-	require.NotNil(t, client, "should create client from env-vars setting")
+	provider := m.newAIClient()
+	require.NotNil(t, provider, "should create client from env-vars setting")
+	client, ok := provider.(*ai.Client)
+	require.True(t, ok, "expected *ai.Client, got %T", provider)
 	assert.Equal(t, "x-api-key", client.AuthHeader())
 	assert.Equal(t, "sk-from-env-vars-setting", client.AuthValue())
 }
@@ -1268,10 +1277,12 @@ func TestNewAIClient_EncryptedKeyOverridesEnvVarsSetting(t *testing.T) {
 		}
 	}()
 
-	client := m.newAIClient()
-	require.NotNil(t, client)
+	provider := m.newAIClient()
+	require.NotNil(t, provider)
 	// The encrypted key should override the env-vars setting key
 	// because loadEnvVars() sets envMap["ANTHROPIC_API_KEY"] = decrypted at the end
+	client, ok := provider.(*ai.Client)
+	require.True(t, ok, "expected *ai.Client, got %T", provider)
 	assert.Equal(t, "sk-encrypted-wins", client.AuthValue())
 }
 

--- a/backend/agent/provider.go
+++ b/backend/agent/provider.go
@@ -1,0 +1,33 @@
+package agent
+
+// AgentProvider describes the capabilities of the current agent-runner implementation.
+// For the initial release, only "claude" is supported. Future providers can be added
+// by implementing a different agent-runner binary that speaks the same stdin/stdout
+// JSON protocol (see docs/agent-runner-protocol.md).
+type AgentProvider struct {
+	// Name identifies the provider (e.g., "claude", "openai").
+	Name string `json:"name"`
+
+	// SupportsThinking indicates whether the provider supports extended thinking / chain-of-thought.
+	SupportsThinking bool `json:"supportsThinking"`
+
+	// SupportsPlanMode indicates whether the provider supports structured plan-then-execute mode.
+	SupportsPlanMode bool `json:"supportsPlanMode"`
+
+	// SupportsSubAgents indicates whether the provider supports spawning sub-agent processes.
+	SupportsSubAgents bool `json:"supportsSubAgents"`
+
+	// SupportsEffort indicates whether the provider supports reasoning effort levels (low/medium/high/max).
+	SupportsEffort bool `json:"supportsEffort"`
+}
+
+// DefaultProvider returns the Claude provider configuration.
+func DefaultProvider() AgentProvider {
+	return AgentProvider{
+		Name:              "claude",
+		SupportsThinking:  true,
+		SupportsPlanMode:  true,
+		SupportsSubAgents: true,
+		SupportsEffort:    true,
+	}
+}

--- a/backend/ai/generate.go
+++ b/backend/ai/generate.go
@@ -20,7 +20,8 @@ const (
 	clientTimeout = 60 * time.Second
 )
 
-// Client is a lightweight Anthropic API client for generating PR descriptions.
+// Client is the Anthropic implementation of the Provider interface.
+// It is a lightweight API client used for PR descriptions, summarization, and suggestions.
 type Client struct {
 	authHeader string // HTTP header name: "x-api-key" or "Authorization"
 	authValue  string // Header value: raw API key or "Bearer <token>"
@@ -34,6 +35,9 @@ func (c *Client) AuthHeader() string { return c.authHeader }
 
 // AuthValue returns the HTTP header value used for authentication (for testing).
 func (c *Client) AuthValue() string { return c.authValue }
+
+// Name returns the provider name.
+func (c *Client) Name() string { return "anthropic" }
 
 // NewClient creates a new AI client using an API key (x-api-key header).
 // Returns nil if apiKey is empty.

--- a/backend/ai/provider.go
+++ b/backend/ai/provider.go
@@ -1,0 +1,32 @@
+package ai
+
+import "context"
+
+// Provider defines the interface for AI model providers used for lightweight tasks
+// (PR generation, summarization, suggestions). The heavy agentic work is handled
+// by the agent-runner process, which is provider-specific.
+//
+// For the initial release, only the Anthropic implementation (Client) exists.
+// Community contributors can implement this interface for other providers.
+type Provider interface {
+	// GeneratePRDescription generates a PR title and body from commit context.
+	GeneratePRDescription(ctx context.Context, req GeneratePRRequest) (*GeneratePRResponse, error)
+
+	// GenerateConversationSummary summarizes a conversation.
+	GenerateConversationSummary(ctx context.Context, req GenerateSummaryRequest) (string, error)
+
+	// GenerateSessionTitle generates a short title from a user message.
+	GenerateSessionTitle(ctx context.Context, userMessage string) (string, error)
+
+	// GenerateSessionSummary summarizes an entire session across all conversations.
+	GenerateSessionSummary(ctx context.Context, req GenerateSessionSummaryRequest) (string, error)
+
+	// GenerateInputSuggestion generates suggested next prompts.
+	GenerateInputSuggestion(ctx context.Context, req SuggestionRequest) (*SuggestionResponse, error)
+
+	// Name returns the provider name (e.g., "anthropic", "openai").
+	Name() string
+}
+
+// Ensure Client implements Provider at compile time.
+var _ Provider = (*Client)(nil)

--- a/backend/main.go
+++ b/backend/main.go
@@ -431,8 +431,12 @@ func main() {
 	issueCache := github.NewIssueCache(2*time.Minute, 10*time.Minute)
 	defer issueCache.Close()
 
-	// AI client for PR description generation
-	aiClient := ai.NewClient(os.Getenv("ANTHROPIC_API_KEY"))
+	// AI client for PR description generation, summarization, and suggestions.
+	// Returns nil if ANTHROPIC_API_KEY is not set; features gracefully degrade.
+	var aiClient ai.Provider
+	if c := ai.NewClient(os.Getenv("ANTHROPIC_API_KEY")); c != nil {
+		aiClient = c
+	}
 
 	// Script runner for setup/run scripts with WebSocket output streaming
 	scriptRunner := scripts.NewRunner(

--- a/backend/server/conversation_handlers.go
+++ b/backend/server/conversation_handlers.go
@@ -102,6 +102,20 @@ func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Gracefully degrade features not supported by the current provider.
+	// For Claude, all capabilities are true so these are no-ops today.
+	// TODO: Replace DefaultProvider() with a session-aware lookup when multi-provider support lands.
+	provider := agent.DefaultProvider()
+	if req.PlanMode && !provider.SupportsPlanMode {
+		req.PlanMode = false
+	}
+	if req.MaxThinkingTokens > 0 && !provider.SupportsThinking {
+		req.MaxThinkingTokens = 0
+	}
+	if req.Effort != "" && !provider.SupportsEffort {
+		req.Effort = ""
+	}
+
 	// Build options for starting the conversation
 	var opts *agent.StartConversationOptions
 	if req.MaxThinkingTokens > 0 || len(req.Attachments) > 0 || req.PlanMode || instructions != "" || req.Model != "" || req.Effort != "" {

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -542,8 +542,13 @@ type Handlers struct {
 	issueCache       *github.IssueCache
 	avatarCache      *github.AvatarCache
 	statsCache       *SessionStatsCache
-	aiClient         *ai.Client
+	aiClient         ai.Provider
 	scriptRunner     *scripts.Runner
+}
+
+// GetProviderCapabilities returns the current AI agent provider's capabilities.
+func (h *Handlers) GetProviderCapabilities(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, agent.DefaultProvider())
 }
 
 // writeJSON writes data as JSON response, logging any encoding errors
@@ -585,7 +590,7 @@ func (h *Handlers) getWorkspacesBaseDir(ctx context.Context) (string, error) {
 	return git.WorkspacesBaseDirWithOverride(configured)
 }
 
-func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, aiClient *ai.Client, scriptRunner *scripts.Runner) *Handlers {
+func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, aiClient ai.Provider, scriptRunner *scripts.Runner) *Handlers {
 	// Initialize session name cache with workspaces directory
 	// Cache initializes lazily on first use
 	workspacesDir, err := git.WorkspacesBaseDir()

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -18,7 +18,7 @@ import (
 	"github.com/rs/cors"
 )
 
-func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, linearClient *linear.Client, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, aiClient *ai.Client, scriptRunner *scripts.Runner) http.Handler {
+func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, linearClient *linear.Client, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, aiClient ai.Provider, scriptRunner *scripts.Runner) http.Handler {
 	r := chi.NewRouter()
 	dirCacheConfig := LoadDirListingCacheConfig()
 	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, issueCache, statsCache, aiClient, scriptRunner)
@@ -32,6 +32,9 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"status": "ok"})
 	})
+
+	// Provider capabilities endpoint
+	r.Get("/api/provider/capabilities", h.GetProviderCapabilities)
 
 	// Auth endpoints (no rate limiting - they're naturally rate limited by OAuth)
 	r.Route("/api/auth", func(r chi.Router) {

--- a/docs/agent-runner-protocol.md
+++ b/docs/agent-runner-protocol.md
@@ -1,0 +1,155 @@
+# Agent Runner Protocol
+
+The Go backend communicates with agent-runner processes via JSON messages over **stdin** (backend → agent) and **stdout** (agent → backend). Each message is a single line of JSON.
+
+This protocol defines the contract that any agent-runner implementation must fulfill. The current implementation wraps the Claude Agent SDK, but alternative providers can implement their own agent-runner that speaks this same protocol.
+
+## Starting an Agent Runner
+
+The backend spawns the agent-runner as a child process with these CLI arguments:
+
+| Argument | Description |
+|----------|-------------|
+| `--model <id>` | Model identifier (e.g., `claude-sonnet-4-6`) |
+| `--fallback-model <id>` | Fallback model if primary is unavailable |
+| `--max-thinking-tokens <n>` | Extended thinking token budget |
+| `--effort <level>` | Reasoning effort: `low`, `medium`, `high`, `max` |
+| `--permission-mode <mode>` | Permission mode: `default`, `acceptEdits`, `bypassPermissions`, `plan` |
+| `--tool-preset <preset>` | Tool preset: `read-only`, `no-bash`, `safe-edit`, `full` |
+| `--max-budget-usd <n>` | Maximum cost in USD |
+| `--max-turns <n>` | Maximum conversation turns |
+| `--resume <sessionId>` | Resume an existing session |
+| `--cwd <path>` | Working directory (session worktree) |
+| `--mcp-servers-file <path>` | Path to JSON file with MCP server configs |
+| `--system-prompt <text>` | Additional system prompt content |
+| `--structured-output <schema>` | JSON schema for structured output |
+| `--betas <features>` | Comma-separated beta feature flags |
+
+## Input Messages (stdin → agent-runner)
+
+All messages have a `type` field.
+
+### Core Messages
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `message` | `content`, `attachments[]` | Send user text to the agent |
+| `stop` | — | Gracefully stop the agent process |
+| `interrupt` | — | Cancel the current operation |
+
+### Runtime Configuration
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `set_model` | `model` | Change model at runtime |
+| `set_permission_mode` | `permissionMode` | Change permission mode |
+| `set_max_thinking_tokens` | `maxThinkingTokens` | Change thinking budget |
+
+### Queries
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `get_supported_models` | — | Request list of available models |
+| `get_supported_commands` | — | Request list of slash commands |
+| `get_mcp_status` | — | Request MCP server health |
+| `get_account_info` | — | Request provider account info |
+
+### Interactive Responses
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `user_question_response` | `questionRequestId`, `answers` | Answer to AskUserQuestion tool |
+| `plan_approval_response` | `planApprovalRequestId`, `planApproved`, `planApprovalReason` | Approve/reject a plan |
+| `rewind_files` | `checkpointUuid` | Rewind files to a checkpoint |
+
+### MCP Management
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `reconnect_mcp_server` | `serverName` | Reconnect a failed MCP server |
+| `toggle_mcp_server` | `serverName`, `serverEnabled` | Enable/disable an MCP server |
+
+## Output Events (agent-runner → stdout)
+
+All events have a `type` field.
+
+### Lifecycle
+
+| Type | Key Fields | Description |
+|------|-----------|-------------|
+| `ready` | `conversationId`, `cwd`, `resuming`, `model`, `provider` | Process initialized and ready |
+| `init` | `model`, `tools`, `mcpServers`, `permissionMode`, `budgetConfig` | Full SDK initialization data |
+| `complete` | `sessionId` | Session completed |
+| `shutdown` | `reason` | Process shutting down |
+| `session_started` | `sessionId`, `cwd` | New session started |
+| `session_ended` | `sessionId`, `reason` | Session ended |
+
+### Streaming Content
+
+| Type | Key Fields | Description |
+|------|-----------|-------------|
+| `assistant_text` | `content` | Streamed text chunk |
+| `thinking` | `content` | Complete thinking block |
+| `thinking_start` | — | Thinking block started |
+| `thinking_delta` | `content` | Streaming thinking content |
+
+### Tool Execution
+
+| Type | Key Fields | Description |
+|------|-----------|-------------|
+| `tool_start` | `id`, `tool`, `params` | Tool execution started |
+| `tool_end` | `id`, `tool`, `success`, `summary`, `duration` | Tool execution completed |
+| `tool_progress` | `toolUseId`, `toolName`, `elapsedTimeSeconds` | Progress update |
+
+### User Interaction
+
+| Type | Key Fields | Description |
+|------|-----------|-------------|
+| `user_question_request` | `requestId`, `questions` | Waiting for user input (AskUserQuestion) |
+| `plan_approval_request` | `requestId`, `planContent` | Waiting for plan approval (ExitPlanMode) |
+
+### Sub-agents
+
+| Type | Key Fields | Description |
+|------|-----------|-------------|
+| `subagent_started` | `agentId`, `agentType`, `parentToolUseId` | Sub-agent spawned |
+| `subagent_stopped` | `agentId`, `stopHookActive` | Sub-agent finished |
+| `subagent_output` | `agentId`, `agentOutput` | Sub-agent result |
+
+### Results
+
+| Type | Key Fields | Description |
+|------|-----------|-------------|
+| `result` | `success`, `cost`, `turns`, `usage`, `stats` | Turn result (success or error) |
+| `turn_complete` | `sessionId` | Single turn finished |
+| `context_usage` | `inputTokens`, `outputTokens`, `cacheReadInputTokens` | Per-message token usage |
+
+### State Changes
+
+| Type | Key Fields | Description |
+|------|-----------|-------------|
+| `model_changed` | `model` | Model successfully changed |
+| `permission_mode_changed` | `mode`, `source` | Permission mode changed |
+| `checkpoint_created` | `checkpointUuid`, `messageIndex` | File checkpoint created |
+| `todo_update` | `todos[]` | Todo list updated |
+| `files_rewound` | `checkpointUuid`, `success` | Checkpoint rewind result |
+
+### Errors
+
+| Type | Key Fields | Description |
+|------|-----------|-------------|
+| `error` | `message` | General error |
+| `auth_error` | `message` | Authentication failure (fatal) |
+| `command_error` | `command`, `error` | Command execution failed |
+| `warning` | `message` | Non-fatal warning |
+
+## Implementing a New Provider
+
+To add support for a new AI provider:
+
+1. Create an agent-runner that accepts the same CLI arguments
+2. Read JSON messages from stdin and write JSON events to stdout
+3. Emit a `ready` event with `provider: "your-provider-name"` on startup
+4. Handle at minimum: `message`, `stop`, `interrupt`, `get_supported_models`
+5. Emit at minimum: `ready`, `assistant_text`, `tool_start`, `tool_end`, `result`, `error`
+6. Features like extended thinking, plan mode, and sub-agents are optional — the backend checks provider capabilities via `GET /api/provider/capabilities`

--- a/src/hooks/useClaudeAuthStatus.ts
+++ b/src/hooks/useClaudeAuthStatus.ts
@@ -1,3 +1,4 @@
+// TODO: When multi-provider support is added, generalize this to check the active provider's auth status.
 import { useState, useEffect } from 'react';
 import { getClaudeAuthStatus } from '@/lib/api';
 

--- a/src/hooks/useProviderCapabilities.ts
+++ b/src/hooks/useProviderCapabilities.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+import { getApiBase } from '@/lib/api';
+
+export interface ProviderCapabilities {
+  name: string;
+  supportsThinking: boolean;
+  supportsPlanMode: boolean;
+  supportsSubAgents: boolean;
+  supportsEffort: boolean;
+}
+
+const DEFAULT_CAPABILITIES: ProviderCapabilities = {
+  name: 'claude',
+  supportsThinking: true,
+  supportsPlanMode: true,
+  supportsSubAgents: true,
+  supportsEffort: true,
+};
+
+// TODO: Invalidate when multi-provider or runtime config changes are supported.
+let cachedCapabilities: ProviderCapabilities | null = null;
+
+export function useProviderCapabilities(): ProviderCapabilities {
+  const [caps, setCaps] = useState<ProviderCapabilities>(
+    cachedCapabilities ?? DEFAULT_CAPABILITIES
+  );
+
+  useEffect(() => {
+    if (cachedCapabilities) return;
+
+    fetch(`${getApiBase()}/api/provider/capabilities`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data: ProviderCapabilities) => {
+        cachedCapabilities = data;
+        setCaps(data);
+      })
+      .catch(() => {
+        cachedCapabilities = DEFAULT_CAPABILITIES;
+      });
+  }, []);
+
+  return caps;
+}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,7 +1,7 @@
 export const MODELS = [
-  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', supportsThinking: true, supportsEffort: true },
-  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', supportsThinking: true, supportsEffort: true },
-  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', supportsThinking: true, supportsEffort: false },
+  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true },
+  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true },
+  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', provider: 'claude', supportsThinking: true, supportsEffort: false },
 ] as const;
 
 export type ModelId = (typeof MODELS)[number]['id'];


### PR DESCRIPTION
## Summary

- **AI Provider interface**: Extract `ai.Provider` from concrete `*ai.Client` so community contributors can implement other providers. Add `agent.AgentProvider` capability struct with a new `/api/provider/capabilities` REST endpoint, and gracefully degrade unsupported features (plan mode, thinking, effort) per provider.
- **Release workflow fixes**: Use `env.APPLE_CERTIFICATE` instead of broken `secrets.*` condition for code signing step. Make OAuth ldflags conditional so builds succeed without secrets.
- **Open-source scaffolding**: Add MIT LICENSE, CONTRIBUTING.md, ARCHITECTURE.md, and agent-runner protocol docs. Improve `.env.example` with `ANTHROPIC_API_KEY` and clearer OAuth setup instructions.
- **Code quality**: Safe type assertions in Go tests, `res.ok` check in frontend capabilities hook, provider field on model definitions.

## Test plan

- [x] `go build ./...` passes in `backend/`
- [x] TypeScript compiles without errors
- [ ] Verify signing step runs correctly in CI when `APPLE_CERTIFICATE` secret is set
- [ ] Verify release build completes without secrets (community fork scenario)
- [ ] Manual: confirm `/api/provider/capabilities` returns expected JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)