### PR TITLE
Add customizable action templates for toolbar actions

### DIFF
--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -12,6 +12,7 @@ import {
   toStoreConversation,
   getCIFailureContext,
   refreshPRStatus,
+  type AttachmentDTO,
 } from '@/lib/api';
 import { formatCIFailureMessage } from '@/lib/check-utils';
 import { useToast } from '@/components/ui/toast';
@@ -65,6 +66,16 @@ import { getAppById, CATEGORY_LABELS } from '@/lib/openApps';
 import type { AppCategory } from '@/lib/openApps';
 import { getAppIcon } from '@/components/icons/AppIcons';
 
+/** Encode a UTF-8 string to base64, safe for non-Latin1 characters. */
+function toBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 // ---------------------------------------------------------------------------
 // Review type options for the split button popover
 // ---------------------------------------------------------------------------
@@ -116,15 +127,20 @@ export function SessionToolbarContent() {
   const isAgentWorking = sessionActivityState === 'working';
 
   const handleGitActionMessage = useCallback((content: string) => {
+    if (isAgentWorking) return;
     if (!selectedConversationId) {
       showWarning('No active conversation');
       return;
     }
-    sendConversationMessage(selectedConversationId, content).catch(console.error);
-  }, [selectedConversationId, showWarning]);
+    sendConversationMessage(selectedConversationId, content).catch((error) => {
+      console.error('Failed to send git action message:', error);
+      showError('Failed to send message to agent');
+    });
+  }, [selectedConversationId, showWarning, showError, isAgentWorking]);
 
   // Wrapper that adds a user bubble before sending — used by PrimaryActionButton
   const handleActionWithBubble = useCallback((content: string) => {
+    if (isAgentWorking) return;
     if (!selectedConversationId) {
       showWarning('No active conversation');
       return;
@@ -143,12 +159,53 @@ export function SessionToolbarContent() {
       console.error('Failed to send action message:', error);
       setStreaming(selectedConversationId, false);
       updateConversation(selectedConversationId, { status: 'idle' });
+      showError('Failed to send message to agent');
     });
-  }, [selectedConversationId, showWarning, addMessage, updateConversation, setStreaming]);
+  }, [selectedConversationId, showWarning, showError, updateConversation, setStreaming, isAgentWorking]);
+
+  // Wrapper that adds a user bubble + sends template content as attachment
+  const handleActionWithBubbleAndTemplate = useCallback((content: string, templateContent: string) => {
+    if (isAgentWorking) return;
+    if (!selectedConversationId) {
+      showWarning('No active conversation');
+      return;
+    }
+    // User bubble shows only the short instruction
+    addMessage({
+      id: crypto.randomUUID(),
+      conversationId: selectedConversationId,
+      role: 'user',
+      content,
+      timestamp: new Date().toISOString(),
+    });
+    window.dispatchEvent(new CustomEvent('chat-message-submitted'));
+    updateConversation(selectedConversationId, { status: 'active' });
+    setStreaming(selectedConversationId, true);
+
+    // Create template attachment
+    const templateAttachment: AttachmentDTO = {
+      id: crypto.randomUUID(),
+      type: 'file',
+      name: 'action-instructions.md',
+      mimeType: 'text/markdown',
+      size: new Blob([templateContent]).size,
+      lineCount: templateContent.split('\n').length,
+      base64Data: toBase64(templateContent),
+      preview: templateContent.slice(0, 200),
+    };
+
+    sendConversationMessage(selectedConversationId, content, [templateAttachment]).catch((error) => {
+      console.error('Failed to send action message:', error);
+      setStreaming(selectedConversationId, false);
+      updateConversation(selectedConversationId, { status: 'idle' });
+      showError('Failed to send message to agent');
+    });
+  }, [selectedConversationId, showWarning, showError, addMessage, updateConversation, setStreaming, isAgentWorking]);
 
   const [, setFixIssuesLoading] = useState(false);
 
   const handleFixIssues = useCallback(async () => {
+    if (isAgentWorking) return;
     if (!selectedConversationId || !selectedWorkspaceId || !selectedSessionId) {
       showWarning('No active conversation');
       return;
@@ -200,7 +257,7 @@ export function SessionToolbarContent() {
     } finally {
       setFixIssuesLoading(false);
     }
-  }, [selectedConversationId, selectedWorkspaceId, selectedSessionId, showWarning, addMessage, updateConversation, setStreaming]);
+  }, [selectedConversationId, selectedWorkspaceId, selectedSessionId, showWarning, addMessage, updateConversation, setStreaming, isAgentWorking]);
 
   const handleNewConversation = useCallback(async () => {
     if (!selectedWorkspaceId || !selectedSessionId) return;
@@ -309,6 +366,7 @@ export function SessionToolbarContent() {
                 workspaceId={selectedWorkspaceId}
                 session={selectedSession}
                 onSendMessage={handleActionWithBubble}
+                onSendMessageWithTemplate={handleActionWithBubbleAndTemplate}
                 onFixIssues={handleFixIssues}
                 onArchiveSession={requestArchive}
                 onCreatePR={() => setShowCreatePRDialog(true)}
@@ -504,7 +562,7 @@ export function SessionToolbarContent() {
         ),
       },
     };
-  }, [selectedWorkspace, selectedSession, selectedWorkspaceId, selectedSessionId, handleGitActionMessage, handleActionWithBubble, handleFixIssues, handleNewConversation, handleCopyBranch, handleArchive, requestArchive, handleTaskStatusChange, reviewPopoverOpen, openAppPopoverOpen, defaultOpenApp, installedApps, workspaceColors, showSuccess, showWarning, isAgentWorking]);
+  }, [selectedWorkspace, selectedSession, selectedWorkspaceId, selectedSessionId, handleGitActionMessage, handleActionWithBubble, handleActionWithBubbleAndTemplate, handleFixIssues, handleNewConversation, handleCopyBranch, handleArchive, requestArchive, handleTaskStatusChange, reviewPopoverOpen, openAppPopoverOpen, defaultOpenApp, installedApps, workspaceColors, showSuccess, showWarning, isAgentWorking]);
 
   useMainToolbarContent(toolbarConfig);
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   Bot,
   GitBranch,
   Eye,
+  Zap,
   User,
   Wrench,
   Info,
@@ -28,6 +29,7 @@ import { AccountSettings } from './sections/AccountSettings';
 import { AdvancedSettings } from './sections/AdvancedSettings';
 import { AboutSettings } from './sections/AboutSettings';
 import { InstructionsSettings } from './sections/InstructionsSettings';
+import { ActionSettings } from './sections/ActionSettings';
 import { SettingsSearchResults } from './SettingsSearchResults';
 import { searchSettings, type SettingsCategory } from './settingsRegistry';
 
@@ -49,6 +51,7 @@ const mainNavItems: NavItem[] = [
   { id: 'instructions', label: 'Instructions', icon: <ScrollText className="w-3.5 h-3.5" /> },
   { id: 'git', label: 'Git', icon: <GitBranch className="w-3.5 h-3.5" /> },
   { id: 'review', label: 'Review & PRs', icon: <Eye className="w-3.5 h-3.5" /> },
+  { id: 'actions', label: 'Actions', icon: <Zap className="w-3.5 h-3.5" /> },
   { id: 'account', label: 'Account', icon: <User className="w-3.5 h-3.5" /> },
 ];
 
@@ -290,6 +293,7 @@ export function SettingsPage({ onBack, initialCategory = 'general' }: SettingsPa
                 {selectedCategory === 'instructions' && <InstructionsSettings />}
                 {selectedCategory === 'git' && <GitSettings />}
                 {selectedCategory === 'review' && <ReviewSettings />}
+                {selectedCategory === 'actions' && <ActionSettings />}
                 {selectedCategory === 'account' && <AccountSettings />}
                 {selectedCategory === 'advanced' && <AdvancedSettings />}
                 {selectedCategory === 'about' && <AboutSettings />}

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -14,9 +14,13 @@ import {
   getGlobalPRTemplate,
   getPRTemplate,
   setPRTemplate,
+  getGlobalActionTemplates,
+  getWorkspaceActionTemplates,
+  setWorkspaceActionTemplates,
 } from '@/lib/api';
 import type { Workspace } from '@/lib/types';
 import { REVIEW_PROMPTS, REVIEW_TYPE_META } from '@/hooks/useReviewTrigger';
+import { ACTION_TEMPLATES, ACTION_TEMPLATE_META } from '@/lib/action-templates';
 import { useToast } from '@/components/ui/toast';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
@@ -25,6 +29,7 @@ import { Input } from '@/components/ui/input';
 import {
   ArrowLeft,
   Eye,
+  Zap,
   GitBranch,
   FolderOpen,
   Globe,
@@ -40,7 +45,7 @@ interface WorkspaceSettingsProps {
   onBack: () => void;
 }
 
-type WorkspaceSettingsSection = 'repository' | 'review';
+type WorkspaceSettingsSection = 'repository' | 'review' | 'actions';
 
 export function WorkspaceSettings({ workspaceId, onBack }: WorkspaceSettingsProps) {
   const workspaces = useAppStore((s) => s.workspaces);
@@ -128,6 +133,18 @@ export function WorkspaceSettings({ workspaceId, onBack }: WorkspaceSettingsProp
                 <Eye className="w-3.5 h-3.5" />
                 Review
               </Button>
+              <Button
+                variant={section === 'actions' ? 'secondary' : 'ghost'}
+                size="sm"
+                className={cn(
+                  'w-full justify-start gap-2 h-7 text-xs',
+                  section === 'actions' && 'bg-sidebar-accent',
+                )}
+                onClick={() => setSection('actions')}
+              >
+                <Zap className="w-3.5 h-3.5" />
+                Actions
+              </Button>
             </div>
           </div>
         </ScrollArea>
@@ -145,6 +162,9 @@ export function WorkspaceSettings({ workspaceId, onBack }: WorkspaceSettingsProp
             )}
             {section === 'review' && (
               <WorkspaceReviewSettings workspaceId={workspaceId} />
+            )}
+            {section === 'actions' && (
+              <WorkspaceActionSettings workspaceId={workspaceId} />
             )}
           </div>
         </ScrollArea>
@@ -568,6 +588,132 @@ function WorkspaceReviewSettings({ workspaceId }: { workspaceId: string }) {
           value={prTemplate}
           onChange={(e) => setPrTemplate(e.target.value)}
         />
+      </div>
+
+      {hasChanges && (
+        <div className="mt-4 flex justify-end">
+          <Button size="sm" disabled={saving} onClick={handleSave}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WorkspaceActionSettings({ workspaceId }: { workspaceId: string }) {
+  const [templates, setTemplates] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState<Record<string, string>>({});
+  const [globalTemplates, setGlobalTemplates] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const { error: showError } = useToast();
+  const showErrorRef = useRef(showError);
+  useEffect(() => { showErrorRef.current = showError; }, [showError]);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      getWorkspaceActionTemplates(workspaceId),
+      getGlobalActionTemplates(),
+    ]).then(([ws, gl]) => {
+      if (cancelled) return;
+      setTemplates(ws);
+      setSaved(ws);
+      setGlobalTemplates(gl);
+    }).catch(() => {
+      if (cancelled) return;
+      showErrorRef.current('Failed to load settings');
+    });
+    return () => { cancelled = true; };
+  }, [workspaceId]);
+
+  const hasChanges = JSON.stringify(templates) !== JSON.stringify(saved);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const cleaned: Record<string, string> = {};
+      for (const [k, v] of Object.entries(templates)) {
+        if (v.trim()) cleaned[k] = v.trim();
+      }
+      await setWorkspaceActionTemplates(workspaceId, cleaned);
+      setTemplates(cleaned);
+      setSaved(cleaned);
+      window.dispatchEvent(new CustomEvent('action-templates-changed'));
+    } catch {
+      showErrorRef.current('Failed to save settings');
+    } finally {
+      setSaving(false);
+    }
+  }, [workspaceId, templates]);
+
+  const hasAnyOverride = Object.values(templates).some((v) => v.trim());
+
+  const handleResetAll = useCallback(async () => {
+    setSaving(true);
+    try {
+      await setWorkspaceActionTemplates(workspaceId, {});
+      setTemplates({});
+      setSaved({});
+      window.dispatchEvent(new CustomEvent('action-templates-changed'));
+    } catch {
+      showErrorRef.current('Failed to reset settings');
+    } finally {
+      setSaving(false);
+    }
+  }, [workspaceId]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-xl font-semibold">Action Templates</h2>
+        {hasAnyOverride && !hasChanges && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs text-muted-foreground hover:text-foreground"
+            disabled={saving}
+            onClick={handleResetAll}
+          >
+            Reset to global defaults
+          </Button>
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground mb-6">
+        Override the global action template settings for this workspace.
+        Leave empty to use the global default.
+      </p>
+
+      <div className="space-y-5">
+        {ACTION_TEMPLATE_META.map(({ key, label, placeholder }) => {
+          const globalOverride = globalTemplates[key];
+          const effectivePlaceholder = globalOverride
+            ? `Global: ${globalOverride.slice(0, 60)}…`
+            : placeholder;
+          const hasOverride = !!(templates[key]?.trim());
+
+          return (
+            <div key={key}>
+              <div className="flex items-center gap-2 mb-1.5">
+                <label className="text-sm font-medium">{label}</label>
+                {hasOverride && (
+                  <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-2xs font-medium text-primary">
+                    Overridden
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground mb-1.5 line-clamp-2">
+                Default: {ACTION_TEMPLATES[key]?.slice(0, 100)}&hellip;
+              </p>
+              <Textarea
+                className="text-sm min-h-[80px]"
+                placeholder={effectivePlaceholder}
+                value={templates[key] || ''}
+                onChange={(e) => setTemplates((prev) => ({ ...prev, [key]: e.target.value }))}
+              />
+            </div>
+          );
+        })}
       </div>
 
       {hasChanges && (

--- a/src/components/settings/sections/ActionSettings.tsx
+++ b/src/components/settings/sections/ActionSettings.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/toast';
+import { getGlobalActionTemplates, setGlobalActionTemplates } from '@/lib/api';
+import { ACTION_TEMPLATES, ACTION_TEMPLATE_META } from '@/lib/action-templates';
+
+function OverridableBadge() {
+  return (
+    <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-2xs font-medium text-muted-foreground">
+      Per-workspace
+    </span>
+  );
+}
+
+export function ActionSettings() {
+  const [templates, setTemplates] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const { error: showError } = useToast();
+  const showErrorRef = useRef(showError);
+  useEffect(() => { showErrorRef.current = showError; }, [showError]);
+
+  useEffect(() => {
+    getGlobalActionTemplates()
+      .then((data) => {
+        setTemplates(data);
+        setSaved(data);
+      })
+      .catch(() => {
+        showErrorRef.current('Failed to load action templates');
+      });
+  }, []);
+
+  const hasChanges = JSON.stringify(templates) !== JSON.stringify(saved);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const cleaned: Record<string, string> = {};
+      for (const [k, v] of Object.entries(templates)) {
+        if (v.trim()) cleaned[k] = v.trim();
+      }
+      await setGlobalActionTemplates(cleaned);
+      setTemplates(cleaned);
+      setSaved(cleaned);
+      window.dispatchEvent(new CustomEvent('action-templates-changed'));
+    } catch {
+      showErrorRef.current('Failed to save action templates');
+    } finally {
+      setSaving(false);
+    }
+  }, [templates]);
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1">
+        <h2 className="text-xl font-semibold">Actions</h2>
+        <OverridableBadge />
+      </div>
+      <p className="text-sm text-muted-foreground mb-6">
+        Customize the instructions sent to the agent for each toolbar action.
+        Per-workspace overrides can be set in workspace settings.
+      </p>
+
+      <div data-setting-id="actionTemplates" className="space-y-5">
+        {ACTION_TEMPLATE_META.map(({ key, label, placeholder }) => (
+          <div key={key}>
+            <label className="text-sm font-medium block mb-1.5">{label}</label>
+            <p className="text-xs text-muted-foreground mb-1.5 line-clamp-2">
+              Default: {ACTION_TEMPLATES[key]?.slice(0, 100)}&hellip;
+            </p>
+            <Textarea
+              className="text-sm min-h-[80px]"
+              placeholder={placeholder}
+              value={templates[key] || ''}
+              onChange={(e) => setTemplates((prev) => ({ ...prev, [key]: e.target.value }))}
+            />
+          </div>
+        ))}
+      </div>
+
+      {hasChanges && (
+        <div className="mt-4 flex justify-end">
+          <Button size="sm" disabled={saving} onClick={handleSave}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -5,6 +5,7 @@ export type SettingsCategory =
   | 'instructions'
   | 'git'
   | 'review'
+  | 'actions'
   | 'account'
   | 'advanced'
   | 'about';
@@ -255,6 +256,16 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
     keywords: ['pr', 'pull request', 'description', 'template', 'prompt'],
     category: 'review',
     categoryLabel: 'Review & PRs',
+  },
+
+  // ── Actions ──
+  {
+    id: 'actionTemplates',
+    title: 'Action templates',
+    description: 'Customize instructions sent to the agent for toolbar actions like merge, sync, and resolve conflicts',
+    keywords: ['action', 'template', 'merge', 'sync', 'resolve', 'conflicts', 'fix', 'issues', 'instructions', 'primary', 'button'],
+    category: 'actions',
+    categoryLabel: 'Actions',
   },
 
   // ── Account: Integrations ──

--- a/src/components/shared/PrimaryActionButton/ActionButton.tsx
+++ b/src/components/shared/PrimaryActionButton/ActionButton.tsx
@@ -12,6 +12,8 @@ import { Loader2, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { ActionButtonProps } from './types';
 
+const PENDING_TIMEOUT_MS = 8000;
+
 export function ActionButton({
   action,
   onSendMessage,
@@ -27,10 +29,10 @@ export function ActionButton({
   const actionKey = action ? `${action.type}:${action.label}` : null;
   const pendingAction = pendingActionKey !== null && pendingActionKey === actionKey;
 
-  // Safety timeout: reset after 3s in case the action object doesn't change
+  // Safety timeout: reset after timeout in case the action object doesn't change
   useEffect(() => {
     if (!pendingActionKey) return;
-    const timer = setTimeout(() => setPendingActionKey(null), 3000);
+    const timer = setTimeout(() => setPendingActionKey(null), PENDING_TIMEOUT_MS);
     return () => clearTimeout(timer);
   }, [pendingActionKey]);
 
@@ -78,6 +80,11 @@ export function ActionButton({
     } else if (action.type === 'create-pr' && onCreatePR) {
       // Open PR creation dialog
       onCreatePR();
+    } else if (action.type === 'merge-pr') {
+      // Merge PR: send the merge instruction to the agent
+      if (action.message) {
+        onSendMessage(action.message, action.type);
+      }
     } else if (action.type === 'view-pr' && action.prUrl) {
       // Open PR in browser
       window.open(action.prUrl, '_blank');
@@ -86,19 +93,24 @@ export function ActionButton({
       onArchiveSession(action.sessionId);
     } else if (action.message) {
       // Send message to agent
-      onSendMessage(action.message);
+      onSendMessage(action.message, action.type);
     }
   };
 
-  // Handle dropdown action click
+  // Handle dropdown action click — uses the parent action.type (not per-item) so
+  // all dropdown items resolve to the same template (e.g. all merge strategies → 'merge-pr').
   const handleDropdownClick = (message: string) => {
-    onSendMessage(message);
+    if (pendingAction) return;
+    markPending();
+    onSendMessage(message, action.type);
   };
 
   // Handle secondary action click (legacy single action)
   const handleSecondaryClick = () => {
+    if (pendingAction) return;
+    markPending();
     if (action.secondaryAction) {
-      onSendMessage(action.secondaryAction.message);
+      onSendMessage(action.secondaryAction.message, action.type);
     }
   };
 

--- a/src/components/shared/PrimaryActionButton/index.tsx
+++ b/src/components/shared/PrimaryActionButton/index.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useGitStatus } from '@/hooks/useGitStatus';
 import { usePRStatus } from '@/hooks/usePRStatus';
 import { useActionState } from './useActionState';
 import { ActionButton } from './ActionButton';
 import { useAppStore } from '@/stores/appStore';
 import type { GitStatusDTO, PRDetails } from '@/lib/api';
+import { getGlobalActionTemplates, getWorkspaceActionTemplates } from '@/lib/api';
+import { ACTION_TEMPLATES, getTemplateKey, fetchMergedActionTemplates } from '@/lib/action-templates';
+import type { ActionTemplateKey } from '@/lib/action-templates';
+import type { PrimaryActionType } from './types';
 
 interface WorktreeSession {
   id: string;
@@ -21,6 +25,7 @@ interface PrimaryActionButtonProps {
   workspaceId: string | null;
   session: WorktreeSession | null | undefined;
   onSendMessage: (content: string) => void;
+  onSendMessageWithTemplate: (content: string, templateContent: string) => void;
   onFixIssues?: () => void;
   onArchiveSession?: (sessionId: string) => void;
   onCreatePR?: () => void;
@@ -33,6 +38,7 @@ export function PrimaryActionButton({
   workspaceId,
   session,
   onSendMessage,
+  onSendMessageWithTemplate,
   onFixIssues,
   onArchiveSession,
   onCreatePR,
@@ -108,11 +114,48 @@ export function PrimaryActionButton({
   // Determine loading state
   const isLoading = gitLoading || prLoading;
 
+  // ---------------------------------------------------------------------------
+  // Action templates — fetch merged templates and wrap onSendMessage
+  // ---------------------------------------------------------------------------
+
+  const [mergedTemplates, setMergedTemplates] = useState<Record<ActionTemplateKey, string>>(ACTION_TEMPLATES);
+
+  // Fetch helper — used on mount and when settings change
+  const refreshTemplates = useCallback(() => {
+    if (!workspaceId) return;
+    fetchMergedActionTemplates(workspaceId, getGlobalActionTemplates, getWorkspaceActionTemplates)
+      .then((t) => setMergedTemplates(t))
+      .catch(() => { /* use built-in defaults */ });
+  }, [workspaceId]);
+
+  useEffect(() => {
+    refreshTemplates();
+  }, [refreshTemplates]);
+
+  // Re-fetch when action templates are saved in settings
+  useEffect(() => {
+    const handler = () => refreshTemplates();
+    window.addEventListener('action-templates-changed', handler);
+    return () => window.removeEventListener('action-templates-changed', handler);
+  }, [refreshTemplates]);
+
+  // Wrap onSendMessage to include template content when available.
+  // Accepts actionType from the click handler to avoid stale closure issues.
+  const handleSendWithTemplate = useCallback((content: string, actionType: PrimaryActionType) => {
+    const templateKey = getTemplateKey(actionType);
+    const templateContent = templateKey ? mergedTemplates[templateKey] : null;
+    if (templateContent) {
+      onSendMessageWithTemplate(content, templateContent);
+    } else {
+      onSendMessage(content);
+    }
+  }, [mergedTemplates, onSendMessage, onSendMessageWithTemplate]);
+
   return (
     <ActionButton
       action={action}
       isLoading={isLoading}
-      onSendMessage={onSendMessage}
+      onSendMessage={handleSendWithTemplate}
       onFixIssues={onFixIssues}
       onArchiveSession={onArchiveSession}
       onCreatePR={onCreatePR}

--- a/src/components/shared/PrimaryActionButton/types.ts
+++ b/src/components/shared/PrimaryActionButton/types.ts
@@ -10,6 +10,7 @@ export type PrimaryActionType =
   | 'sync-branch'
   | 'create-pr'
   | 'view-pr'
+  | 'merge-pr'
   | 'archive-session';
 
 export type ButtonVariant = 'default' | 'destructive' | 'success' | 'warning';
@@ -42,7 +43,7 @@ export interface PrimaryAction {
 export interface ActionButtonProps {
   action: PrimaryAction | null;
   isLoading: boolean;
-  onSendMessage: (content: string) => void;
+  onSendMessage: (content: string, actionType: PrimaryActionType) => void;
   onFixIssues?: () => void;
   onArchiveSession?: (sessionId: string) => void;
   onCreatePR?: () => void;

--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -233,7 +233,7 @@ export function useActionState(
       );
 
       return {
-        type: 'view-pr',
+        type: 'merge-pr',
         tier: 'action',
         label: 'Merge PR',
         icon: GitMerge,

--- a/src/lib/action-templates.ts
+++ b/src/lib/action-templates.ts
@@ -1,0 +1,136 @@
+/**
+ * Action Templates — built-in defaults, metadata, and merge logic for
+ * the PrimaryActionButton system.
+ *
+ * Follows the same pattern as REVIEW_PROMPTS / REVIEW_TYPE_META in
+ * src/hooks/useReviewTrigger.ts.
+ */
+
+export type ActionTemplateKey =
+  | 'resolve-conflicts'
+  | 'fix-issues'
+  | 'continue-operation'
+  | 'sync-branch'
+  | 'create-pr'
+  | 'merge-pr';
+
+/**
+ * Built-in default templates for each action.
+ * These provide detailed instructions to the agent beyond the short label.
+ */
+export const ACTION_TEMPLATES: Record<ActionTemplateKey, string> = {
+  'resolve-conflicts': `## Resolve Merge Conflicts
+
+1. Run \`git status\` to identify all files with conflicts
+2. For each conflicted file:
+   - Read the file to understand both sides of the conflict
+   - Determine the correct resolution based on the intent of both changes
+   - Resolve the conflict markers (<<<<<<, =======, >>>>>>>)
+3. Stage all resolved files with \`git add\`
+4. If this is a rebase, run \`git rebase --continue\`; if a merge, commit the resolution
+5. Verify the build still passes after resolution`,
+
+  'fix-issues': `## Fix CI Failures
+
+1. Analyze the failing checks and their error output carefully
+2. Identify the root cause for each failure (test failure, lint error, type error, build error)
+3. Fix each issue in priority order: build errors > type errors > test failures > lint
+4. Run the relevant checks locally to verify fixes before pushing
+5. If a test needs updating due to intentional behavior changes, update the test expectations
+6. Push the fixes`,
+
+  'continue-operation': `## Continue Git Operation
+
+1. Check \`git status\` to see the current state of the operation
+2. If there are remaining conflicts, resolve them
+3. Stage resolved files
+4. Continue the operation with the appropriate command (rebase --continue, merge --continue, etc.)
+5. If the operation cannot be continued cleanly, explain the situation and suggest options`,
+
+  'sync-branch': `## Sync Branch
+
+1. Fetch the latest changes from the remote
+2. Rebase the current branch onto the target branch
+3. If conflicts arise during rebase, resolve them carefully:
+   - Preserve the intent of our branch's changes
+   - Incorporate the upstream changes correctly
+4. Force-push the rebased branch (since history was rewritten)
+5. Verify the build passes after sync`,
+
+  'create-pr': `## Create Pull Request
+
+1. Ensure all changes are committed and pushed
+2. Create the pull request with a clear title and description
+3. The PR title should be concise and describe the change
+4. The PR description should explain what changed and why
+5. Link any related issues`,
+
+  'merge-pr': `## Merge Pull Request
+
+1. Verify all CI checks have passed
+2. Verify the branch is up to date with the base branch
+3. If the branch is behind, rebase or merge the base branch first
+4. Perform the merge using the requested strategy (squash, merge commit, or rebase)
+5. Confirm the merge was successful`,
+};
+
+/**
+ * Metadata for the settings UI — label and placeholder for each template key.
+ */
+export const ACTION_TEMPLATE_META: { key: ActionTemplateKey; label: string; placeholder: string }[] = [
+  { key: 'resolve-conflicts', label: 'Resolve Conflicts', placeholder: 'e.g., Always prefer our branch changes for package-lock.json' },
+  { key: 'fix-issues', label: 'Fix Issues', placeholder: 'e.g., Run `npm test` locally before pushing fixes' },
+  { key: 'continue-operation', label: 'Continue Operation', placeholder: 'e.g., Always abort if more than 3 conflicts remain' },
+  { key: 'sync-branch', label: 'Sync Branch', placeholder: 'e.g., Use merge instead of rebase for this repo' },
+  { key: 'create-pr', label: 'Create PR', placeholder: 'e.g., Always create as draft first' },
+  { key: 'merge-pr', label: 'Merge PR', placeholder: 'e.g., Default to squash and merge' },
+];
+
+/**
+ * Maps a PrimaryActionType to its template key.
+ * Multiple action types can map to the same template key
+ * (e.g., all continue-* variants map to 'continue-operation').
+ * Returns null for actions that don't use templates (view-pr, archive-session).
+ */
+const ACTION_TYPE_TO_TEMPLATE: Record<string, ActionTemplateKey> = {
+  'resolve-conflicts': 'resolve-conflicts',
+  'fix-issues': 'fix-issues',
+  'continue-rebase': 'continue-operation',
+  'continue-merge': 'continue-operation',
+  'continue-cherry-pick': 'continue-operation',
+  'continue-revert': 'continue-operation',
+  'sync-branch': 'sync-branch',
+  'create-pr': 'create-pr',
+  'merge-pr': 'merge-pr',
+};
+
+export function getTemplateKey(actionType: string): ActionTemplateKey | null {
+  return ACTION_TYPE_TO_TEMPLATE[actionType] ?? null;
+}
+
+/**
+ * Fetches global and per-workspace overrides and merges them with built-in defaults.
+ * Per-workspace overrides > global overrides > built-in defaults.
+ *
+ * Mirrors fetchMergedOverrides() in useReviewTrigger.ts.
+ */
+export async function fetchMergedActionTemplates(
+  workspaceId: string,
+  getGlobal: () => Promise<Record<string, string>>,
+  getWorkspace: (id: string) => Promise<Record<string, string>>,
+): Promise<Record<ActionTemplateKey, string>> {
+  const [global, workspace] = await Promise.all([
+    getGlobal().catch(() => ({} as Record<string, string>)),
+    getWorkspace(workspaceId).catch(() => ({} as Record<string, string>)),
+  ]);
+
+  const merged = { ...ACTION_TEMPLATES };
+  for (const key of Object.keys(ACTION_TEMPLATES) as ActionTemplateKey[]) {
+    if (workspace[key]) {
+      merged[key] = workspace[key];
+    } else if (global[key]) {
+      merged[key] = global[key];
+    }
+  }
+  return merged;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1885,6 +1885,48 @@ export async function setWorkspaceReviewPrompts(
 }
 
 // ---------------------------------------------------------------------------
+// Action Template Overrides
+// ---------------------------------------------------------------------------
+
+export async function getGlobalActionTemplates(): Promise<Record<string, string>> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/action-templates`);
+  const data = await handleResponse<{ templates: Record<string, string> }>(res);
+  return data.templates;
+}
+
+export async function setGlobalActionTemplates(templates: Record<string, string>): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/action-templates`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ templates }),
+  });
+  await handleVoidResponse(res, 'Failed to save action templates');
+}
+
+export async function getWorkspaceActionTemplates(workspaceId: string): Promise<Record<string, string>> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/settings/action-templates`
+  );
+  const data = await handleResponse<{ templates: Record<string, string> }>(res);
+  return data.templates;
+}
+
+export async function setWorkspaceActionTemplates(
+  workspaceId: string,
+  templates: Record<string, string>,
+): Promise<void> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/settings/action-templates`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ templates }),
+    },
+  );
+  await handleVoidResponse(res, 'Failed to save workspace action templates');
+}
+
+// ---------------------------------------------------------------------------
 // Custom Instructions
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Introduces a template system that sends detailed instructions to the agent alongside toolbar actions (merge, sync, resolve conflicts, fix issues, etc.)
- Templates are configurable at global and per-workspace levels in Settings → Actions, with merge precedence: workspace > global > built-in defaults
- Changes `merge-pr` from a passive `view-pr` type to a proper agent-driven action that sends merge instructions
- Fixes double-click bug in secondary action handler and adds `isAgentWorking` guards to all action paths

## Test plan
- [ ] Click each toolbar action (Sync Branch, Resolve Conflicts, Fix Issues, Merge PR) and verify the agent receives both the short message and template attachment
- [ ] Open Settings → Actions, customize a global template, verify it's used by the toolbar
- [ ] Open Workspace Settings → Actions, override a template, verify workspace override takes precedence
- [ ] Reset workspace overrides and verify global/defaults are restored
- [ ] Rapidly double-click any action button (including dropdown items and secondary actions) and verify only one message is sent
- [ ] Verify actions are blocked while the agent is working

🤖 Generated with [Claude Code](https://claude.com/claude-code)