### PR TITLE
Unify Changes panel group sort order

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -1231,8 +1231,7 @@ function FileChangeRow({ change, onSelect, containerWidth, commentStats }: {
 }
 
 const KNOWN_STATUSES = ['added', 'modified', 'deleted', 'untracked'] as const;
-const CHANGES_GROUP_ORDER_ALL = ['added', 'modified', 'deleted', 'untracked'] as const;
-const CHANGES_GROUP_ORDER_UNCOMMITTED = ['untracked', 'added', 'modified', 'deleted'] as const;
+const CHANGES_GROUP_ORDER = ['untracked', 'added', 'modified', 'deleted'] as const;
 const CHANGES_GROUP_LABELS: Record<string, string> = {
   added: 'ADDED',
   modified: 'MODIFIED',
@@ -1295,7 +1294,7 @@ export function ChangesFileList({
     return groups;
   }, [displayFiles]);
 
-  const groupOrder = changesView === 'all' ? CHANGES_GROUP_ORDER_ALL : CHANGES_GROUP_ORDER_UNCOMMITTED;
+  const groupOrder = CHANGES_GROUP_ORDER;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- The "All" and "Uncommitted" views in the Changes panel had different group orderings (All: Added→Modified→Deleted→Untracked vs Uncommitted: Untracked→Added→Modified→Deleted)
- Consolidated into a single `CHANGES_GROUP_ORDER` constant so both views use the same order: Untracked → Added → Modified → Deleted
- Simplified the code by removing the per-view ternary selection

## Test plan
- [ ] Toggle between "All" and "Uncommitted" in the Changes panel and verify groups appear in the same order
- [ ] Verify Untracked files appear first in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)