### PR TITLE
Fix bottom panel visibility persistence and race conditions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -610,11 +610,7 @@ export default function Home() {
                         direction="vertical"
                         className="h-full"
                         defaultLayout={layout.layoutVertical}
-                        onLayoutChange={(layoutVal) => {
-                          if (layoutVal['bottom-terminal'] && layoutVal['bottom-terminal'] > 0) {
-                            layout.setLayoutVertical(layoutVal);
-                          }
-                        }}
+                        onLayoutChange={layout.setLayoutVertical}
                       >
                         <ResizablePanel id="conversation" minSize={20}>
                           {selectedSessionId ? (
@@ -634,7 +630,24 @@ export default function Home() {
                           className={cn(!layout.showBottomTerminal && "hidden")}
                         />
                         <ResizablePanel
-                          ref={layout.bottomTerminalPanelRef}
+                          ref={(handle) => {
+                            layout.bottomTerminalPanelRef.current = handle;
+                            if (handle) {
+                              // Sync collapse state on mount. Handles the case where the
+                              // useLayoutEffect already ran before the panel mounted (ref was null).
+                              queueMicrotask(() => {
+                                // Guard: handle may be stale if component unmounted before microtask ran
+                                if (layout.bottomTerminalPanelRef.current !== handle) return;
+                                const state = useAppStore.getState();
+                                const sid = state.selectedSessionId;
+                                if (!sid) return;
+                                const visible = state.terminalPanelVisible[sid] ?? false;
+                                if (!visible && !handle.isCollapsed()) {
+                                  handle.collapse();
+                                }
+                              });
+                            }
+                          }}
                           id="bottom-terminal"
                           defaultSize="250px"
                           minSize="100px"
@@ -642,15 +655,24 @@ export default function Home() {
                           collapsible={true}
                           collapsedSize={0}
                           onResize={(size) => {
-                            // Only sync manual drag-to-collapse → store.
-                            // Expansion is driven by user actions (toggle/show) that update the store directly;
-                            // useLayoutEffect then calls panel.expand(). Never set visible here — it races
-                            // with mount/remount (defaultSize="250px" fires onResize before the layout effect
-                            // can collapse the panel).
                             const collapsed = size.asPercentage === 0;
-                            if (!layout.selectedSessionId) return;
-                            if (collapsed && layout.showBottomTerminal) {
-                              layout.setTerminalPanelVisible(layout.selectedSessionId, false);
+                            // Read store directly to avoid stale closure values from render.
+                            // The useLayoutEffect may have just called expand() which triggers
+                            // this handler before React re-renders with the new state.
+                            const state = useAppStore.getState();
+                            const sid = state.selectedSessionId;
+                            if (!sid) return;
+                            const visible = state.terminalPanelVisible[sid] ?? false;
+                            // Sync manual drag-to-collapse -> store
+                            if (collapsed && visible) {
+                              layout.setTerminalPanelVisible(sid, false);
+                            }
+                            // Guard: re-collapse if panel expanded but store says hidden.
+                            // Handles parent resize (sidebar toggle) inadvertently expanding the panel.
+                            if (!collapsed && !visible) {
+                              queueMicrotask(() => {
+                                layout.bottomTerminalPanelRef.current?.collapse();
+                              });
                             }
                           }}
                         >

--- a/src/hooks/useLayoutState.ts
+++ b/src/hooks/useLayoutState.ts
@@ -97,7 +97,7 @@ export function useLayoutState() {
     } else if (!showBottomTerminal && !panel.isCollapsed()) {
       panel.collapse();
     }
-  }, [showBottomTerminal]);
+  }, [showBottomTerminal, selectedSessionId]);
 
   // Zen mode ref for keyboard handler closures
   const zenModeRef = useRef(zenMode);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -463,9 +463,12 @@ export const useSettingsStore = create<SettingsState>()(
           merged.hiddenBottomTabs = persisted.hiddenBottomTabs.filter((t) => validBottomTabs.includes(t));
         }
 
-        // Clear poisoned vertical layout (terminal collapsed state shouldn't be persisted)
-        if (persisted.layoutVertical && persisted.layoutVertical['bottom-terminal'] === 0) {
-          merged.layoutVertical = undefined;
+        // Always strip bottom-terminal from persisted vertical layout.
+        // Terminal panel visibility is managed by appStore (in-memory, per-session)
+        // and must always start collapsed on app restart.
+        if (merged.layoutVertical && 'bottom-terminal' in merged.layoutVertical) {
+          const { 'bottom-terminal': _, ...rest } = merged.layoutVertical;
+          merged.layoutVertical = Object.keys(rest).length > 0 ? rest : undefined;
         }
 
         return merged;


### PR DESCRIPTION
## Summary

- **Strip `bottom-terminal` from persisted layout on hydration** — old code only cleared when value was `0`, missing cases where a non-zero size was persisted (causing panel to appear expanded on restart)
- **Fix expand/collapse race condition** — `onResize` now reads store directly via `getState()` instead of stale closure values, preventing the layout effect's `expand()` from being immediately undone
- **Add stale handle guard** — ref callback microtask checks the handle is still current before operating, preventing errors on unmounted panels
- **Re-collapse on parent resize** — sidebar toggles could inadvertently expand a collapsed panel; now detected and corrected
- **Fix session switch sync** — added `selectedSessionId` to `useLayoutEffect` deps so panel state re-syncs when switching sessions (even if visibility value is the same)
- **Consistent null checks** — replaced `?? ''` session ID fallback with explicit null guard

## Test plan

- [ ] Toggle terminal panel open/closed, switch sessions — panel state should persist per-session
- [ ] Close terminal, toggle sidebar — panel should stay collapsed
- [ ] Restart app — terminal panel should start collapsed regardless of previous state
- [ ] Rapid session switching — no flicker or stuck-open terminal panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)