### PR TITLE
Upgrade Agent SDK to 0.2.50 with dynamic model info and subagent usage stats

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chatml-agent-runner",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.45",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.50",
         "jsdom": "^28.1.0",
         "zod": "^4.3.6"
       },
@@ -24,22 +24,23 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.45",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.45.tgz",
-      "integrity": "sha512-AKH2hKoJNyjLf9ThAttKqbmCjUFg7qs/8+LR/UTVX20fCLn359YH9WrQc6dAiAfi8RYNA+mWwrNYCAq+Sdo5Ag==",
+      "version": "0.2.50",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.50.tgz",
+      "integrity": "sha512-zVQzJbicfTmvS6uarFQYYVYiYedKE0FgXmhiGC1oSLm6OkIbuuKM7XV4fXEFxPZHcWQc7ZYv6HA2/P5HOE7b2Q==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.33.5",
-        "@img/sharp-darwin-x64": "^0.33.5",
-        "@img/sharp-linux-arm": "^0.33.5",
-        "@img/sharp-linux-arm64": "^0.33.5",
-        "@img/sharp-linux-x64": "^0.33.5",
-        "@img/sharp-linuxmusl-arm64": "^0.33.5",
-        "@img/sharp-linuxmusl-x64": "^0.33.5",
-        "@img/sharp-win32-x64": "^0.33.5"
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -235,9 +236,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -253,13 +254,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -275,13 +276,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -295,9 +296,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -311,9 +312,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -327,9 +328,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -343,9 +344,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -359,9 +360,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
@@ -375,9 +376,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
@@ -391,9 +392,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -409,13 +410,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -431,13 +432,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -453,13 +454,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
@@ -475,13 +476,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
@@ -497,13 +498,32 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.45",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.50",
     "jsdom": "^28.1.0",
     "zod": "^4.3.6"
   },

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -9,6 +9,7 @@ import {
   type SDKHookResponseMessage,
   type SDKToolProgressMessage,
   type SDKAuthStatusMessage,
+  type SDKTaskNotificationMessage,
   type Query,
   type HookCallback,
   type PreToolUseHookInput,
@@ -121,7 +122,7 @@ const effort: EffortLevel | undefined = effortArg
   : undefined;
 
 // Permission mode (e.g., "plan" for plan mode at startup)
-const validPermissionModes = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk", "delegate"] as const;
+const validPermissionModes = ["default", "acceptEdits", "bypassPermissions", "plan", "dontAsk"] as const;
 type PermissionMode = typeof validPermissionModes[number];
 let initialPermissionMode: PermissionMode = "bypassPermissions";
 // Tracks the current permission mode and the mode before plan mode was activated.
@@ -2169,7 +2170,7 @@ function handleMessage(message: SDKMessage): void {
     }
 
     case "system": {
-      const sysMsg = message as SDKSystemMessage | SDKCompactBoundaryMessage | SDKStatusMessage | SDKHookResponseMessage;
+      const sysMsg = message as SDKSystemMessage | SDKCompactBoundaryMessage | SDKStatusMessage | SDKHookResponseMessage | SDKTaskNotificationMessage;
 
       if (sysMsg.subtype === "init") {
         const initMsg = sysMsg as SDKSystemMessage;
@@ -2242,6 +2243,20 @@ function handleMessage(message: SDKMessage): void {
           exitCode: hookMsg.exit_code,
           sessionId: hookMsg.session_id,
         });
+      } else if (sysMsg.subtype === "task_notification") {
+        const taskMsg = sysMsg as SDKTaskNotificationMessage;
+        // Emit usage data for completed subagents (correlate via tool_use_id)
+        if (taskMsg.usage && taskMsg.tool_use_id) {
+          emit({
+            type: "subagent_usage",
+            toolUseId: taskMsg.tool_use_id,
+            usage: {
+              totalTokens: taskMsg.usage.total_tokens,
+              toolUses: taskMsg.usage.tool_uses,
+              durationMs: taskMsg.usage.duration_ms,
+            },
+          });
+        }
       }
       break;
     }

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -832,6 +832,21 @@ outer:
 					markSnapshotDirty()
 				}
 
+			case EventTypeSubagentUsage:
+				// Correlate usage data with sub-agent via parentToolUseId matching event.ToolUseId
+				if event.ToolUseId != "" && event.Usage != nil {
+					usage := parseSubAgentUsage(event.Usage)
+					if usage != nil {
+						for _, sa := range activeSubAgents {
+							if sa.ParentToolUseId == event.ToolUseId {
+								sa.Usage = usage
+								markSnapshotDirty()
+								break
+							}
+						}
+					}
+				}
+
 			case EventTypeSubagentOutput:
 				if sa, ok := activeSubAgents[event.AgentId]; ok {
 					sa.Output = event.AgentOutput
@@ -1882,6 +1897,27 @@ func (m *Manager) buildSessionContext(ctx context.Context, convID string) string
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// parseSubAgentUsage extracts SubAgentUsage from a raw JSON map.
+func parseSubAgentUsage(raw map[string]interface{}) *SubAgentUsage {
+	if raw == nil {
+		return nil
+	}
+	usage := &SubAgentUsage{}
+	if v, ok := raw["totalTokens"].(float64); ok {
+		usage.TotalTokens = int(v)
+	}
+	if v, ok := raw["toolUses"].(float64); ok {
+		usage.ToolUses = int(v)
+	}
+	if v, ok := raw["durationMs"].(float64); ok {
+		usage.DurationMs = int64(v)
+	}
+	if usage.TotalTokens == 0 && usage.ToolUses == 0 && usage.DurationMs == 0 {
+		return nil
+	}
+	return usage
 }
 
 // generateInputSuggestion uses the AI client to generate a suggested next prompt

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -144,6 +144,7 @@ type AgentEvent struct {
 
 	// Tool metadata (structured data extracted from tool results)
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+
 }
 
 // McpServerStatus represents MCP server connection status
@@ -172,9 +173,12 @@ type RunStats struct {
 
 // ModelInfo represents available model information
 type ModelInfo struct {
-	Value       string `json:"value"`
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
+	Value                    string   `json:"value"`
+	DisplayName              string   `json:"displayName"`
+	Description              string   `json:"description"`
+	SupportsEffort           *bool    `json:"supportsEffort,omitempty"`
+	SupportedEffortLevels    []string `json:"supportedEffortLevels,omitempty"`
+	SupportsAdaptiveThinking *bool    `json:"supportsAdaptiveThinking,omitempty"`
 }
 
 // SlashCmd represents a slash command/skill
@@ -268,6 +272,9 @@ const (
 
 	// Input suggestion events (Haiku-generated prompt suggestions)
 	EventTypeInputSuggestion = "input_suggestion"
+
+	// Sub-agent usage stats (from SDK task_notification)
+	EventTypeSubagentUsage = "subagent_usage"
 )
 
 // TodoItem represents a single todo item from the agent's TodoWrite tool
@@ -319,6 +326,13 @@ type ActiveToolEntry struct {
 	AgentId   string                 `json:"agentId,omitempty"`
 }
 
+// SubAgentUsage represents token/tool usage stats for a sub-agent.
+type SubAgentUsage struct {
+	TotalTokens int   `json:"totalTokens"`
+	ToolUses    int   `json:"toolUses"`
+	DurationMs  int64 `json:"durationMs"`
+}
+
 // SubAgentEntry represents a sub-agent spawned during streaming.
 type SubAgentEntry struct {
 	AgentId         string            `json:"agentId"`
@@ -329,6 +343,7 @@ type SubAgentEntry struct {
 	StartTime       int64             `json:"startTime"`
 	ActiveTools     []ActiveToolEntry `json:"activeTools"`
 	Completed       bool              `json:"completed"`
+	Usage           *SubAgentUsage    `json:"usage,omitempty"`
 }
 
 // ParseAgentLine parses a line of JSON output from the agent-runner

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -83,12 +83,50 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
   return result;
 }
 
-const MODELS = [
-  { ...SHARED_MODELS[0], icon: Bot },
-  { ...SHARED_MODELS[1], icon: Bot },
-  { ...SHARED_MODELS[2], icon: Bot },
-];
+/** Static fallback model list (used when no SDK models are available). */
+const STATIC_MODELS: ModelEntry[] = SHARED_MODELS.map((m) => ({
+  id: m.id,
+  name: m.name,
+  icon: Bot,
+  supportsThinking: m.supportsThinking,
+  supportsEffort: m.supportsEffort,
+}));
 
+interface ModelEntry {
+  id: string;
+  name: string;
+  icon: typeof Bot;
+  supportsThinking: boolean;
+  supportsEffort: boolean;
+  supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
+}
+
+/** Build the model list from SDK-reported dynamic models, with static fallback. */
+function buildModelList(dynamic: ReturnType<typeof useAppStore.getState>['supportedModels']): ModelEntry[] {
+  if (dynamic.length === 0) return STATIC_MODELS;
+  return dynamic.map((m) => ({
+    id: m.value,
+    name: m.displayName,
+    icon: Bot,
+    supportsThinking: m.supportsAdaptiveThinking ?? true,
+    supportsEffort: m.supportsEffort ?? false,
+    supportedEffortLevels: m.supportedEffortLevels,
+  }));
+}
+
+
+/** Get available thinking level IDs for a model, respecting SDK-reported supported levels. */
+function getAvailableThinkingLevels(model: ModelEntry): ThinkingLevel[] {
+  const allLevels = THINKING_LEVELS.map(l => l.id);
+  const allowOff = canDisableThinking(model);
+  let available = allowOff ? allLevels : allLevels.filter(l => l !== 'off');
+  // Filter by SDK-reported supported effort levels when available
+  if (model.supportsEffort && model.supportedEffortLevels) {
+    const supported = new Set(model.supportedEffortLevels);
+    available = available.filter(l => l === 'off' || supported.has(l as 'low' | 'medium' | 'high' | 'max'));
+  }
+  return available;
+}
 
 interface ChatInputProps {
   onMessageSubmit?: () => void;
@@ -104,7 +142,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const setDefaultModel = useSettingsStore((s) => s.setDefaultModel);
   const defaultThinkingLevel = useSettingsStore((s) => s.defaultThinkingLevel);
   const setDefaultThinkingLevel = useSettingsStore((s) => s.setDefaultThinkingLevel);
-  const [selectedModel, setSelectedModel] = useState(
+
+  // Dynamic model list from SDK, with static fallback
+  const dynamicModels = useAppStore((s) => s.supportedModels);
+  const MODELS = useMemo(() => buildModelList(dynamicModels), [dynamicModels]);
+
+  const [selectedModel, setSelectedModel] = useState<ModelEntry>(
     () => MODELS.find((m) => m.id === defaultModel) ?? MODELS[0]
   );
   const [isSending, setIsSending] = useState(false);
@@ -272,7 +315,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       // Reset to default when conversation has no saved model
       setSelectedModel(MODELS.find((m) => m.id === defaultModel) ?? MODELS[0]);
     }
-  }, [selectedConversationId, currentConversationModel, defaultModel]);
+  }, [selectedConversationId, currentConversationModel, defaultModel, MODELS]);
 
   // Derive available slash commands from store
   const getAllCommands = useSlashCommandStore((s) => s.getAllCommands);
@@ -791,9 +834,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       if (e.code === 'KeyT' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
         setThinkingLevel(prev => {
-          const levels = THINKING_LEVELS.map(l => l.id);
-          const allowOff = canDisableThinking(selectedModel);
-          const available = allowOff ? levels : levels.filter(l => l !== 'off');
+          const available = getAvailableThinkingLevels(selectedModel);
           const idx = available.indexOf(prev);
           return available[(idx + 1) % available.length];
         });
@@ -820,9 +861,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     const handleFocusInput = () => plateInputRef.current?.focus();
     const handleToggleThinking = () => {
       setThinkingLevel(prev => {
-        const levels = THINKING_LEVELS.map(l => l.id);
-        const allowOff = canDisableThinking(selectedModel);
-        const available = allowOff ? levels : levels.filter(l => l !== 'off');
+        const available = getAvailableThinkingLevels(selectedModel);
         const idx = available.indexOf(prev);
         return available[(idx + 1) % available.length];
       });
@@ -839,7 +878,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       window.removeEventListener('toggle-thinking', handleToggleThinking);
       window.removeEventListener('toggle-plan-mode', handleTogglePlanMode);
     };
-  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel]);
+  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel, MODELS]);
 
   const handleSubmit = async () => {
     const { text: content, mentionedFiles } = plateInputRef.current?.getContent() ?? { text: '', mentionedFiles: [] };
@@ -1416,7 +1455,14 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
                 <span className="normal-case tracking-normal text-muted-foreground/60">⌥T</span>
               </DropdownMenuLabel>
               {THINKING_LEVELS
-                .filter((level) => level.id !== 'off' || canDisableThinking(selectedModel))
+                .filter((level) => {
+                  if (level.id === 'off') return canDisableThinking(selectedModel);
+                  // Filter by SDK-reported supported effort levels when available
+                  if (selectedModel.supportsEffort && selectedModel.supportedEffortLevels) {
+                    return selectedModel.supportedEffortLevels.includes(level.id as 'low' | 'medium' | 'high' | 'max');
+                  }
+                  return true;
+                })
                 .map((level, index, arr) => {
                   const isSelected = level.id === thinkingLevel;
                   const isDefault = level.id === defaultThinkingLevel;

--- a/src/components/conversation/SubAgentGroup.tsx
+++ b/src/components/conversation/SubAgentGroup.tsx
@@ -16,6 +16,13 @@ import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
 import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
 import type { SubAgent } from '@/lib/types';
 
+/** Format token count compactly (e.g., 1234 → "1.2k", 56789 → "57k"). */
+function formatTokensCompact(tokens: number): string {
+  if (tokens < 1000) return `${tokens}`;
+  if (tokens < 10000) return `${(tokens / 1000).toFixed(1)}k`;
+  return `${Math.round(tokens / 1000)}k`;
+}
+
 // Map agent types to short display labels
 function getAgentLabel(agentType: string): string {
   switch (agentType) {
@@ -132,10 +139,11 @@ export const SubAgentRow = memo(function SubAgentRow({ agent, worktreePath }: Su
 
         <span className="flex-1" />
 
-        {/* Duration: live elapsed for active, final for completed */}
+        {/* Duration and token usage: live elapsed for active, final stats for completed */}
         {agent.completed && agent.endTime ? (
           <span className="text-2xs text-muted-foreground/70 font-mono tabular-nums shrink-0">
             {((agent.endTime - agent.startTime) / 1000).toFixed(1)}s
+            {agent.usage ? ` · ${formatTokensCompact(agent.usage.totalTokens)} tokens` : ''}
           </span>
         ) : !agent.completed ? (
           <AgentElapsedTime startTime={agent.startTime} />
@@ -241,6 +249,7 @@ const SubAgentCompactRow = memo(function SubAgentCompactRow({ agent, worktreePat
         {agent.completed && agent.endTime ? (
           <span className="text-2xs text-muted-foreground/70 font-mono tabular-nums shrink-0">
             {((agent.endTime - agent.startTime) / 1000).toFixed(1)}s
+            {agent.usage ? ` · ${formatTokensCompact(agent.usage.totalTokens)} tokens` : ''}
           </span>
         ) : !agent.completed ? (
           <AgentElapsedTime startTime={agent.startTime} />
@@ -358,10 +367,14 @@ export const SubAgentGroupedRow = memo(function SubAgentGroupedRow({ agents, wor
 
         <span className="flex-1" />
 
-        {/* Total duration */}
+        {/* Total duration and aggregate token usage */}
         {totalDuration ? (
           <span className="text-2xs text-muted-foreground/70 font-mono tabular-nums shrink-0">
             {(totalDuration / 1000).toFixed(1)}s
+            {(() => {
+              const totalTokens = agents.reduce((sum, a) => sum + (a.usage?.totalTokens ?? 0), 0);
+              return totalTokens > 0 ? ` · ${formatTokensCompact(totalTokens)} tokens` : '';
+            })()}
           </span>
         ) : anyActive ? (
           <AgentElapsedTime startTime={Math.min(...agents.map(a => a.startTime))} />

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -979,7 +979,14 @@ export function useWebSocket(enabled: boolean = true) {
       // ====================================================================
       case 'supported_models':
         if (event?.models) {
-          store.setSupportedModels(event.models as Array<{ value: string; displayName: string; description: string }>);
+          store.setSupportedModels(event.models as Array<{
+            value: string;
+            displayName: string;
+            description: string;
+            supportsEffort?: boolean;
+            supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
+            supportsAdaptiveThinking?: boolean;
+          }>);
         }
         break;
 
@@ -1031,6 +1038,13 @@ export function useWebSocket(enabled: boolean = true) {
       case 'subagent_output':
         if (event?.agentId) {
           store.setSubAgentOutput(conversationId, event.agentId as string, event.agentOutput || '');
+        }
+        break;
+
+      case 'subagent_usage':
+        if (event?.toolUseId && event?.usage) {
+          const usage = event.usage as { totalTokens: number; toolUses: number; durationMs: number };
+          store.setSubAgentUsage(conversationId, event.toolUseId as string, usage);
         }
         break;
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,3 +1,6 @@
+import { useAppStore } from '@/stores/appStore';
+
+/** Static fallback model definitions used when no agent is connected. */
 export const MODELS = [
   { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true },
   { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true },
@@ -6,8 +9,47 @@ export const MODELS = [
 
 export type ModelId = (typeof MODELS)[number]['id'];
 
-export function getModelInfo(modelId: string) {
-  return MODELS.find((m) => m.id === modelId);
+export interface DynamicModelInfo {
+  id: string;
+  name: string;
+  provider: string;
+  supportsThinking: boolean;
+  supportsEffort: boolean;
+  supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
+}
+
+/**
+ * Get model info by ID. Checks SDK-reported dynamic models first,
+ * falls back to hardcoded MODELS for offline/pre-connection state.
+ */
+export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
+  // Check dynamic models from SDK
+  const dynamic = useAppStore.getState().supportedModels;
+  const sdkModel = dynamic.find((m) => m.value === modelId);
+  if (sdkModel) {
+    return {
+      id: sdkModel.value,
+      name: sdkModel.displayName,
+      provider: 'claude',
+      supportsThinking: sdkModel.supportsAdaptiveThinking ?? true,
+      supportsEffort: sdkModel.supportsEffort ?? false,
+      supportedEffortLevels: sdkModel.supportedEffortLevels,
+    };
+  }
+
+  // Fallback to hardcoded
+  const staticModel = MODELS.find((m) => m.id === modelId);
+  if (staticModel) {
+    return {
+      id: staticModel.id,
+      name: staticModel.name,
+      provider: staticModel.provider,
+      supportsThinking: staticModel.supportsThinking,
+      supportsEffort: staticModel.supportsEffort,
+    };
+  }
+
+  return undefined;
 }
 
 export function getModelDisplayName(modelId: string): string {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -174,6 +174,13 @@ export interface ActiveTool {
   agentId?: string; // Sub-agent that owns this tool (undefined = parent agent)
 }
 
+// Sub-agent usage stats from SDK task_notification
+export interface SubAgentUsage {
+  totalTokens: number;
+  toolUses: number;
+  durationMs: number;
+}
+
 // Sub-agent spawned by the Task tool during parallel execution
 export interface SubAgent {
   agentId: string;
@@ -185,6 +192,7 @@ export interface SubAgent {
   endTime?: number;
   completed: boolean;
   tools: ActiveTool[];
+  usage?: SubAgentUsage; // Token/tool usage stats from SDK
 }
 
 // Setup info for system messages

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -253,8 +253,15 @@ interface AppState {
   // File watcher: last file change event (for reactive subscriptions)
   lastFileChange: { workspaceId: string; path: string; fullPath: string; timestamp: number } | null;
 
-  // Query responses from agent
-  supportedModels: Array<{ value: string; displayName: string; description: string }>;
+  // Query responses from agent (dynamic model info from SDK)
+  supportedModels: Array<{
+    value: string;
+    displayName: string;
+    description: string;
+    supportsEffort?: boolean;
+    supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
+    supportsAdaptiveThinking?: boolean;
+  }>;
   supportedCommands: Array<{ name: string; description: string; argumentHint: string }>;
   accountInfo: Record<string, unknown> | null;
 
@@ -384,6 +391,7 @@ interface AppState {
   addSubAgentTool: (conversationId: string, agentId: string, tool: ActiveTool) => void;
   completeSubAgentTool: (conversationId: string, agentId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string) => void;
   setSubAgentOutput: (conversationId: string, agentId: string, output: string) => void;
+  setSubAgentUsage: (conversationId: string, toolUseId: string, usage: import('@/lib/types').SubAgentUsage) => void;
   clearSubAgents: (conversationId: string) => void;
 
   restoreStreamingFromSnapshot: (conversationId: string, snapshot: {
@@ -430,7 +438,14 @@ interface AppState {
   saveMcpServerConfigs: (workspaceId: string, configs: McpServerConfig[]) => Promise<void>;
 
   // Query response actions
-  setSupportedModels: (models: Array<{ value: string; displayName: string; description: string }>) => void;
+  setSupportedModels: (models: Array<{
+    value: string;
+    displayName: string;
+    description: string;
+    supportsEffort?: boolean;
+    supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
+    supportsAdaptiveThinking?: boolean;
+  }>) => void;
   setSupportedCommands: (commands: Array<{ name: string; description: string; argumentHint: string }>) => void;
   setAccountInfo: (info: Record<string, unknown>) => void;
 
@@ -1563,6 +1578,14 @@ updateFileTabContent: (id, content) => set((state) => ({
       ...state.subAgents,
       [conversationId]: (state.subAgents[conversationId] || []).map((a) =>
         a.agentId === agentId ? { ...a, output } : a
+      ),
+    },
+  })),
+  setSubAgentUsage: (conversationId, toolUseId, usage) => set((state) => ({
+    subAgents: {
+      ...state.subAgents,
+      [conversationId]: (state.subAgents[conversationId] || []).map((a) =>
+        a.parentToolUseId === toolUseId ? { ...a, usage } : a
       ),
     },
   })),


### PR DESCRIPTION
## Summary

- **SDK upgrade**: Bump `@anthropic-ai/claude-agent-sdk` from 0.2.45 → 0.2.50, remove deprecated `delegate` permission mode
- **Dynamic model info**: Model selector and thinking level picker now use SDK-reported capabilities (`supportsEffort`, `supportedEffortLevels`, `supportsAdaptiveThinking`) instead of hardcoded values, with static fallback for offline state
- **Subagent usage stats**: Per-subagent token counts from SDK `task_notification` messages displayed next to duration in the sub-agent UI (e.g., `12.3s · 45k tokens`)

## Changes across the stack

| Layer | Files | What changed |
|-------|-------|-------------|
| Agent Runner | `index.ts`, `package.json` | SDK bump, new `task_notification` handler, `delegate` removal |
| Go Backend | `parser.go`, `manager.go` | `ModelInfo` expanded, `SubAgentUsage` struct, `subagent_usage` event handling |
| Frontend | `models.ts`, `ChatInput.tsx`, `appStore.ts`, `useWebSocket.ts`, `types.ts`, `SubAgentGroup.tsx` | Dynamic model list, filtered thinking levels, subagent usage display |

## Test plan

- [ ] Verify model selector populates from SDK dynamic models when agent is running
- [ ] Verify model selector falls back to hardcoded list when no agent connected
- [ ] Verify thinking level picker filters by `supportedEffortLevels` when available
- [ ] Verify Alt+M model cycling and Alt+T thinking cycling still work
- [ ] Verify sub-agent rows show token count after completion (e.g., `12.3s · 45k tokens`)
- [ ] Verify grouped sub-agent rows show aggregate token totals
- [ ] Run `npm run lint` — 0 errors
- [ ] Run `npm run build` — succeeds
- [ ] Run `go test ./...` — all pass
- [ ] Run `go build ./...` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)