### PR TITLE
Persist streamed content when agent is stopped

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -790,9 +790,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     try {
       // Commit any queued message to history before stopping
       commitQueuedMessage(selectedConversationId);
+      // Compute elapsed time for the stopped run
+      const startTime = useAppStore.getState().streamingState[selectedConversationId]?.startTime;
+      const durationMs = startTime ? Date.now() - startTime : undefined;
       // Finalize streaming content into a committed message before stopping
-      // so it persists in the message list (same as normal turn completion)
-      finalizeStreamingMessage(selectedConversationId, {});
+      // so it persists in the message list (same as normal turn completion).
+      // toolUsage is auto-derived from activeTools inside finalizeStreamingMessage.
+      finalizeStreamingMessage(selectedConversationId, { durationMs });
       // Add system message indicating the agent was stopped
       addMessage({
         id: `msg-stopped-${Date.now()}`,
@@ -802,14 +806,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         timestamp: new Date().toISOString(),
       });
       await stopConversation(selectedConversationId);
-      setStreaming(selectedConversationId, false);
       updateConversation(selectedConversationId, { status: 'idle' });
-      clearActiveTools(selectedConversationId);
     } catch (error) {
       console.error('Failed to stop conversation:', error);
       showError('Failed to stop conversation. Please try again.');
     }
-  }, [selectedConversationId, isStreaming, commitQueuedMessage, finalizeStreamingMessage, addMessage, setStreaming, updateConversation, clearActiveTools, showError]);
+  }, [selectedConversationId, isStreaming, commitQueuedMessage, finalizeStreamingMessage, addMessage, updateConversation, showError]);
 
   useShortcut('stopAgent', handleStop, { enabled: isStreaming });
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -253,14 +253,15 @@ export function useWebSocket(enabled: boolean = true) {
     if (data.type === 'conversation_status') {
       if (typeof data.payload === 'string' && isValidConversationStatus(data.payload)) {
         store.updateConversation(conversationId, { status: data.payload });
-        // Safety net: when backend says idle, clear any stale streaming state.
+        // Safety net: when backend says idle, finalize any stale streaming state.
         // This catches cases where result/complete events were dropped or missed.
+        // Uses finalizeStreamingMessage instead of clearStreamingText to preserve
+        // any streamed content (text + tool blocks) that hasn't been committed yet.
         if (data.payload === 'idle' && store.streamingState[conversationId]?.isStreaming) {
           store.commitQueuedMessage(conversationId);
-          store.clearStreamingText(conversationId);
-          store.clearActiveTools(conversationId);
-          store.clearThinking(conversationId);
-          store.clearSubAgents(conversationId);
+          const startTime = store.streamingState[conversationId]?.startTime;
+          const durationMs = startTime ? Date.now() - startTime : undefined;
+          store.finalizeStreamingMessage(conversationId, { durationMs });
           store.clearAgentTodos(conversationId);
         }
       } else {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1735,6 +1735,26 @@ updateFileTabContent: (id, content) => set((state) => ({
       const timeline: TimelineEntry[] | undefined =
         timelineItems.length > 0 ? timelineItems.map(item => item.entry) : undefined;
 
+      // Auto-derive toolUsage from activeTools when not explicitly provided.
+      // This ensures tool blocks render correctly even when callers (handleStop,
+      // complete event, safety net) don't capture toolUsage themselves.
+      const derivedToolUsage: ToolUsage[] | undefined =
+        metadata.toolUsage !== undefined
+          ? metadata.toolUsage
+          : tools.length > 0
+            ? tools.map((t) => ({
+                id: t.id,
+                tool: t.tool,
+                params: t.params,
+                success: t.success,
+                summary: t.summary,
+                durationMs: t.endTime && t.startTime ? t.endTime - t.startTime : undefined,
+                stdout: t.stdout,
+                stderr: t.stderr,
+                metadata: t.metadata,
+              }))
+            : undefined;
+
       // Create the message from streaming text
       const pendingCpUuid = state.pendingCheckpointUuid[conversationId];
       const newMessage: Message = {
@@ -1744,7 +1764,7 @@ updateFileTabContent: (id, content) => set((state) => ({
         content: streaming.text,
         timestamp: new Date().toISOString(),
         durationMs: metadata.durationMs,
-        toolUsage: metadata.toolUsage,
+        toolUsage: derivedToolUsage,
         runSummary: metadata.runSummary,
         ...(streaming.thinking ? { thinkingContent: streaming.thinking } : {}),
         ...(timeline ? { timeline } : {}),


### PR DESCRIPTION
## Summary
- **Preserve streamed content on stop**: `finalizeStreamingMessage` now commits text and tool blocks into message history when the user stops the agent or the safety net fires, instead of discarding them
- **Auto-derive toolUsage**: `finalizeStreamingMessage` auto-derives `toolUsage` from `activeTools` when not explicitly provided, removing the burden from callers
- **Cleanup**: Removed redundant `setStreaming(false)` and `clearActiveTools` calls from `handleStop` since `finalizeStreamingMessage` already handles both

## Test plan
- [ ] Start an agent, let it stream some text and tool calls, then stop it — verify the partial response persists in the message list with tool blocks visible
- [ ] Simulate a dropped `complete` event (safety net path) — verify content is preserved and duration is shown
- [ ] Normal agent completion — verify no regression in message finalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)