### PR TITLE
Persist workspace drag-drop reordering across sessions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import {
   usePageActions,
   useMessages,
 } from '@/stores/selectors';
-import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix } from '@/stores/settingsStore';
+import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix, applyWorkspaceOrder } from '@/stores/settingsStore';
 import { useShallow } from 'zustand/react/shallow';
 import { navigate } from '@/lib/navigation';
 import { ENABLE_BROWSER_TABS } from '@/lib/constants';
@@ -578,7 +578,13 @@ export default function Home() {
       try {
         // Step 1: Fetch all workspaces
         const repos = await listRepos();
-        const mappedWorkspaces = repos.map(repoToWorkspace);
+        let mappedWorkspaces = repos.map(repoToWorkspace);
+
+        // Apply persisted workspace order (if any)
+        const { workspaceOrder } = useSettingsStore.getState();
+        const reordered = applyWorkspaceOrder(mappedWorkspaces, workspaceOrder);
+        if (reordered) mappedWorkspaces = reordered;
+
         setWorkspaces(mappedWorkspaces);
 
         // Prefetch branch lists for all workspaces (fire-and-forget)

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -592,7 +592,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       w.id === id ? { ...w, ...updates } : w
     ),
   })),
-  removeWorkspace: (id) => set((state) => {
+  removeWorkspace: (id) => {
+    set((state) => {
     // Get all sessions for this workspace
     const workspaceSessions = state.sessions.filter((s) => s.workspaceId === id);
     const workspaceSessionIds = workspaceSessions.map((s) => s.id);
@@ -652,7 +653,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedFileTabId: null,
       fileTabs: [],
     };
-  }),
+    });
+
+    // Clean up persisted workspace order (outside set() to avoid cross-store side effects)
+    const { workspaceOrder, setWorkspaceOrder } = useSettingsStore.getState();
+    if (workspaceOrder.includes(id)) {
+      setWorkspaceOrder(workspaceOrder.filter((wId) => wId !== id));
+    }
+  },
   selectWorkspace: (id) => set({ selectedWorkspaceId: id }),
   reorderWorkspaces: (activeId, overId) => set((state) => {
     const oldIndex = state.workspaces.findIndex((w) => w.id === activeId);
@@ -661,6 +669,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     const newWorkspaces = [...state.workspaces];
     const [removed] = newWorkspaces.splice(oldIndex, 1);
     newWorkspaces.splice(newIndex, 0, removed);
+    // Persist the new order to localStorage via settingsStore
+    useSettingsStore.getState().setWorkspaceOrder(newWorkspaces.map((w) => w.id));
     return { workspaces: newWorkspaces };
   }),
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -168,6 +168,7 @@ interface SettingsState {
   sidebarGroupBy: SidebarGroupBy;
   sidebarSortBy: SidebarSortBy;
   collapsedSidebarGroups: string[]; // composite keys toggled from default, e.g. "status:done"
+  workspaceOrder: string[]; // Persisted workspace display order (array of workspace IDs)
 
   // Last selected workspace for PR/Branches dashboard views (shared between both)
   lastRepoDashboardWorkspaceId: string | null;
@@ -231,6 +232,7 @@ interface SettingsState {
   toggleSidebarGroupCollapsed: (key: string) => void;
   ensureSidebarGroupExpanded: (key: string, defaultCollapsed: boolean) => void;
   setLastRepoDashboardWorkspaceId: (id: string | null) => void;
+  setWorkspaceOrder: (order: string[]) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -261,6 +263,7 @@ export const useSettingsStore = create<SettingsState>()(
       sidebarGroupBy: 'project', // Default: group by project
       sidebarSortBy: 'recent', // Default: sort by recency
       collapsedSidebarGroups: [], // Keys toggled from default state
+      workspaceOrder: [], // Empty = use natural backend order until user first reorders
       lastRepoDashboardWorkspaceId: null, // Last workspace selected in PR/Branches views
 
       // Actions
@@ -381,6 +384,7 @@ export const useSettingsStore = create<SettingsState>()(
       setSidebarGroupBy: (value) => set({ sidebarGroupBy: value }),
       setSidebarSortBy: (value) => set({ sidebarSortBy: value }),
       setLastRepoDashboardWorkspaceId: (id) => set({ lastRepoDashboardWorkspaceId: id }),
+      setWorkspaceOrder: (order) => set({ workspaceOrder: order }),
       toggleSidebarGroupCollapsed: (key) =>
         set((state) => {
           const has = state.collapsedSidebarGroups.includes(key);
@@ -507,4 +511,32 @@ export function getWorkspaceBranchPrefix(workspace: Workspace): string | undefin
       return login || undefined;
     }
   }
+}
+
+/**
+ * Apply persisted workspace order to a list of workspaces.
+ * Workspaces in `order` appear first (in that order), followed by any new workspaces
+ * not yet in the persisted order. Stale IDs in `order` are silently skipped.
+ * Returns null if no custom order has been set (order is empty).
+ */
+export function applyWorkspaceOrder<T extends { id: string }>(
+  workspaces: T[],
+  order: string[],
+): T[] | null {
+  if (order.length === 0) return null;
+  const wsMap = new Map(workspaces.map((w) => [w.id, w]));
+  const ordered: T[] = [];
+  for (const id of order) {
+    const ws = wsMap.get(id);
+    if (ws) {
+      ordered.push(ws);
+      wsMap.delete(id);
+    }
+  }
+  for (const ws of workspaces) {
+    if (wsMap.has(ws.id)) {
+      ordered.push(ws);
+    }
+  }
+  return ordered;
 }


### PR DESCRIPTION
## Summary
- Persist user-defined workspace order to localStorage via `settingsStore`, so drag-drop reordering survives page reloads and reconnects
- Apply persisted order on every data load (including reconnects), with graceful handling of new/removed workspaces
- Move cross-store `setWorkspaceOrder` side effect in `removeWorkspace` outside the `set()` updater to avoid rendering ordering issues

## Test plan
- [ ] Drag-drop reorder workspaces in the sidebar, reload the page — order should persist
- [ ] Add a new workspace — it should appear at the end of the list
- [ ] Remove a workspace — its ID should be cleaned from the persisted order
- [ ] Reconnect (toggle backend) — workspace order should be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)