### PR TITLE
Add Linear issue linking and workspace context to compose area

### DIFF
--- a/backend/linear/client.go
+++ b/backend/linear/client.go
@@ -312,6 +312,198 @@ func (c *Client) GetViewer(ctx context.Context) (*User, error) {
 	}, nil
 }
 
+// Issue represents a Linear issue.
+type Issue struct {
+	ID          string   `json:"id"`
+	Identifier  string   `json:"identifier"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	StateName   string   `json:"stateName"`
+	Labels      []string `json:"labels"`
+	Assignee    string   `json:"assignee,omitempty"`
+	Project     string   `json:"project,omitempty"`
+}
+
+// issueFields is the shared set of GraphQL fields for issue queries.
+const issueFields = `id identifier title description state { name } labels { nodes { name } } assignee { name } project { name }`
+
+// issueNode is the GraphQL response shape for a single issue node.
+type issueNode struct {
+	ID          string `json:"id"`
+	Identifier  string `json:"identifier"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	State       struct {
+		Name string `json:"name"`
+	} `json:"state"`
+	Labels struct {
+		Nodes []struct {
+			Name string `json:"name"`
+		} `json:"nodes"`
+	} `json:"labels"`
+	Assignee *struct {
+		Name string `json:"name"`
+	} `json:"assignee"`
+	Project *struct {
+		Name string `json:"name"`
+	} `json:"project"`
+}
+
+// parseIssueNodes converts GraphQL issue nodes into Issue structs.
+func parseIssueNodes(nodes []issueNode) []Issue {
+	issues := make([]Issue, 0, len(nodes))
+	for _, n := range nodes {
+		labels := make([]string, 0, len(n.Labels.Nodes))
+		for _, l := range n.Labels.Nodes {
+			labels = append(labels, l.Name)
+		}
+		issue := Issue{
+			ID:          n.ID,
+			Identifier:  n.Identifier,
+			Title:       n.Title,
+			Description: n.Description,
+			StateName:   n.State.Name,
+			Labels:      labels,
+		}
+		if n.Assignee != nil {
+			issue.Assignee = n.Assignee.Name
+		}
+		if n.Project != nil {
+			issue.Project = n.Project.Name
+		}
+		issues = append(issues, issue)
+	}
+	return issues
+}
+
+// ListMyIssues fetches active issues assigned to the authenticated user.
+func (c *Client) ListMyIssues(ctx context.Context) ([]Issue, error) {
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf(`{
+		viewer {
+			assignedIssues(
+				first: 30
+				orderBy: updatedAt
+				filter: { state: { type: { nin: ["completed", "canceled"] } } }
+			) {
+				nodes { %s }
+			}
+		}
+	}`, issueFields)
+
+	body := map[string]string{"query": query}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.apiURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching issues: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Linear returned %d: %s", resp.StatusCode, respBody)
+	}
+
+	var result struct {
+		Data struct {
+			Viewer struct {
+				AssignedIssues struct {
+					Nodes []issueNode `json:"nodes"`
+				} `json:"assignedIssues"`
+			} `json:"viewer"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if len(result.Errors) > 0 {
+		return nil, fmt.Errorf("Linear GraphQL error: %s", result.Errors[0].Message)
+	}
+
+	return parseIssueNodes(result.Data.Viewer.AssignedIssues.Nodes), nil
+}
+
+// SearchIssues searches Linear issues by query text.
+func (c *Client) SearchIssues(ctx context.Context, query string) ([]Issue, error) {
+	token, err := c.getValidToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	gql := fmt.Sprintf(`{
+		issueSearch(query: %q, first: 20) {
+			nodes { %s }
+		}
+	}`, query, issueFields)
+
+	body := map[string]string{"query": gql}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.apiURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("searching issues: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Linear returned %d: %s", resp.StatusCode, respBody)
+	}
+
+	var result struct {
+		Data struct {
+			IssueSearch struct {
+				Nodes []issueNode `json:"nodes"`
+			} `json:"issueSearch"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if len(result.Errors) > 0 {
+		return nil, fmt.Errorf("Linear GraphQL error: %s", result.Errors[0].Message)
+	}
+
+	return parseIssueNodes(result.Data.IssueSearch.Nodes), nil
+}
+
 // SetTokens stores tokens in memory.
 func (c *Client) SetTokens(tokens *TokenSet) {
 	c.mu.Lock()

--- a/backend/server/conversation_handlers.go
+++ b/backend/server/conversation_handlers.go
@@ -41,6 +41,14 @@ type CreateConversationRequest struct {
 	Effort            string              `json:"effort"`            // Reasoning effort: low, medium, high, max (optional)
 	Attachments       []models.Attachment `json:"attachments"`       // File attachments (optional)
 	SummaryIDs        []string            `json:"summaryIds"`        // Summaries to attach as context (optional)
+	LinearIssue       *struct {
+		Identifier  string   `json:"identifier"`
+		Title       string   `json:"title"`
+		Description string   `json:"description,omitempty"`
+		StateName   string   `json:"stateName"`
+		Labels      []string `json:"labels"`
+	} `json:"linearIssue,omitempty"` // Linked Linear issue (optional)
+	LinkedWorkspaceIDs []string `json:"linkedWorkspaceIds,omitempty"` // Additional workspace IDs for context (optional)
 }
 
 func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
@@ -99,6 +107,48 @@ func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
 		}
 		if len(parts) > 0 {
 			instructions = "## Context from Previous Conversations\n\n" + strings.Join(parts, "\n\n")
+		}
+	}
+
+	// Build instructions from linked Linear issue
+	if req.LinearIssue != nil {
+		section := fmt.Sprintf("## Linked Linear Issue\n\n**%s: %s**\nStatus: %s",
+			req.LinearIssue.Identifier, req.LinearIssue.Title, req.LinearIssue.StateName)
+		if len(req.LinearIssue.Labels) > 0 {
+			section += " | Labels: " + strings.Join(req.LinearIssue.Labels, ", ")
+		}
+		if req.LinearIssue.Description != "" {
+			// Truncate very long descriptions to keep instructions manageable
+			desc := req.LinearIssue.Description
+			if len(desc) > 2000 {
+				desc = desc[:2000] + "\n\n(description truncated)"
+			}
+			section += "\n\n" + desc
+		}
+		if instructions != "" {
+			instructions += "\n\n"
+		}
+		instructions += section
+	}
+
+	// Build instructions from linked workspaces
+	if len(req.LinkedWorkspaceIDs) > 0 {
+		var wsParts []string
+		for _, wsID := range req.LinkedWorkspaceIDs {
+			repo, err := h.store.GetRepo(ctx, wsID)
+			if err != nil || repo == nil {
+				continue
+			}
+			wsParts = append(wsParts, fmt.Sprintf("- **%s** at %s (branch: %s)", repo.Name, repo.Path, repo.Branch))
+		}
+		if len(wsParts) > 0 {
+			section := "## Linked Workspaces\n\nThe user has linked the following additional workspaces for reference:\n" +
+				strings.Join(wsParts, "\n") +
+				"\n\nThese workspaces provide additional context about related codebases. You can read files from these paths if needed."
+			if instructions != "" {
+				instructions += "\n\n"
+			}
+			instructions += section
 		}
 	}
 

--- a/backend/server/linear_auth_handlers.go
+++ b/backend/server/linear_auth_handlers.go
@@ -223,3 +223,41 @@ func (h *LinearAuthHandlers) persistTokens(ctx context.Context, tokens *linear.T
 
 	return nil
 }
+
+// ListMyIssues handles GET /api/auth/linear/issues
+func (h *LinearAuthHandlers) ListMyIssues(w http.ResponseWriter, r *http.Request) {
+	if !h.linearClient.IsAuthenticated() {
+		writeUnauthorized(w, "Linear not authenticated")
+		return
+	}
+
+	issues, err := h.linearClient.ListMyIssues(r.Context())
+	if err != nil {
+		writeBadGateway(w, "failed to fetch Linear issues", err)
+		return
+	}
+
+	writeJSON(w, issues)
+}
+
+// SearchLinearIssues handles GET /api/auth/linear/issues/search?q=...
+func (h *LinearAuthHandlers) SearchLinearIssues(w http.ResponseWriter, r *http.Request) {
+	if !h.linearClient.IsAuthenticated() {
+		writeUnauthorized(w, "Linear not authenticated")
+		return
+	}
+
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		writeValidationError(w, "query parameter 'q' is required")
+		return
+	}
+
+	issues, err := h.linearClient.SearchIssues(r.Context(), q)
+	if err != nil {
+		writeBadGateway(w, "failed to search Linear issues", err)
+		return
+	}
+
+	writeJSON(w, issues)
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -47,6 +47,10 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Post("/linear/callback", linearAuth.Callback)
 		r.Get("/linear/status", linearAuth.GetStatus)
 		r.Post("/linear/logout", linearAuth.Logout)
+
+		// Linear issue endpoints
+		r.Get("/linear/issues", linearAuth.ListMyIssues)
+		r.Get("/linear/issues/search", linearAuth.SearchLinearIssues)
 	})
 
 	// WebSocket

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -49,6 +49,9 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { THINKING_LEVELS, type ThinkingLevel, resolveThinkingParams, clampThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
 import { useSlashCommandStore, type UnifiedSlashCommand } from '@/stores/slashCommandStore';
 import { SummaryPicker } from './SummaryPicker';
+import { LinearIssuePicker } from './LinearIssuePicker';
+import { WorkspacePicker } from './WorkspacePicker';
+import type { LinearIssueDTO } from '@/lib/api';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
 import { MODELS as SHARED_MODELS } from '@/lib/models';
 import type { MentionItem } from '@/components/ui/mention-node';
@@ -121,6 +124,10 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const [summaryPickerOpen, setSummaryPickerOpen] = useState(false);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const [selectedSummaryIds, setSelectedSummaryIds] = useState<string[]>([]);
+  const [linearPickerOpen, setLinearPickerOpen] = useState(false);
+  const [linkedLinearIssue, setLinkedLinearIssue] = useState<LinearIssueDTO | null>(null);
+  const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false);
+  const [linkedWorkspaceIds, setLinkedWorkspaceIds] = useState<string[]>([]);
   const plateInputRef = useRef<PlateInputHandle>(null);
   const attachmentsRef = useRef<Attachment[]>(attachments);
   attachmentsRef.current = attachments;
@@ -801,6 +808,11 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         e.preventDefault();
         handleOpenFilePicker();
       }
+      // Cmd+I to open Linear issue picker
+      if (e.code === 'KeyI' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        setLinearPickerOpen(true);
+      }
       // Note: Cmd+Shift+Enter for plan approval is handled in handleKeyDown on the textarea
     };
 
@@ -895,6 +907,14 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           effort: thinkingParams.effort,
           attachments: loadedAttachments.length > 0 ? loadedAttachments : undefined,
           summaryIds: selectedSummaryIds.length > 0 ? selectedSummaryIds : undefined,
+          linearIssue: linkedLinearIssue ? {
+            identifier: linkedLinearIssue.identifier,
+            title: linkedLinearIssue.title,
+            description: linkedLinearIssue.description,
+            stateName: linkedLinearIssue.stateName,
+            labels: linkedLinearIssue.labels,
+          } : undefined,
+          linkedWorkspaceIds: linkedWorkspaceIds.length > 0 ? linkedWorkspaceIds : undefined,
         });
 
         // Clear streaming on placeholder before removing it
@@ -1000,8 +1020,11 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         );
       }
 
-      // Clear attachments only after successful send
+      // Clear attachments and linked context after successful send
       setAttachments([]);
+      setSelectedSummaryIds([]);
+      setLinkedLinearIssue(null);
+      setLinkedWorkspaceIds([]);
     } catch (error) {
       console.error('Failed to send message:', error);
       const convId = selectedConversationId;
@@ -1232,6 +1255,43 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           </div>
         )}
 
+        {/* Linked Linear issue indicator */}
+        {linkedLinearIssue && (
+          <div className="px-3 py-1.5 flex items-center gap-2">
+            <div className="flex items-center gap-1.5 text-xs text-primary bg-primary/10 px-2 py-1 rounded-md">
+              <Link className="size-3" />
+              <span className="font-mono">{linkedLinearIssue.identifier}</span>
+              <span className="truncate max-w-[200px]">{linkedLinearIssue.title}</span>
+              <button
+                type="button"
+                className="ml-1 hover:text-destructive"
+                onClick={() => setLinkedLinearIssue(null)}
+                aria-label="Remove linked issue"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Linked workspaces indicator */}
+        {linkedWorkspaceIds.length > 0 && (
+          <div className="px-3 py-1.5 flex items-center gap-2">
+            <div className="flex items-center gap-1.5 text-xs text-primary bg-primary/10 px-2 py-1 rounded-md">
+              <FolderSymlink className="size-3" />
+              {linkedWorkspaceIds.length} {linkedWorkspaceIds.length === 1 ? 'workspace' : 'workspaces'} linked
+              <button
+                type="button"
+                className="ml-1 hover:text-destructive"
+                onClick={() => setLinkedWorkspaceIds([])}
+                aria-label="Remove linked workspaces"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Text Input with Cmd+L hint */}
         <div className="relative px-3 py-2">
           <PlateInput
@@ -1446,15 +1506,26 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                 Add attachment
                 <span className="ml-auto text-xs text-muted-foreground">⌘U</span>
               </DropdownMenuItem>
-              <DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setLinearPickerOpen(true)}>
                 <Link className="size-4" />
                 Link Linear issue
-                <span className="ml-auto text-xs text-muted-foreground">⌘I</span>
+                {linkedLinearIssue ? (
+                  <span className="ml-auto text-xs bg-primary/20 text-primary px-1.5 py-0.5 rounded-full">
+                    1
+                  </span>
+                ) : (
+                  <span className="ml-auto text-xs text-muted-foreground">⌘I</span>
+                )}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setWorkspacePickerOpen(true)}>
                 <FolderSymlink className="size-4" />
                 Link workspaces
+                {linkedWorkspaceIds.length > 0 && (
+                  <span className="ml-auto text-xs bg-primary/20 text-primary px-1.5 py-0.5 rounded-full">
+                    {linkedWorkspaceIds.length}
+                  </span>
+                )}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setSummaryPickerOpen(true)}>
@@ -1525,6 +1596,25 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           sessionId={selectedSessionId}
           selectedIds={selectedSummaryIds}
           onSelectionChange={setSelectedSummaryIds}
+        />
+      )}
+
+      {/* Linear Issue Picker Dialog */}
+      <LinearIssuePicker
+        open={linearPickerOpen}
+        onOpenChange={setLinearPickerOpen}
+        selectedIssue={linkedLinearIssue}
+        onIssueChange={setLinkedLinearIssue}
+      />
+
+      {/* Workspace Picker Dialog */}
+      {selectedWorkspaceId && (
+        <WorkspacePicker
+          open={workspacePickerOpen}
+          onOpenChange={setWorkspacePickerOpen}
+          currentWorkspaceId={selectedWorkspaceId}
+          selectedIds={linkedWorkspaceIds}
+          onSelectionChange={setLinkedWorkspaceIds}
         />
       )}
 

--- a/src/components/conversation/LinearIssuePicker.tsx
+++ b/src/components/conversation/LinearIssuePicker.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Link, Check, Search, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import { listMyLinearIssues, searchLinearIssues, type LinearIssueDTO } from '@/lib/api';
+import { useLinearAuthStore } from '@/stores/linearAuthStore';
+import { startLinearOAuthFlow } from '@/lib/linearAuth';
+
+interface LinearIssuePickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedIssue: LinearIssueDTO | null;
+  onIssueChange: (issue: LinearIssueDTO | null) => void;
+}
+
+export function LinearIssuePicker({
+  open,
+  onOpenChange,
+  selectedIssue,
+  onIssueChange,
+}: LinearIssuePickerProps) {
+  const [issues, setIssues] = useState<LinearIssueDTO[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { isAuthenticated } = useLinearAuthStore();
+
+  useEffect(() => {
+    if (!open || !isAuthenticated) return;
+    let cancelled = false;
+
+    const fetchIssues = async (query?: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = query
+          ? await searchLinearIssues(query)
+          : await listMyLinearIssues();
+        if (!cancelled) setIssues(data);
+      } catch (err) {
+        if (cancelled) return;
+        // 401 means not authenticated — don't show as error
+        if (err instanceof Error && err.message.includes('401')) {
+          setIssues([]);
+        } else {
+          setError('Failed to load issues');
+          console.error('Failed to fetch Linear issues:', err);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+    if (searchQuery.trim() === '') {
+      fetchIssues();
+    } else {
+      searchTimeoutRef.current = setTimeout(() => {
+        fetchIssues(searchQuery.trim());
+      }, 300);
+    }
+    return () => {
+      cancelled = true;
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, [searchQuery, open, isAuthenticated]);
+
+  const handleSelect = (issue: LinearIssueDTO) => {
+    if (selectedIssue?.id === issue.id) {
+      onIssueChange(null);
+    } else {
+      onIssueChange(issue);
+    }
+  };
+
+  const handleConnectLinear = async () => {
+    try {
+      useLinearAuthStore.getState().startOAuth();
+      await startLinearOAuthFlow();
+    } catch (err) {
+      console.error('Failed to start Linear OAuth:', err);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Link Linear Issue</DialogTitle>
+        </DialogHeader>
+
+        {!isAuthenticated ? (
+          <div className="flex flex-col items-center gap-3 py-8">
+            <Link className="size-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground text-center">
+              Connect your Linear account to link issues to conversations.
+            </p>
+            <Button onClick={handleConnectLinear} size="sm">
+              <ExternalLink className="size-3.5 mr-1.5" />
+              Connect Linear
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
+              <Input
+                placeholder="Search issues..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+
+            <div className="max-h-[300px] overflow-y-auto space-y-2">
+              {loading ? (
+                <div className="text-sm text-muted-foreground text-center py-8">Loading issues...</div>
+              ) : error ? (
+                <div className="text-sm text-destructive text-center py-8">{error}</div>
+              ) : issues.length === 0 ? (
+                <div className="text-sm text-muted-foreground text-center py-8">
+                  {searchQuery ? 'No issues found.' : 'No active issues assigned to you.'}
+                </div>
+              ) : (
+                issues.map((issue) => {
+                  const isSelected = selectedIssue?.id === issue.id;
+                  return (
+                    <button
+                      key={issue.id}
+                      type="button"
+                      onClick={() => handleSelect(issue)}
+                      className={cn(
+                        'w-full text-left p-3 rounded-lg border transition-colors',
+                        isSelected
+                          ? 'border-primary bg-primary/5'
+                          : 'border-border hover:border-primary/50 hover:bg-muted/50'
+                      )}
+                    >
+                      <div className="flex items-start gap-2">
+                        <div className={cn(
+                          'mt-0.5 size-4 rounded border flex items-center justify-center shrink-0',
+                          isSelected ? 'bg-primary border-primary' : 'border-muted-foreground/30'
+                        )}>
+                          {isSelected && <Check className="size-3 text-primary-foreground" />}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs font-mono text-muted-foreground shrink-0">
+                              {issue.identifier}
+                            </span>
+                            <span className="text-sm font-medium truncate">
+                              {issue.title}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2 mt-1 flex-wrap">
+                            <span className="text-xs text-muted-foreground">
+                              {issue.stateName}
+                            </span>
+                            {issue.labels.map((label) => (
+                              <span
+                                key={label}
+                                className="text-xs bg-muted px-1.5 py-0.5 rounded"
+                              >
+                                {label}
+                              </span>
+                            ))}
+                            {issue.project && (
+                              <span className="text-xs text-muted-foreground">
+                                {issue.project}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => onOpenChange(false)}>
+            {selectedIssue ? `Link ${selectedIssue.identifier}` : 'Done'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/conversation/WorkspacePicker.tsx
+++ b/src/components/conversation/WorkspacePicker.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { FolderGit2, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import { listRepos, type RepoDTO } from '@/lib/api';
+
+interface WorkspacePickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentWorkspaceId: string;
+  selectedIds: string[];
+  onSelectionChange: (ids: string[]) => void;
+}
+
+export function WorkspacePicker({
+  open,
+  onOpenChange,
+  currentWorkspaceId,
+  selectedIds,
+  onSelectionChange,
+}: WorkspacePickerProps) {
+  const [workspaces, setWorkspaces] = useState<RepoDTO[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const fetchWorkspaces = async () => {
+      setLoading(true);
+      try {
+        const repos = await listRepos();
+        if (!cancelled) {
+          setWorkspaces(repos.filter((r) => r.id !== currentWorkspaceId));
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    fetchWorkspaces();
+    return () => { cancelled = true; };
+  }, [open, currentWorkspaceId]);
+
+  const toggleWorkspace = (id: string) => {
+    if (selectedIds.includes(id)) {
+      onSelectionChange(selectedIds.filter((s) => s !== id));
+    } else {
+      onSelectionChange([...selectedIds, id]);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[450px]">
+        <DialogHeader>
+          <DialogTitle>Link Workspaces</DialogTitle>
+        </DialogHeader>
+        <p className="text-xs text-muted-foreground -mt-2">
+          Linked workspaces are added as context so the agent can reference files in those codebases.
+        </p>
+        <div className="max-h-[300px] overflow-y-auto space-y-2">
+          {loading ? (
+            <div className="text-sm text-muted-foreground text-center py-8">Loading workspaces...</div>
+          ) : workspaces.length === 0 ? (
+            <div className="text-sm text-muted-foreground text-center py-8">
+              No other workspaces available.
+            </div>
+          ) : (
+            workspaces.map((ws) => {
+              const isSelected = selectedIds.includes(ws.id);
+              return (
+                <button
+                  key={ws.id}
+                  type="button"
+                  onClick={() => toggleWorkspace(ws.id)}
+                  className={cn(
+                    'w-full text-left p-3 rounded-lg border transition-colors',
+                    isSelected
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border hover:border-primary/50 hover:bg-muted/50'
+                  )}
+                >
+                  <div className="flex items-start gap-2">
+                    <div className={cn(
+                      'mt-0.5 size-4 rounded border flex items-center justify-center shrink-0',
+                      isSelected ? 'bg-primary border-primary' : 'border-muted-foreground/30'
+                    )}>
+                      {isSelected && <Check className="size-3 text-primary-foreground" />}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <FolderGit2 className="size-3.5 text-muted-foreground shrink-0" />
+                        <span className="text-sm font-medium truncate">{ws.name}</span>
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                        {ws.path}
+                      </p>
+                    </div>
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => onOpenChange(false)}>
+            {selectedIds.length > 0
+              ? `Link ${selectedIds.length} ${selectedIds.length === 1 ? 'workspace' : 'workspaces'}`
+              : 'Done'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1048,6 +1048,14 @@ export async function createConversation(
     effort?: string;
     attachments?: AttachmentDTO[];
     summaryIds?: string[];
+    linearIssue?: {
+      identifier: string;
+      title: string;
+      description?: string;
+      stateName: string;
+      labels: string[];
+    };
+    linkedWorkspaceIds?: string[];
   }
 ): Promise<ConversationDTO> {
   const res = await fetchWithAuth(
@@ -1219,6 +1227,31 @@ export async function listSessionSummaries(
     `${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/summaries`
   );
   return handleResponse<SummaryDTO[]>(res);
+}
+
+// Linear Issue DTOs and functions
+
+export interface LinearIssueDTO {
+  id: string;
+  identifier: string;
+  title: string;
+  description?: string;
+  stateName: string;
+  labels: string[];
+  assignee?: string;
+  project?: string;
+}
+
+export async function listMyLinearIssues(): Promise<LinearIssueDTO[]> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/auth/linear/issues`);
+  return handleResponse<LinearIssueDTO[]>(res);
+}
+
+export async function searchLinearIssues(query: string): Promise<LinearIssueDTO[]> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/auth/linear/issues/search?q=${encodeURIComponent(query)}`
+  );
+  return handleResponse<LinearIssueDTO[]>(res);
 }
 
 // File Tab DTOs and functions


### PR DESCRIPTION
## Summary

- Adds "Link Linear issue" and "Link workspaces" menu items to the ChatInput compose area with full picker dialogs
- Linked context (Linear issue details, workspace paths) is sent as agent instructions when creating a conversation
- New backend endpoints (`GET /api/auth/linear/issues`, `GET /api/auth/linear/issues/search`) for fetching/searching Linear issues
- Includes review fixes: nil labels slice → `[]` JSON, deduplicated fetch on dialog open, cancellation guards on async effects, clear all linked context after send, React compiler lint fix

## Test plan

- [ ] Open compose area → click "+" menu → verify "Link Linear issue" and "Link workspaces" items appear
- [ ] Click "Link Linear issue" → verify dialog opens, issues load (requires Linear auth)
- [ ] Search for an issue → verify debounced search works, results update
- [ ] Select an issue → verify indicator badge appears in compose area, can be dismissed
- [ ] Click "Link workspaces" → verify dialog shows other workspaces (not current one)
- [ ] Select workspaces → verify indicator badge with count appears
- [ ] Send a message with linked context → verify context is cleared after send
- [ ] Verify `npm run lint` passes with 0 errors
- [ ] Verify `go test ./...` passes (except pre-existing appdir env issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)