### PR TITLE
Add append/replace mode for action template overrides

### DIFF
--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -128,6 +128,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Put("/{id}/settings/pr-template", h.SetPRTemplate)
 		r.Get("/{id}/settings/review-prompts", h.GetWorkspaceReviewPrompts)
 		r.Put("/{id}/settings/review-prompts", h.SetWorkspaceReviewPrompts)
+		r.Get("/{id}/settings/action-templates", h.GetWorkspaceActionTemplates)
+		r.Put("/{id}/settings/action-templates", h.SetWorkspaceActionTemplates)
 		r.Get("/{id}/sessions/{sessionId}/branch-sync", h.GetSessionBranchSyncStatus)
 		r.Post("/{id}/sessions/{sessionId}/branch-sync", h.SyncSessionBranch)
 		r.Post("/{id}/sessions/{sessionId}/branch-sync/abort", h.AbortSessionSync)
@@ -219,6 +221,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	r.Put("/api/settings/pr-template", h.SetGlobalPRTemplate)
 	r.Get("/api/settings/anthropic-api-key", h.GetAnthropicApiKey)
 	r.Put("/api/settings/anthropic-api-key", h.SetAnthropicApiKey)
+	r.Get("/api/settings/action-templates", h.GetActionTemplates)
+	r.Put("/api/settings/action-templates", h.SetActionTemplates)
 	r.Get("/api/settings/claude-auth-status", h.GetClaudeAuthStatus)
 
 	// Attachment endpoints

--- a/backend/server/settings_handlers.go
+++ b/backend/server/settings_handlers.go
@@ -89,6 +89,81 @@ func (h *Handlers) SetWorkspaceReviewPrompts(w http.ResponseWriter, r *http.Requ
 	h.setReviewPrompts(w, r, fmt.Sprintf("review-prompts:%s", workspaceID))
 }
 
+// getActionTemplates reads action template overrides from the given settings key.
+func (h *Handlers) getActionTemplates(w http.ResponseWriter, ctx context.Context, key string) {
+	value, found, err := h.store.GetSetting(ctx, key)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if !found {
+		writeJSON(w, map[string]any{"templates": map[string]string{}})
+		return
+	}
+
+	var templates map[string]string
+	if err := json.Unmarshal([]byte(value), &templates); err != nil {
+		writeError(w, http.StatusInternalServerError, ErrCodeInternal, "corrupted action templates data", err)
+		return
+	}
+
+	writeJSON(w, map[string]any{"templates": templates})
+}
+
+// setActionTemplates writes action template overrides to the given settings key.
+func (h *Handlers) setActionTemplates(w http.ResponseWriter, r *http.Request, key string) {
+	ctx := r.Context()
+
+	var req struct {
+		Templates map[string]string `json:"templates"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	if len(req.Templates) == 0 {
+		if err := h.store.DeleteSetting(ctx, key); err != nil {
+			writeDBError(w, err)
+			return
+		}
+	} else {
+		data, err := json.Marshal(req.Templates)
+		if err != nil {
+			writeValidationError(w, "failed to encode templates")
+			return
+		}
+		if err := h.store.SetSetting(ctx, key, string(data)); err != nil {
+			writeDBError(w, err)
+			return
+		}
+	}
+
+	writeJSON(w, map[string]string{"status": "ok"})
+}
+
+// GetActionTemplates returns the global custom action template overrides
+func (h *Handlers) GetActionTemplates(w http.ResponseWriter, r *http.Request) {
+	h.getActionTemplates(w, r.Context(), "action-templates")
+}
+
+// SetActionTemplates updates the global custom action template overrides
+func (h *Handlers) SetActionTemplates(w http.ResponseWriter, r *http.Request) {
+	h.setActionTemplates(w, r, "action-templates")
+}
+
+// GetWorkspaceActionTemplates returns per-workspace custom action template overrides
+func (h *Handlers) GetWorkspaceActionTemplates(w http.ResponseWriter, r *http.Request) {
+	workspaceID := chi.URLParam(r, "id")
+	h.getActionTemplates(w, r.Context(), fmt.Sprintf("action-templates:%s", workspaceID))
+}
+
+// SetWorkspaceActionTemplates updates per-workspace custom action template overrides
+func (h *Handlers) SetWorkspaceActionTemplates(w http.ResponseWriter, r *http.Request) {
+	workspaceID := chi.URLParam(r, "id")
+	h.setActionTemplates(w, r, fmt.Sprintf("action-templates:%s", workspaceID))
+}
+
 // GetCustomInstructions returns the global custom instructions for agent system prompts
 func (h *Handlers) GetCustomInstructions(w http.ResponseWriter, r *http.Request) {
 	value, found, err := h.store.GetSetting(r.Context(), "custom-instructions")

--- a/backend/server/settings_handlers_test.go
+++ b/backend/server/settings_handlers_test.go
@@ -352,6 +352,204 @@ func TestGetReviewPrompts_CorruptedData(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
+
+func TestGetActionTemplates_Empty(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("GET", "/api/settings/action-templates", nil)
+	w := httptest.NewRecorder()
+
+	h.GetActionTemplates(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]any{}, resp["templates"].(map[string]any))
+}
+
+func TestSetActionTemplates_Success(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	templates := map[string]any{"templates": map[string]string{"resolve-conflicts": "Custom conflict instructions"}}
+	body, _ := json.Marshal(templates)
+	req := httptest.NewRequest("PUT", "/api/settings/action-templates", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.SetActionTemplates(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify it was saved
+	req2 := httptest.NewRequest("GET", "/api/settings/action-templates", nil)
+	w2 := httptest.NewRecorder()
+
+	h.GetActionTemplates(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	p := resp["templates"].(map[string]any)
+	assert.Equal(t, "Custom conflict instructions", p["resolve-conflicts"])
+}
+
+func TestSetActionTemplates_EmptyDeletes(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.SetSetting(ctx, "action-templates", `{"resolve-conflicts":"old"}`))
+
+	body, _ := json.Marshal(map[string]any{"templates": map[string]string{}})
+	req := httptest.NewRequest("PUT", "/api/settings/action-templates", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.SetActionTemplates(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify deleted
+	req2 := httptest.NewRequest("GET", "/api/settings/action-templates", nil)
+	w2 := httptest.NewRecorder()
+	h.GetActionTemplates(w2, req2)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]any{}, resp["templates"].(map[string]any))
+}
+
+func TestSetActionTemplates_InvalidBody(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("PUT", "/api/settings/action-templates", bytes.NewReader([]byte("invalid")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.SetActionTemplates(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetWorkspaceActionTemplates_Empty(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/settings/action-templates", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetWorkspaceActionTemplates(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]any{}, resp["templates"].(map[string]any))
+}
+
+func TestSetWorkspaceActionTemplates_Success(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	templates := map[string]any{"templates": map[string]string{"sync-branch": "Use merge not rebase"}}
+	body, _ := json.Marshal(templates)
+	req := httptest.NewRequest("PUT", "/api/repos/ws-1/settings/action-templates", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.SetWorkspaceActionTemplates(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify saved
+	req2 := httptest.NewRequest("GET", "/api/repos/ws-1/settings/action-templates", nil)
+	req2 = withChiContext(req2, map[string]string{"id": "ws-1"})
+	w2 := httptest.NewRecorder()
+
+	h.GetWorkspaceActionTemplates(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	p := resp["templates"].(map[string]any)
+	assert.Equal(t, "Use merge not rebase", p["sync-branch"])
+}
+
+func TestSetWorkspaceActionTemplates_IsolatedPerWorkspace(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	// Set for ws-1
+	body1, _ := json.Marshal(map[string]any{"templates": map[string]string{"create-pr": "ws1 instructions"}})
+	req1 := httptest.NewRequest("PUT", "/api/repos/ws-1/settings/action-templates", bytes.NewReader(body1))
+	req1.Header.Set("Content-Type", "application/json")
+	req1 = withChiContext(req1, map[string]string{"id": "ws-1"})
+	w1 := httptest.NewRecorder()
+	h.SetWorkspaceActionTemplates(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// ws-2 should still be empty
+	req2 := httptest.NewRequest("GET", "/api/repos/ws-2/settings/action-templates", nil)
+	req2 = withChiContext(req2, map[string]string{"id": "ws-2"})
+	w2 := httptest.NewRecorder()
+	h.GetWorkspaceActionTemplates(w2, req2)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]any{}, resp["templates"].(map[string]any))
+}
+
+func TestActionTemplates_GlobalAndWorkspaceIsolated(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	// Set a global template
+	globalBody, _ := json.Marshal(map[string]any{"templates": map[string]string{"merge-pr": "global merge instructions"}})
+	req1 := httptest.NewRequest("PUT", "/api/settings/action-templates", bytes.NewReader(globalBody))
+	req1.Header.Set("Content-Type", "application/json")
+	w1 := httptest.NewRecorder()
+	h.SetActionTemplates(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// Workspace endpoint should still be empty
+	req2 := httptest.NewRequest("GET", "/api/repos/ws-1/settings/action-templates", nil)
+	req2 = withChiContext(req2, map[string]string{"id": "ws-1"})
+	w2 := httptest.NewRecorder()
+	h.GetWorkspaceActionTemplates(w2, req2)
+
+	var wsResp map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &wsResp))
+	assert.Equal(t, map[string]any{}, wsResp["templates"].(map[string]any))
+
+	// Set a workspace template
+	wsBody, _ := json.Marshal(map[string]any{"templates": map[string]string{"fix-issues": "workspace fix instructions"}})
+	req3 := httptest.NewRequest("PUT", "/api/repos/ws-1/settings/action-templates", bytes.NewReader(wsBody))
+	req3.Header.Set("Content-Type", "application/json")
+	req3 = withChiContext(req3, map[string]string{"id": "ws-1"})
+	w3 := httptest.NewRecorder()
+	h.SetWorkspaceActionTemplates(w3, req3)
+	assert.Equal(t, http.StatusOK, w3.Code)
+
+	// Global should still only have "merge-pr", not "fix-issues"
+	req4 := httptest.NewRequest("GET", "/api/settings/action-templates", nil)
+	w4 := httptest.NewRecorder()
+	h.GetActionTemplates(w4, req4)
+
+	var globalResp map[string]any
+	require.NoError(t, json.Unmarshal(w4.Body.Bytes(), &globalResp))
+	gp := globalResp["templates"].(map[string]any)
+	assert.Equal(t, "global merge instructions", gp["merge-pr"])
+	assert.Nil(t, gp["fix-issues"])
+}
+
+func TestGetActionTemplates_CorruptedData(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	// Store invalid JSON
+	require.NoError(t, s.SetSetting(ctx, "action-templates", "not-json"))
+
+	req := httptest.NewRequest("GET", "/api/settings/action-templates", nil)
+	w := httptest.NewRecorder()
+	h.GetActionTemplates(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 func TestGetEnvSettings_Empty(t *testing.T) {
 	h, st := setupTestHandlers(t)
 	defer st.Close()

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -20,7 +20,14 @@ import {
 } from '@/lib/api';
 import type { Workspace } from '@/lib/types';
 import { REVIEW_PROMPTS, REVIEW_TYPE_META } from '@/hooks/useReviewTrigger';
-import { ACTION_TEMPLATES, ACTION_TEMPLATE_META } from '@/lib/action-templates';
+import {
+  ACTION_TEMPLATES,
+  ACTION_TEMPLATE_META,
+  parseOverrides,
+  serializeOverrides,
+} from '@/lib/action-templates';
+import type { ActionTemplateKey, ActionTemplateOverride, OverrideMode } from '@/lib/action-templates';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { useToast } from '@/components/ui/toast';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
@@ -28,6 +35,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import {
   ArrowLeft,
+  ChevronRight,
   Eye,
   Zap,
   GitBranch,
@@ -603,9 +611,9 @@ function WorkspaceReviewSettings({ workspaceId }: { workspaceId: string }) {
 }
 
 function WorkspaceActionSettings({ workspaceId }: { workspaceId: string }) {
-  const [templates, setTemplates] = useState<Record<string, string>>({});
-  const [saved, setSaved] = useState<Record<string, string>>({});
-  const [globalTemplates, setGlobalTemplates] = useState<Record<string, string>>({});
+  const [templates, setTemplatesState] = useState<Partial<Record<ActionTemplateKey, ActionTemplateOverride>>>({});
+  const [saved, setSaved] = useState<Partial<Record<ActionTemplateKey, ActionTemplateOverride>>>({});
+  const [globalOverrides, setGlobalOverrides] = useState<Partial<Record<ActionTemplateKey, ActionTemplateOverride>>>({});
   const [saving, setSaving] = useState(false);
   const { error: showError } = useToast();
   const showErrorRef = useRef(showError);
@@ -618,9 +626,11 @@ function WorkspaceActionSettings({ workspaceId }: { workspaceId: string }) {
       getGlobalActionTemplates(),
     ]).then(([ws, gl]) => {
       if (cancelled) return;
-      setTemplates(ws);
-      setSaved(ws);
-      setGlobalTemplates(gl);
+      const wsParsed = parseOverrides(ws);
+      const glParsed = parseOverrides(gl);
+      setTemplatesState(wsParsed);
+      setSaved(wsParsed);
+      setGlobalOverrides(glParsed);
     }).catch(() => {
       if (cancelled) return;
       showErrorRef.current('Failed to load settings');
@@ -633,13 +643,11 @@ function WorkspaceActionSettings({ workspaceId }: { workspaceId: string }) {
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      const cleaned: Record<string, string> = {};
-      for (const [k, v] of Object.entries(templates)) {
-        if (v.trim()) cleaned[k] = v.trim();
-      }
-      await setWorkspaceActionTemplates(workspaceId, cleaned);
-      setTemplates(cleaned);
-      setSaved(cleaned);
+      const serialized = serializeOverrides(templates);
+      await setWorkspaceActionTemplates(workspaceId, serialized);
+      const parsed = parseOverrides(serialized);
+      setTemplatesState(parsed);
+      setSaved(parsed);
       window.dispatchEvent(new CustomEvent('action-templates-changed'));
     } catch {
       showErrorRef.current('Failed to save settings');
@@ -648,13 +656,13 @@ function WorkspaceActionSettings({ workspaceId }: { workspaceId: string }) {
     }
   }, [workspaceId, templates]);
 
-  const hasAnyOverride = Object.values(templates).some((v) => v.trim());
+  const hasAnyOverride = Object.values(templates).some((v) => v?.text?.trim());
 
   const handleResetAll = useCallback(async () => {
     setSaving(true);
     try {
       await setWorkspaceActionTemplates(workspaceId, {});
-      setTemplates({});
+      setTemplatesState({});
       setSaved({});
       window.dispatchEvent(new CustomEvent('action-templates-changed'));
     } catch {
@@ -663,6 +671,20 @@ function WorkspaceActionSettings({ workspaceId }: { workspaceId: string }) {
       setSaving(false);
     }
   }, [workspaceId]);
+
+  const setTemplateText = useCallback((key: ActionTemplateKey, text: string) => {
+    setTemplatesState((prev) => ({
+      ...prev,
+      [key]: { text, mode: prev[key]?.mode || 'append' },
+    }));
+  }, []);
+
+  const setTemplateMode = useCallback((key: ActionTemplateKey, mode: OverrideMode) => {
+    setTemplatesState((prev) => ({
+      ...prev,
+      [key]: { text: prev[key]?.text || '', mode },
+    }));
+  }, []);
 
   return (
     <div>
@@ -687,31 +709,70 @@ function WorkspaceActionSettings({ workspaceId }: { workspaceId: string }) {
 
       <div className="space-y-5">
         {ACTION_TEMPLATE_META.map(({ key, label, placeholder }) => {
-          const globalOverride = globalTemplates[key];
-          const effectivePlaceholder = globalOverride
-            ? `Global: ${globalOverride.slice(0, 60)}…`
-            : placeholder;
-          const hasOverride = !!(templates[key]?.trim());
+          const override = templates[key];
+          const hasText = !!override?.text?.trim();
+          const hasGlobalOverride = !!globalOverrides[key]?.text?.trim();
 
           return (
-            <div key={key}>
-              <div className="flex items-center gap-2 mb-1.5">
+            <div key={key} className="border rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-2">
                 <label className="text-sm font-medium">{label}</label>
-                {hasOverride && (
+                {hasText && (
                   <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-2xs font-medium text-primary">
-                    Overridden
+                    Overridden ({override?.mode === 'replace' ? 'replaced' : 'appended'})
                   </span>
                 )}
               </div>
-              <p className="text-xs text-muted-foreground mb-1.5 line-clamp-2">
-                Default: {ACTION_TEMPLATES[key]?.slice(0, 100)}&hellip;
-              </p>
+
+              <Collapsible>
+                <CollapsibleTrigger className="group flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+                  <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
+                  View built-in default
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="mt-2 p-3 bg-muted/50 rounded-md text-xs font-mono whitespace-pre-wrap max-h-48 overflow-y-auto border border-border/50">
+                    {ACTION_TEMPLATES[key]}
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+
+              {hasGlobalOverride && (
+                <p className="text-xs text-muted-foreground mt-2">
+                  Global override active ({globalOverrides[key]?.mode === 'replace' ? 'replaces' : 'appends to'} default)
+                </p>
+              )}
+
+              {hasText && (
+                <RadioGroup
+                  value={override?.mode || 'append'}
+                  onValueChange={(v) => setTemplateMode(key, v as OverrideMode)}
+                  className="flex gap-4 mt-3"
+                >
+                  <div className="flex items-center gap-1.5">
+                    <RadioGroupItem value="append" id={`ws-${key}-append`} />
+                    <label htmlFor={`ws-${key}-append`} className="text-xs cursor-pointer">Add to default</label>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <RadioGroupItem value="replace" id={`ws-${key}-replace`} />
+                    <label htmlFor={`ws-${key}-replace`} className="text-xs cursor-pointer">Replace default</label>
+                  </div>
+                </RadioGroup>
+              )}
+
               <Textarea
-                className="text-sm min-h-[80px]"
-                placeholder={effectivePlaceholder}
-                value={templates[key] || ''}
-                onChange={(e) => setTemplates((prev) => ({ ...prev, [key]: e.target.value }))}
+                className="text-sm min-h-[80px] mt-3"
+                placeholder={placeholder}
+                value={override?.text || ''}
+                onChange={(e) => setTemplateText(key, e.target.value)}
               />
+
+              {hasText && (
+                <p className="text-xs text-muted-foreground mt-1.5">
+                  {override?.mode === 'replace'
+                    ? 'Your text will completely replace the built-in default.'
+                    : 'Your text will be appended after the built-in default.'}
+                </p>
+              )}
             </div>
           );
         })}

--- a/src/components/settings/sections/ActionSettings.tsx
+++ b/src/components/settings/sections/ActionSettings.tsx
@@ -1,11 +1,20 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { useToast } from '@/components/ui/toast';
 import { getGlobalActionTemplates, setGlobalActionTemplates } from '@/lib/api';
-import { ACTION_TEMPLATES, ACTION_TEMPLATE_META } from '@/lib/action-templates';
+import {
+  ACTION_TEMPLATES,
+  ACTION_TEMPLATE_META,
+  parseOverrides,
+  serializeOverrides,
+} from '@/lib/action-templates';
+import type { ActionTemplateKey, ActionTemplateOverride, OverrideMode } from '@/lib/action-templates';
 
 function OverridableBadge() {
   return (
@@ -16,8 +25,8 @@ function OverridableBadge() {
 }
 
 export function ActionSettings() {
-  const [templates, setTemplates] = useState<Record<string, string>>({});
-  const [saved, setSaved] = useState<Record<string, string>>({});
+  const [templates, setTemplates] = useState<Partial<Record<ActionTemplateKey, ActionTemplateOverride>>>({});
+  const [saved, setSaved] = useState<Partial<Record<ActionTemplateKey, ActionTemplateOverride>>>({});
   const [saving, setSaving] = useState(false);
   const { error: showError } = useToast();
   const showErrorRef = useRef(showError);
@@ -26,8 +35,9 @@ export function ActionSettings() {
   useEffect(() => {
     getGlobalActionTemplates()
       .then((data) => {
-        setTemplates(data);
-        setSaved(data);
+        const parsed = parseOverrides(data);
+        setTemplates(parsed);
+        setSaved(parsed);
       })
       .catch(() => {
         showErrorRef.current('Failed to load action templates');
@@ -39,13 +49,11 @@ export function ActionSettings() {
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      const cleaned: Record<string, string> = {};
-      for (const [k, v] of Object.entries(templates)) {
-        if (v.trim()) cleaned[k] = v.trim();
-      }
-      await setGlobalActionTemplates(cleaned);
-      setTemplates(cleaned);
-      setSaved(cleaned);
+      const serialized = serializeOverrides(templates);
+      await setGlobalActionTemplates(serialized);
+      const parsed = parseOverrides(serialized);
+      setTemplates(parsed);
+      setSaved(parsed);
       window.dispatchEvent(new CustomEvent('action-templates-changed'));
     } catch {
       showErrorRef.current('Failed to save action templates');
@@ -53,6 +61,20 @@ export function ActionSettings() {
       setSaving(false);
     }
   }, [templates]);
+
+  const setTemplateText = useCallback((key: ActionTemplateKey, text: string) => {
+    setTemplates((prev) => ({
+      ...prev,
+      [key]: { text, mode: prev[key]?.mode || 'append' },
+    }));
+  }, []);
+
+  const setTemplateMode = useCallback((key: ActionTemplateKey, mode: OverrideMode) => {
+    setTemplates((prev) => ({
+      ...prev,
+      [key]: { text: prev[key]?.text || '', mode },
+    }));
+  }, []);
 
   return (
     <div>
@@ -66,20 +88,60 @@ export function ActionSettings() {
       </p>
 
       <div data-setting-id="actionTemplates" className="space-y-5">
-        {ACTION_TEMPLATE_META.map(({ key, label, placeholder }) => (
-          <div key={key}>
-            <label className="text-sm font-medium block mb-1.5">{label}</label>
-            <p className="text-xs text-muted-foreground mb-1.5 line-clamp-2">
-              Default: {ACTION_TEMPLATES[key]?.slice(0, 100)}&hellip;
-            </p>
-            <Textarea
-              className="text-sm min-h-[80px]"
-              placeholder={placeholder}
-              value={templates[key] || ''}
-              onChange={(e) => setTemplates((prev) => ({ ...prev, [key]: e.target.value }))}
-            />
-          </div>
-        ))}
+        {ACTION_TEMPLATE_META.map(({ key, label, placeholder }) => {
+          const override = templates[key];
+          const hasText = !!override?.text?.trim();
+
+          return (
+            <div key={key} className="border rounded-lg p-4">
+              <label className="text-sm font-medium block mb-2">{label}</label>
+
+              <Collapsible>
+                <CollapsibleTrigger className="group flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+                  <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
+                  View built-in default
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="mt-2 p-3 bg-muted/50 rounded-md text-xs font-mono whitespace-pre-wrap max-h-48 overflow-y-auto border border-border/50">
+                    {ACTION_TEMPLATES[key]}
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+
+              {hasText && (
+                <RadioGroup
+                  value={override?.mode || 'append'}
+                  onValueChange={(v) => setTemplateMode(key, v as OverrideMode)}
+                  className="flex gap-4 mt-3"
+                >
+                  <div className="flex items-center gap-1.5">
+                    <RadioGroupItem value="append" id={`${key}-append`} />
+                    <label htmlFor={`${key}-append`} className="text-xs cursor-pointer">Add to default</label>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <RadioGroupItem value="replace" id={`${key}-replace`} />
+                    <label htmlFor={`${key}-replace`} className="text-xs cursor-pointer">Replace default</label>
+                  </div>
+                </RadioGroup>
+              )}
+
+              <Textarea
+                className="text-sm min-h-[80px] mt-3"
+                placeholder={placeholder}
+                value={override?.text || ''}
+                onChange={(e) => setTemplateText(key, e.target.value)}
+              />
+
+              {hasText && (
+                <p className="text-xs text-muted-foreground mt-1.5">
+                  {override?.mode === 'replace'
+                    ? 'Your text will completely replace the built-in default.'
+                    : 'Your text will be appended after the built-in default.'}
+                </p>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {hasChanges && (

--- a/src/lib/action-templates.ts
+++ b/src/lib/action-templates.ts
@@ -14,6 +14,13 @@ export type ActionTemplateKey =
   | 'create-pr'
   | 'merge-pr';
 
+export type OverrideMode = 'replace' | 'append';
+
+export interface ActionTemplateOverride {
+  text: string;
+  mode: OverrideMode;
+}
+
 /**
  * Built-in default templates for each action.
  * These provide detailed instructions to the agent beyond the short label.
@@ -108,29 +115,90 @@ export function getTemplateKey(actionType: string): ActionTemplateKey | null {
   return ACTION_TYPE_TO_TEMPLATE[actionType] ?? null;
 }
 
+const VALID_MODES: Set<string> = new Set<string>(['append', 'replace']);
+
+/**
+ * Parse the flat key-value map from the backend into structured overrides.
+ * Keys like "resolve-conflicts" hold the text; "resolve-conflicts:mode" hold the mode.
+ * Absence of a :mode key defaults to 'append' (the safer default — preserves built-in).
+ */
+export function parseOverrides(raw: Record<string, string>): Partial<Record<ActionTemplateKey, ActionTemplateOverride>> {
+  const result: Partial<Record<ActionTemplateKey, ActionTemplateOverride>> = {};
+  for (const key of Object.keys(ACTION_TEMPLATES) as ActionTemplateKey[]) {
+    const text = raw[key];
+    if (text) {
+      const rawMode = raw[`${key}:mode`];
+      const mode: OverrideMode = (rawMode && VALID_MODES.has(rawMode)) ? rawMode as OverrideMode : 'append';
+      result[key] = { text, mode };
+    }
+  }
+  return result;
+}
+
+/**
+ * Serialize structured overrides back to the flat map for storage.
+ * Only stores :mode keys when mode is 'replace' (append is the default).
+ */
+export function serializeOverrides(overrides: Partial<Record<ActionTemplateKey, ActionTemplateOverride>>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, override] of Object.entries(overrides)) {
+    if (override && override.text.trim()) {
+      result[key] = override.text.trim();
+      if (override.mode === 'replace') {
+        result[`${key}:mode`] = 'replace';
+      }
+    }
+  }
+  return result;
+}
+
 /**
  * Fetches global and per-workspace overrides and merges them with built-in defaults.
- * Per-workspace overrides > global overrides > built-in defaults.
  *
- * Mirrors fetchMergedOverrides() in useReviewTrigger.ts.
+ * Merge strategy per key:
+ *  - 'replace' at any level replaces everything below it.
+ *  - 'append' stacks: builtIn + global append + workspace append.
+ *  - Workspace replace wins over global (even if global is append).
+ *  - Global replace replaces built-in; workspace append then appends to that.
  */
 export async function fetchMergedActionTemplates(
   workspaceId: string,
   getGlobal: () => Promise<Record<string, string>>,
   getWorkspace: (id: string) => Promise<Record<string, string>>,
 ): Promise<Record<ActionTemplateKey, string>> {
-  const [global, workspace] = await Promise.all([
+  const [globalRaw, workspaceRaw] = await Promise.all([
     getGlobal().catch(() => ({} as Record<string, string>)),
     getWorkspace(workspaceId).catch(() => ({} as Record<string, string>)),
   ]);
 
+  const globalOverrides = parseOverrides(globalRaw);
+  const workspaceOverrides = parseOverrides(workspaceRaw);
+
   const merged = { ...ACTION_TEMPLATES };
   for (const key of Object.keys(ACTION_TEMPLATES) as ActionTemplateKey[]) {
-    if (workspace[key]) {
-      merged[key] = workspace[key];
-    } else if (global[key]) {
-      merged[key] = global[key];
+    let base = ACTION_TEMPLATES[key];
+    const global = globalOverrides[key];
+    const workspace = workspaceOverrides[key];
+
+    // Apply global override first
+    if (global) {
+      if (global.mode === 'replace') {
+        base = global.text;
+      } else {
+        base = `${base}\n\n## Additional Instructions\n\n${global.text}`;
+      }
     }
+
+    // Apply workspace override on top
+    if (workspace) {
+      if (workspace.mode === 'replace') {
+        base = workspace.text;
+      } else {
+        base = `${base}\n\n## Additional Instructions (Workspace)\n\n${workspace.text}`;
+      }
+    }
+
+    merged[key] = base;
   }
   return merged;
 }


### PR DESCRIPTION
## Summary

- Action template overrides now support **append** (default) and **replace** modes, giving users control over whether custom instructions extend or replace built-in defaults
- Global and workspace overrides stack properly when both use append mode (previously workspace silently dropped global)
- New backend endpoints for persisting action template overrides at global and workspace levels

## Changes Made

- **`src/lib/action-templates.ts`** — Added `parseOverrides`/`serializeOverrides` for structured override storage with mode validation; rewrote `fetchMergedActionTemplates` to layer global + workspace overrides instead of winner-takes-all
- **`src/components/settings/sections/ActionSettings.tsx`** — Updated global settings UI with append/replace radio toggle, collapsible built-in default viewer
- **`src/components/settings/WorkspaceSettings.tsx`** — Same UI updates for workspace-level settings, shows global override status
- **`backend/server/router.go`** — Added GET/PUT routes for action-templates at global and workspace scope
- **`backend/server/settings_handlers.go`** — Added handler functions for action template CRUD
- **`backend/server/settings_handlers_test.go`** — 8 new tests covering empty state, save/load, isolation between workspaces, global/workspace isolation, corrupted data

## Test Plan

- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `cd backend && go test ./server/` — all tests pass
- [x] `npx tsc --noEmit` — no TypeScript errors in changed files
- [ ] Manual: open global Preferences > Actions, type override text, verify append/replace toggle appears
- [ ] Manual: switch to workspace settings, verify global override indicator shows
- [ ] Manual: save with append mode, reload, verify mode persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)