### PR TITLE
Add recently-closed tabs with restore and Cmd+Shift+T shortcut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "chatml",
       "version": "0.1.0",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "@ariakit/react": "^0.4.21",
         "@dnd-kit/core": "^6.3.1",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,12 +30,14 @@ import { useMenuState } from '@/hooks/useMenuState';
 import { useMessagePrefetch } from '@/hooks/useMessagePrefetch';
 import { useToast } from '@/components/ui/toast';
 import {
-  createSession, createConversation, deleteConversation, addRepo,
-  mapSessionDTO, listConversations,
-  type RepoDTO,
+  createSession, createConversation, addRepo,
+  mapSessionDTO, listConversations, type RepoDTO,
 } from '@/lib/api';
 import { registerSession, getSessionDirName, openFolderDialog } from '@/lib/tauri';
 import { useBranchCacheStore } from '@/stores/branchCacheStore';
+import { useRecentlyClosedStore } from '@/stores/recentlyClosedStore';
+import { captureClosedConversation, useRestoreConversation } from '@/hooks/useRecentlyClosed';
+import { useShortcut } from '@/hooks/useShortcut';
 import type { SetupInfo } from '@/lib/types';
 
 import { OnboardingScreen } from '@/components/shared/OnboardingScreen';
@@ -305,9 +307,15 @@ export default function Home() {
   const doCloseTab = useCallback(async (convId: string) => {
     const currentConvs = conversations.filter((c) => c.sessionId === selectedSessionId);
     const currentIndex = currentConvs.findIndex((c) => c.id === convId);
+    const conv = conversations.find((c) => c.id === convId);
 
     try {
-      await deleteConversation(convId);
+      // Capture metadata for recently-closed before removing from store
+      if (conv && selectedWorkspaceId) {
+        captureClosedConversation(conv, selectedWorkspaceId);
+      }
+
+      // Remove from local store (do NOT delete from backend — keep for restore)
       removeConversation(convId);
 
       if (currentConvs.length > 1) {
@@ -320,7 +328,7 @@ export default function Home() {
       console.error('Failed to close tab:', error);
       showError('Failed to close conversation. Please try again.');
     }
-  }, [selectedSessionId, conversations, removeConversation, showError]);
+  }, [selectedSessionId, selectedWorkspaceId, conversations, removeConversation, showError]);
 
   const handleCloseTab = useCallback(async () => {
     if (!selectedConversationId) return;
@@ -341,6 +349,17 @@ export default function Home() {
       setPendingCloseConvId(null);
     }
   }, [pendingCloseConvId, doCloseTab]);
+
+  // ─── Restore Closed Conversation Handler ────────────────────────────────
+  const handleRestoreConversation = useRestoreConversation(showError);
+
+  // ─── Reopen Last Closed Tab Shortcut (Cmd+Shift+T) ─────────────────────
+  useShortcut('reopenClosedTab', useCallback(() => {
+    if (!selectedSessionId) return;
+    const entry = useRecentlyClosedStore.getState().closedConversations
+      .find((c) => c.sessionId === selectedSessionId);
+    if (entry) handleRestoreConversation(entry.id);
+  }, [selectedSessionId, handleRestoreConversation]));
 
   // ─── Workspace Registration Helper ────────────────────────────────────
   const registerAndNavigateWorkspace = useCallback(async (repo: RepoDTO) => {

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -860,17 +860,28 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     };
     const handleTogglePlanMode = () => handlePlanModeToggle();
 
+    // Handle template selection from SessionHomeState quick actions
+    const handleTemplateSelected = (e: Event) => {
+      const text = (e as CustomEvent<{ text: string }>).detail.text;
+      plateInputRef.current?.setText(text);
+      setMessage(text);
+      // Use requestAnimationFrame to ensure the editor has updated before focusing
+      requestAnimationFrame(() => plateInputRef.current?.focus());
+    };
+
     document.addEventListener('keydown', handleGlobalKeyDown);
     window.addEventListener('focus-input', handleFocusInput);
     window.addEventListener('toggle-thinking', handleToggleThinking);
     window.addEventListener('toggle-plan-mode', handleTogglePlanMode);
+    window.addEventListener('session-home-template-selected', handleTemplateSelected);
     return () => {
       document.removeEventListener('keydown', handleGlobalKeyDown);
       window.removeEventListener('focus-input', handleFocusInput);
       window.removeEventListener('toggle-thinking', handleToggleThinking);
       window.removeEventListener('toggle-plan-mode', handleTogglePlanMode);
+      window.removeEventListener('session-home-template-selected', handleTemplateSelected);
     };
-  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel, MODELS]);
+  }, [handlePlanModeToggle, handleOpenFilePicker, selectedModel, MODELS, setMessage]);
 
   const handleSubmit = async () => {
     const { text: content, mentionedFiles } = plateInputRef.current?.getContent() ?? { text: '', mentionedFiles: [] };

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, startTransition } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from '@/stores/appStore';
+import { captureClosedConversation, useRestoreConversation } from '@/hooks/useRecentlyClosed';
 import {
   useConversationState,
   useFileTabState,
@@ -34,6 +35,11 @@ import {
   CheckCircle2,
   Terminal,
   FileCode,
+  Bug,
+  TestTube2,
+  Eye,
+  RefreshCw,
+  FileText,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { FileTab, Conversation } from '@/lib/types';
@@ -900,11 +906,19 @@ export function ConversationArea({ children }: ConversationAreaProps) {
         // startTransition defers Pierre's heavy Shadow DOM cleanup so the tab disappears instantly
         startTransition(() => closeFileTab(id));
       } else {
+        // Capture metadata for recently-closed before removing from store
+        const conv = conversations.find((c) => c.id === id);
+        if (conv && selectedWorkspaceId) {
+          captureClosedConversation(conv, selectedWorkspaceId);
+        }
         startTransition(() => removeConversation(id));
       }
     },
-    [fileTabs, closeFileTab, removeConversation, setPendingCloseFileTabId]
+    [fileTabs, closeFileTab, removeConversation, setPendingCloseFileTabId, conversations, selectedWorkspaceId]
   );
+
+  // Restore a recently closed conversation
+  const handleRestoreConversation = useRestoreConversation(showError);
 
   // Rename conversation handler for TabBar
   const handleRenameConversation = useCallback(
@@ -1028,6 +1042,8 @@ export function ConversationArea({ children }: ConversationAreaProps) {
         onGenerateSummary={handleGenerateSummary}
         onViewSummary={handleViewSummary}
         getSummaryStatus={getSummaryStatus}
+        onRestoreConversation={handleRestoreConversation}
+        sessionId={selectedSessionId}
       />
 
       {/* Content Area - File viewer and messages are BOTH rendered but only one is visible.
@@ -1179,7 +1195,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
             emptyState={
               (!selectedConversationId || conversationMessages.length === 0) ? (
                 sessionConversations.length === 0
-                  ? <SessionPreparingState sessionName={currentSession?.branch || currentSession?.name} />
+                  ? <SessionHomeState sessionName={currentSession?.branch || currentSession?.name} />
                   : <ConversationEmptyState sessionName={currentSession?.name} />
               ) : undefined
             }
@@ -1273,23 +1289,50 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   );
 }
 
-function SessionPreparingState({ sessionName }: { sessionName?: string }) {
+const QUICK_ACTIONS = [
+  { icon: Bug, label: 'Fix a bug', prompt: 'Fix a bug: ' },
+  { icon: TestTube2, label: 'Write tests', prompt: 'Write tests for ' },
+  { icon: Sparkles, label: 'Add a feature', prompt: 'Add a feature: ' },
+  { icon: Eye, label: 'Review code', prompt: 'Review the code in ' },
+  { icon: RefreshCw, label: 'Refactor', prompt: 'Refactor ' },
+  { icon: FileText, label: 'Documentation', prompt: 'Write documentation for ' },
+];
+
+function SessionHomeState({ sessionName }: { sessionName?: string }) {
+  const handleTemplateClick = useCallback((prompt: string) => {
+    window.dispatchEvent(
+      new CustomEvent('session-home-template-selected', { detail: { text: prompt } }),
+    );
+  }, []);
+
   return (
     <div className="pt-3 pl-5 pr-12 pb-10 animate-fade-in">
-      <div className="max-w-lg mx-auto text-center">
+      <div className="max-w-md mx-auto text-center">
         {sessionName && (
           <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-primary/10 text-primary text-sm font-medium mb-6 animate-scale-in">
             <GitBranch className="w-4 h-4" />
             {sessionName}
           </div>
         )}
-        <div className="flex items-center justify-center gap-2 mb-2">
-          <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
-          <h2 className="font-display text-[1.375rem] leading-[1.25] tracking-display">Preparing session</h2>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          Setting up your workspace and git branch...
+        <h2 className="font-display text-[1.375rem] leading-[1.25] tracking-display mb-2">
+          What would you like to work on?
+        </h2>
+        <p className="text-sm text-muted-foreground mb-6">
+          Type below to start, or pick a quick action
         </p>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          {QUICK_ACTIONS.map(({ icon: Icon, label, prompt }) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => handleTemplateClick(prompt)}
+              className="flex items-center gap-2 px-3 py-2.5 rounded-lg border border-border bg-card text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors cursor-pointer text-left"
+            >
+              <Icon className="w-4 h-4 shrink-0" />
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/tabs/RecentlyClosedPopover.tsx
+++ b/src/components/tabs/RecentlyClosedPopover.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { History, MessageSquare, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover';
+import { useRecentlyClosedStore, type ClosedConversation } from '@/stores/recentlyClosedStore';
+import { deleteClosedConversations } from '@/hooks/useRecentlyClosed';
+import { cn } from '@/lib/utils';
+
+interface RecentlyClosedPopoverProps {
+  sessionId: string | null;
+  onRestore: (convId: string) => Promise<void>;
+}
+
+function formatRelativeTime(closedAt: number): string {
+  const diff = Date.now() - closedAt;
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function RecentlyClosedPopover({ sessionId, onRestore }: RecentlyClosedPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  const closedConversations = useRecentlyClosedStore(
+    useShallow((s) =>
+      sessionId ? s.closedConversations.filter((c) => c.sessionId === sessionId) : [],
+    ),
+  );
+
+  if (closedConversations.length === 0) return null;
+
+  const handleRestore = async (conv: ClosedConversation) => {
+    if (restoringId) return;
+    setRestoringId(conv.id);
+    try {
+      await onRestore(conv.id);
+      // onRestore removes the entry from the store synchronously; check what's left
+      if (closedConversations.length <= 1) setOpen(false);
+    } finally {
+      setRestoringId(null);
+    }
+  };
+
+  const handleClearAll = () => {
+    if (sessionId) {
+      const toDelete = useRecentlyClosedStore.getState()
+        .closedConversations.filter((c) => c.sessionId === sessionId);
+      useRecentlyClosedStore.getState().clearForSession(sessionId);
+      // Permanently delete from backend (fire-and-forget)
+      deleteClosedConversations(toDelete.map((c) => c.id));
+    }
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-muted-foreground hover:text-foreground"
+          title="Recently closed conversations"
+          aria-label="Recently closed conversations"
+        >
+          <History className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64 p-0">
+        <div className="px-3 py-2 border-b border-border">
+          <p className="text-xs font-medium text-muted-foreground">Recently closed</p>
+        </div>
+        <div className="max-h-64 overflow-y-auto">
+          {closedConversations.map((conv) => (
+            <button
+              key={conv.id}
+              type="button"
+              onClick={() => handleRestore(conv)}
+              disabled={restoringId === conv.id}
+              className={cn(
+                'w-full text-left px-3 py-2 hover:bg-accent/50 transition-colors flex items-start gap-2',
+                restoringId === conv.id && 'opacity-50',
+              )}
+            >
+              <MessageSquare className="w-3.5 h-3.5 mt-0.5 shrink-0 text-muted-foreground" />
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-medium truncate">{conv.name}</p>
+                <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                  <span>{formatRelativeTime(conv.closedAt)}</span>
+                  {conv.messageCount > 0 && (
+                    <span>{conv.messageCount} msg{conv.messageCount !== 1 ? 's' : ''}</span>
+                  )}
+                </div>
+              </div>
+              {restoringId === conv.id && (
+                <Loader2 className="w-3 h-3 animate-spin shrink-0 mt-0.5 text-muted-foreground" />
+              )}
+            </button>
+          ))}
+        </div>
+        <div className="px-3 py-1.5 border-t border-border">
+          <button
+            type="button"
+            onClick={handleClearAll}
+            className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Clear all
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -24,6 +24,7 @@ import { TabItem } from './TabItem';
 import { TabScrollArea } from './TabScrollArea';
 import { useTabScroll } from './useTabScroll';
 import { useTabAnimation } from './useTabAnimation';
+import { RecentlyClosedPopover } from './RecentlyClosedPopover';
 import type { TabBarProps, TabItemData } from './tab.types';
 
 /**
@@ -114,6 +115,8 @@ export function TabBar({
   onGenerateSummary,
   onViewSummary,
   getSummaryStatus,
+  onRestoreConversation,
+  sessionId,
 }: TabBarProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const {
@@ -260,8 +263,14 @@ export function TabBar({
         </SortableContext>
       </DndContext>
 
-      {/* Fixed action area - Plus button */}
+      {/* Fixed action area - Recently closed + Plus button */}
       <div className="flex items-center px-1 border-l border-border shrink-0">
+        {onRestoreConversation && (
+          <RecentlyClosedPopover
+            sessionId={sessionId ?? null}
+            onRestore={onRestoreConversation}
+          />
+        )}
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/tabs/tab.types.ts
+++ b/src/components/tabs/tab.types.ts
@@ -39,6 +39,8 @@ export interface TabBarProps {
   onGenerateSummary?: (conversationId: string) => void;
   onViewSummary?: (conversationId: string) => void;
   getSummaryStatus?: (conversationId: string) => 'generating' | 'completed' | 'failed' | null;
+  onRestoreConversation?: (convId: string) => Promise<void>;
+  sessionId?: string | null;
 }
 
 /**

--- a/src/hooks/useRecentlyClosed.ts
+++ b/src/hooks/useRecentlyClosed.ts
@@ -1,0 +1,80 @@
+import { useCallback } from 'react';
+import { useAppStore } from '@/stores/appStore';
+import { useRecentlyClosedStore } from '@/stores/recentlyClosedStore';
+import { getConversation, getConversationMessages, deleteConversation, toStoreMessage } from '@/lib/api';
+import type { Conversation } from '@/lib/types';
+
+/**
+ * Captures a conversation's metadata into the recently-closed store.
+ * Call this before removing a conversation from the app store.
+ */
+export function captureClosedConversation(conv: Conversation, workspaceId: string) {
+  useRecentlyClosedStore.getState().addClosedConversation({
+    id: conv.id,
+    sessionId: conv.sessionId,
+    workspaceId,
+    name: conv.name,
+    type: conv.type,
+    closedAt: Date.now(),
+    // messageCount is set by lazy loading; messages.length is accurate when loaded eagerly.
+    // If neither is available, we store 0 (popover hides "0 msgs").
+    messageCount: conv.messageCount ?? conv.messages?.length ?? 0,
+    model: conv.model,
+  });
+}
+
+/**
+ * Permanently delete conversations from the backend. Fire-and-forget; errors are logged.
+ */
+export async function deleteClosedConversations(ids: string[]) {
+  await Promise.allSettled(
+    ids.map((id) => deleteConversation(id).catch((err) => {
+      console.warn(`Failed to delete closed conversation ${id}:`, err);
+    })),
+  );
+}
+
+/**
+ * Hook that returns a stable callback for restoring a recently-closed conversation
+ * from the backend into the app store.
+ */
+export function useRestoreConversation(showError: (msg: string) => void) {
+  return useCallback(async (convId: string) => {
+    try {
+      const convDTO = await getConversation(convId);
+      const messagesPage = await getConversationMessages(convId, { limit: 50 });
+      const messages = messagesPage.messages.map((m) => toStoreMessage(m, convDTO.id));
+
+      const store = useAppStore.getState();
+      store.addConversation({
+        id: convDTO.id,
+        sessionId: convDTO.sessionId,
+        type: convDTO.type,
+        name: convDTO.name,
+        status: convDTO.status,
+        model: convDTO.model,
+        messages,
+        toolSummary: convDTO.toolSummary?.map((t) => ({
+          id: t.id,
+          tool: t.tool,
+          target: t.target,
+          success: t.success,
+        })) ?? [],
+        createdAt: convDTO.createdAt,
+        updatedAt: convDTO.updatedAt,
+      });
+      store.setMessagePage(
+        convDTO.id,
+        messages,
+        messagesPage.hasMore,
+        messagesPage.oldestPosition ?? 0,
+        messagesPage.totalCount,
+      );
+      store.selectConversation(convDTO.id);
+      useRecentlyClosedStore.getState().removeClosedConversation(convId);
+    } catch {
+      showError('Could not restore conversation. It may have been deleted.');
+      useRecentlyClosedStore.getState().removeClosedConversation(convId);
+    }
+  }, [showError]);
+}

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -140,6 +140,13 @@ export const SHORTCUTS: Shortcut[] = [
     category: 'Navigation',
   },
   {
+    id: 'reopenClosedTab',
+    key: 't',
+    modifiers: ['meta', 'shift'],
+    label: 'Reopen last closed tab',
+    category: 'Navigation',
+  },
+  {
     id: 'sidebarFilesTab',
     key: 'f',
     modifiers: ['alt'],

--- a/src/stores/recentlyClosedStore.ts
+++ b/src/stores/recentlyClosedStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const MAX_PER_SESSION = 10;
+
+export interface ClosedConversation {
+  id: string;
+  sessionId: string;
+  workspaceId: string;
+  name: string;
+  type: 'task' | 'review' | 'chat';
+  closedAt: number;
+  messageCount: number;
+  model?: string;
+}
+
+interface RecentlyClosedState {
+  closedConversations: ClosedConversation[];
+
+  addClosedConversation: (conv: ClosedConversation) => void;
+  removeClosedConversation: (id: string) => void;
+  clearForSession: (sessionId: string) => void;
+  getClosedForSession: (sessionId: string) => ClosedConversation[];
+}
+
+export const useRecentlyClosedStore = create<RecentlyClosedState>()(
+  persist(
+    (set, get) => ({
+      closedConversations: [],
+
+      addClosedConversation: (conv) => {
+        const state = get();
+
+        // Dedup: remove any existing entry for this conversation (e.g. close → restore → close)
+        const withoutDup = state.closedConversations.filter((c) => c.id !== conv.id);
+
+        let updated = [conv, ...withoutDup];
+
+        // Evict oldest for this session if over the cap (drop from list only — no backend deletion)
+        const sessionItems = updated.filter((c) => c.sessionId === conv.sessionId);
+        if (sessionItems.length > MAX_PER_SESSION) {
+          const oldest = sessionItems[sessionItems.length - 1];
+          updated = updated.filter((c) => c.id !== oldest.id);
+        }
+
+        set({ closedConversations: updated });
+      },
+
+      removeClosedConversation: (id) => {
+        set((state) => ({
+          closedConversations: state.closedConversations.filter((c) => c.id !== id),
+        }));
+      },
+
+      clearForSession: (sessionId) => {
+        set((state) => ({
+          closedConversations: state.closedConversations.filter(
+            (c) => c.sessionId !== sessionId,
+          ),
+        }));
+      },
+
+      getClosedForSession: (sessionId) => {
+        return get().closedConversations.filter((c) => c.sessionId === sessionId);
+      },
+    }),
+    {
+      name: 'chatml-recently-closed',
+      partialize: (state) => ({
+        closedConversations: state.closedConversations,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

- **Recently-closed tabs**: Closing a conversation now soft-deletes it (removed from UI, kept in backend) so it can be restored. A new "Recently closed" popover in the tab bar lists closed tabs with relative timestamps.
- **Cmd+Shift+T shortcut**: Reopens the most recently closed tab, matching browser UX conventions.
- **Session home quick actions**: Replaces the old "Preparing session" spinner with actionable quick-start buttons (Fix a bug, Write tests, Add a feature, etc.).

## Changes Made

- **`src/stores/recentlyClosedStore.ts`** — New persisted Zustand store tracking up to 10 closed conversations per session with dedup and eviction
- **`src/hooks/useRecentlyClosed.ts`** — `captureClosedConversation()` to snapshot metadata on close, `useRestoreConversation()` hook that fetches from backend with proper pagination (`limit: 50`, `setMessagePage`), `deleteClosedConversations()` for permanent backend cleanup
- **`src/components/tabs/RecentlyClosedPopover.tsx`** — Popover UI with restore-per-item, loading state, and "Clear all" (which permanently deletes from backend)
- **`src/app/page.tsx`** — Wired soft-close, restore handler, and `Cmd+Shift+T` shortcut
- **`src/components/conversation/ConversationArea.tsx`** — Second close path (tab bar X) also captures to recently-closed; `SessionHomeState` replaces `SessionPreparingState` with quick-action grid
- **`src/components/conversation/ChatInput.tsx`** — Listens for `session-home-template-selected` events from quick actions
- **`src/components/tabs/TabBar.tsx`**, **`tab.types.ts`** — Pass `onRestoreConversation` and `sessionId` props to render the popover
- **`src/lib/shortcuts.ts`** — Added `reopenClosedTab` shortcut definition

## Test Plan

- [ ] `npm run lint` — passes (0 errors, only pre-existing warnings)
- [ ] `npm run build` — passes
- [ ] Close a conversation tab → verify it appears in the recently-closed popover (clock icon in tab bar)
- [ ] Click a closed tab in the popover → verify it restores with messages and pagination intact
- [ ] Press `Cmd+Shift+T` → verify it reopens the most recently closed tab
- [ ] Click "Clear all" in the popover → verify conversations are permanently deleted from backend
- [ ] Open a new session with no conversations → verify quick-action buttons appear and populate the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)