### PR TITLE
Fix conversation message ordering on reload

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -393,6 +393,24 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 // handleConversationOutput processes output from the agent process.
 // Note: Uses the app-level context so background work is cancelled on shutdown.
 // Store errors are logged but not propagated since this is async processing.
+// flushPendingUserMessage takes any deferred user message from the process and
+// persists it to the database. Returns true if a message was flushed.
+func (m *Manager) flushPendingUserMessage(ctx context.Context, convID string, proc *Process) bool {
+	pending := proc.TakePendingUserMessage()
+	if pending == nil {
+		return false
+	}
+	if err := m.store.AddMessageToConversation(ctx, convID, *pending); err != nil {
+		logger.Manager.Errorf("Failed to store deferred user message for conv %s: %v", convID, err)
+	}
+	if len(pending.Attachments) > 0 {
+		if err := m.store.SaveAttachments(ctx, pending.ID, pending.Attachments); err != nil {
+			logger.Manager.Errorf("Failed to save attachments for deferred message: %v", err)
+		}
+	}
+	return true
+}
+
 func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	ctx := m.ctx
 	var currentAssistantMessage string
@@ -1048,6 +1066,12 @@ outer:
 					}
 					currentAssistantMessage = ""
 				}
+
+				// Flush deferred user message (sent during active turn).
+				// Must happen AFTER storing the assistant message so the DB
+				// position ordering is correct: [assistant_N, user_N+1].
+				m.flushPendingUserMessage(ctx, convID, proc)
+
 				// Reset per-turn accumulation state
 				currentThinking = ""
 				pendingPlanContent = ""
@@ -1235,6 +1259,10 @@ outer:
 			logger.Manager.Errorf("Failed to store final assistant message for conv %s: %v", convID, err)
 		}
 	}
+
+	// Flush any remaining deferred user message so it is not lost when the
+	// process exits without a turn_complete event (e.g. crash, forced stop).
+	m.flushPendingUserMessage(ctx, convID, proc)
 
 	// Clear snapshot on process exit — but only if this process is still the current
 	// one in the map. If a new process has already been started (via SendConversationMessage),
@@ -1519,7 +1547,14 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 		m.mu.Unlock()
 	}
 
-	// Store user message with attachments
+	// Store user message with attachments.
+	// When the process was restarted (or freshly started), there is no pending
+	// assistant turn, so the user message can be stored immediately with the
+	// correct position. When the process is already running, the agent may be
+	// mid-turn streaming a response — storing now would give this message a
+	// position before the assistant response, breaking chronological order on
+	// reload. Defer storage until the current turn completes (flushed in
+	// handleConversationOutput).
 	msg := models.Message{
 		ID:          uuid.New().String()[:8],
 		Role:        "user",
@@ -1527,21 +1562,26 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 		Attachments: attachments,
 		Timestamp:   time.Now(),
 	}
-	if err := m.store.AddMessageToConversation(ctx, convID, msg); err != nil {
-		logger.Manager.Errorf("Failed to store user message for conv %s: %v", convID, err)
-	}
-
-	// Save attachments to database if any
-	if len(attachments) > 0 {
-		if err := m.store.SaveAttachments(ctx, msg.ID, attachments); err != nil {
-			logger.Manager.Errorf("Failed to save attachments: %v", err)
+	if needsRestart {
+		if err := m.store.AddMessageToConversation(ctx, convID, msg); err != nil {
+			logger.Manager.Errorf("Failed to store user message for conv %s: %v", convID, err)
 		}
+		if len(attachments) > 0 {
+			if err := m.store.SaveAttachments(ctx, msg.ID, attachments); err != nil {
+				logger.Manager.Errorf("Failed to save attachments: %v", err)
+			}
+		}
+	} else {
+		proc.SetPendingUserMessage(&msg)
 	}
 
 	// Send to process with attachments
 	logger.Manager.Infof("Sending message to conv %s (content=%d chars, attachments=%d, processRestarted=%v)",
 		convID, len(message), len(attachments), needsRestart)
 	if err := proc.SendMessageWithAttachments(message, attachments); err != nil {
+		// Discard the pending message — it was never delivered to the agent,
+		// so it should not be flushed to the DB later.
+		proc.TakePendingUserMessage()
 		logger.Manager.Errorf("Failed to send message to conv %s: %v (attachments=%d)", convID, err, len(attachments))
 		return err
 	}

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -81,6 +81,7 @@ type Process struct {
 	lastStderrLines    []string      // Ring buffer of last N stderr lines for crash diagnostics
 	sawErrorEvent      bool          // Whether the agent emitted an error/auth_error event
 	producedOutput     bool          // Whether any assistant text was emitted during this process lifetime
+	pendingUserMessage *models.Message // User message deferred until turn completes (correct DB position ordering)
 }
 
 // InputMessage represents a message sent to the agent runner via stdin
@@ -851,4 +852,29 @@ func (p *Process) SetOptionsPlanMode(enabled bool) {
 	defer p.mu.Unlock()
 	p.opts.PlanMode = enabled
 	p.planModeActive = enabled
+}
+
+// SetPendingUserMessage stores a user message to be flushed to the DB after
+// the current assistant turn completes. This ensures correct position ordering
+// when a user submits a message while the agent is still streaming.
+// If a pending message already exists (rapid double-send), the old message is
+// logged as a warning — this should not happen in normal UI flow.
+func (p *Process) SetPendingUserMessage(msg *models.Message) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.pendingUserMessage != nil {
+		logger.Process.Warnf("Overwriting pending user message %s with %s — previous message will be lost",
+			p.pendingUserMessage.ID, msg.ID)
+	}
+	p.pendingUserMessage = msg
+}
+
+// TakePendingUserMessage returns and clears the pending user message.
+// Returns nil if no message is pending.
+func (p *Process) TakePendingUserMessage() *models.Message {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	msg := p.pendingUserMessage
+	p.pendingUserMessage = nil
+	return msg
 }

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -788,15 +788,17 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     if (!selectedConversationId || !isStreaming) return;
 
     try {
-      // Commit any queued message to history before stopping
-      commitQueuedMessage(selectedConversationId);
-      // Compute elapsed time for the stopped run
+      // Compute elapsed time for the stopped run (must read before finalize clears state)
       const startTime = useAppStore.getState().streamingState[selectedConversationId]?.startTime;
       const durationMs = startTime ? Date.now() - startTime : undefined;
-      // Finalize streaming content into a committed message before stopping
-      // so it persists in the message list (same as normal turn completion).
+      // Finalize streaming content first, then commit queued message.
+      // Order matters: assistant message must be appended before the queued
+      // user message to maintain correct timeline ordering. Also,
+      // finalizeStreamingMessage checks for queued message to keep
+      // isStreaming=true, preventing a visual flash between turns.
       // toolUsage is auto-derived from activeTools inside finalizeStreamingMessage.
       finalizeStreamingMessage(selectedConversationId, { durationMs });
+      commitQueuedMessage(selectedConversationId);
       // Add system message indicating the agent was stopped
       addMessage({
         id: `msg-stopped-${Date.now()}`,

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -306,10 +306,14 @@ export function useWebSocket(enabled: boolean = true) {
         // Uses finalizeStreamingMessage instead of clearStreamingText to preserve
         // any streamed content (text + tool blocks) that hasn't been committed yet.
         if (data.payload === 'idle' && store.streamingState[conversationId]?.isStreaming) {
-          store.commitQueuedMessage(conversationId);
           const startTime = store.streamingState[conversationId]?.startTime;
           const durationMs = startTime ? Date.now() - startTime : undefined;
+          // Must finalize BEFORE committing queued message so the assistant
+          // message is appended first (correct timeline ordering).
+          // Also: finalizeStreamingMessage checks for queued message to keep
+          // isStreaming=true, preventing a visual flash between turns.
           store.finalizeStreamingMessage(conversationId, { durationMs });
+          store.commitQueuedMessage(conversationId);
           store.clearAgentTodos(conversationId);
         }
       } else {
@@ -646,10 +650,11 @@ export function useWebSocket(enabled: boolean = true) {
 
       case 'complete': {
         // Complete event signals the entire conversation ended (stdin closed)
-        // Commit any queued message so it appears in history
-        store.commitQueuedMessage(conversationId);
-        // Finalize any remaining streaming content into a committed message
+        // Finalize streaming content first, then commit queued message.
+        // Order matters: assistant message must be appended before the queued
+        // user message to maintain correct timeline ordering.
         store.finalizeStreamingMessage(conversationId, {});
+        store.commitQueuedMessage(conversationId);
         store.setStreaming(conversationId, false);
         store.clearAgentTodos(conversationId);
         store.clearPendingUserQuestion(conversationId);
@@ -750,7 +755,9 @@ export function useWebSocket(enabled: boolean = true) {
           break;
         }
 
-        // Commit any queued message so it appears in history
+        // Finalize any partial assistant content before committing the queued
+        // user message — preserves correct timeline ordering.
+        store.finalizeStreamingMessage(conversationId, {});
         store.commitQueuedMessage(conversationId);
         store.setStreamingError(conversationId, errorMessage);
         // Update conversation status to idle
@@ -958,10 +965,11 @@ export function useWebSocket(enabled: boolean = true) {
       // Group F: Interrupted + User Question Timeout
       // ====================================================================
       case 'interrupted':
-        // Commit any queued message so it appears in history
-        store.commitQueuedMessage(conversationId);
-        // Finalize streaming content into a committed message so it persists
+        // Finalize streaming content first, then commit queued message.
+        // Order matters: assistant message must be appended before the queued
+        // user message to maintain correct timeline ordering.
         store.finalizeStreamingMessage(conversationId, {});
+        store.commitQueuedMessage(conversationId);
         addSystemMessage(conversationId, 'Agent was stopped by user.')
           .then(({ id }) => {
             store.addMessage({


### PR DESCRIPTION
## Summary

- **Fix message ordering bug**: User messages sent mid-turn were stored to the DB before the assistant response, causing out-of-order messages on reload
- **Backend**: Defer user message storage until `turn_complete`, with post-loop fallback for crash/stop scenarios. Extract `flushPendingUserMessage` helper to deduplicate flush logic across 3 call sites
- **Frontend**: Reorder `finalizeStreamingMessage` before `commitQueuedMessage` in all WebSocket event paths (idle, complete, interrupted, error, stop)
- **Safety**: Warn on pending message overwrite (rapid double-send), clear pending message on send failure to prevent ghost messages

## Test plan

- [ ] Send a message while the agent is actively streaming — verify messages appear in correct order after page reload
- [ ] Stop the agent mid-turn after sending a follow-up message — verify the user message is persisted
- [ ] Force-kill the agent process while a deferred message is pending — verify the post-loop flush saves it
- [ ] Verify no regressions in normal send-reply-send flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)