### PR TITLE
Fix terminal panel showing on startup and after session switches

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -642,12 +642,15 @@ export default function Home() {
                           collapsible={true}
                           collapsedSize={0}
                           onResize={(size) => {
+                            // Only sync manual drag-to-collapse → store.
+                            // Expansion is driven by user actions (toggle/show) that update the store directly;
+                            // useLayoutEffect then calls panel.expand(). Never set visible here — it races
+                            // with mount/remount (defaultSize="250px" fires onResize before the layout effect
+                            // can collapse the panel).
                             const collapsed = size.asPercentage === 0;
                             if (!layout.selectedSessionId) return;
                             if (collapsed && layout.showBottomTerminal) {
                               layout.setTerminalPanelVisible(layout.selectedSessionId, false);
-                            } else if (!collapsed && !layout.showBottomTerminal) {
-                              layout.setTerminalPanelVisible(layout.selectedSessionId, true);
                             }
                           }}
                         >
@@ -682,12 +685,7 @@ export default function Home() {
                       collapsedSize={0}
                       onResize={(size) => {
                         const collapsed = size.asPercentage === 0;
-                        if (!layout.selectedSessionId) return;
-                        if (collapsed && layout.showBottomTerminal) {
-                          layout.setTerminalPanelVisible(layout.selectedSessionId, false);
-                        } else if (!collapsed && !layout.showBottomTerminal) {
-                          layout.setTerminalPanelVisible(layout.selectedSessionId, true);
-                        }
+                        layout.setRightSidebarCollapsed((prev) => prev === collapsed ? prev : collapsed);
                       }}
                       className={cn(
                         "overflow-hidden bg-content-background dark:bg-transparent",


### PR DESCRIPTION
## Summary

- **Right sidebar `onResize`** was a copy-paste of the terminal panel handler — it set `terminalPanelVisible` instead of tracking `rightSidebarCollapsed`, causing the terminal to appear on startup
- **Bottom terminal `onResize`** had an `else-if` branch that set `visible=true` whenever the panel was not collapsed — this raced with mount/remount (`defaultSize="250px"` fires `onResize` before `useLayoutEffect` can collapse the panel), causing the terminal to reappear after session switches or content view transitions

## Test plan

- [ ] Start the app fresh — terminal panel should NOT be visible
- [ ] Toggle terminal on, then hide it, switch sessions and switch back — should stay hidden
- [ ] Toggle terminal via toolbar button — should expand/collapse correctly
- [ ] Drag terminal resize handle to collapse — should hide and update toggle state
- [ ] Navigate to PR dashboard/settings and back to a session — terminal should respect per-session state
- [ ] Collapse/expand right sidebar — should not affect terminal panel visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)