### PR TITLE
Expand sidebar groups when auto-selecting session after archive

### DIFF
--- a/src/hooks/useArchiveSession.ts
+++ b/src/hooks/useArchiveSession.ts
@@ -4,6 +4,7 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { useTabStore } from '@/stores/tabStore';
 import { ENABLE_BROWSER_TABS } from '@/lib/constants';
 import { updateSession as updateSessionApi, getGitStatus } from '@/lib/api';
+import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 import type { ArchiveSessionDialogGitStatus } from '@/components/dialogs/ArchiveSessionDialog';
 
 interface ArchiveDialogState {
@@ -58,6 +59,15 @@ export function useArchiveSession(options?: {
         } else {
           // Session was archived normally
           archiveSession(sessionId);
+
+          // If a new session was auto-selected, ensure its sidebar group is visible
+          const { selectedSessionId, sessions } = useAppStore.getState();
+          if (selectedSessionId) {
+            const newSession = sessions.find((s) => s.id === selectedSessionId && !s.archived);
+            if (newSession) {
+              expandGroupsForSession(newSession);
+            }
+          }
         }
 
         // Sync updated selection to tabStore so persisted state doesn't reference archived/removed session

--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { Workspace, WorktreeSession, SessionTaskStatus } from '@/lib/types';
+import { useSettingsStore } from '@/stores/settingsStore';
 import type { SidebarGroupBy, SidebarSortBy } from '@/stores/settingsStore';
 
 export interface SidebarGroup {
@@ -214,4 +215,38 @@ export function isSidebarGroupExpanded(
   const isToggled = collapsedSidebarGroups.includes(key);
   // If default is collapsed and toggled, it's now expanded (and vice versa)
   return defaultCollapsed ? isToggled : !isToggled;
+}
+
+/**
+ * Expand any collapsed sidebar groups that contain the given session.
+ * Call this after auto-selecting a session (e.g. after archiving) so
+ * the user can see the newly selected session in the sidebar.
+ */
+export function expandGroupsForSession(session: WorktreeSession): void {
+  const {
+    sidebarGroupBy,
+    ensureSidebarGroupExpanded,
+    expandWorkspace,
+  } = useSettingsStore.getState();
+
+  if (sidebarGroupBy === 'none') return;
+
+  if (sidebarGroupBy === 'status') {
+    const key = `status:${session.taskStatus}`;
+    const defaultCollapsed = DEFAULT_COLLAPSED_STATUSES.has(session.taskStatus);
+    ensureSidebarGroupExpanded(key, defaultCollapsed);
+    return;
+  }
+
+  if (sidebarGroupBy === 'project') {
+    expandWorkspace(session.workspaceId);
+    return;
+  }
+
+  if (sidebarGroupBy === 'project-status') {
+    expandWorkspace(session.workspaceId);
+    const subKey = `project:${session.workspaceId}:status:${session.taskStatus}`;
+    const defaultCollapsed = DEFAULT_COLLAPSED_STATUSES.has(session.taskStatus);
+    ensureSidebarGroupExpanded(subKey, defaultCollapsed);
+  }
 }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -229,6 +229,7 @@ interface SettingsState {
   setSidebarGroupBy: (value: SidebarGroupBy) => void;
   setSidebarSortBy: (value: SidebarSortBy) => void;
   toggleSidebarGroupCollapsed: (key: string) => void;
+  ensureSidebarGroupExpanded: (key: string, defaultCollapsed: boolean) => void;
   setLastRepoDashboardWorkspaceId: (id: string | null) => void;
 }
 
@@ -385,6 +386,18 @@ export const useSettingsStore = create<SettingsState>()(
           const has = state.collapsedSidebarGroups.includes(key);
           return {
             collapsedSidebarGroups: has
+              ? state.collapsedSidebarGroups.filter((k) => k !== key)
+              : [...state.collapsedSidebarGroups, key],
+          };
+        }),
+      // Same toggle-from-default logic as isSidebarGroupExpanded() in useSidebarSessions.ts
+      ensureSidebarGroupExpanded: (key, defaultCollapsed) =>
+        set((state) => {
+          const isToggled = state.collapsedSidebarGroups.includes(key);
+          const isExpanded = defaultCollapsed ? isToggled : !isToggled;
+          if (isExpanded) return state;
+          return {
+            collapsedSidebarGroups: isToggled
               ? state.collapsedSidebarGroups.filter((k) => k !== key)
               : [...state.collapsedSidebarGroups, key],
           };


### PR DESCRIPTION
## Summary
- After archiving a session, if a new session is auto-selected, any collapsed sidebar group containing that session is now automatically expanded so it's visible
- Adds `ensureSidebarGroupExpanded` action to settings store (idempotent — no-op if already expanded)
- Adds `expandGroupsForSession` helper that handles all grouping modes: status, project, and project-status
- Adds defensive `!s.archived` guard when looking up the newly selected session

## Test plan
- [ ] Archive a session while grouped by status — verify the auto-selected session's group expands if it was collapsed (e.g. Done/Cancelled groups)
- [ ] Archive a session while grouped by project — verify the workspace group expands
- [ ] Archive a session while grouped by project-status — verify both the workspace and status sub-group expand
- [ ] Archive a session with grouping set to "none" — verify no errors
- [ ] Verify already-expanded groups remain unchanged (no flicker/toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)