### PR TITLE
Improve tab selection visual indicator with macOS-style segmented control

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -1309,12 +1309,12 @@ export function ChangesFileList({
             <span>across {displayStats.totalFiles} file{displayStats.totalFiles !== 1 ? 's' : ''}</span>
           </>
         )}
-        <div className="ml-auto flex items-center gap-0.5 bg-surface-2 rounded-sm p-0.5">
+        <div className="ml-auto flex items-center gap-0.5 bg-surface-2 dark:bg-surface-1 rounded-md p-0.5 shadow-inner">
           <button
             onClick={() => onChangesViewChange('all')}
             className={cn(
-              "px-1.5 py-0.5 rounded-sm text-2xs transition-colors",
-              changesView === 'all' ? "bg-accent/30 text-foreground font-medium" : "text-muted-foreground hover:text-foreground"
+              "px-1.5 py-0.5 rounded-sm text-2xs transition-all duration-150",
+              changesView === 'all' ? "bg-white dark:bg-surface-3 text-foreground font-medium shadow-sm ring-1 ring-black/[0.04] dark:ring-white/[0.06]" : "text-muted-foreground hover:text-foreground/80"
             )}
           >
             All
@@ -1322,8 +1322,8 @@ export function ChangesFileList({
           <button
             onClick={() => onChangesViewChange('uncommitted')}
             className={cn(
-              "px-1.5 py-0.5 rounded-sm text-2xs transition-colors",
-              changesView === 'uncommitted' ? "bg-accent/30 text-foreground font-medium" : "text-muted-foreground hover:text-foreground"
+              "px-1.5 py-0.5 rounded-sm text-2xs transition-all duration-150",
+              changesView === 'uncommitted' ? "bg-white dark:bg-surface-3 text-foreground font-medium shadow-sm ring-1 ring-black/[0.04] dark:ring-white/[0.06]" : "text-muted-foreground hover:text-foreground/80"
             )}
           >
             Uncommitted

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "text-muted-foreground inline-flex h-8 w-fit items-center justify-center rounded-lg p-0.5 gap-0.5 bg-transparent",
+        "text-muted-foreground inline-flex h-8 w-fit items-center justify-center rounded-lg p-0.5 gap-0.5 bg-surface-2 dark:bg-surface-1 shadow-inner",
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-accent/30 data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/30 focus-visible:outline-ring text-muted-foreground hover:text-foreground/80 inline-flex h-7 flex-1 items-center justify-center gap-1.5 rounded-sm border border-transparent px-2.5 py-1 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-1 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-white dark:data-[state=active]:bg-surface-3 data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=active]:ring-1 data-[state=active]:ring-black/[0.04] dark:data-[state=active]:ring-white/[0.06] focus-visible:border-ring focus-visible:ring-ring/30 focus-visible:outline-ring text-muted-foreground hover:text-foreground/80 inline-flex h-7 flex-1 items-center justify-center gap-1.5 rounded-sm border border-transparent px-2.5 py-1 text-xs font-medium whitespace-nowrap transition-all duration-150 focus-visible:ring-1 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Replace the low-contrast `bg-accent/30` active state with a macOS-style raised pill (`bg-white` / `dark:bg-surface-3` + `shadow-sm` + hairline `ring-1`) on a recessed track (`shadow-inner`)
- Apply the same treatment to the shared `TabsTrigger`/`TabsList` components so all tabs in the app benefit
- Soften inactive hover state and use `transition-all duration-150` for smooth shadow + background animation

## Test plan
- [ ] Open the Changes panel with uncommitted changes and verify the "All/Uncommitted" toggle has a clearly visible raised pill on the selected segment
- [ ] Click between "All" and "Uncommitted" — verify smooth 150ms transition
- [ ] Toggle between light and dark mode — verify both modes have strong contrast
- [ ] Check other views that use `TabsList`/`TabsTrigger` (e.g. CreateFromPRModal) to confirm they also look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)