### PR TITLE
Fix duplicate dialog when opening project from welcome page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -398,7 +398,7 @@ export default function Home() {
       await registerAndNavigateWorkspace(repo);
     } catch (error) {
       console.error('Failed to add workspace directly:', error);
-      dialogRef.current?.showAddWorkspace();
+      showError(error instanceof Error ? error.message : 'Failed to add workspace. Please try again.', 'Workspace Error');
     }
   }, [registerAndNavigateWorkspace]);
 


### PR DESCRIPTION
## Summary
- When clicking "Open Project" on the welcome page, if `addRepo()` failed the error handler opened the "Add Repository" modal dialog on top of the already-completed native file dialog — showing two dialogs for one action
- Replaced the fallback `showAddWorkspace()` call with an error toast notification so the user gets clear feedback without a redundant dialog

## Test plan
- [ ] Go to the welcome page ("Good morning") with no projects
- [ ] Click the green "Open Project" folder icon
- [ ] Select a folder in the native file dialog — confirm no "Add Repository" dialog appears
- [ ] Select an invalid (non-git) folder — confirm an error toast appears instead of the "Add Repository" dialog
- [ ] Cancel the native file dialog — confirm nothing happens
- [ ] Test sidebar "+" → "Open Project" has the same correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)