### PR TITLE
Add top margin to Thinking node

### DIFF
--- a/src/components/conversation/ThinkingNode.tsx
+++ b/src/components/conversation/ThinkingNode.tsx
@@ -20,7 +20,7 @@ export const ThinkingNode = memo(function ThinkingNode({
   if (!showThinkingBlocks) return null;
 
   return (
-    <div className="flex flex-col gap-1 animate-slide-up-fade" aria-label="Agent thinking">
+    <div className="flex flex-col gap-1 mt-2 animate-slide-up-fade" aria-label="Agent thinking">
       <button
         onClick={() => setIsExpanded(!isExpanded)}
         className="flex items-center gap-2 text-xs text-ai-thinking hover:text-ai-thinking/80 transition-colors"


### PR DESCRIPTION
## Summary
- Adds `mt-2` top margin to the ThinkingNode component so it has visual breathing room from the content above it (tool blocks, text, etc.)

## Test plan
- [ ] Open a conversation with thinking blocks visible
- [ ] Confirm the Thinking node has appropriate spacing from content above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)