### PR TITLE
Merge slash command lists and retry supported commands after init

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -526,8 +526,12 @@ function setupInputQueue(): void {
       if (input.type === "get_supported_commands") {
         if (queryRef) {
           void queryRef.supportedCommands().then((commands: unknown) => {
+            const count = Array.isArray(commands) ? commands.length : 0;
+            const names = Array.isArray(commands) ? (commands as Array<{name?: string}>).map(c => c.name ?? JSON.stringify(c)).join(", ") : "N/A";
+            lifecycle(`supportedCommands() returned ${count} commands: [${names}]`);
             emit({ type: "supported_commands", commands });
           }).catch((cmdErr: unknown) => {
+            lifecycle(`supportedCommands() error: ${String(cmdErr)}`);
             emit({ type: "command_error", command: "get_supported_commands", error: String(cmdErr) });
           });
         } else {

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -22,6 +22,7 @@ import (
 )
 
 const snapshotDebounceInterval = 500 * time.Millisecond
+const supportedCommandsRetryDelay = 3 * time.Second
 
 // prURLPattern matches GitHub PR URLs in tool output (e.g., "https://github.com/owner/repo/pull/123")
 // Capture group 1 = PR number.
@@ -1029,6 +1030,19 @@ outer:
 				if err := proc.GetSupportedCommands(); err != nil {
 					logger.Manager.Errorf("Conversation %s: failed to request supported commands: %v", convID, err)
 				}
+				// Retry after delay — plugins may still be loading during init.
+				// The frontend merges responses, so a second call enriches rather
+				// than overwrites the first result.
+				// Look up proc by convID instead of capturing the reference so
+				// the goroutine doesn't keep a terminated process alive.
+				go func(cID string) {
+					time.Sleep(supportedCommandsRetryDelay)
+					if p := m.GetConversationProcess(cID); p != nil && p.IsRunning() {
+						if err := p.GetSupportedCommands(); err != nil {
+							logger.Manager.Debugf("Conversation %s: retry GetSupportedCommands failed: %v", cID, err)
+						}
+					}
+				}(convID)
 			}
 
 			// Generate input suggestion after turn completes (async, fire-and-forget)

--- a/src/stores/__tests__/slashCommandStore.test.ts
+++ b/src/stores/__tests__/slashCommandStore.test.ts
@@ -260,6 +260,73 @@ describe('setSdkCommandsRich', () => {
       argumentHint: '<pattern>',
     });
   });
+
+  it('merges with existing init-reported commands instead of replacing', () => {
+    // Simulate init event populating bare SDK commands
+    useSlashCommandStore.getState().setSdkCommands(['alpha', 'beta', 'gamma']);
+
+    // Simulate supported_commands response with a different/smaller set
+    useSlashCommandStore.getState().setSdkCommandsRich([
+      { name: 'beta', description: 'Beta command' },
+      { name: 'delta', description: 'Delta command' },
+    ]);
+
+    const state = useSlashCommandStore.getState();
+
+    // New commands first, then init-only commands preserved
+    expect(state.sdkCommands).toEqual(['beta', 'delta', 'alpha', 'gamma']);
+    // Rich metadata available for new commands
+    expect(state.sdkCommandMeta['beta']).toEqual({ name: 'beta', description: 'Beta command' });
+    expect(state.sdkCommandMeta['delta']).toEqual({ name: 'delta', description: 'Delta command' });
+    // Init-only commands have no metadata (but are still in the list)
+    expect(state.sdkCommandMeta['alpha']).toBeUndefined();
+  });
+
+  it('preserves existing metadata when merging', () => {
+    // First call with metadata
+    useSlashCommandStore.getState().setSdkCommandsRich([
+      { name: 'cmd-a', description: 'First description' },
+    ]);
+
+    // Second call with different commands — first metadata should survive
+    useSlashCommandStore.getState().setSdkCommandsRich([
+      { name: 'cmd-b', description: 'Second description' },
+    ]);
+
+    const state = useSlashCommandStore.getState();
+    expect(state.sdkCommands).toEqual(['cmd-b', 'cmd-a']);
+    expect(state.sdkCommandMeta['cmd-a']).toEqual({ name: 'cmd-a', description: 'First description' });
+    expect(state.sdkCommandMeta['cmd-b']).toEqual({ name: 'cmd-b', description: 'Second description' });
+  });
+});
+
+// ============================================================================
+// setSdkCommands (merge behavior)
+// ============================================================================
+
+describe('setSdkCommands', () => {
+  it('merges with existing commands instead of replacing', () => {
+    useSlashCommandStore.getState().setSdkCommandsRich([
+      { name: 'rich-cmd', description: 'Has metadata' },
+    ]);
+
+    // A late init event with a different set should merge, not clobber
+    useSlashCommandStore.getState().setSdkCommands(['init-cmd', 'rich-cmd']);
+
+    const state = useSlashCommandStore.getState();
+    expect(state.sdkCommands).toEqual(['init-cmd', 'rich-cmd']);
+    // Metadata from earlier setSdkCommandsRich call is preserved
+    expect(state.sdkCommandMeta['rich-cmd']).toEqual({ name: 'rich-cmd', description: 'Has metadata' });
+  });
+
+  it('appends previously-known commands not in new list', () => {
+    useSlashCommandStore.getState().setSdkCommands(['alpha', 'beta']);
+    useSlashCommandStore.getState().setSdkCommands(['beta', 'gamma']);
+
+    const state = useSlashCommandStore.getState();
+    // beta and gamma from the new call, alpha preserved from existing
+    expect(state.sdkCommands).toEqual(['beta', 'gamma', 'alpha']);
+  });
 });
 
 // ============================================================================

--- a/src/stores/slashCommandStore.ts
+++ b/src/stores/slashCommandStore.ts
@@ -278,15 +278,42 @@ export const useSlashCommandStore = create<SlashCommandStoreState>((set, get) =>
 
   setInstalledSkills: (skills) => { _commandCache = null; set({ installedSkills: skills }); },
   setUserCommands: (commands) => { _commandCache = null; set({ userCommands: commands }); },
-  setSdkCommands: (commands) => { _commandCache = null; set({ sdkCommands: commands }); },
+  setSdkCommands: (commands) => {
+    // Merge with existing list so a late init event doesn't clobber
+    // enriched data from setSdkCommandsRich.
+    const { sdkCommands: existing } = get();
+    const seen = new Set(commands);
+    const merged = [...commands];
+    for (const name of existing) {
+      if (!seen.has(name)) {
+        merged.push(name);
+      }
+    }
+    _commandCache = null;
+    set({ sdkCommands: merged });
+  },
   setSdkCommandsRich: (commands) => {
-    const names = commands.map((c) => c.name);
-    const meta: Record<string, SdkCommandInfo> = {};
+    const { sdkCommands: existing, sdkCommandMeta: existingMeta } = get();
+
+    // Build merged set: new commands first, then any init-reported commands
+    // not present in the new set. This preserves plugin commands from init
+    // even if supportedCommands() returns a smaller set.
+    const newNames = new Set(commands.map((c) => c.name));
+    const merged = [...newNames];
+    for (const name of existing) {
+      if (!newNames.has(name)) {
+        merged.push(name);
+      }
+    }
+
+    // Merge metadata (new commands enrich, existing preserved)
+    const meta: Record<string, SdkCommandInfo> = { ...existingMeta };
     for (const c of commands) {
       meta[c.name] = c;
     }
+
     _commandCache = null;
-    set({ sdkCommands: names, sdkCommandMeta: meta });
+    set({ sdkCommands: merged, sdkCommandMeta: meta });
   },
 
   fetchUserCommands: async (workspaceId, sessionId) => {


### PR DESCRIPTION
## Summary
- Add delayed retry for `GetSupportedCommands` after init to capture late-loading plugins
- Switch `setSdkCommands` and `setSdkCommandsRich` to merge-based updates so out-of-order responses enrich rather than clobber
- Add lifecycle logging in agent-runner for supported commands debugging
- 4 new tests covering merge behavior

## Test plan
- [ ] Verify slash commands from plugins appear in the command palette even when plugins load slowly
- [ ] Confirm a second `supported_commands` response merges with (not replaces) the first
- [ ] Run `vitest` — all slashCommandStore tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)