### PR TITLE
Persist terminal sessions across session switches

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useLayoutEffect, useState, useCallback, useRef } from 'react';
 import { useTheme } from 'next-themes';
 import { Loader2 } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
@@ -190,6 +190,7 @@ export default function Home() {
   // Panel refs for imperative collapse/expand
   const leftSidebarPanelRef = useRef<PanelImperativeHandle>(null);
   const rightSidebarPanelRef = useRef<PanelImperativeHandle>(null);
+  const bottomTerminalPanelRef = useRef<PanelImperativeHandle>(null);
 
   const leftSidebarDomRef = useRef<HTMLDivElement>(null);
 
@@ -244,12 +245,30 @@ export default function Home() {
   })));
 
   const toggleBottomTerminal = useCallback(() => {
-    setShowBottomTerminal(!showBottomTerminal);
-  }, [showBottomTerminal, setShowBottomTerminal]);
+    const panel = bottomTerminalPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) {
+      panel.expand();
+    } else {
+      panel.collapse();
+    }
+  }, []);
 
   const hideBottomTerminal = useCallback(() => {
-    setShowBottomTerminal(false);
-  }, [setShowBottomTerminal]);
+    bottomTerminalPanelRef.current?.collapse();
+  }, []);
+
+  // Sync bottom terminal panel collapse state on mount from persisted setting
+  // useLayoutEffect to prevent flash of expanded panel before collapsing
+  useLayoutEffect(() => {
+    const panel = bottomTerminalPanelRef.current;
+    if (!panel) return;
+    if (!showBottomTerminal && !panel.isCollapsed()) {
+      panel.collapse();
+    }
+    // Only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Determine if we're in a Full Content view (not conversation)
   // Also treat as full content view when no session is selected (to show welcome screen)
@@ -1392,7 +1411,7 @@ export default function Home() {
     const handleToggleRightPanel = () => toggleRightSidebar();
     const handleToggleBottomPanel = () => toggleBottomTerminal();
     const handleShowBottomPanel = () => {
-      setShowBottomTerminal(true);
+      bottomTerminalPanelRef.current?.expand();
     };
     const handleOpenInVSCode = () => {
       const { selectedSessionId, sessions } = useAppStore.getState();
@@ -1623,28 +1642,39 @@ export default function Home() {
                       ) : null}
                     </ResizablePanel>
 
-                    {/* Bottom Terminal - conditionally rendered */}
-                    {selectedSession && showBottomTerminal && (
-                      <>
-                        <ResizableHandle direction="vertical" />
-                        <ResizablePanel
-                          id="bottom-terminal"
-                          defaultSize="250px"
-                          minSize="100px"
-                          maxSize="400px"
-                        >
-                          <div className="h-full">
-                            <ErrorBoundary section="Terminal">
-                              <BottomTerminal
-                                sessionId={selectedSession.id}
-                                workspacePath={selectedSession.worktreePath}
-                                onHide={hideBottomTerminal}
-                              />
-                            </ErrorBoundary>
-                          </div>
-                        </ResizablePanel>
-                      </>
-                    )}
+                    {/* Bottom Terminal - always mounted, collapsible */}
+                    <ResizableHandle
+                      direction="vertical"
+                      className={cn(!showBottomTerminal && "hidden")}
+                    />
+                    <ResizablePanel
+                      ref={bottomTerminalPanelRef}
+                      id="bottom-terminal"
+                      defaultSize="250px"
+                      minSize="100px"
+                      maxSize="400px"
+                      collapsible={true}
+                      collapsedSize={0}
+                      onResize={(size) => {
+                        const collapsed = size.asPercentage === 0;
+                        if (collapsed && showBottomTerminal) {
+                          setShowBottomTerminal(false);
+                        } else if (!collapsed && !showBottomTerminal) {
+                          setShowBottomTerminal(true);
+                        }
+                      }}
+                    >
+                      <div className="h-full">
+                        <ErrorBoundary section="Terminal">
+                          <BottomTerminal
+                            currentSessionId={selectedSessionId}
+                            currentWorkspacePath={selectedSession?.worktreePath ?? null}
+                            isExpanded={showBottomTerminal}
+                            onHide={hideBottomTerminal}
+                          />
+                        </ErrorBoundary>
+                      </div>
+                    </ResizablePanel>
                   </ResizablePanelGroup>
                 </ResizablePanel>
 

--- a/src/components/layout/BottomTerminal.tsx
+++ b/src/components/layout/BottomTerminal.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { X, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { useTerminalState } from '@/stores/selectors';
+import { useTerminalState, useAllTerminalInstances } from '@/stores/selectors';
 import { cn } from '@/lib/utils';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { BlockErrorFallback } from '@/components/shared/ErrorFallbacks';
@@ -22,13 +22,14 @@ const Terminal = dynamic(
 );
 
 interface BottomTerminalProps {
-  sessionId: string;
-  workspacePath: string;
+  currentSessionId: string | null;
+  currentWorkspacePath: string | null;
+  isExpanded: boolean;
   onHide: () => void;
 }
 
-export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTerminalProps) {
-  // Use optimized selector scoped to this session
+export function BottomTerminal({ currentSessionId, currentWorkspacePath, isExpanded, onHide }: BottomTerminalProps) {
+  // Current session's terminals for tab bar display
   const {
     instances,
     activeId,
@@ -36,7 +37,11 @@ export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTermi
     closeTerminal,
     setActiveTerminal,
     markTerminalExited,
-  } = useTerminalState(sessionId);
+  } = useTerminalState(currentSessionId);
+
+  // ALL sessions' terminals for persistent rendering
+  const { allInstances, allActiveIds } = useAllTerminalInstances();
+
   const canCreateMore = instances.length < 5;
 
   // Ref to track if we've already created a terminal for this session
@@ -45,30 +50,32 @@ export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTermi
 
   // Auto-create first terminal when panel is shown and no terminals exist
   // Deferred so it doesn't block session navigation render
+  // Gated on isExpanded to avoid spawning PTYs when the panel is collapsed
   useEffect(() => {
-    if (instances.length === 0 && createdRef.current !== sessionId) {
+    if (isExpanded && currentSessionId && currentWorkspacePath && instances.length === 0 && createdRef.current !== currentSessionId) {
       const id = setTimeout(() => {
-        createdRef.current = sessionId;
-        createTerminal(sessionId);
+        createdRef.current = currentSessionId;
+        createTerminal(currentSessionId, currentWorkspacePath);
       }, 500);
       return () => clearTimeout(id);
     }
-  }, [sessionId, instances.length, createTerminal]);
+  }, [isExpanded, currentSessionId, currentWorkspacePath, instances.length, createTerminal]);
 
   const handleCreateTerminal = () => {
-    if (canCreateMore) {
-      createTerminal(sessionId);
+    if (canCreateMore && currentSessionId && currentWorkspacePath) {
+      createTerminal(currentSessionId, currentWorkspacePath);
     }
   };
 
   const handleCloseTerminal = (terminalId: string, e: React.MouseEvent) => {
     e.stopPropagation();
+    if (!currentSessionId) return;
     // If this is the last terminal, hide the panel
     if (instances.length === 1) {
-      closeTerminal(sessionId, terminalId);
+      closeTerminal(currentSessionId, terminalId);
       onHide();
     } else {
-      closeTerminal(sessionId, terminalId);
+      closeTerminal(currentSessionId, terminalId);
     }
   };
 
@@ -78,7 +85,7 @@ export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTermi
 
   return (
     <div className="flex flex-col h-full bg-background border-t">
-      {/* Header with tabs */}
+      {/* Header with tabs - shows current session's terminals */}
       <div className="flex items-center gap-1 px-2 py-1 border-b bg-muted/30 shrink-0">
         {/* Terminal tabs */}
         <div role="tablist" aria-label="Terminal tabs" className="flex items-center gap-1 flex-1 min-w-0 overflow-x-auto">
@@ -91,7 +98,7 @@ export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTermi
               aria-label={`Terminal ${terminal.slotNumber}${terminal.status === 'exited' ? ' (exited)' : ''}`}
               aria-controls={`terminal-panel-${terminal.id}`}
               tabIndex={activeId === terminal.id ? 0 : -1}
-              onClick={() => setActiveTerminal(sessionId, terminal.id)}
+              onClick={() => currentSessionId && setActiveTerminal(currentSessionId, terminal.id)}
               className={cn(
                 'flex items-center gap-1 px-2 py-1 text-xs rounded-sm shrink-0',
                 'hover:bg-surface-2 transition-colors',
@@ -121,7 +128,7 @@ export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTermi
             size="icon"
             className="h-6 w-6 shrink-0"
             onClick={handleCreateTerminal}
-            disabled={!canCreateMore}
+            disabled={!canCreateMore || !currentSessionId}
             title={canCreateMore ? 'New terminal' : 'Maximum 5 terminals'}
             aria-label={canCreateMore ? 'New terminal' : 'Maximum 5 terminals'}
           >
@@ -142,36 +149,45 @@ export function BottomTerminal({ sessionId, workspacePath, onHide }: BottomTermi
         </Button>
       </div>
 
-      {/* Terminal content */}
+      {/* Terminal content - render ALL sessions' terminals for persistence */}
       <div className="flex-1 min-h-0 relative bg-background">
-        {instances.length === 0 ? (
+        {currentSessionId && instances.length === 0 && (
           <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
             Click + to create a terminal
           </div>
-        ) : (
-          instances.map((terminal) => (
-            <div
-              key={terminal.id}
-              id={`terminal-panel-${terminal.id}`}
-              role="tabpanel"
-              aria-labelledby={`terminal-tab-${terminal.id}`}
-              className={cn(
-                'absolute inset-0 bg-background',
-                activeId === terminal.id ? 'block' : 'hidden'
-              )}
-            >
-              <ErrorBoundary
-                section="TerminalTab"
-                fallback={<BlockErrorFallback title="Terminal error" description="This terminal encountered an error" />}
+        )}
+
+        {/* Render terminals for EVERY session that has instances - CSS controls visibility */}
+        {Object.entries(allInstances).map(([sessionId, sessionTerminals]) =>
+          sessionTerminals.map((terminal) => {
+            const isCurrentSession = sessionId === currentSessionId;
+            const isActiveTab = allActiveIds[sessionId] === terminal.id;
+            const isVisible = isCurrentSession && isActiveTab;
+
+            return (
+              <div
+                key={terminal.id}
+                id={`terminal-panel-${terminal.id}`}
+                role="tabpanel"
+                aria-labelledby={`terminal-tab-${terminal.id}`}
+                className={cn(
+                  'absolute inset-0 bg-background',
+                  isVisible ? 'block' : 'hidden'
+                )}
               >
-                <Terminal
-                  sessionId={terminal.id}
-                  workspacePath={workspacePath}
-                  onExit={() => handleTerminalExit(terminal.id)}
-                />
-              </ErrorBoundary>
-            </div>
-          ))
+                <ErrorBoundary
+                  section="TerminalTab"
+                  fallback={<BlockErrorFallback title="Terminal error" description="This terminal encountered an error" />}
+                >
+                  <Terminal
+                    sessionId={terminal.id}
+                    workspacePath={terminal.workspacePath}
+                    onExit={() => handleTerminalExit(terminal.id)}
+                  />
+                </ErrorBoundary>
+              </div>
+            );
+          })
         )}
       </div>
     </div>

--- a/src/components/shared/Terminal.tsx
+++ b/src/components/shared/Terminal.tsx
@@ -47,9 +47,11 @@ export function Terminal({ sessionId, workspacePath, className, onExit }: Termin
     if (!container) return;
 
     resizeObserverRef.current = new ResizeObserver(() => {
-      // Debounce fit calls
+      // Debounce fit calls, skip when hidden (0 dimensions)
       requestAnimationFrame(() => {
-        fit();
+        if (container.offsetWidth > 0 && container.offsetHeight > 0) {
+          fit();
+        }
       });
     });
 

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -268,8 +268,10 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
     };
   }, []);
 
-  // Fit terminal to container
+  // Fit terminal to container (skip when container has 0 dimensions to avoid resizing PTY to 0x0)
   const fit = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || container.offsetWidth === 0 || container.offsetHeight === 0) return;
     if (fitAddonRef.current && terminalRef.current) {
       fitAddonRef.current.fit();
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -641,6 +641,7 @@ export interface TerminalInstance {
   sessionId: string;
   slotNumber: number;   // 1-5
   status: 'active' | 'exited';
+  workspacePath: string; // cwd for this terminal's PTY
 }
 
 // Review comment for code review inline comments

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -426,7 +426,7 @@ interface AppState {
   deleteCustomTodo: (sessionId: string, todoId: string) => void;
 
   // Terminal instance actions (bottom panel)
-  createTerminal: (sessionId: string) => TerminalInstance | null;
+  createTerminal: (sessionId: string, workspacePath: string) => TerminalInstance | null;
   closeTerminal: (sessionId: string, terminalId: string) => void;
   setActiveTerminal: (sessionId: string, terminalId: string) => void;
   markTerminalExited: (terminalId: string) => void;
@@ -741,6 +741,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       const { [id]: _toggleState, ...remainingToggleState } = state.sessionToggleState;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [id]: _draft, ...remainingDraftInputs } = state.draftInputs;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [id]: _terminals, ...remainingTerminalInstances } = state.terminalInstances;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [id]: _activeTerminal, ...remainingActiveTerminalId } = state.activeTerminalId;
 
       return {
         sessions: state.sessions.filter((s) => s.id !== id),
@@ -761,6 +765,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         lastActiveConversationPerSession: remainingLastActive,
         sessionToggleState: remainingToggleState,
         draftInputs: remainingDraftInputs,
+        terminalInstances: remainingTerminalInstances,
+        activeTerminalId: remainingActiveTerminalId,
         selectedFileTabId: null,
         fileTabs: [],
       };
@@ -850,10 +856,18 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     }
 
+    // Clean up terminal instances — PTYs for archived sessions should not stay alive
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [id]: _terminals, ...remainingTerminalInstances } = state.terminalInstances;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [id]: _activeTerminal, ...remainingActiveTerminalId } = state.activeTerminalId;
+
     return {
       sessions: updatedSessions,
       selectedSessionId: newSelectedSessionId,
       selectedConversationId: newSelectedConversationId,
+      terminalInstances: remainingTerminalInstances,
+      activeTerminalId: remainingActiveTerminalId,
     };
   }),
   unarchiveSession: (id) => set((state) => {
@@ -1847,7 +1861,7 @@ updateFileTabContent: (id, content) => set((state) => ({
   })),
 
   // Terminal instance actions (bottom panel)
-  createTerminal: (sessionId) => {
+  createTerminal: (sessionId, workspacePath) => {
     const state = get();
     const existing = state.terminalInstances[sessionId] || [];
 
@@ -1864,6 +1878,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       sessionId,
       slotNumber: slot,
       status: 'active',
+      workspacePath,
     };
 
     set({

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -277,6 +277,18 @@ export const useTerminalState = (sessionId: string | null) =>
     }))
   );
 
+/**
+ * All terminal instances across all sessions.
+ * Use in: BottomTerminal (for persistent rendering of all sessions' terminals)
+ */
+export const useAllTerminalInstances = () =>
+  useAppStore(
+    useShallow((s) => ({
+      allInstances: s.terminalInstances,
+      allActiveIds: s.activeTerminalId,
+    }))
+  );
+
 // ============================================================================
 // Todo State
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Terminal persistence**: Terminals stay alive when switching sessions — no more losing shell history, running processes, or scroll position
- **Panel always mounted**: Bottom terminal uses collapsible `ResizablePanel` instead of conditional rendering, keeping xterm instances in the DOM
- **Cleanup on archive/delete**: Terminal state is properly cleaned up when sessions are archived or deleted

## Changes Made

- **`page.tsx`** — Bottom terminal panel is always mounted with `collapsible` prop; `useLayoutEffect` syncs initial collapse state from persisted settings; toggle/hide use imperative panel API
- **`BottomTerminal.tsx`** — Renders terminals for *all* sessions (CSS hides inactive ones); new `isExpanded` prop gates auto-terminal-creation to avoid spawning PTYs when panel is collapsed
- **`Terminal.tsx` / `useTerminal.ts`** — Added 0-dimension guards to `fit()` and `ResizeObserver` to prevent resizing hidden terminals' PTY to 0×0
- **`types.ts`** — Added `workspacePath` to `TerminalInstance` so each terminal keeps its own cwd
- **`appStore.ts`** — `createTerminal` accepts `workspacePath`; `archiveSession` now cleans up terminal state (matching `deleteSession`); `deleteSession` also cleans up terminal state
- **`selectors.ts`** — Added `useAllTerminalInstances` selector for cross-session terminal rendering

## Test Plan

- [ ] Open terminal in session A, run a command, switch to session B, switch back — terminal A preserves history and scroll position
- [ ] Toggle terminal panel closed and open — terminals persist
- [ ] Archive a session with open terminals — no orphaned PTY processes
- [ ] Delete a session with open terminals — terminal state cleaned up
- [ ] Start app with terminal panel persisted as collapsed — no PTY spawned until panel is opened
- [ ] `npm run lint` — no new errors
- [ ] `npm run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)