### PR TITLE
Add y-margin and purple color to model output label

### DIFF
--- a/src/components/conversation/TurnStatusIndicator.tsx
+++ b/src/components/conversation/TurnStatusIndicator.tsx
@@ -18,10 +18,12 @@ export const TurnStatusIndicator = memo(function TurnStatusIndicator({
 
   const colorClass = variant === 'thinking_enabled'
     ? 'text-ai-thinking'
+    : variant === 'config'
+    ? 'text-ai-active'
     : 'text-muted-foreground';
 
   return (
-    <div className="flex items-center gap-2" aria-label={content}>
+    <div className="flex items-center gap-2 my-2" aria-label={content}>
       <Icon className={`w-3.5 h-3.5 shrink-0 ${colorClass}`} aria-hidden="true" />
       <span className={`text-xs ${colorClass}`}>{content}</span>
     </div>


### PR DESCRIPTION
## Summary
- The turn-start config indicator (e.g., "Claude Opus 4.6") now uses the `text-ai-active` purple color instead of `text-muted-foreground` gray
- Added `my-2` vertical margin for visual breathing room in the conversation timeline

## Test plan
- [ ] Start a conversation and verify the model label appears in purple in both light and dark themes
- [ ] Verify vertical spacing above and below the label looks balanced
- [ ] Confirm the "thinking enabled" status indicator still uses its gold/amber color

🤖 Generated with [Claude Code](https://claude.com/claude-code)