### PR TITLE
Add retry logic for MCP backend fetch calls

### DIFF
--- a/agent-runner/src/mcp/tools/comments.ts
+++ b/agent-runner/src/mcp/tools/comments.ts
@@ -2,6 +2,7 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { WorkspaceContext } from "../context.js";
+import { fetchWithRetry } from "./fetch-utils.js";
 
 // Backend URL from environment. This matches the default port used by the Go backend.
 // TODO: Consider adding backendUrl to WorkspaceContext for consistency with other tools
@@ -30,7 +31,7 @@ export function createCommentTools(context: WorkspaceContext) {
       },
       async ({ filePath, lineNumber, title, content, severity }) => {
         try {
-          const response = await fetch(
+          const response = await fetchWithRetry(
             `${BACKEND_URL}/api/repos/${context.workspaceId}/sessions/${context.sessionId}/comments`,
             {
               method: "POST",
@@ -90,7 +91,7 @@ export function createCommentTools(context: WorkspaceContext) {
             url += `?filePath=${encodeURIComponent(filePath)}`;
           }
 
-          const response = await fetch(url, { headers: buildHeaders() });
+          const response = await fetchWithRetry(url, { headers: buildHeaders() });
           if (!response.ok) {
             const error = await response.text();
             return {
@@ -152,7 +153,7 @@ export function createCommentTools(context: WorkspaceContext) {
       {},
       async () => {
         try {
-          const response = await fetch(
+          const response = await fetchWithRetry(
             `${BACKEND_URL}/api/repos/${context.workspaceId}/sessions/${context.sessionId}/comments/stats`,
             { headers: buildHeaders() }
           );

--- a/agent-runner/src/mcp/tools/fetch-utils.ts
+++ b/agent-runner/src/mcp/tools/fetch-utils.ts
@@ -1,0 +1,31 @@
+// agent-runner/src/mcp/tools/fetch-utils.ts
+//
+// Retry wrapper for fetch() calls to the local Go backend.
+// Retries only on TypeError (network-level failures like ECONNREFUSED),
+// never on HTTP error responses (4xx, 5xx).
+
+const RETRY_DELAYS_MS = [500, 1000, 2000];
+
+export async function fetchWithRetry(
+  url: string,
+  options?: RequestInit
+): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return await fetch(url, options);
+    } catch (error) {
+      if (!(error instanceof TypeError)) {
+        throw error;
+      }
+      lastError = error;
+
+      if (attempt < RETRY_DELAYS_MS.length) {
+        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAYS_MS[attempt]));
+      }
+    }
+  }
+
+  throw lastError;
+}

--- a/agent-runner/src/mcp/tools/pr.ts
+++ b/agent-runner/src/mcp/tools/pr.ts
@@ -2,6 +2,7 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { WorkspaceContext } from "../context.js";
+import { fetchWithRetry } from "./fetch-utils.js";
 
 const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://localhost:9876";
 const AUTH_TOKEN = process.env.CHATML_AUTH_TOKEN || "";
@@ -36,7 +37,7 @@ export function createPRTools(context: WorkspaceContext) {
         }
 
         try {
-          const response = await fetch(
+          const response = await fetchWithRetry(
             `${BACKEND_URL}/api/repos/${context.workspaceId}/sessions/${context.sessionId}/pr/report`,
             {
               method: "POST",
@@ -81,7 +82,7 @@ export function createPRTools(context: WorkspaceContext) {
       },
       async ({ prNumber }) => {
         try {
-          const response = await fetch(
+          const response = await fetchWithRetry(
             `${BACKEND_URL}/api/repos/${context.workspaceId}/sessions/${context.sessionId}/pr/report-merge`,
             {
               method: "POST",


### PR DESCRIPTION
## Summary
- Adds a `fetchWithRetry` utility that retries fetch calls up to 3 times with exponential backoff (500ms, 1s, 2s) on `TypeError` network errors only
- Applies retry to all 5 backend fetch calls in `pr.ts` (report_pr_created, report_pr_merged) and `comments.ts` (add_review_comment, list_review_comments, get_review_comment_stats)
- Fixes transient "TypeError: fetch failed" errors when the local Go backend is momentarily unreachable

## Test plan
- [ ] Build agent-runner (`cd agent-runner && npm run build`)
- [ ] Merge a PR and verify `report_pr_merged` succeeds without error
- [ ] Create a PR and verify `report_pr_created` succeeds without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)