### PR TITLE
Render session summary as markdown

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1115,14 +1115,14 @@ code.hljs { padding: 3px 5px; }
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08), 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
-/* Skill detail dialog — compact markdown styling (scoped, does not affect other markdown) */
-.skill-detail-markdown {
+/* Dialog markdown — compact styling for markdown rendered inside dialogs */
+.dialog-markdown {
   color: var(--color-foreground);
   font-size: 0.8125rem; /* 13px */
   line-height: 1.6;
 }
 
-.skill-detail-markdown h1 {
+.dialog-markdown h1 {
   font-size: 1.125rem;
   font-weight: 600;
   margin-top: 1.5em;
@@ -1130,7 +1130,7 @@ code.hljs { padding: 3px 5px; }
   line-height: 1.3;
 }
 
-.skill-detail-markdown h2 {
+.dialog-markdown h2 {
   font-size: 0.9375rem;
   font-weight: 600;
   margin-top: 1.25em;
@@ -1138,7 +1138,7 @@ code.hljs { padding: 3px 5px; }
   line-height: 1.3;
 }
 
-.skill-detail-markdown h3 {
+.dialog-markdown h3 {
   font-size: 0.8125rem;
   font-weight: 600;
   margin-top: 1em;
@@ -1146,31 +1146,31 @@ code.hljs { padding: 3px 5px; }
   line-height: 1.4;
 }
 
-.skill-detail-markdown p {
+.dialog-markdown p {
   margin-top: 0;
   margin-bottom: 0.6em;
 }
 
-.skill-detail-markdown ul,
-.skill-detail-markdown ol {
+.dialog-markdown ul,
+.dialog-markdown ol {
   margin-top: 0.3em;
   margin-bottom: 0.6em;
   padding-left: 1.25em;
 }
 
-.skill-detail-markdown li {
+.dialog-markdown li {
   margin-top: 0.15em;
   margin-bottom: 0.15em;
 }
 
-.skill-detail-markdown code:not(pre code) {
+.dialog-markdown code:not(pre code) {
   font-size: 0.75rem;
   padding: 0.15em 0.35em;
   border-radius: 0.25rem;
   background: var(--color-muted);
 }
 
-.skill-detail-markdown pre {
+.dialog-markdown pre {
   font-size: 0.75rem;
   line-height: 1.5;
   margin-top: 0.5em;
@@ -1181,13 +1181,13 @@ code.hljs { padding: 3px 5px; }
   overflow-x: auto;
 }
 
-.skill-detail-markdown a {
+.dialog-markdown a {
   color: var(--color-primary);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.skill-detail-markdown blockquote {
+.dialog-markdown blockquote {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
   padding-left: 0.75em;
@@ -1195,13 +1195,13 @@ code.hljs { padding: 3px 5px; }
   color: var(--color-muted-foreground);
 }
 
-.skill-detail-markdown hr {
+.dialog-markdown hr {
   margin-top: 1em;
   margin-bottom: 1em;
   border-color: var(--color-border);
 }
 
-.skill-detail-markdown table {
+.dialog-markdown table {
   font-size: 0.75rem;
   width: 100%;
   border-collapse: collapse;
@@ -1209,22 +1209,22 @@ code.hljs { padding: 3px 5px; }
   margin-bottom: 0.75em;
 }
 
-.skill-detail-markdown th,
-.skill-detail-markdown td {
+.dialog-markdown th,
+.dialog-markdown td {
   padding: 0.3em 0.6em;
   border: 1px solid var(--color-border);
   text-align: left;
 }
 
-.skill-detail-markdown th {
+.dialog-markdown th {
   font-weight: 600;
   background: var(--color-muted);
 }
 
-.skill-detail-markdown > *:first-child {
+.dialog-markdown > *:first-child {
   margin-top: 0;
 }
 
-.skill-detail-markdown > *:last-child {
+.dialog-markdown > *:last-child {
   margin-bottom: 0;
 }

--- a/src/components/dialogs/ArchivedSessionPreviewDialog.tsx
+++ b/src/components/dialogs/ArchivedSessionPreviewDialog.tsx
@@ -31,8 +31,8 @@ import {
   Plus,
   Minus,
   Loader2,
-  FileText,
 } from 'lucide-react';
+import { DialogMarkdown } from '@/components/shared/DialogMarkdown';
 
 interface ArchivedSessionPreviewDialogProps {
   open: boolean;
@@ -181,12 +181,10 @@ export function ArchivedSessionPreviewDialog({
                   <span>Generating summary...</span>
                 </div>
               ) : session.archiveSummaryStatus === 'completed' && session.archiveSummary ? (
-                <div className="flex items-start gap-1.5 text-xs">
-                  <FileText className="w-3 h-3 mt-0.5 text-muted-foreground shrink-0" />
-                  <p className="text-foreground/80 leading-relaxed break-words min-w-0 whitespace-pre-wrap">
-                    {session.archiveSummary}
-                  </p>
-                </div>
+                <DialogMarkdown
+                  cacheKey={`archive-summary:${session.id}`}
+                  content={session.archiveSummary}
+                />
               ) : session.archiveSummaryStatus === 'failed' ? (
                 <div className="flex items-center gap-2 text-xs text-text-error/80 py-1">
                   <AlertTriangle className="w-3 h-3 shrink-0" />

--- a/src/components/dialogs/__tests__/ArchivedSessionPreviewDialog.test.tsx
+++ b/src/components/dialogs/__tests__/ArchivedSessionPreviewDialog.test.tsx
@@ -8,6 +8,10 @@ vi.mock('@/lib/tauri', () => ({
   copyToClipboard: vi.fn(),
 }));
 
+vi.mock('@/components/shared/DialogMarkdown', () => ({
+  DialogMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
 const baseSession: WorktreeSession = {
   id: 'sess-1',
   workspaceId: 'ws-1',

--- a/src/components/shared/DialogMarkdown.tsx
+++ b/src/components/shared/DialogMarkdown.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
+import { cn } from '@/lib/utils';
+
+interface DialogMarkdownProps {
+  /** Unique cache key for the LRU markdown cache */
+  cacheKey: string;
+  /** Raw markdown string to render */
+  content: string;
+  /** Additional CSS classes to merge onto the wrapper div */
+  className?: string;
+}
+
+export function DialogMarkdown({ cacheKey, content, className }: DialogMarkdownProps) {
+  return (
+    <div className={cn('dialog-markdown', className)}>
+      <CachedMarkdown cacheKey={cacheKey} content={content} />
+    </div>
+  );
+}

--- a/src/components/skills/SkillDetailDialog.tsx
+++ b/src/components/skills/SkillDetailDialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog';
-import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
+import { DialogMarkdown } from '@/components/shared/DialogMarkdown';
 import { Button } from '@/components/ui/button';
 import { Loader2, AlertCircle } from 'lucide-react';
 import { getSkillContent } from '@/lib/api';
@@ -120,30 +120,29 @@ export function SkillDetailDialog({
 
         {/* Body — native scroll, no ScrollArea */}
         <div className="flex-1 min-h-0 overflow-y-auto border-y">
-          <div className="p-6 skill-detail-markdown">
-            {contentLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-              </div>
-            ) : contentError ? (
-              <div className="flex flex-col items-center justify-center py-12 gap-3">
-                <AlertCircle className="h-5 w-5 text-destructive" />
-                <p className="text-sm text-destructive">{contentError}</p>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={retry}
-                >
-                  Retry
-                </Button>
-              </div>
-            ) : strippedContent ? (
-              <CachedMarkdown
-                cacheKey={`skill-detail-${skill.id}`}
-                content={strippedContent}
-              />
-            ) : null}
-          </div>
+          {contentLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : contentError ? (
+            <div className="flex flex-col items-center justify-center py-12 gap-3 px-6">
+              <AlertCircle className="h-5 w-5 text-destructive" />
+              <p className="text-sm text-destructive">{contentError}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={retry}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : strippedContent ? (
+            <DialogMarkdown
+              cacheKey={`skill-detail-${skill.id}`}
+              content={strippedContent}
+              className="p-6"
+            />
+          ) : null}
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
## Summary

- Extracts a reusable `DialogMarkdown` component that pairs the compact dialog markdown CSS with `CachedMarkdown`
- Renames CSS class from `skill-detail-markdown` to `dialog-markdown` for reuse across dialogs
- Archive session summaries now render as proper markdown instead of plain preformatted text

## Changes Made

- **`src/components/shared/DialogMarkdown.tsx`** — New shared component wrapping `CachedMarkdown` with `dialog-markdown` styling and optional `className` prop
- **`src/app/globals.css`** — Renamed `.skill-detail-markdown` → `.dialog-markdown`
- **`src/components/dialogs/ArchivedSessionPreviewDialog.tsx`** — Replaced plain text summary display with `DialogMarkdown`
- **`src/components/skills/SkillDetailDialog.tsx`** — Switched from `CachedMarkdown` to `DialogMarkdown`, flattened unnecessary wrapper div
- **`src/components/dialogs/__tests__/ArchivedSessionPreviewDialog.test.tsx`** — Added mock for `DialogMarkdown`

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds
- [ ] Open an archived session preview — summary renders with markdown formatting (headings, lists, code blocks)
- [ ] Open a skill detail dialog — content renders identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)