### PR TITLE
Add `make build-release` for local production DMG builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-debug dev backend agent-runner clean init deps install-debug test test-cover test-cover-html
+.PHONY: build build-release build-debug dev backend agent-runner clean init deps install-debug test test-cover test-cover-html
 
 # Load .env file if it exists (for OAuth credentials, API keys)
 -include .env
@@ -41,6 +41,12 @@ dev: deps backend agent-runner
 # Production build (auto-installs deps if needed)
 build: deps backend agent-runner
 	npm run tauri:build
+
+# Production release build for local distribution (creates DMG with embedded OAuth credentials)
+# Requires GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET (via env vars or .env file)
+# Skips updater artifacts (no TAURI_SIGNING_PRIVATE_KEY needed)
+build-release: deps backend-release agent-runner
+	npm run tauri:build -- --bundles dmg
 
 # Debug build (for testing deep links, OAuth, etc.)
 # Note: The updater plugin fails without a valid signing key, but we only need the .app bundle


### PR DESCRIPTION
## Summary
- Adds a `build-release` Makefile target that creates a production DMG with embedded OAuth credentials
- Uses `backend-release` to bake in `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` at compile time
- Passes `--bundles dmg` to skip updater artifacts (no `TAURI_SIGNING_PRIVATE_KEY` needed)

## Usage
```bash
# With .env file (auto-loaded by Makefile):
make build-release

# Or with explicit env vars:
GITHUB_CLIENT_ID="..." GITHUB_CLIENT_SECRET="..." make build-release
```

Output: `src-tauri/target/release/bundle/dmg/chatml_0.1.0_aarch64.dmg`

## Test plan
- [ ] Run `make build-release` with OAuth credentials set
- [ ] Verify DMG is created at `src-tauri/target/release/bundle/dmg/`
- [ ] Mount DMG, install app, and confirm it launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)