### PR TITLE
Load attachment previews from DB API for history messages

### DIFF
--- a/src/components/conversation/AttachmentPreviewModal.tsx
+++ b/src/components/conversation/AttachmentPreviewModal.tsx
@@ -15,6 +15,7 @@ import {
   getAttachmentSubtitle,
   loadAttachmentContent,
 } from '@/lib/attachments';
+import { fetchAttachmentData } from '@/lib/api';
 import type { Attachment } from '@/lib/types';
 import {
   XIcon,
@@ -41,6 +42,8 @@ interface AttachmentPreviewModalProps {
   onOpenChange: (open: boolean) => void;
   attachments: Attachment[];
   initialIndex: number;
+  /** When true, load attachment content from the DB API instead of from the original file path on disk. */
+  fromHistory?: boolean;
 }
 
 // ============================================================================
@@ -138,6 +141,7 @@ export function AttachmentPreviewModal({
   onOpenChange,
   attachments,
   initialIndex,
+  fromHistory = false,
 }: AttachmentPreviewModalProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [asyncState, setAsyncState] = useState<AsyncLoadState>({ status: 'idle' });
@@ -174,17 +178,18 @@ export function AttachmentPreviewModal({
       }
     }
 
-    // No path and no inline data — can't load
-    if (!attachment.path) {
+    // No path and no inline data — can't load from disk
+    if (!attachment.path && !fromHistory) {
       return { status: 'error', message: 'No file path available' };
     }
 
-    return null; // needs async load from disk
-  }, [open, attachment, isBinaryPreview]);
+    return null; // needs async load (from disk or DB)
+  }, [open, attachment, isBinaryPreview, fromHistory]);
 
-  // Whether we need to load from disk
-  const needsAsyncLoad = open && attachment && !syncContent && !!attachment.path;
+  // Whether we need to load asynchronously (from disk or DB)
+  const needsAsyncLoad = open && attachment && !syncContent && (fromHistory || !!attachment.path);
   const attachmentPath = attachment?.path;
+  const attachmentId = attachment?.id;
 
   // Reset async state when switching attachments
   useEffect(() => {
@@ -192,26 +197,33 @@ export function AttachmentPreviewModal({
     setAsyncState({ status: 'idle' });
   }, [currentIndex]);
 
-  // Async load from disk when base64Data is not available
+  // Async load: from DB API (history) or from disk (compose)
   useEffect(() => {
-    if (!needsAsyncLoad || !attachmentPath) return;
+    if (!needsAsyncLoad) return;
+    if (!fromHistory && !attachmentPath) return;
 
     let cancelled = false;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setAsyncState({ status: 'loading' });
 
-    loadAttachmentContent(attachment!)
-      .then((loaded) => {
+    const loadPromise = fromHistory
+      ? attachmentId
+        ? fetchAttachmentData(attachmentId).then((base64) => ({ base64Data: base64 }))
+        : Promise.reject(new Error('Attachment ID missing for history load'))
+      : loadAttachmentContent(attachment!).then((loaded) => ({ base64Data: loaded.base64Data }));
+
+    loadPromise
+      .then(({ base64Data }) => {
         if (cancelled) return;
-        if (!loaded.base64Data) {
+        if (!base64Data) {
           setAsyncState({ status: 'error', message: 'Failed to read file content' });
           return;
         }
         if (isBinaryPreview) {
-          setAsyncState({ status: 'loaded', content: loaded.base64Data });
+          setAsyncState({ status: 'loaded', content: base64Data });
         } else {
           try {
-            setAsyncState({ status: 'loaded', content: decodeBase64ToString(loaded.base64Data) });
+            setAsyncState({ status: 'loaded', content: decodeBase64ToString(base64Data) });
           } catch {
             setAsyncState({ status: 'error', message: 'Failed to decode file content' });
           }
@@ -223,7 +235,7 @@ export function AttachmentPreviewModal({
       });
 
     return () => { cancelled = true; };
-  }, [needsAsyncLoad, attachmentPath, isBinaryPreview]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [needsAsyncLoad, fromHistory, attachmentId, attachmentPath, isBinaryPreview]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Derive final state: prefer sync content, fall back to async
   const loadState: ResolvedContent = syncContent ?? (asyncState.status === 'idle' ? { status: 'loading' } : asyncState);

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -148,6 +148,7 @@ export const MessageBlock = memo(function MessageBlock({
                     onOpenChange={(open) => { if (!open) setPreviewIndex(null); }}
                     attachments={message.attachments}
                     initialIndex={previewIndex}
+                    fromHistory
                   />
                 )}
               </>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1327,6 +1327,13 @@ export async function deleteFileTab(workspaceId: string, tabId: string): Promise
   await handleVoidResponse(res, 'Failed to delete file tab');
 }
 
+// Attachment data — returns base64 content, or null when the DB has no data for this attachment.
+export async function fetchAttachmentData(attachmentId: string): Promise<string | null> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/attachments/${encodeURIComponent(attachmentId)}/data`);
+  const json = await handleResponse<{ base64Data: string }>(res);
+  return json.base64Data || null;
+}
+
 // File save function
 export async function saveFile(
   workspaceId: string,


### PR DESCRIPTION
## Summary
- Add `fromHistory` prop to `AttachmentPreviewModal` that fetches attachment content from the backend DB API instead of reading from the original file path on disk
- Add `fetchAttachmentData()` API function with `string | null` return type to signal when the DB has no data
- Pass `fromHistory` in `MessageBlock` so persisted message attachments load correctly even when the original file is gone

## Test plan
- [ ] Open a past conversation with user attachments (images and text files)
- [ ] Click an attachment thumbnail to open the preview modal — content should load from the DB
- [ ] Compose a new message with attachments and preview them — should still load from disk as before
- [ ] Verify arrow-key navigation between attachments still works in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)