### PR TITLE
Add two-layer diff cache to reduce file diff latency

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -154,6 +154,10 @@ func main() {
 	statsCache := server.NewSessionStatsCache(30 * time.Second)
 	defer statsCache.Close()
 
+	// Diff cache with 10 second TTL — avoids repeated git show subprocess spawns
+	diffCache := server.NewDiffCache(10 * time.Second)
+	defer diffCache.Close()
+
 	// Repo manager for stats computation in callbacks
 	repoManager := git.NewRepoManager()
 
@@ -233,8 +237,9 @@ func main() {
 					return
 				}
 
-				// Invalidate cache first
+				// Invalidate caches first
 				statsCache.Invalidate(sessionID)
+				diffCache.InvalidateSession(sessionID)
 
 				// Get session and workspace data to recompute stats
 				sess, err := s.GetSession(ctx, sessionID)
@@ -470,7 +475,7 @@ func main() {
 		},
 	)
 
-	router := server.NewRouter(s, hub, agentMgr, ghClient, linearClient, branchWatcher, prWatcher, prCache, issueCache, statsCache, aiClient, scriptRunner)
+	router := server.NewRouter(s, hub, agentMgr, ghClient, linearClient, branchWatcher, prWatcher, prCache, issueCache, statsCache, diffCache, aiClient, scriptRunner)
 
 	// Pre-warm session stats cache in background so the first getDashboardData
 	// returns stats from cache instead of computing them on-the-fly.

--- a/backend/server/diff_cache.go
+++ b/backend/server/diff_cache.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// diffEntry holds cached file diff data
+type diffEntry struct {
+	response  *FileDiffResponse
+	expiresAt time.Time
+}
+
+// DiffCache provides TTL-based caching for individual file diffs.
+// Follows the same pattern as SessionStatsCache.
+type DiffCache struct {
+	mu      sync.RWMutex
+	entries map[string]*diffEntry
+	ttl     time.Duration
+	done    chan struct{}
+}
+
+// NewDiffCache creates a new diff cache with the given TTL
+func NewDiffCache(ttl time.Duration) *DiffCache {
+	cache := &DiffCache{
+		entries: make(map[string]*diffEntry),
+		ttl:     ttl,
+		done:    make(chan struct{}),
+	}
+
+	// Start cleanup goroutine
+	go cache.cleanupLoop()
+
+	return cache
+}
+
+func diffCacheKey(sessionID, path string) string {
+	return sessionID + ":" + path
+}
+
+// Get retrieves a cached diff for a session file.
+// Returns a defensive copy so callers cannot mutate cached data.
+func (c *DiffCache) Get(sessionID, path string) (*FileDiffResponse, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.entries[diffCacheKey(sessionID, path)]
+	if !ok {
+		return nil, false
+	}
+
+	// Check if expired
+	if time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+
+	copied := *entry.response
+	return &copied, true
+}
+
+// Set stores a defensive copy of the diff in the cache.
+func (c *DiffCache) Set(sessionID, path string, resp *FileDiffResponse) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	copied := *resp
+	c.entries[diffCacheKey(sessionID, path)] = &diffEntry{
+		response:  &copied,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+// InvalidateSession removes all cached diffs for a session
+func (c *DiffCache) InvalidateSession(sessionID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	prefix := sessionID + ":"
+	for key := range c.entries {
+		if strings.HasPrefix(key, prefix) {
+			delete(c.entries, key)
+		}
+	}
+}
+
+// Close stops the cleanup goroutine
+func (c *DiffCache) Close() {
+	close(c.done)
+}
+
+// cleanupLoop periodically removes expired entries
+func (c *DiffCache) cleanupLoop() {
+	// Use a minimum cleanup interval of 30 seconds to avoid excessive CPU usage
+	cleanupInterval := c.ttl
+	if cleanupInterval < 30*time.Second {
+		cleanupInterval = 30 * time.Second
+	}
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.cleanup()
+		case <-c.done:
+			return
+		}
+	}
+}
+
+// cleanup removes expired entries
+func (c *DiffCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/backend/server/diff_cache_test.go
+++ b/backend/server/diff_cache_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffCache_GetSet(t *testing.T) {
+	cache := NewDiffCache(5 * time.Minute)
+	t.Cleanup(func() { cache.Close() })
+
+	resp := &FileDiffResponse{
+		Path:       "main.go",
+		OldContent: "old",
+		NewContent: "new",
+	}
+	cache.Set("session-1", "main.go", resp)
+
+	got, ok := cache.Get("session-1", "main.go")
+	require.True(t, ok, "expected cache hit")
+	assert.Equal(t, "old", got.OldContent)
+	assert.Equal(t, "new", got.NewContent)
+	assert.Equal(t, "main.go", got.Path)
+}
+
+func TestDiffCache_GetMiss(t *testing.T) {
+	cache := NewDiffCache(5 * time.Minute)
+	t.Cleanup(func() { cache.Close() })
+
+	got, ok := cache.Get("nonexistent", "file.go")
+	assert.False(t, ok, "expected cache miss for nonexistent key")
+	assert.Nil(t, got, "expected nil on cache miss")
+}
+
+func TestDiffCache_Expiration(t *testing.T) {
+	cache := NewDiffCache(50 * time.Millisecond)
+	t.Cleanup(func() { cache.Close() })
+
+	resp := &FileDiffResponse{Path: "test.go", OldContent: "a", NewContent: "b"}
+	cache.Set("session-exp", "test.go", resp)
+
+	// Should be available immediately
+	got, ok := cache.Get("session-exp", "test.go")
+	require.True(t, ok, "expected cache hit before expiration")
+	assert.Equal(t, "a", got.OldContent)
+
+	// Wait for expiration
+	time.Sleep(100 * time.Millisecond)
+
+	got, ok = cache.Get("session-exp", "test.go")
+	assert.False(t, ok, "expected cache miss after TTL expiry")
+	assert.Nil(t, got, "expected nil after TTL expiry")
+}
+
+func TestDiffCache_InvalidateSession(t *testing.T) {
+	cache := NewDiffCache(5 * time.Minute)
+	t.Cleanup(func() { cache.Close() })
+
+	// Add multiple files for the same session
+	cache.Set("session-inv", "file1.go", &FileDiffResponse{Path: "file1.go"})
+	cache.Set("session-inv", "file2.go", &FileDiffResponse{Path: "file2.go"})
+	cache.Set("other-session", "file1.go", &FileDiffResponse{Path: "file1.go"})
+
+	// Verify all entries exist
+	_, ok := cache.Get("session-inv", "file1.go")
+	require.True(t, ok)
+	_, ok = cache.Get("session-inv", "file2.go")
+	require.True(t, ok)
+	_, ok = cache.Get("other-session", "file1.go")
+	require.True(t, ok)
+
+	// Invalidate one session
+	cache.InvalidateSession("session-inv")
+
+	// Session entries should be gone
+	_, ok = cache.Get("session-inv", "file1.go")
+	assert.False(t, ok, "expected cache miss after session invalidation")
+	_, ok = cache.Get("session-inv", "file2.go")
+	assert.False(t, ok, "expected cache miss after session invalidation")
+
+	// Other session should be unaffected
+	got, ok := cache.Get("other-session", "file1.go")
+	assert.True(t, ok, "other session should not be invalidated")
+	assert.Equal(t, "file1.go", got.Path)
+}
+
+func TestDiffCache_ConcurrentAccess(t *testing.T) {
+	cache := NewDiffCache(5 * time.Minute)
+	t.Cleanup(func() { cache.Close() })
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+
+	// Concurrent writers
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			session := fmt.Sprintf("session-%d", n%10)
+			path := fmt.Sprintf("file-%d.go", n%5)
+			cache.Set(session, path, &FileDiffResponse{Path: path, OldContent: fmt.Sprintf("old-%d", n)})
+		}(i)
+	}
+
+	// Concurrent readers
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			session := fmt.Sprintf("session-%d", n%10)
+			path := fmt.Sprintf("file-%d.go", n%5)
+			cache.Get(session, path)
+		}(i)
+	}
+
+	// Concurrent invalidators
+	for i := 0; i < numGoroutines/5; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			session := fmt.Sprintf("session-%d", n%10)
+			cache.InvalidateSession(session)
+		}(i)
+	}
+
+	wg.Wait()
+	// No panics, races, or deadlocks
+}
+
+func TestDiffCache_Close(t *testing.T) {
+	cache := NewDiffCache(5 * time.Minute)
+
+	// Close should not panic
+	assert.NotPanics(t, func() {
+		cache.Close()
+	})
+
+	// Cache should still be usable after close (just no auto-cleanup)
+	cache.Set("after-close", "file.go", &FileDiffResponse{Path: "file.go", NewContent: "content"})
+	got, ok := cache.Get("after-close", "file.go")
+	assert.True(t, ok, "expected cache to remain usable after Close")
+	require.NotNil(t, got)
+	assert.Equal(t, "content", got.NewContent)
+}

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -542,6 +542,7 @@ type Handlers struct {
 	issueCache       *github.IssueCache
 	avatarCache      *github.AvatarCache
 	statsCache       *SessionStatsCache
+	diffCache        *DiffCache
 	aiClient         ai.Provider
 	scriptRunner     *scripts.Runner
 }
@@ -590,7 +591,7 @@ func (h *Handlers) getWorkspacesBaseDir(ctx context.Context) (string, error) {
 	return git.WorkspacesBaseDirWithOverride(configured)
 }
 
-func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, aiClient ai.Provider, scriptRunner *scripts.Runner) *Handlers {
+func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, diffCache *DiffCache, aiClient ai.Provider, scriptRunner *scripts.Runner) *Handlers {
 	// Initialize session name cache with workspaces directory
 	// Cache initializes lazily on first use
 	workspacesDir, err := git.WorkspacesBaseDir()
@@ -615,6 +616,7 @@ func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirList
 		issueCache:       issueCache,
 		avatarCache:      github.NewAvatarCache(24 * time.Hour), // Cache avatars for 24 hours
 		statsCache:       statsCache,
+		diffCache:        diffCache,
 		aiClient:         aiClient,
 		scriptRunner:     scriptRunner,
 	}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -18,10 +18,10 @@ import (
 	"github.com/rs/cors"
 )
 
-func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, linearClient *linear.Client, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, aiClient ai.Provider, scriptRunner *scripts.Runner) http.Handler {
+func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, linearClient *linear.Client, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, diffCache *DiffCache, aiClient ai.Provider, scriptRunner *scripts.Runner) http.Handler {
 	r := chi.NewRouter()
 	dirCacheConfig := LoadDirListingCacheConfig()
-	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, issueCache, statsCache, aiClient, scriptRunner)
+	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, issueCache, statsCache, diffCache, aiClient, scriptRunner)
 	auth := NewAuthHandlers(ghClient, s)
 	linearAuth := NewLinearAuthHandlers(linearClient, s)
 

--- a/backend/server/router_test.go
+++ b/backend/server/router_test.go
@@ -38,8 +38,8 @@ func setupTestRouter(t *testing.T) (http.Handler, *store.SQLiteStore) {
 
 	linearClient := linear.NewClient("")
 
-	// Create router without branch watcher, pr watcher, or stats cache
-	router := NewRouter(s, hub, agentMgr, ghClient, linearClient, nil, nil, prCache, nil, nil, nil, nil)
+	// Create router without branch watcher, pr watcher, stats cache, or diff cache
+	router := NewRouter(s, hub, agentMgr, ghClient, linearClient, nil, nil, prCache, nil, nil, nil, nil, nil)
 
 	return router, s
 }

--- a/backend/server/session_git_handlers.go
+++ b/backend/server/session_git_handlers.go
@@ -192,6 +192,14 @@ func (h *Handlers) GetSessionFileDiff(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check diff cache
+	if h.diffCache != nil {
+		if cached, ok := h.diffCache.Get(sessionID, cleanPath); ok {
+			writeJSON(w, cached)
+			return
+		}
+	}
+
 	// Read current file content from the worktree
 	var isDeleted bool
 	fullPath := filepath.Join(workingPath, cleanPath)
@@ -225,6 +233,11 @@ func (h *Handlers) GetSessionFileDiff(w http.ResponseWriter, r *http.Request) {
 		NewFilename: cleanPath,
 		HasConflict: hasConflict,
 		IsDeleted:   isDeleted,
+	}
+
+	// Cache the result
+	if h.diffCache != nil {
+		h.diffCache.Set(sessionID, cleanPath, &response)
 	}
 
 	writeJSON(w, response)

--- a/backend/server/testhelpers_test.go
+++ b/backend/server/testhelpers_test.go
@@ -55,7 +55,7 @@ func setupTestHandlers(t *testing.T) (*Handlers, *store.SQLiteStore) {
 		prCache.Close()
 	})
 
-	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, nil)
+	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, nil, nil)
 
 	return handlers, sqliteStore
 }
@@ -81,7 +81,7 @@ func setupTestHandlersWithAgentManager(t *testing.T) (*Handlers, *store.SQLiteSt
 		prCache.Close()
 	})
 
-	handlers := NewHandlers(sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, nil)
+	handlers := NewHandlers(sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, nil, nil)
 
 	return handlers, sqliteStore, agentManager
 }
@@ -235,7 +235,7 @@ func setupTestHandlersWithAIClient(t *testing.T, aiServerURL string) (*Handlers,
 		prCache.Close()
 	})
 
-	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, aiClient, nil)
+	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, aiClient, nil)
 
 	return handlers, sqliteStore
 }
@@ -258,7 +258,7 @@ func setupTestHandlersWithGitHub(t *testing.T, ghServer *httptest.Server) (*Hand
 		prCache.Close()
 	})
 
-	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, ghClient, prCache, nil, nil, nil, nil)
+	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, ghClient, prCache, nil, nil, nil, nil, nil)
 
 	return handlers, sqliteStore
 }

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -46,6 +46,7 @@ import { VirtualizedMessageList, type VirtualizedMessageListHandle } from '@/com
 import { ChatSearchBar, countSearchMatches } from '@/components/conversation/ChatSearchBar';
 import { useShortcut } from '@/hooks/useShortcut';
 import { getSessionFileContent, getSessionFileDiff, updateReviewComment, deleteReviewComment as deleteReviewCommentApi, listReviewComments, createConversation, createReviewComment, getConversationMessages, toStoreMessage, generateSummary, getConversationSummary } from '@/lib/api';
+import { getDiffFromCache, setDiffInCache } from '@/lib/diffCache';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { BlockErrorFallback, InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { BranchSyncBanner } from '@/components/BranchSyncBanner';
@@ -677,9 +678,22 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     // For diff view without diff content, load it
     if (currentFileTab.viewMode === 'diff' && !currentFileTab.diff && !currentFileTab.isBinary && !currentFileTab.isTooLarge && !currentFileTab.loadError && currentFileTab.sessionId) {
       const loadDiff = async () => {
+        // Check frontend diff cache first
+        const cachedDiff = getDiffFromCache(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path);
+        if (cachedDiff) {
+          updateFileTab(currentFileTab.id, {
+            diff: {
+              oldContent: cachedDiff.oldContent ?? '',
+              newContent: cachedDiff.newContent ?? '',
+            },
+            isLoading: false,
+          });
+          return;
+        }
         updateFileTab(currentFileTab.id, { isLoading: true });
         try {
           const diffData = await getSessionFileDiff(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path);
+          setDiffInCache(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path, diffData);
           updateFileTab(currentFileTab.id, {
             diff: {
               oldContent: diffData.oldContent ?? '',
@@ -776,22 +790,35 @@ export function ConversationArea({ children }: ConversationAreaProps) {
 
     // For diff view without diff content, load it
     if (tab.viewMode === 'diff' && !tab.diff && !tab.isBinary && !tab.isTooLarge && !tab.loadError && tab.sessionId) {
-      updateFileTab(id, { isLoading: true });
-      try {
-        const diffData = await getSessionFileDiff(tab.workspaceId, tab.sessionId, tab.path);
+      // Check frontend diff cache first
+      const cachedDiff = getDiffFromCache(tab.workspaceId, tab.sessionId, tab.path);
+      if (cachedDiff) {
         updateFileTab(id, {
           diff: {
-            oldContent: diffData.oldContent ?? '',
-            newContent: diffData.newContent ?? '',
+            oldContent: cachedDiff.oldContent ?? '',
+            newContent: cachedDiff.newContent ?? '',
           },
           isLoading: false,
         });
-      } catch (error) {
-        console.error('Failed to load diff:', error);
-        updateFileTab(id, {
-          loadError: error instanceof Error ? error.message : 'Unknown error',
-          isLoading: false,
-        });
+      } else {
+        updateFileTab(id, { isLoading: true });
+        try {
+          const diffData = await getSessionFileDiff(tab.workspaceId, tab.sessionId, tab.path);
+          setDiffInCache(tab.workspaceId, tab.sessionId, tab.path, diffData);
+          updateFileTab(id, {
+            diff: {
+              oldContent: diffData.oldContent ?? '',
+              newContent: diffData.newContent ?? '',
+            },
+            isLoading: false,
+          });
+        } catch (error) {
+          console.error('Failed to load diff:', error);
+          updateFileTab(id, {
+            loadError: error instanceof Error ? error.message : 'Unknown error',
+            isLoading: false,
+          });
+        }
       }
     }
   }, [fileTabs, selectFileTab, updateFileTab]);

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useSelectedIds, useFileTabState, useTodoState, useFileCommentStats, useReviewComments } from '@/stores/selectors';
 import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, createConversation, updateReviewComment as apiUpdateReviewComment, ApiError, ErrorCode, type FileChangeDTO, type BranchStatsDTO } from '@/lib/api';
+import { getDiffFromCache, setDiffInCache, invalidateDiffCache } from '@/lib/diffCache';
 import { formatReviewFeedback } from '@/lib/formatReviewFeedback';
 import { FileTree, FileIcon, type FileNode, type FileTreeHandle } from '@/components/files/FileTree';
 import { TodoPanel } from '@/components/panels/TodoPanel';
@@ -122,6 +123,7 @@ export function ChangesPanel() {
   const [filesLoading, setFilesLoading] = useState(false);
   const [filesError, setFilesError] = useState<string | null>(null);
   const [changes, setChanges] = useState<FileChangeDTO[]>([]);
+  const prevChangesKeyRef = useRef<string>('');
   const [changesLoading, setChangesLoading] = useState(false);
   const [allChanges, setAllChanges] = useState<FileChangeDTO[]>([]);
   const [branchStats, setBranchStats] = useState<BranchStatsDTO | null>(null);
@@ -141,6 +143,12 @@ export function ChangesPanel() {
     try {
       const data = await getSessionChanges(selectedWorkspaceId, selectedSessionId);
       setChanges(data || []);
+      // Only invalidate diff cache when the set of changed files actually differs
+      const newKey = (data || []).map(f => `${f.path}:${f.status}:${f.additions}:${f.deletions}`).sort().join('\n');
+      if (newKey !== prevChangesKeyRef.current) {
+        prevChangesKeyRef.current = newKey;
+        invalidateDiffCache(selectedWorkspaceId, selectedSessionId);
+      }
     } catch (error) {
       console.error('Failed to fetch changes:', error);
     }
@@ -241,6 +249,56 @@ export function ChangesPanel() {
     }
   };
 
+  // Shared helper: check cache then fetch diff, applying size check and updating tab state.
+  const loadDiffForTab = async (tabId: string, workspaceId: string, sessionId: string, path: string) => {
+    // Check frontend diff cache first — avoids HTTP round-trip on re-open
+    const cachedDiff = getDiffFromCache(workspaceId, sessionId, path);
+    if (cachedDiff) {
+      const totalSize = (cachedDiff.oldContent?.length || 0) + (cachedDiff.newContent?.length || 0);
+      if (totalSize > MAX_DIFF_SIZE) {
+        updateFileTab(tabId, { isLoading: false, isTooLarge: true });
+        return;
+      }
+      updateFileTab(tabId, {
+        diff: {
+          oldContent: cachedDiff.oldContent ?? '',
+          newContent: cachedDiff.newContent ?? '',
+        },
+        isLoading: false,
+      });
+      return;
+    }
+
+    updateFileTab(tabId, { isLoading: true });
+
+    try {
+      const diffData = await getSessionFileDiff(workspaceId, sessionId, path);
+
+      // Cache the result for fast re-opens
+      setDiffInCache(workspaceId, sessionId, path, diffData);
+
+      const totalSize = (diffData.oldContent?.length || 0) + (diffData.newContent?.length || 0);
+      if (totalSize > MAX_DIFF_SIZE) {
+        updateFileTab(tabId, { isLoading: false, isTooLarge: true });
+        return;
+      }
+
+      updateFileTab(tabId, {
+        diff: {
+          oldContent: diffData.oldContent ?? '',
+          newContent: diffData.newContent ?? '',
+        },
+        isLoading: false,
+      });
+    } catch (error) {
+      console.error('Failed to load diff:', error);
+      updateFileTab(tabId, {
+        loadError: error instanceof Error ? error.message : 'Unknown error',
+        isLoading: false,
+      });
+    }
+  };
+
   // Handle changed file selection - shows diff view (session-scoped tab)
   const handleChangedFileSelect = async (path: string) => {
     if (!selectedWorkspaceId || !selectedSessionId) return;
@@ -248,6 +306,13 @@ export function ChangesPanel() {
     const filename = path.split('/').pop() || path;
     // Include sessionId in tab ID to allow same file open in different sessions
     const tabId = `${selectedWorkspaceId}-${selectedSessionId}-diff-${path}`;
+
+    // If this tab is already open, just select it
+    const existingTab = fileTabs.find((t) => t.id === tabId);
+    if (existingTab) {
+      selectFileTab(tabId);
+      return;
+    }
 
     // Check if it's a binary file
     if (isBinaryFile(filename)) {
@@ -277,39 +342,7 @@ export function ChangesPanel() {
     };
 
     openFileTab(newTab);
-
-    // Always set loading state for existing tabs (e.g., restored from persistence without content)
-    updateFileTab(tabId, { isLoading: true });
-
-    // Fetch diff
-    try {
-      const diffData = await getSessionFileDiff(selectedWorkspaceId, selectedSessionId, path);
-
-      // Check if file is too large
-      const totalSize = (diffData.oldContent?.length || 0) + (diffData.newContent?.length || 0);
-      if (totalSize > MAX_DIFF_SIZE) {
-        updateFileTab(tabId, {
-          isLoading: false,
-          isTooLarge: true,
-        });
-        return;
-      }
-
-      updateFileTab(tabId, {
-        diff: {
-          // Ensure strings even if API returns undefined
-          oldContent: diffData.oldContent ?? '',
-          newContent: diffData.newContent ?? '',
-        },
-        isLoading: false,
-      });
-    } catch (error) {
-      console.error('Failed to load diff:', error);
-      updateFileTab(tabId, {
-        loadError: error instanceof Error ? error.message : 'Unknown error',
-        isLoading: false,
-      });
-    }
+    await loadDiffForTab(tabId, selectedWorkspaceId, selectedSessionId, path);
   };
 
   // Handle review comment click - opens diff view scrolled to the comment line
@@ -360,31 +393,7 @@ export function ChangesPanel() {
     };
 
     openFileTab(newTab);
-
-    // Fetch diff
-    try {
-      const diffData = await getSessionFileDiff(selectedWorkspaceId, selectedSessionId, path);
-
-      const totalSize = (diffData.oldContent?.length || 0) + (diffData.newContent?.length || 0);
-      if (totalSize > MAX_DIFF_SIZE) {
-        updateFileTab(tabId, { isLoading: false, isTooLarge: true });
-        return;
-      }
-
-      updateFileTab(tabId, {
-        diff: {
-          oldContent: diffData.oldContent ?? '',
-          newContent: diffData.newContent ?? '',
-        },
-        isLoading: false,
-      });
-    } catch (error) {
-      console.error('Failed to load diff:', error);
-      updateFileTab(tabId, {
-        loadError: error instanceof Error ? error.message : 'Unknown error',
-        isLoading: false,
-      });
-    }
+    await loadDiffForTab(tabId, selectedWorkspaceId, selectedSessionId, path);
   };
 
   // Get current session and workspace for status-based styling

--- a/src/lib/diffCache.ts
+++ b/src/lib/diffCache.ts
@@ -1,0 +1,68 @@
+import type { FileDiffDTO } from '@/lib/api';
+
+interface CacheEntry {
+  data: FileDiffDTO;
+  cachedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const MAX_ENTRIES = 50;
+const MAX_AGE_MS = 10_000; // 10s TTL — matches backend DiffCache TTL
+
+function makeKey(workspaceId: string, sessionId: string, path: string): string {
+  return `${workspaceId}:${sessionId}:${path}`;
+}
+
+export function getDiffFromCache(
+  workspaceId: string,
+  sessionId: string,
+  path: string
+): FileDiffDTO | null {
+  const key = makeKey(workspaceId, sessionId, path);
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.cachedAt > MAX_AGE_MS) {
+    cache.delete(key);
+    return null;
+  }
+  // Move to end for LRU ordering
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry.data;
+}
+
+export function setDiffInCache(
+  workspaceId: string,
+  sessionId: string,
+  path: string,
+  data: FileDiffDTO
+): void {
+  const key = makeKey(workspaceId, sessionId, path);
+  cache.delete(key); // Remove if exists (for LRU reorder)
+  cache.set(key, { data, cachedAt: Date.now() });
+  // Evict oldest if over limit
+  if (cache.size > MAX_ENTRIES) {
+    const firstKey = cache.keys().next().value;
+    if (firstKey) cache.delete(firstKey);
+  }
+}
+
+export function invalidateDiffCache(
+  workspaceId: string,
+  sessionId: string,
+  path?: string
+): void {
+  if (path) {
+    cache.delete(makeKey(workspaceId, sessionId, path));
+  } else {
+    // Invalidate all entries for this session
+    const prefix = `${workspaceId}:${sessionId}:`;
+    for (const key of cache.keys()) {
+      if (key.startsWith(prefix)) cache.delete(key);
+    }
+  }
+}
+
+export function clearDiffCache(): void {
+  cache.clear();
+}


### PR DESCRIPTION
## Summary

- Adds a **backend DiffCache** (Go, TTL-based, 10s) to avoid repeated `git show` subprocess spawns on the file diff endpoint
- Adds a **frontend diffCache** (TypeScript, 10s TTL + LRU eviction at 50 entries) to skip HTTP round-trips when re-opening previously viewed diffs
- Deduplicates diff-loading logic in `ChangesPanel` via a shared `loadDiffForTab` helper

## Changes Made

- **backend/server/diff_cache.go** — New `DiffCache` struct with `Get`/`Set`/`InvalidateSession`/`Close`, defensive copying, and background cleanup goroutine
- **backend/server/diff_cache_test.go** — Tests for get/set, TTL expiration, session invalidation, concurrent access, and close behavior
- **backend/server/session_git_handlers.go** — Cache check before `os.ReadFile`/`git show`; cache set after computing response
- **backend/main.go** — Instantiate `DiffCache`, invalidate on git events alongside `statsCache`
- **backend/server/handlers.go, router.go** — Thread `diffCache` through to handlers
- **src/lib/diffCache.ts** — Frontend cache module with LRU eviction and per-session invalidation
- **src/components/panels/ChangesPanel.tsx** — Extract `loadDiffForTab` helper, add early return for already-open tabs, invalidate frontend cache when changes fingerprint changes
- **src/components/conversation/ConversationArea.tsx** — Check frontend cache before fetching diffs
- **Test helpers** — Updated `NewHandlers`/`NewRouter` call sites for new parameter

## Test Plan

- [ ] `cd backend && go test ./...` — all tests pass including new `diff_cache_test.go`
- [ ] `npm run lint && npm run build` — frontend compiles cleanly
- [ ] Manual: open Changes panel, click a file to view diff, close tab, re-open — should load instantly from cache
- [ ] Manual: edit a file in the worktree, wait >10s, view diff — should show updated content (TTL expired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)