### PR TITLE
Allow reviews and new PR cycles after session merge

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -1010,7 +1010,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   return (
     <div className="flex-1 min-h-0 flex flex-col bg-chat-background">
       {/* Branch sync banner - shows when origin/main has updates */}
-      {branchSyncStatus && branchSyncStatus.behindBy > 0 && !branchSyncDismissed && currentSession?.prStatus !== 'merged' && (
+      {branchSyncStatus && branchSyncStatus.behindBy > 0 && !branchSyncDismissed && (
         <BranchSyncBanner
           status={branchSyncStatus}
           loading={branchSyncing}

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -388,8 +388,6 @@ export function SessionToolbarContent() {
 
             <div className="w-1.5" />
 
-            {selectedSession.prStatus !== 'merged' && (() => {
-              return (
             <div className="inline-flex rounded-sm shadow-sm">
               <Button
                 variant="secondary"
@@ -456,8 +454,6 @@ export function SessionToolbarContent() {
                 </PopoverContent>
               </Popover>
             </div>
-              );
-            })()}
 
             <div className="w-1.5" />
 

--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -39,7 +39,8 @@ interface Session {
  * 4. Diverged         → "Sync Branch"         (purple)
  * 5. Work to ship     → "New Pull Request"    (green)
  * 6. Open PR (CI ok)  → "Merge PR"            (green) — hidden while CI pending
- * 7. PR merged        → "Archive Session"     (purple)
+ * 7. PR merged (clean) → "Archive Session"     (purple)
+ * 7b. PR merged + work → falls through to 1–6  (allows new PR cycle)
  */
 export function useActionState(
   gitStatus: GitStatusDTO | null,
@@ -47,19 +48,40 @@ export function useActionState(
   prDetails: PRDetails | null,
 ): PrimaryAction | null {
   return useMemo(() => {
-    // Priority 7: PR is merged — show archive session button
-    // Check both the session store (updated by PRWatcher) and live prDetails
-    // (fetched from GitHub) to handle the case where the PR was just merged
-    // but the store hasn't been updated yet.
-    if (session?.prStatus === 'merged' || prDetails?.merged) {
-      return {
-        type: 'archive-session',
-        tier: 'complete',
-        label: 'Archive Session',
-        icon: Archive,
-        variant: 'default',
-        sessionId: session?.id,
-      };
+    const archiveAction: PrimaryAction = {
+      type: 'archive-session',
+      tier: 'complete',
+      label: 'Archive Session',
+      icon: Archive,
+      variant: 'default',
+      sessionId: session?.id,
+    };
+
+    // Helper: does the working tree have new work beyond the merged PR?
+    const hasNewWork = gitStatus && (
+      gitStatus.workingDirectory.hasChanges ||
+      gitStatus.sync.unpushedCommits > 0 ||
+      gitStatus.sync.aheadBy > 0
+    );
+
+    // Priority 7: PR is merged
+    // When the store confirms the merge AND there's new work (uncommitted changes,
+    // unpushed commits, or commits ahead of base), fall through to the normal
+    // priority chain so the user can sync, review, and create a new PR.
+    if (session?.prStatus === 'merged') {
+      if (!gitStatus || !hasNewWork) {
+        return archiveAction;
+      }
+      // Fall through — normal chain handles sync, PR creation, etc.
+    }
+
+    // Catch-up: GitHub says merged but the store hasn't synced yet.
+    // Show archive to avoid briefly showing stale actions while the store updates.
+    // Also check for new work so the behavior is consistent with the branch above.
+    if (prDetails?.merged && session?.prStatus !== 'merged') {
+      if (!gitStatus || !hasNewWork) {
+        return archiveAction;
+      }
     }
 
     // If we don't have git status yet, hide button until we know the state


### PR DESCRIPTION
## Summary

- After a PR is merged, allow users to continue working in the session — review code, sync branches, and create follow-up PRs instead of only showing "Archive Session"
- If no new work exists, the session still shows "Archive Session" as before
- The review button and branch sync banner are now always visible regardless of merge status

## Changes Made

- **ConversationArea.tsx** — Removed `prStatus !== 'merged'` guard from the branch sync banner so users can sync after a merge
- **SessionToolbarContent.tsx** — Removed `prStatus !== 'merged'` gate from the review button, cleaned up vestigial IIFE wrapper
- **useActionState.ts** — Reworked Priority 7 logic: when `prStatus === 'merged'` and there's new work (uncommitted changes, unpushed commits, or ahead-of-base), falls through to the normal 1–6 action chain. Extracted shared `archiveAction` object, made both merged-check branches (store-confirmed and catch-up) consistent, added explicit `gitStatus` null guard

## Test plan

- [ ] `npm run lint` — no new warnings
- [ ] `npm run build` — builds cleanly
- [ ] Manual: merge a PR in a session, confirm "Archive Session" appears
- [ ] Manual: make a change in a merged session, confirm primary action switches to "New Pull Request"
- [ ] Manual: verify review button and branch sync banner remain visible after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)