### PR TITLE
Add sidebar bottom panel minimize/expand with collapsible API

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -47,6 +47,7 @@ import {
   ResizablePanelGroup,
   ResizablePanel,
   ResizableHandle,
+  type PanelImperativeHandle,
 } from '@/components/ui/resizable';
 import {
   MoreVertical,
@@ -116,6 +117,9 @@ export function ChangesPanel() {
   const updateSession = useAppStore((s) => s.updateSession);
   const layoutChanges = useSettingsStore((s) => s.layoutChanges);
   const setLayoutChanges = useSettingsStore((s) => s.setLayoutChanges);
+  const sidebarBottomPanelMinimized = useSettingsStore((s) => s.sidebarBottomPanelMinimized);
+  const setSidebarBottomPanelMinimized = useSettingsStore((s) => s.setSidebarBottomPanelMinimized);
+  const toggleSidebarBottomPanel = useSettingsStore((s) => s.toggleSidebarBottomPanel);
   const [selectedTab, setSelectedTab] = useState('files');
   const [bottomTab, setBottomTab] = useState('todos');
   const [files, setFiles] = useState<FileNode[]>([]);
@@ -133,6 +137,7 @@ export function ChangesPanel() {
   const fileTreeRef = useRef<FileTreeHandle>(null);
   const checksPanelRef = useRef<ChecksPanelHandle>(null);
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const bottomPanelRef = useRef<PanelImperativeHandle>(null);
 
   // Fetch working changes (truly uncommitted files only — diff against HEAD)
   const fetchChanges = useCallback(async () => {
@@ -594,6 +599,25 @@ export function ChangesPanel() {
     }
   }, [fetchChanges, fetchBranchData]);
 
+  // Handle bottom tab click when panel is minimized: expand and select the tab
+  const handleBottomTabClick = useCallback((tabId: string) => {
+    setBottomTab(tabId);
+    if (sidebarBottomPanelMinimized) {
+      setSidebarBottomPanelMinimized(false);
+    }
+  }, [sidebarBottomPanelMinimized, setSidebarBottomPanelMinimized]);
+
+  // Sync imperative panel collapse/expand with the persisted minimized state
+  useEffect(() => {
+    const panel = bottomPanelRef.current;
+    if (!panel) return;
+    if (sidebarBottomPanelMinimized) {
+      panel.collapse();
+    } else {
+      panel.expand();
+    }
+  }, [sidebarBottomPanelMinimized]);
+
   // Auto-switch to a tab when requested by other components (e.g., WebSocket comment_added).
   // Debounced so rapid-fire events (many comments in a review) only switch once.
   useEffect(() => {
@@ -632,14 +656,14 @@ export function ChangesPanel() {
         menuContext={menuContext}
       />
 
-      {/* Resizable content area */}
+      {/* Always-mounted resizable layout — bottom panel uses collapsible API to avoid remounting */}
       <ResizablePanelGroup
         direction="vertical"
         className="flex-1 min-h-0"
         defaultLayout={layoutChanges}
         onLayoutChange={setLayoutChanges}
       >
-        {/* File List */}
+        {/* Top Panel - Files/Changes/Review/Checks */}
         <ResizablePanel id="file-list" defaultSize="65%" minSize="20%" className="overflow-hidden">
           {/* All panels stay mounted; CSS visibility toggling prevents unmount/remount flash */}
           <div className={cn("h-full", selectedTab !== 'files' && 'hidden')}>
@@ -718,40 +742,56 @@ export function ChangesPanel() {
           </div>
         </ResizablePanel>
 
-        <ResizableHandle direction="vertical" />
+        <ResizableHandle direction="vertical" onDoubleClick={toggleSidebarBottomPanel} />
 
-        {/* Bottom Panel - Todos/MCP/History */}
-        <ResizablePanel id="terminal" defaultSize="35%" minSize="15%" className="overflow-hidden">
+        {/* Bottom Panel - Todos/MCP/History — collapsible to avoid remounting */}
+        <ResizablePanel
+          ref={bottomPanelRef}
+          id="terminal"
+          defaultSize="35%"
+          minSize="15%"
+          collapsible
+          collapsedSize={0}
+          onResize={(size) => {
+            // Sync minimized state when user drags the panel to/from collapsed
+            const isCollapsed = size.asPercentage === 0;
+            if (isCollapsed !== sidebarBottomPanelMinimized) {
+              setSidebarBottomPanelMinimized(isCollapsed);
+            }
+          }}
+          className="overflow-hidden"
+        >
           <div className="flex flex-col h-full w-full">
             {/* Tabs Row - matching top panel style */}
             <BottomPanelTabs
               bottomTab={bottomTab}
-              setBottomTab={setBottomTab}
+              setBottomTab={handleBottomTabClick}
               totalPendingTodos={totalPendingTodos}
+              isMinimized={sidebarBottomPanelMinimized}
+              onToggleMinimize={toggleSidebarBottomPanel}
             />
-            {/* Tab content */}
+            {/* Tab content — CSS visibility toggling prevents unmount/remount */}
             <div className="flex-1 min-h-0">
-              {bottomTab === 'todos' && (
+              <div className={cn("h-full", bottomTab !== 'todos' && 'hidden')}>
                 <ErrorBoundary section="TodoPanel" fallback={<InlineErrorFallback message="Unable to display tasks" />}>
                   <TodoPanel />
                 </ErrorBoundary>
-              )}
-              {bottomTab === 'budget' && (
+              </div>
+              <div className={cn("h-full", bottomTab !== 'budget' && 'hidden')}>
                 <ErrorBoundary section="BudgetPanel" fallback={<InlineErrorFallback message="Unable to display usage" />}>
                   <BudgetStatusPanel />
                 </ErrorBoundary>
-              )}
-              {bottomTab === 'mcp' && (
+              </div>
+              <div className={cn("h-full", bottomTab !== 'mcp' && 'hidden')}>
                 <ErrorBoundary section="McpPanel" fallback={<InlineErrorFallback message="Unable to display MCP servers" />}>
                   <McpServersPanel />
                 </ErrorBoundary>
-              )}
-              {bottomTab === 'file-history' && (
+              </div>
+              <div className={cn("h-full", bottomTab !== 'file-history' && 'hidden')}>
                 <ErrorBoundary section="FileHistory" fallback={<InlineErrorFallback message="Unable to display file history" />}>
                   <FileHistoryPanel />
                 </ErrorBoundary>
-              )}
-              {/* TODO: Re-enable Scripts tab when the feature is reintroduced (see ScriptsPanel.tsx) */}
+              </div>
             </div>
           </div>
         </ResizablePanel>
@@ -866,10 +906,14 @@ function BottomPanelTabs({
   bottomTab,
   setBottomTab,
   totalPendingTodos,
+  isMinimized,
+  onToggleMinimize,
 }: {
   bottomTab: string;
   setBottomTab: (tab: string) => void;
   totalPendingTodos: number;
+  isMinimized: boolean;
+  onToggleMinimize: () => void;
 }) {
   // Use individual selectors to prevent unnecessary re-renders
   const hiddenBottomTabs = useSettingsStore((s) => s.hiddenBottomTabs);
@@ -967,6 +1011,27 @@ function BottomPanelTabs({
           })}
         </DropdownMenuContent>
       </DropdownMenu>
+
+      {/* Minimize/expand toggle */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 shrink-0"
+            onClick={onToggleMinimize}
+          >
+            {isMinimized ? (
+              <ChevronsUpDown className="size-3" />
+            ) : (
+              <ChevronsDownUp className="size-3" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          {isMinimized ? 'Expand Panel' : 'Minimize Panel'}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -137,6 +137,7 @@ interface SettingsState {
   unreadSessions: string[]; // Session IDs with unread agent completions
   showBottomTerminal: boolean;
   zenMode: boolean; // Distraction-free mode that hides sidebars
+  sidebarBottomPanelMinimized: boolean; // Whether the sidebar bottom panel (Tasks/History/etc) is minimized
   hiddenBottomTabs: BottomPanelTab[]; // Bottom panel tabs that are hidden (Tasks always visible)
   bottomTabOrder: AllBottomPanelTab[]; // Order of bottom panel tabs
   topTabOrder: AllTopPanelTab[]; // Order of top panel tabs
@@ -202,6 +203,8 @@ interface SettingsState {
   setStrictPrivacy: (value: boolean) => void;
   setShowBottomTerminal: (value: boolean) => void;
   setZenMode: (value: boolean) => void;
+  setSidebarBottomPanelMinimized: (value: boolean) => void;
+  toggleSidebarBottomPanel: () => void;
   toggleWorkspaceCollapsed: (workspaceId: string) => void;
   expandWorkspace: (workspaceId: string) => void;
   markWorkspaceUnread: (workspaceId: string) => void;
@@ -246,6 +249,7 @@ export const useSettingsStore = create<SettingsState>()(
       unreadSessions: [], // Session IDs with unread agent completions
       showBottomTerminal: false,
       zenMode: false,
+      sidebarBottomPanelMinimized: false,
       hiddenBottomTabs: [], // All tabs visible by default
       bottomTabOrder: DEFAULT_BOTTOM_TAB_ORDER, // Default tab order
       topTabOrder: DEFAULT_TOP_TAB_ORDER, // Default top tab order
@@ -295,6 +299,8 @@ export const useSettingsStore = create<SettingsState>()(
       setStrictPrivacy: (value) => set({ strictPrivacy: value }),
       setShowBottomTerminal: (value) => set({ showBottomTerminal: value }),
       setZenMode: (value) => set({ zenMode: value }),
+      setSidebarBottomPanelMinimized: (value) => set({ sidebarBottomPanelMinimized: value }),
+      toggleSidebarBottomPanel: () => set((state) => ({ sidebarBottomPanelMinimized: !state.sidebarBottomPanelMinimized })),
       toggleWorkspaceCollapsed: (workspaceId) =>
         set((state) => {
           const isCollapsed = state.collapsedWorkspaces.includes(workspaceId);


### PR DESCRIPTION
## Summary
- Use `react-resizable-panels` collapsible API (`collapsible`, `collapsedSize={0}`, imperative `collapse()`/`expand()`) to minimize/expand the bottom panel without unmounting any components — preserves scroll position, selection state, and avoids remount flash
- Switch bottom panel tabs (Tasks, Usage, MCP, File History) from conditional rendering to CSS `hidden` class pattern, matching the top panel approach to preserve component state across tab switches
- Replace `ChevronUp`/`ChevronDown` icons with `ChevronsUpDown`/`ChevronsDownUp` for clearer collapse/expand semantics
- Persist minimized state in settings store; sync via imperative panel ref, `onResize` callback, and resize handle double-click

## Test plan
- [ ] Toggle minimize via the button in the bottom panel tab bar — top panel should expand to full height, bottom tabs still visible as a bar
- [ ] Toggle expand — bottom panel restores to previous size with content intact
- [ ] Double-click the resize handle to toggle minimize/expand
- [ ] Switch bottom tabs while expanded — components should not remount (verify scroll position preserved in Tasks list)
- [ ] Click a bottom tab while minimized — panel should expand and switch to that tab
- [ ] Drag resize handle to collapse bottom panel to zero — should sync minimized state
- [ ] Reload app — minimized state should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)