### PR TITLE
Replace spinner with static list in Update Tasks tool block

### DIFF
--- a/src/components/conversation/tool-details/TodoToolDetail.tsx
+++ b/src/components/conversation/tool-details/TodoToolDetail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { memo } from 'react';
-import { CheckCircle2, Circle, Loader2 } from 'lucide-react';
+import { CheckCircle2, Circle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface TodoItem {
@@ -31,7 +31,7 @@ export const TodoToolDetail = memo(function TodoToolDetail({ todos }: TodoToolDe
             {todo.status === 'completed' ? (
               <CheckCircle2 className="w-3 h-3 text-text-success" />
             ) : todo.status === 'in_progress' ? (
-              <Loader2 className="w-3 h-3 text-primary animate-spin" />
+              <Circle className="w-3 h-3 text-primary" />
             ) : (
               <Circle className="w-3 h-3 text-muted-foreground/50" />
             )}


### PR DESCRIPTION
## Summary
- Replaced the animated spinner (`Loader2` with `animate-spin`) with a static `Circle` icon for in-progress tasks in the conversation area's "Update tasks" tool content block
- The Tasks panel already provides live task monitoring with spinners, making the conversation block spinners redundant

## Test plan
- [ ] Trigger an agent that uses TodoWrite and verify the "Update tasks" block shows static circles (no spinning)
- [ ] Verify the Tasks panel still shows live spinners as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)