### PR TITLE
Make bottom terminal panel visibility per-session and store-driven

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   useFileTabState,
   usePageActions,
   useMessages,
+  useTerminalPanelVisible,
 } from '@/stores/selectors';
 import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix, applyWorkspaceOrder } from '@/stores/settingsStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -224,15 +225,12 @@ export default function Home() {
   const contentView = useSettingsStore((s) => s.contentView);
   const { error: showError } = useToast();
   const {
-    showBottomTerminal, setShowBottomTerminal,
     zenMode, setZenMode,
     layoutOuter, setLayoutOuter,
     layoutInner, setLayoutInner,
     layoutVertical, setLayoutVertical,
     resetLayouts,
   } = useSettingsStore(useShallow((s) => ({
-    showBottomTerminal: s.showBottomTerminal,
-    setShowBottomTerminal: s.setShowBottomTerminal,
     zenMode: s.zenMode,
     setZenMode: s.setZenMode,
     layoutOuter: s.layoutOuter,
@@ -245,29 +243,16 @@ export default function Home() {
   })));
 
   const toggleBottomTerminal = useCallback(() => {
-    const panel = bottomTerminalPanelRef.current;
-    if (!panel) return;
-    if (panel.isCollapsed()) {
-      panel.expand();
-    } else {
-      panel.collapse();
-    }
+    const { selectedSessionId: sid } = useAppStore.getState();
+    if (!sid) return;
+    const current = useAppStore.getState().terminalPanelVisible[sid] ?? false;
+    useAppStore.getState().setTerminalPanelVisible(sid, !current);
   }, []);
 
   const hideBottomTerminal = useCallback(() => {
-    bottomTerminalPanelRef.current?.collapse();
-  }, []);
-
-  // Sync bottom terminal panel collapse state on mount from persisted setting
-  // useLayoutEffect to prevent flash of expanded panel before collapsing
-  useLayoutEffect(() => {
-    const panel = bottomTerminalPanelRef.current;
-    if (!panel) return;
-    if (!showBottomTerminal && !panel.isCollapsed()) {
-      panel.collapse();
-    }
-    // Only run on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const { selectedSessionId: sid } = useAppStore.getState();
+    if (!sid) return;
+    useAppStore.getState().setTerminalPanelVisible(sid, false);
   }, []);
 
   // Determine if we're in a Full Content view (not conversation)
@@ -460,6 +445,21 @@ export default function Home() {
   const conversationMessages = useMessages(selectedConversationId);
   const selectNextTab = useAppStore((s) => s.selectNextTab);
   const selectPreviousTab = useAppStore((s) => s.selectPreviousTab);
+
+  // Per-session terminal panel visibility (hidden by default, not persisted across restarts)
+  const showBottomTerminal = useTerminalPanelVisible(selectedSessionId);
+  const setTerminalPanelVisible = useAppStore((s) => s.setTerminalPanelVisible);
+
+  // Sync bottom terminal panel collapse/expand state when session changes
+  useLayoutEffect(() => {
+    const panel = bottomTerminalPanelRef.current;
+    if (!panel) return;
+    if (showBottomTerminal && panel.isCollapsed()) {
+      panel.expand();
+    } else if (!showBottomTerminal && !panel.isCollapsed()) {
+      panel.collapse();
+    }
+  }, [showBottomTerminal]);
 
   const expandWorkspace = useSettingsStore((s) => s.expandWorkspace);
   const { showWizard, showGuidedTour, completeWizard, completeTour, skipAll } = useOnboarding();
@@ -1411,7 +1411,9 @@ export default function Home() {
     const handleToggleRightPanel = () => toggleRightSidebar();
     const handleToggleBottomPanel = () => toggleBottomTerminal();
     const handleShowBottomPanel = () => {
-      bottomTerminalPanelRef.current?.expand();
+      const { selectedSessionId: sid } = useAppStore.getState();
+      if (!sid) return;
+      useAppStore.getState().setTerminalPanelVisible(sid, true);
     };
     const handleOpenInVSCode = () => {
       const { selectedSessionId, sessions } = useAppStore.getState();
@@ -1448,7 +1450,7 @@ export default function Home() {
       window.removeEventListener('show-bottom-panel', handleShowBottomPanel);
       window.removeEventListener('open-in-vscode', handleOpenInVSCode);
     };
-  }, [handleNewSession, handleNewConversation, resolvedTheme, setTheme, toggleLeftSidebar, toggleRightSidebar, toggleBottomTerminal, setShowBottomTerminal]);
+  }, [handleNewSession, handleNewConversation, resolvedTheme, setTheme, toggleLeftSidebar, toggleRightSidebar, toggleBottomTerminal]);
 
   // Don't render anything until client-side mounted - prevents hydration flash
   // Body background (set by ThemeScript) shows through
@@ -1657,10 +1659,11 @@ export default function Home() {
                       collapsedSize={0}
                       onResize={(size) => {
                         const collapsed = size.asPercentage === 0;
+                        if (!selectedSessionId) return;
                         if (collapsed && showBottomTerminal) {
-                          setShowBottomTerminal(false);
+                          setTerminalPanelVisible(selectedSessionId, false);
                         } else if (!collapsed && !showBottomTerminal) {
-                          setShowBottomTerminal(true);
+                          setTerminalPanelVisible(selectedSessionId, true);
                         }
                       }}
                     >

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -212,6 +212,7 @@ interface AppState {
   // Terminal instances (bottom panel terminals per session)
   terminalInstances: Record<string, TerminalInstance[]>; // keyed by sessionId
   activeTerminalId: Record<string, string | null>;       // keyed by sessionId
+  terminalPanelVisible: Record<string, boolean>;         // keyed by sessionId
 
   // MCP servers state
   mcpServers: McpServerStatus[];
@@ -426,6 +427,7 @@ interface AppState {
   deleteCustomTodo: (sessionId: string, todoId: string) => void;
 
   // Terminal instance actions (bottom panel)
+  setTerminalPanelVisible: (sessionId: string, visible: boolean) => void;
   createTerminal: (sessionId: string, workspacePath: string) => TerminalInstance | null;
   closeTerminal: (sessionId: string, terminalId: string) => void;
   setActiveTerminal: (sessionId: string, terminalId: string) => void;
@@ -509,6 +511,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   customTodos: {},
   terminalInstances: {},
   activeTerminalId: {},
+  terminalPanelVisible: {},
   mcpServers: [],
   mcpServerConfigs: [],
   mcpConfigLoading: false,
@@ -633,6 +636,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const cleanedSessionOutputs = { ...state.sessionOutputs };
     const cleanedTerminalInstances = { ...state.terminalInstances };
     const cleanedActiveTerminalId = { ...state.activeTerminalId };
+    const cleanedTerminalPanelVisible = { ...state.terminalPanelVisible };
     const cleanedTerminalSessions = { ...state.terminalSessions };
     const cleanedLastActive = { ...state.lastActiveConversationPerSession };
     for (const sessionId of workspaceSessionIds) {
@@ -640,6 +644,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       delete cleanedSessionOutputs[sessionId];
       delete cleanedTerminalInstances[sessionId];
       delete cleanedActiveTerminalId[sessionId];
+      delete cleanedTerminalPanelVisible[sessionId];
       delete cleanedTerminalSessions[sessionId];
       delete cleanedLastActive[sessionId];
     }
@@ -663,6 +668,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       sessionOutputs: cleanedSessionOutputs,
       terminalInstances: cleanedTerminalInstances,
       activeTerminalId: cleanedActiveTerminalId,
+      terminalPanelVisible: cleanedTerminalPanelVisible,
       terminalSessions: cleanedTerminalSessions,
       lastActiveConversationPerSession: cleanedLastActive,
       selectedFileTabId: null,
@@ -745,6 +751,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       const { [id]: _terminals, ...remainingTerminalInstances } = state.terminalInstances;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [id]: _activeTerminal, ...remainingActiveTerminalId } = state.activeTerminalId;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [id]: _panelVisible, ...remainingTerminalPanelVisible } = state.terminalPanelVisible;
 
       return {
         sessions: state.sessions.filter((s) => s.id !== id),
@@ -767,6 +775,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         draftInputs: remainingDraftInputs,
         terminalInstances: remainingTerminalInstances,
         activeTerminalId: remainingActiveTerminalId,
+        terminalPanelVisible: remainingTerminalPanelVisible,
         selectedFileTabId: null,
         fileTabs: [],
       };
@@ -861,6 +870,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { [id]: _terminals, ...remainingTerminalInstances } = state.terminalInstances;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [id]: _activeTerminal, ...remainingActiveTerminalId } = state.activeTerminalId;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [id]: _panelVisible, ...remainingTerminalPanelVisible } = state.terminalPanelVisible;
 
     return {
       sessions: updatedSessions,
@@ -868,6 +879,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedConversationId: newSelectedConversationId,
       terminalInstances: remainingTerminalInstances,
       activeTerminalId: remainingActiveTerminalId,
+      terminalPanelVisible: remainingTerminalPanelVisible,
     };
   }),
   unarchiveSession: (id) => set((state) => {
@@ -1881,6 +1893,10 @@ updateFileTabContent: (id, content) => set((state) => ({
   })),
 
   // Terminal instance actions (bottom panel)
+  setTerminalPanelVisible: (sessionId, visible) => set((state) => ({
+    terminalPanelVisible: { ...state.terminalPanelVisible, [sessionId]: visible },
+  })),
+
   createTerminal: (sessionId, workspacePath) => {
     const state = get();
     const existing = state.terminalInstances[sessionId] || [];

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -289,6 +289,13 @@ export const useAllTerminalInstances = () =>
     }))
   );
 
+/**
+ * Terminal panel visibility for a specific session.
+ * Returns false (collapsed) by default — panels start hidden.
+ */
+export const useTerminalPanelVisible = (sessionId: string | null) =>
+  useAppStore((s) => (sessionId ? s.terminalPanelVisible[sessionId] ?? false : false));
+
 // ============================================================================
 // Todo State
 // ============================================================================

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -135,7 +135,6 @@ interface SettingsState {
   collapsedWorkspaces: string[]; // Workspace IDs that are collapsed (all others are expanded)
   unreadWorkspaces: string[]; // Workspace IDs marked as unread
   unreadSessions: string[]; // Session IDs with unread agent completions
-  showBottomTerminal: boolean;
   zenMode: boolean; // Distraction-free mode that hides sidebars
   sidebarBottomPanelMinimized: boolean; // Whether the sidebar bottom panel (Tasks/History/etc) is minimized
   hiddenBottomTabs: BottomPanelTab[]; // Bottom panel tabs that are hidden (Tasks always visible)
@@ -201,7 +200,6 @@ interface SettingsState {
   setArchiveOnMerge: (value: boolean) => void;
   setAutoApproveSafeCommands: (value: boolean) => void;
   setStrictPrivacy: (value: boolean) => void;
-  setShowBottomTerminal: (value: boolean) => void;
   setZenMode: (value: boolean) => void;
   setSidebarBottomPanelMinimized: (value: boolean) => void;
   toggleSidebarBottomPanel: () => void;
@@ -247,7 +245,6 @@ export const useSettingsStore = create<SettingsState>()(
       collapsedWorkspaces: [], // Workspace IDs that are collapsed (all others expanded by default)
       unreadWorkspaces: [], // Workspace IDs marked as unread
       unreadSessions: [], // Session IDs with unread agent completions
-      showBottomTerminal: false,
       zenMode: false,
       sidebarBottomPanelMinimized: false,
       hiddenBottomTabs: [], // All tabs visible by default
@@ -297,7 +294,6 @@ export const useSettingsStore = create<SettingsState>()(
       setArchiveOnMerge: (value) => set({ archiveOnMerge: value }),
       setAutoApproveSafeCommands: (value) => set({ autoApproveSafeCommands: value }),
       setStrictPrivacy: (value) => set({ strictPrivacy: value }),
-      setShowBottomTerminal: (value) => set({ showBottomTerminal: value }),
       setZenMode: (value) => set({ zenMode: value }),
       setSidebarBottomPanelMinimized: (value) => set({ sidebarBottomPanelMinimized: value }),
       toggleSidebarBottomPanel: () => set((state) => ({ sidebarBottomPanelMinimized: !state.sidebarBottomPanelMinimized })),


### PR DESCRIPTION
## Summary
- Move terminal panel visibility from a global persisted setting (`settingsStore`) to per-session ephemeral state (`appStore.terminalPanelVisible`)
- Route all toggle/show/hide code paths through the Zustand store instead of directly manipulating the panel ref — `toggleBottomTerminal`, `hideBottomTerminal`, and `handleShowBottomPanel` now update store state
- A single `useLayoutEffect` syncs the panel ref (collapse/expand) from the store, preventing desync when switching sessions

## Test plan
- [ ] Open a terminal panel in session A, switch to session B — panel should be collapsed
- [ ] Switch back to session A — panel should still be expanded
- [ ] Toggle terminal via keyboard shortcut — state persists across session switches
- [ ] Use "show bottom panel" event — state persists across session switches
- [ ] Restart app — terminal panels start collapsed (not persisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)