### PR TITLE
Fix MCP tool validation error: coerce string numbers from LLM tool calls

### DIFF
--- a/agent-runner/src/mcp/tools/comments.ts
+++ b/agent-runner/src/mcp/tools/comments.ts
@@ -24,7 +24,7 @@ export function createCommentTools(context: WorkspaceContext) {
       "Add a code review comment to a specific line in a file. Use this to leave feedback, suggestions, or highlight issues during code review.",
       {
         filePath: z.string().describe("Relative path to the file being reviewed"),
-        lineNumber: z.number().int().min(1).describe("Line number for the comment (1-based)"),
+        lineNumber: z.coerce.number().int().min(1).describe("Line number for the comment (1-based)"),
         title: z.string().optional().describe("Short title summarizing the issue (e.g., 'Potential memory leak', 'Missing error handling')"),
         content: z.string().describe("The review comment content with details (supports markdown)"),
         severity: z.enum(["error", "warning", "suggestion", "info"]).optional().describe("Optional severity level: 'error' for bugs/critical issues, 'warning' for potential problems, 'suggestion' for improvements, 'info' for informational notes"),

--- a/agent-runner/src/mcp/tools/pr.ts
+++ b/agent-runner/src/mcp/tools/pr.ts
@@ -23,7 +23,7 @@ export function createPRTools(context: WorkspaceContext) {
       "report_pr_created",
       "Report that a pull request was created for this session. Call this AFTER successfully creating a PR with `gh pr create` or any other method. This ensures the PR is immediately tracked in the ChatML UI.",
       {
-        prNumber: z.number().int().positive().describe("The PR number (e.g., 123)"),
+        prNumber: z.coerce.number().int().positive().describe("The PR number (e.g., 123)"),
         prUrl: z.string().describe("The full PR URL (e.g., https://github.com/owner/repo/pull/123)"),
       },
       async ({ prNumber, prUrl }) => {
@@ -78,7 +78,7 @@ export function createPRTools(context: WorkspaceContext) {
       "report_pr_merged",
       "Report that a pull request was merged for this session. Call this AFTER successfully merging a PR with `gh pr merge` or any other method. This updates the session status in ChatML.",
       {
-        prNumber: z.number().int().positive().optional().describe("The PR number that was merged (optional if the session already has a PR associated)"),
+        prNumber: z.coerce.number().int().positive().optional().describe("The PR number that was merged (optional if the session already has a PR associated)"),
       },
       async ({ prNumber }) => {
         try {


### PR DESCRIPTION
## Summary
- LLMs frequently pass numbers as strings in tool call arguments (e.g., `"673"` instead of `673`), causing MCP validation errors like `Invalid input: expected number, received string`
- Changed `z.number()` to `z.coerce.number()` in all MCP tool schemas with numeric parameters (`report_pr_created`, `report_pr_merged`, `add_review_comment`) so Zod auto-converts string inputs before validation

## Test plan
- [ ] Create a PR in a session and verify `report_pr_created` succeeds without validation errors
- [ ] Verify `report_pr_merged` and `add_review_comment` also accept both string and number inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)