### PR TITLE
Improve plan approve button styling with inverted colors

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -1207,11 +1207,11 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
               <Button
                 variant="secondary"
                 size="sm"
-                className="h-7 gap-1.5 text-xs bg-background hover:bg-surface-2"
+                className="h-7 gap-1.5 text-xs bg-foreground text-background hover:bg-foreground/90 dark:bg-foreground dark:text-background dark:hover:bg-foreground/90"
                 onClick={handleApprovePlan}
               >
-                Approve
-                <kbd className="px-1 py-0.5 rounded bg-muted text-2xs font-mono">⌘⇧↵</kbd>
+                Approve Plan
+                <kbd className="px-1 py-0.5 rounded bg-background/20 text-background text-2xs font-mono">⌘⇧↵</kbd>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Rename "Approve" to "Approve Plan" to be more descriptive
- Invert button colors: dark/black background with white text in light mode, light/white background with dark text in dark mode
- Update the keyboard shortcut badge to stay visible against the inverted background

## Test plan
- [ ] Verify the "Approve Plan" button appears with dark background and white text in light mode
- [ ] Verify the button flips to light background with dark text in dark mode
- [ ] Verify hover state works in both modes
- [ ] Verify the keyboard shortcut badge (⌘⇧↵) is visible in both modes
- [ ] Verify clicking the button still approves the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)