### PR TITLE
Fix dialog overflow in archived session preview

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1120,6 +1120,8 @@ code.hljs { padding: 3px 5px; }
   color: var(--color-foreground);
   font-size: 0.8125rem; /* 13px */
   line-height: 1.6;
+  overflow-wrap: break-word;
+  min-width: 0;
 }
 
 .dialog-markdown h1 {
@@ -1168,6 +1170,7 @@ code.hljs { padding: 3px 5px; }
   padding: 0.15em 0.35em;
   border-radius: 0.25rem;
   background: var(--color-muted);
+  overflow-wrap: break-word;
 }
 
 .dialog-markdown pre {

--- a/src/components/dialogs/ArchivedSessionPreviewDialog.tsx
+++ b/src/components/dialogs/ArchivedSessionPreviewDialog.tsx
@@ -56,7 +56,7 @@ export function ArchivedSessionPreviewDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent showCloseButton={false} className="sm:max-w-lg p-0 gap-0">
-        <DialogHeader className="px-4 pt-4 pb-2">
+        <DialogHeader className="px-4 pt-4 pb-2 overflow-hidden">
           <DialogTitle className="flex items-center gap-2 text-sm">
             <Archive className="w-4 h-4 text-muted-foreground" />
             <span className="font-mono truncate">{session.branch}</span>


### PR DESCRIPTION
## Summary

- Prevent long text (branch names, markdown content, inline code) from breaking out of the archived session preview dialog
- Use `overflow-wrap: break-word` and `min-width: 0` for proper text wrapping in flex containers

## Changes Made

- **`ArchivedSessionPreviewDialog.tsx`** — Added `overflow-hidden` to `DialogHeader` to contain long branch names that escape `truncate`
- **`globals.css`** — Added `overflow-wrap: break-word` and `min-width: 0` to `.dialog-markdown` root for proper flex child wrapping; added `overflow-wrap: break-word` to inline code elements

## Test plan

- [ ] Open an archived session with a long branch name — title should truncate
- [ ] Open an archived session with a long markdown summary containing inline code — text should wrap within the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)