### PR TITLE
Optimize UI performance: index messages by conversationId and reduce layout thrashing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -617,26 +617,41 @@ code.hljs { padding: 3px 5px; }
   animation: dash-march 60s linear infinite;
 }
 
-/* Dictation button pulsing animation */
+/* Dictation button pulsing animation
+   Uses a pseudo-element with transform + opacity instead of box-shadow
+   to avoid expensive recompositing on every animation frame. */
 @keyframes dictation-pulse {
   0%, 100% {
-    box-shadow: 0 0 0 0 rgba(249, 115, 22, 0.4);
+    transform: scale(1);
+    opacity: 0.4;
   }
   50% {
-    box-shadow: 0 0 0 6px rgba(249, 115, 22, 0);
+    transform: scale(1.4);
+    opacity: 0;
   }
 }
 
 .dictation-active {
-  animation: dictation-pulse 1.5s ease-in-out infinite;
+  position: relative;
   background-color: rgba(249, 115, 22, 0.1);
+}
+
+.dictation-active::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2px solid rgba(249, 115, 22, 0.4);
+  animation: dictation-pulse 1.5s ease-in-out infinite;
+  will-change: transform, opacity;
+  pointer-events: none;
 }
 
 .dictation-active:hover {
   background-color: rgba(249, 115, 22, 0.2);
 }
 
-/* Sound level bars animation */
+/* Sound level bars animation — currently unused, no component references .sound-bar */
 .sound-bar {
   transition: height 75ms ease-out;
 }
@@ -651,7 +666,8 @@ code.hljs { padding: 3px 5px; }
   margin-right: 0 !important;
   opacity: 0 !important;
   overflow: hidden;
-  transition: all 150ms ease-in;
+  --tab-close-dur: 150ms;
+  transition: width var(--tab-close-dur) ease-in, min-width var(--tab-close-dur) ease-in, padding var(--tab-close-dur) ease-in, margin var(--tab-close-dur) ease-in, opacity var(--tab-close-dur) ease-in;
 }
 
 .tab-opening {
@@ -1001,20 +1017,22 @@ code.hljs { padding: 3px 5px; }
   z-index: 10;
 }
 
-/* Session active indicator - equalizer bars animation */
+/* Session active indicator - equalizer bars animation
+   Uses transform: scaleY() instead of height to avoid layout reflow.
+   Bars have a fixed base height and scale from there. */
 @keyframes session-bar-1 {
-  0%, 100% { height: 3px; }
-  50% { height: 10px; }
+  0%, 100% { transform: scaleY(0.27); }
+  50% { transform: scaleY(0.91); }
 }
 
 @keyframes session-bar-2 {
-  0%, 100% { height: 8px; }
-  50% { height: 4px; }
+  0%, 100% { transform: scaleY(0.73); }
+  50% { transform: scaleY(0.36); }
 }
 
 @keyframes session-bar-3 {
-  0%, 100% { height: 5px; }
-  50% { height: 11px; }
+  0%, 100% { transform: scaleY(0.45); }
+  50% { transform: scaleY(1); }
 }
 
 .session-active-indicator {
@@ -1028,8 +1046,11 @@ code.hljs { padding: 3px 5px; }
 
 .session-active-indicator .bar {
   width: 2.5px;
+  height: 11px;
   border-radius: 1px;
   background: linear-gradient(to top, #8b5cf6, #a78bfa);
+  transform-origin: center bottom;
+  will-change: transform;
 }
 
 .session-active-indicator .bar:nth-child(1) {
@@ -1049,7 +1070,7 @@ code.hljs { padding: 3px 5px; }
 @media (prefers-reduced-motion: reduce) {
   .session-active-indicator .bar {
     animation: none;
-    height: 6px;
+    transform: scaleY(0.55);
   }
 }
 
@@ -1071,22 +1092,31 @@ code.hljs { padding: 3px 5px; }
   }
 }
 
-/* Agent working indicator - equalizer bars */
+/* Agent working indicator - equalizer bars
+   Uses transform: scaleY() instead of height to avoid layout reflow. */
 @keyframes agent-bar-1 {
-  0%, 100% { height: 25%; }
-  50% { height: 100%; }
+  0%, 100% { transform: scaleY(0.25); }
+  50% { transform: scaleY(1); }
 }
 
 @keyframes agent-bar-2 {
-  0%, 100% { height: 50%; }
-  50% { height: 25%; }
-  75% { height: 100%; }
+  0%, 100% { transform: scaleY(0.5); }
+  50% { transform: scaleY(0.25); }
+  75% { transform: scaleY(1); }
 }
 
 @keyframes agent-bar-3 {
-  0%, 100% { height: 100%; }
-  25% { height: 25%; }
-  75% { height: 50%; }
+  0%, 100% { transform: scaleY(1); }
+  25% { transform: scaleY(0.25); }
+  75% { transform: scaleY(0.5); }
+}
+
+.animate-agent-bar-1,
+.animate-agent-bar-2,
+.animate-agent-bar-3 {
+  height: 100%;
+  transform-origin: center bottom;
+  will-change: transform;
 }
 
 .animate-agent-bar-1 {
@@ -1106,7 +1136,7 @@ code.hljs { padding: 3px 5px; }
   .animate-agent-bar-2,
   .animate-agent-bar-3 {
     animation: none;
-    height: 50%;
+    transform: scaleY(0.5);
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import {
   useWorkspaceSelection,
   useConversationState,
   useFileTabState,
-  useMessages,
+  useConversationHasMessages,
 } from '@/stores/selectors';
 import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix } from '@/stores/settingsStore';
 import { navigate } from '@/lib/navigation';
@@ -155,7 +155,9 @@ export default function Home() {
   const { workspaces, sessions, selectedWorkspaceId, selectedSessionId } = useWorkspaceSelection();
   const { conversations, selectedConversationId, removeConversation } = useConversationState();
   const { fileTabs, closeFileTab, pendingCloseFileTabId, setPendingCloseFileTabId } = useFileTabState();
-  const conversationMessages = useMessages(selectedConversationId);
+  // Boolean check only — avoids subscribing to the full messages array,
+  // which would cause page-level re-renders on every message during streaming.
+  const conversationHasMessages = useConversationHasMessages(selectedConversationId);
   const selectNextTab = useAppStore((s) => s.selectNextTab);
   const selectPreviousTab = useAppStore((s) => s.selectPreviousTab);
   const confirmCloseActiveTab = useSettingsStore((s) => s.confirmCloseActiveTab);
@@ -325,15 +327,14 @@ export default function Home() {
   const handleCloseTab = useCallback(async () => {
     if (!selectedConversationId) return;
 
-    const hasMessages = conversationMessages.length > 0;
-    if (hasMessages && confirmCloseActiveTab) {
+    if (conversationHasMessages && confirmCloseActiveTab) {
       setPendingCloseConvId(selectedConversationId);
       setShowCloseConfirm(true);
       return;
     }
 
     await doCloseTab(selectedConversationId);
-  }, [selectedConversationId, conversationMessages, confirmCloseActiveTab, doCloseTab]);
+  }, [selectedConversationId, conversationHasMessages, confirmCloseActiveTab, doCloseTab]);
 
   const handleConfirmClose = useCallback(async () => {
     if (pendingCloseConvId) {

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -44,7 +44,7 @@ import { AttachmentGrid } from './AttachmentGrid';
 import { AttachmentPreviewModal } from './AttachmentPreviewModal';
 import { processDroppedFiles, validateAttachments, SUPPORTED_EXTENSIONS, loadAllAttachmentContents, generateAttachmentId } from '@/lib/attachments';
 import { UserQuestionPrompt } from './UserQuestionPrompt';
-import { usePendingUserQuestion, useStreamingState } from '@/stores/selectors';
+import { usePendingUserQuestion, useStreamingState, useSelectedIds, useConversationState, useChatInputActions, useConversationHasMessages } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { THINKING_LEVELS, type ThinkingLevel, resolveThinkingParams, clampThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
 import { useSlashCommandStore, type UnifiedSlashCommand } from '@/stores/slashCommandStore';
@@ -178,16 +178,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   messageRef.current = message;
   const currentSessionIdRef = useRef<string | null>(null);
 
+  // Scoped selectors — avoids subscribing to the entire store.
+  // ChatInput only re-renders when selected IDs, conversations, or the
+  // inline selectors below actually change.
+  const { selectedWorkspaceId, selectedSessionId, selectedConversationId } = useSelectedIds();
+  const { conversations, selectConversation, addConversation, removeConversation, updateConversation } = useConversationState();
   const {
-    selectedConversationId,
-    selectedWorkspaceId,
-    selectedSessionId,
-    conversations,
     addMessage,
-    addConversation,
-    removeConversation,
-    updateConversation,
-    selectConversation,
     setStreaming,
     setQueuedMessage,
     commitQueuedMessage,
@@ -201,7 +198,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     setSessionToggleState,
     setDraftInput,
     clearDraftInput,
-  } = useAppStore();
+  } = useChatInputActions();
   currentSessionIdRef.current = selectedSessionId;
   // Session-scoped streaming state — prevents cross-session plan/state leakage
   const streaming = useStreamingState(selectedConversationId);
@@ -429,9 +426,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const planModeActive = streaming?.planModeActive ?? false;
 
   // Check if conversation has messages (for ghost text vs placeholder)
-  const conversationHasMessages = useAppStore(
-    (s) => selectedConversationId ? s.messages.some(m => m.conversationId === selectedConversationId) : false
-  );
+  const conversationHasMessages = useConversationHasMessages(selectedConversationId);
 
   // Suggestions older than 5 minutes are considered stale and auto-hidden
   const SUGGESTION_MAX_AGE_MS = 5 * 60 * 1000;
@@ -880,7 +875,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
     // Can't queue a message to a conversation that doesn't exist yet — check before clearing input
     const conversationMessagesEarly = currentConversation
-      ? useAppStore.getState().messages.filter(m => m.conversationId === currentConversation.id)
+      ? useAppStore.getState().messagesByConversation[currentConversation.id] ?? []
       : [];
     const isNewConversation = !selectedConversationId || conversationMessagesEarly.length === 0;
     if (isNewConversation && isStreaming) return;
@@ -1330,8 +1325,8 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             onSlashCommandExecute={handleSlashCommandExecute}
             onInput={(text) => {
               setMessage(text);
-              // Clear suggestion when user starts typing
-              if (text.trim() && selectedConversationId) {
+              // Clear suggestion when user starts typing (skip no-op store writes)
+              if (text.trim() && selectedConversationId && useAppStore.getState().inputSuggestions[selectedConversationId]) {
                 clearInputSuggestion(selectedConversationId);
               }
             }}

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -186,7 +186,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     if (existingPagination) return;
 
     // Also skip if messages were already added inline (e.g., via addConversation with messages)
-    const hasInlineMessages = state.messages.some((m) => m.conversationId === selectedConversationId);
+    const hasInlineMessages = (state.messagesByConversation[selectedConversationId]?.length ?? 0) > 0;
     if (hasInlineMessages) return;
 
     let cancelled = false;

--- a/src/components/conversation/VirtualizedMessageList.tsx
+++ b/src/components/conversation/VirtualizedMessageList.tsx
@@ -176,7 +176,7 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
         alignToBottom
         startReached={onStartReached}
         rangeChanged={onRangeChanged}
-        increaseViewportBy={{ top: 2000, bottom: 2000 }}
+        increaseViewportBy={{ top: 400, bottom: 800 }}
         atBottomStateChange={onAtBottomStateChange}
         atBottomThreshold={50}
         className="h-full"

--- a/src/components/files/PierreDiffEditor.tsx
+++ b/src/components/files/PierreDiffEditor.tsx
@@ -200,18 +200,29 @@ export const PierreDiffEditor = memo(function PierreDiffEditor({
     return content;
   }, [onResolveComment, onDeleteComment, onCreateComment, activeCommentLine, wordWrap, containerWidth]);
 
-  // Track visible container width so annotations can be clamped in scroll mode
+  // Track visible container width so annotations can be clamped in scroll mode.
+  // Uses RAF to debounce — avoids setting state on every resize frame.
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
+    let rafId: number | null = null;
+    let latestWidth = 0;
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        setContainerWidth(entry.contentRect.width);
+        latestWidth = entry.contentRect.width;
       }
+      if (rafId !== null) return; // Already scheduled — will use latestWidth
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        setContainerWidth(latestWidth);
+      });
     });
     observer.observe(el);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
   }, []);
 
   // Scroll to target line when scrollToLine or diff content changes (e.g. review comment click)

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -103,7 +103,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import type { Workspace, WorktreeSession, SessionTaskStatus } from '@/lib/types';
-import { useSessionActivityState, useIsSessionUnread } from '@/stores/selectors';
+import { useSessionActivityState, useIsSessionUnread, useWorkspaceSelection, useSidebarActions } from '@/stores/selectors';
 import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog';
 import { useArchiveSession } from '@/hooks/useArchiveSession';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -138,17 +138,10 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
     github: onGitHubRepos,
   };
 
-  const {
-    workspaces,
-    sessions,
-    selectedWorkspaceId,
-    selectedSessionId,
-    addSession,
-    addConversation,
-    reorderWorkspaces,
-    removeWorkspace,
-    updateSession,
-  } = useAppStore();
+  // Scoped selectors — avoids subscribing to the entire store.
+  // Sidebar only re-renders when workspaces, sessions, or selected IDs change.
+  const { workspaces, sessions, selectedWorkspaceId, selectedSessionId } = useWorkspaceSelection();
+  const { addSession, addConversation, reorderWorkspaces, removeWorkspace, updateSession } = useSidebarActions();
   const { requestArchive, dialogProps: archiveDialogProps } = useArchiveSession({
     onError: () => showError('Failed to archive session'),
   });

--- a/src/components/panels/BudgetStatusPanel.tsx
+++ b/src/components/panels/BudgetStatusPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { AlertCircle, ArrowDownToLine, ArrowUpFromLine, Gauge } from 'lucide-react';
@@ -8,10 +9,21 @@ import { formatTokens, formatCost } from '@/lib/format';
 import { getModelInfo, getModelDisplayName } from '@/lib/models';
 import { EmptyState } from '@/components/ui/empty-state';
 import { useShallow } from 'zustand/react/shallow';
-import type { TokenUsage } from '@/lib/types';
+import type { Message, TokenUsage } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
-// Hooks
+// Shared: O(1) selector to get conversation message bucket reference
+// ---------------------------------------------------------------------------
+
+const EMPTY_MESSAGES: readonly Message[] = [];
+
+const useConversationMessages = (conversationId: string | null) =>
+  useAppStore((s) =>
+    conversationId ? s.messagesByConversation[conversationId] ?? EMPTY_MESSAGES : EMPTY_MESSAGES
+  );
+
+// ---------------------------------------------------------------------------
+// Hooks — O(n) scans are in useMemo, only re-run when bucket ref changes
 // ---------------------------------------------------------------------------
 
 interface CumulativeTokens {
@@ -24,12 +36,11 @@ interface CumulativeTokens {
 
 const EMPTY_CUMULATIVE: CumulativeTokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
 
-const useCumulativeTokens = (conversationId: string | null): CumulativeTokens =>
-  useAppStore(useShallow((s) => {
-    if (!conversationId) return EMPTY_CUMULATIVE;
+const useCumulativeTokens = (conversationId: string | null): CumulativeTokens => {
+  const messages = useConversationMessages(conversationId);
+  return useMemo(() => {
     let input = 0, output = 0, cacheRead = 0, cacheWrite = 0;
-    for (const msg of s.messages) {
-      if (msg.conversationId !== conversationId) continue;
+    for (const msg of messages) {
       const usage: TokenUsage | undefined = msg.runSummary?.usage;
       if (usage) {
         input += usage.inputTokens;
@@ -40,7 +51,8 @@ const useCumulativeTokens = (conversationId: string | null): CumulativeTokens =>
     }
     if (input === 0 && output === 0) return EMPTY_CUMULATIVE;
     return { input, output, cacheRead, cacheWrite, total: input + output };
-  }));
+  }, [messages]);
+};
 
 interface ConversationUsage {
   model?: string;
@@ -53,19 +65,24 @@ interface ConversationUsage {
 
 const EMPTY_USAGE: ConversationUsage = {};
 
-const useConversationUsage = (conversationId: string | null): ConversationUsage =>
-  useAppStore(useShallow((s) => {
-    if (!conversationId) return EMPTY_USAGE;
-    const conv = s.conversations.find(c => c.id === conversationId);
+const useConversationUsage = (conversationId: string | null): ConversationUsage => {
+  const messages = useConversationMessages(conversationId);
+  const conv = useAppStore(useShallow((s) => {
+    if (!conversationId) return null;
+    const c = s.conversations.find(c => c.id === conversationId);
+    if (!c) return null;
+    return { model: c.model, budgetConfig: c.budgetConfig, thinkingConfig: c.thinkingConfig };
+  }));
+
+  return useMemo(() => {
     if (!conv) return EMPTY_USAGE;
 
     // Walk messages backwards to find the latest runSummary
     let cost: number | undefined;
     let turns: number | undefined;
     let limitExceeded: 'budget' | 'turns' | undefined;
-    for (let i = s.messages.length - 1; i >= 0; i--) {
-      const msg = s.messages[i];
-      if (msg.conversationId !== conversationId) continue;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
       if (msg.runSummary) {
         cost = msg.runSummary.cost;
         turns = msg.runSummary.turns;
@@ -74,15 +91,9 @@ const useConversationUsage = (conversationId: string | null): ConversationUsage 
       }
     }
 
-    return {
-      model: conv.model,
-      budgetConfig: conv.budgetConfig,
-      thinkingConfig: conv.thinkingConfig,
-      cost,
-      turns,
-      limitExceeded,
-    };
-  }));
+    return { ...conv, cost, turns, limitExceeded };
+  }, [messages, conv]);
+};
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/hooks/__tests__/useMessagePrefetch.test.ts
+++ b/src/hooks/__tests__/useMessagePrefetch.test.ts
@@ -79,7 +79,7 @@ function setupStore(overrides: Record<string, unknown> = {}) {
     selectedWorkspaceId: 'ws-1',
     sessions: [makeSession()],
     conversations: [],
-    messages: [],
+    messagesByConversation: {},
     messagePagination: {},
     ...overrides,
   });
@@ -156,7 +156,7 @@ describe('useMessagePrefetch', () => {
       selectedWorkspaceId: null,
       sessions: [],
       conversations: [],
-      messages: [],
+      messagesByConversation: {},
       messagePagination: {},
     });
   });
@@ -438,7 +438,7 @@ describe('useMessagePrefetch', () => {
       setupStore({
         selectedConversationId: null,
         conversations: [conv1],
-        messages: [makeMessage('conv-with-msgs')],
+        messagesByConversation: { 'conv-with-msgs': [makeMessage('conv-with-msgs')] },
         messagePagination: {},
       });
 
@@ -666,7 +666,7 @@ describe('useMessagePrefetch', () => {
 
       // Verify messages ended up in the store
       const state = useAppStore.getState();
-      const storedMessages = state.messages.filter((m) => m.conversationId === 'conv-store');
+      const storedMessages = state.messagesByConversation['conv-store'] ?? [];
       expect(storedMessages).toHaveLength(1);
       expect(storedMessages[0].id).toBe('dto-1');
 

--- a/src/hooks/__tests__/useReviewTrigger.test.ts
+++ b/src/hooks/__tests__/useReviewTrigger.test.ts
@@ -40,7 +40,7 @@ function resetStore() {
     selectedSessionId: null,
     selectedConversationId: null,
     conversations: [],
-    messages: [],
+    messagesByConversation: {},
     reviewComments: {},
     streamingState: {},
   });
@@ -249,8 +249,7 @@ describe('useReviewTrigger', () => {
         dispatchStartReview('quick');
       });
 
-      const messages = useAppStore.getState().messages;
-      const reviewMessages = messages.filter((m) => m.conversationId === 'new-review-conv');
+      const reviewMessages = useAppStore.getState().messagesByConversation['new-review-conv'] ?? [];
       expect(reviewMessages).toHaveLength(1);
       expect(reviewMessages[0].role).toBe('user');
       expect(reviewMessages[0].content).toContain('Review the changes');

--- a/src/hooks/__tests__/useWebSocket.events.test.ts
+++ b/src/hooks/__tests__/useWebSocket.events.test.ts
@@ -28,7 +28,7 @@ describe('useWebSocket — missing event handling', () => {
           updatedAt: '',
         },
       ],
-      messages: [],
+      messagesByConversation: {},
       checkpoints: [],
       mcpServers: [],
       supportedModels: [],
@@ -655,7 +655,7 @@ describe('useWebSocket — missing event handling', () => {
       store.finalizeStreamingMessage(CONV_ID, { durationMs: 1500 });
 
       const state = useAppStore.getState();
-      const msgs = state.messages.filter((m) => m.conversationId === CONV_ID && m.role === 'assistant');
+      const msgs = (state.messagesByConversation[CONV_ID] ?? []).filter((m) => m.role === 'assistant');
       expect(msgs.length).toBe(1);
       expect(msgs[0].content).toContain('Turn 1 response text');
     });

--- a/src/hooks/__tests__/useWebSocket.initialReconcile.test.ts
+++ b/src/hooks/__tests__/useWebSocket.initialReconcile.test.ts
@@ -32,7 +32,7 @@ describe('useWebSocket — initial streaming state reconciliation', () => {
       activeTools: {},
       subAgents: {},
       conversations: [],
-      messages: [],
+      messagesByConversation: {},
     });
   });
 

--- a/src/hooks/__tests__/useWebSocket.reconnect.test.ts
+++ b/src/hooks/__tests__/useWebSocket.reconnect.test.ts
@@ -289,7 +289,7 @@ describe('useWebSocket — reconnect streaming reconciliation', () => {
       expect(conv1?.status).toBe('completed');
 
       // CONV_1: messages should be reloaded
-      const msgs = useAppStore.getState().messages.filter(m => m.conversationId === CONV_1);
+      const msgs = useAppStore.getState().messagesByConversation[CONV_1] ?? [];
       expect(msgs).toHaveLength(1);
 
       // CONV_2: still streaming — untouched

--- a/src/hooks/__tests__/useWebSocket.snapshot.test.ts
+++ b/src/hooks/__tests__/useWebSocket.snapshot.test.ts
@@ -32,7 +32,7 @@ describe('useWebSocket — streaming snapshot recovery', () => {
       streamingState: {},
       activeTools: {},
       conversations: [],
-      messages: [],
+      messagesByConversation: {},
     });
   });
 
@@ -348,7 +348,7 @@ describe('useWebSocket — streaming snapshot recovery', () => {
       const finishedConv = useAppStore.getState().conversations.find(c => c.id === CONV_FINISHED);
       expect(finishedConv?.status).toBe('completed');
 
-      const msgs = useAppStore.getState().messages.filter(m => m.conversationId === CONV_FINISHED);
+      const msgs = useAppStore.getState().messagesByConversation[CONV_FINISHED] ?? [];
       expect(msgs).toHaveLength(1);
     });
 
@@ -385,7 +385,7 @@ describe('useWebSocket — streaming snapshot recovery', () => {
       await reconcileStreamingState();
 
       // Messages should be reloaded as fallback
-      const msgs = useAppStore.getState().messages.filter(m => m.conversationId === CONV_ACTIVE);
+      const msgs = useAppStore.getState().messagesByConversation[CONV_ACTIVE] ?? [];
       expect(msgs).toHaveLength(1);
 
       // Streaming should still be active (agent process hasn't exited)

--- a/src/hooks/__tests__/useWebSocket.subagents.test.ts
+++ b/src/hooks/__tests__/useWebSocket.subagents.test.ts
@@ -30,7 +30,7 @@ describe('useWebSocket — sub-agent event handling', () => {
           updatedAt: '',
         },
       ],
-      messages: [],
+      messagesByConversation: {},
     });
   });
 

--- a/src/hooks/useMessagePrefetch.ts
+++ b/src/hooks/useMessagePrefetch.ts
@@ -22,24 +22,25 @@ export function useMessagePrefetch(enabled: boolean) {
       const state = useAppStore.getState();
       const initialConvId = state.selectedConversationId;
 
-      // Wait until the initial conversation's messages are loaded
+      // Wait until the initial conversation's messages are loaded.
+      // Uses Zustand subscribe() instead of polling — resolves immediately
+      // when messagePagination is set, with no wasted CPU in between.
       if (initialConvId && !state.messagePagination[initialConvId]) {
         await new Promise<void>((resolve) => {
-          const check = () => {
-            if (useAppStore.getState().messagePagination[initialConvId!] || abortRef.current) {
+          if (abortRef.current) { resolve(); return; }
+          const unsub = useAppStore.subscribe((s) => {
+            if (s.messagePagination[initialConvId!] || abortRef.current) {
+              unsub();
               resolve();
-            } else {
-              setTimeout(check, 200);
             }
-          };
-          check();
+          });
         });
       }
 
       if (abortRef.current) return;
 
       // Collect all conversation IDs that need prefetching
-      const { conversations, sessions, messagePagination, messages,
+      const { conversations, sessions, messagePagination, messagesByConversation,
         selectedWorkspaceId } = useAppStore.getState();
 
       const archivedSessionIds = new Set(
@@ -47,7 +48,7 @@ export function useMessagePrefetch(enabled: boolean) {
       );
 
       // Build a set of conversation IDs that already have messages loaded
-      const convsWithMessages = new Set(messages.map(m => m.conversationId));
+      const convsWithMessages = new Set(Object.keys(messagesByConversation).filter(id => messagesByConversation[id].length > 0));
 
       const needsFetch = conversations.filter(c => {
         if (archivedSessionIds.has(c.sessionId)) return false;

--- a/src/stores/__tests__/appStore.recovery.test.ts
+++ b/src/stores/__tests__/appStore.recovery.test.ts
@@ -8,7 +8,7 @@ describe('appStore - agent recovery', () => {
   beforeEach(() => {
     useAppStore.setState({
       streamingState: {},
-      messages: [],
+      messagesByConversation: {},
     });
   });
 

--- a/src/stores/__tests__/appStore.thinking.test.ts
+++ b/src/stores/__tests__/appStore.thinking.test.ts
@@ -10,7 +10,7 @@ describe('appStore - thinking content preservation', () => {
 
     // Reset store state
     useAppStore.setState({
-      messages: [],
+      messagesByConversation: {},
       streamingState: {},
       activeTools: {},
     });
@@ -44,7 +44,7 @@ describe('appStore - thinking content preservation', () => {
     });
 
     // Check the finalized message has thinking content
-    const messages = useAppStore.getState().messages;
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toBe('The answer is 42.');
     expect(messages[0].thinkingContent).toBe('Let me reason through this step by step...');
@@ -71,7 +71,7 @@ describe('appStore - thinking content preservation', () => {
       durationMs: 500,
     });
 
-    const messages = useAppStore.getState().messages;
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toBe('Simple response.');
     expect(messages[0].thinkingContent).toBeUndefined();
@@ -98,7 +98,7 @@ describe('appStore - thinking content preservation', () => {
       durationMs: 500,
     });
 
-    const messages = useAppStore.getState().messages;
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
     expect(messages).toHaveLength(1);
     expect(messages[0].thinkingContent).toBeUndefined();
   });
@@ -155,7 +155,7 @@ describe('appStore - thinking content preservation', () => {
       durationMs: 3000,
     });
 
-    const messages = useAppStore.getState().messages;
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
     expect(messages[0].thinkingContent).toBe(longThinking);
   });
 
@@ -181,7 +181,7 @@ describe('appStore - thinking content preservation', () => {
     });
 
     // No message should be created since there's no text
-    const messages = useAppStore.getState().messages;
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
     expect(messages).toHaveLength(0);
   });
 
@@ -210,7 +210,7 @@ describe('appStore - thinking content preservation', () => {
       runSummary: { success: true, durationMs: 5000, turns: 2 },
     });
 
-    const msg = useAppStore.getState().messages[0];
+    const msg = (useAppStore.getState().messagesByConversation[conversationId] ?? [])[0];
     expect(msg.thinkingContent).toBe('Reasoning about the problem...');
     expect(msg.durationMs).toBe(5000);
     expect(msg.toolUsage).toHaveLength(1);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -193,7 +193,7 @@ interface AppState {
   workspaces: Workspace[];
   sessions: WorktreeSession[];
   conversations: Conversation[];
-  messages: Message[];
+  messagesByConversation: Record<string, Message[]>;
   fileChanges: FileChange[];
 
   selectedWorkspaceId: string | null;
@@ -338,9 +338,8 @@ interface AppState {
   clearInputSuggestion: (conversationId: string) => void;
 
   // Message actions
-  setMessages: (messages: Message[]) => void;
   addMessage: (message: Message) => void;
-  updateMessage: (id: string, updates: Partial<Message>) => void;
+  updateMessage: (conversationId: string, id: string, updates: Partial<Message>) => void;
   // Message pagination state & actions
   messagePagination: Record<string, {
     hasMore: boolean;
@@ -522,7 +521,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   workspaces: [],
   sessions: [],
   conversations: [],
-  messages: [],
+  messagesByConversation: {},
   fileChanges: [],
   selectedWorkspaceId: null,
   selectedSessionId: null,
@@ -685,7 +684,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       workspaces: state.workspaces.filter((w) => w.id !== id),
       sessions: state.sessions.filter((s) => s.workspaceId !== id),
       conversations: state.conversations.filter((c) => !workspaceSessionIds.includes(c.sessionId)),
-      messages: state.messages.filter((m) => !workspaceConvIds.includes(m.conversationId)),
+      messagesByConversation: Object.fromEntries(
+        Object.entries(state.messagesByConversation).filter(([convId]) => !workspaceConvIds.includes(convId))
+      ),
       selectedWorkspaceId: state.selectedWorkspaceId === id ? null : state.selectedWorkspaceId,
       selectedSessionId: workspaceSessionIds.includes(state.selectedSessionId || '')
         ? null
@@ -789,7 +790,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       return {
         sessions: state.sessions.filter((s) => s.id !== id),
         conversations: state.conversations.filter((c) => c.sessionId !== id),
-        messages: state.messages.filter((m) => !convIds.includes(m.conversationId)),
+        messagesByConversation: Object.fromEntries(
+          Object.entries(state.messagesByConversation).filter(([convId]) => !convIds.includes(convId))
+        ),
         selectedSessionId: state.selectedSessionId === id ? null : state.selectedSessionId,
         selectedConversationId: convIds.includes(state.selectedConversationId || '')
           ? null
@@ -931,9 +934,15 @@ export const useAppStore = create<AppState>((set, get) => ({
   addConversation: (conversation) => set((state) => ({
     conversations: [...state.conversations, conversation],
     // Also add any initial messages (e.g., system setup message from createConversation)
-    messages: conversation.messages.length > 0
-      ? [...state.messages, ...conversation.messages]
-      : state.messages,
+    messagesByConversation: conversation.messages.length > 0
+      ? {
+          ...state.messagesByConversation,
+          [conversation.id]: [
+            ...(state.messagesByConversation[conversation.id] ?? []),
+            ...conversation.messages,
+          ],
+        }
+      : state.messagesByConversation,
   })),
   updateConversation: (id, updates) => set((state) => ({
     conversations: state.conversations.map((c) =>
@@ -989,7 +998,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     return {
       conversations: newConversations,
-      messages: state.messages.filter((m) => m.conversationId !== id),
+      messagesByConversation: (() => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { [id]: _removedMsgs, ...rest } = state.messagesByConversation;
+        return rest;
+      })(),
       selectedConversationId: newSelectedConversationId,
       lastActiveConversationPerSession: updatedLastActive,
       streamingState: remainingStreamingState,
@@ -1035,22 +1048,27 @@ export const useAppStore = create<AppState>((set, get) => ({
     inputSuggestions: { ...state.inputSuggestions, [conversationId]: { ...suggestion, timestamp: Date.now() } },
   })),
   clearInputSuggestion: (conversationId) => set((state) => {
+    if (!state.inputSuggestions[conversationId]) return state; // No-op if already cleared
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [conversationId]: _removed, ...rest } = state.inputSuggestions;
     return { inputSuggestions: rest };
   }),
 
   // Message actions
-  setMessages: (messages) => set({ messages }),
   addMessage: (message) => set((state) => {
-    const convPagination = state.messagePagination[message.conversationId];
+    const convId = message.conversationId;
+    const existing = state.messagesByConversation[convId] ?? [];
+    const convPagination = state.messagePagination[convId];
     return {
-      messages: [...state.messages, message],
+      messagesByConversation: {
+        ...state.messagesByConversation,
+        [convId]: [...existing, message],
+      },
       // Keep totalCount in sync so firstItemIndex stays stable
       ...(convPagination ? {
         messagePagination: {
           ...state.messagePagination,
-          [message.conversationId]: {
+          [convId]: {
             ...convPagination,
             totalCount: convPagination.totalCount + 1,
           },
@@ -1058,33 +1076,38 @@ export const useAppStore = create<AppState>((set, get) => ({
       } : {}),
     };
   }),
-  updateMessage: (id, updates) => set((state) => ({
-    messages: state.messages.map((m) =>
-      m.id === id ? { ...m, ...updates } : m
-    ),
-  })),
+  updateMessage: (conversationId, id, updates) => set((state) => {
+    const existing = state.messagesByConversation[conversationId];
+    if (!existing) return state;
+    return {
+      messagesByConversation: {
+        ...state.messagesByConversation,
+        [conversationId]: existing.map((m) =>
+          m.id === id ? { ...m, ...updates } : m
+        ),
+      },
+    };
+  }),
   // Message pagination actions
   setMessagePage: (convId, messages, hasMore, oldestPosition, totalCount) => set((state) => ({
-    // Replace any existing messages for this conversation with the new page
-    messages: [
-      ...state.messages.filter((m) => m.conversationId !== convId),
-      ...messages,
-    ],
+    messagesByConversation: {
+      ...state.messagesByConversation,
+      [convId]: messages,
+    },
     messagePagination: {
       ...state.messagePagination,
       [convId]: { hasMore, oldestPosition, isLoadingMore: false, totalCount },
     },
   })),
   prependMessages: (convId, messages, hasMore, oldestPosition) => set((state) => {
-    // Find where this conversation's messages start and prepend
-    const existingIds = new Set(state.messages.filter((m) => m.conversationId === convId).map((m) => m.id));
+    const existing = state.messagesByConversation[convId] ?? [];
+    const existingIds = new Set(existing.map((m) => m.id));
     const newMessages = messages.filter((m) => !existingIds.has(m.id));
     return {
-      messages: [
-        ...state.messages.filter((m) => m.conversationId !== convId),
-        ...newMessages,
-        ...state.messages.filter((m) => m.conversationId === convId),
-      ],
+      messagesByConversation: {
+        ...state.messagesByConversation,
+        [convId]: [...newMessages, ...existing],
+      },
       messagePagination: {
         ...state.messagePagination,
         [convId]: {
@@ -1885,7 +1908,10 @@ updateFileTabContent: (id, content) => set((state) => ({
       // Atomically: add message AND clear streaming state
       const { [conversationId]: _removedCp, ...remainingPendingCp } = state.pendingCheckpointUuid;
       return {
-        messages: [...state.messages, newMessage],
+        messagesByConversation: {
+          ...state.messagesByConversation,
+          [conversationId]: [...(state.messagesByConversation[conversationId] ?? []), newMessage],
+        },
         streamingState: {
           ...state.streamingState,
           [conversationId]: clearedStreaming,
@@ -1920,7 +1946,10 @@ updateFileTabContent: (id, content) => set((state) => ({
     };
     const convPagination = state.messagePagination[conversationId];
     return {
-      messages: [...state.messages, msg],
+      messagesByConversation: {
+        ...state.messagesByConversation,
+        [conversationId]: [...(state.messagesByConversation[conversationId] ?? []), msg],
+      },
       queuedMessage: { ...state.queuedMessage, [conversationId]: null },
       // Keep totalCount in sync (same pattern as addMessage)
       ...(convPagination ? {

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -60,14 +60,15 @@ export const useConversationState = () =>
  * Messages for a specific conversation.
  * Use in: ConversationArea, MessageList
  *
- * Uses useShallow to prevent infinite re-render loops by comparing array
- * elements by reference rather than creating new array references.
+ * O(1) lookup into messagesByConversation. The returned array reference is
+ * stable when unrelated store state changes, so useShallow is still used
+ * to handle cases where the bucket array is replaced (e.g., new message added).
  */
 export const useMessages = (conversationId: string | null) =>
   useAppStore(
     useShallow((s) =>
       conversationId
-        ? s.messages.filter((m) => m.conversationId === conversationId)
+        ? s.messagesByConversation[conversationId] ?? EMPTY_MESSAGES
         : EMPTY_MESSAGES
     )
   );
@@ -89,7 +90,7 @@ export const useMessagePagination = (conversationId: string | null) =>
 export const useHasUserMessages = (conversationId: string | null) =>
   useAppStore((s) =>
     conversationId
-      ? s.messages.some((m) => m.conversationId === conversationId && m.role === 'user')
+      ? (s.messagesByConversation[conversationId] ?? []).some((m) => m.role === 'user')
       : false
   );
 
@@ -109,11 +110,9 @@ export const useConversationsWithUserMessages = () =>
   useAppStore(
     useShallow((s) => {
       const ids: string[] = [];
-      const seen = new Set<string>();
-      for (const m of s.messages) {
-        if (m.role === 'user' && !seen.has(m.conversationId)) {
-          seen.add(m.conversationId);
-          ids.push(m.conversationId);
+      for (const [convId, msgs] of Object.entries(s.messagesByConversation)) {
+        if (msgs.some((m) => m.role === 'user')) {
+          ids.push(convId);
         }
       }
       return ids.length > 0 ? ids : EMPTY_CONVERSATION_IDS;
@@ -437,6 +436,73 @@ export const useReviewCommentActions = () =>
       deleteReviewComment: s.deleteReviewComment,
       setReviewComments: s.setReviewComments,
     }))
+  );
+
+// ============================================================================
+// ChatInput Actions
+// ============================================================================
+
+/**
+ * Actions needed by ChatInput that don't carry data dependencies.
+ * useShallow required — see usePageActions comment.
+ * Action refs are stable, so this selector never triggers re-renders after init.
+ * Use in: ChatInput
+ */
+export const useChatInputActions = () =>
+  useAppStore(
+    useShallow((s) => ({
+      addMessage: s.addMessage,
+      setStreaming: s.setStreaming,
+      setQueuedMessage: s.setQueuedMessage,
+      commitQueuedMessage: s.commitQueuedMessage,
+      clearPendingPlanApproval: s.clearPendingPlanApproval,
+      setApprovedPlanContent: s.setApprovedPlanContent,
+      clearApprovedPlanContent: s.clearApprovedPlanContent,
+      clearActiveTools: s.clearActiveTools,
+      finalizeStreamingMessage: s.finalizeStreamingMessage,
+      setPlanModeActive: s.setPlanModeActive,
+      clearInputSuggestion: s.clearInputSuggestion,
+      setSessionToggleState: s.setSessionToggleState,
+      setDraftInput: s.setDraftInput,
+      clearDraftInput: s.clearDraftInput,
+    }))
+  );
+
+// ============================================================================
+// Sidebar Actions
+// ============================================================================
+
+/**
+ * Actions needed by WorkspaceSidebar that don't carry data dependencies.
+ * useShallow required — see usePageActions comment.
+ * Action refs are stable, so this selector never triggers re-renders after init.
+ * Use in: WorkspaceSidebar
+ */
+export const useSidebarActions = () =>
+  useAppStore(
+    useShallow((s) => ({
+      addSession: s.addSession,
+      addConversation: s.addConversation,
+      reorderWorkspaces: s.reorderWorkspaces,
+      removeWorkspace: s.removeWorkspace,
+      updateSession: s.updateSession,
+    }))
+  );
+
+// ============================================================================
+// Conversation Has Messages
+// ============================================================================
+
+/**
+ * Check if a conversation has any messages at all.
+ * O(1) lookup into messagesByConversation — just checks array length.
+ * Use in: ChatInput for ghost text vs placeholder logic
+ */
+export const useConversationHasMessages = (conversationId: string | null) =>
+  useAppStore((s) =>
+    conversationId
+      ? (s.messagesByConversation[conversationId]?.length ?? 0) > 0
+      : false
   );
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Message store refactor**: Replace flat `messages: Message[]` with `messagesByConversation: Record<string, Message[]>` — all selectors and mutations now use O(1) key lookups instead of O(n) array scans on every store update
- **Scoped Zustand selectors**: Decompose monolithic `useAppStore()` destructuring in `ChatInput` and `WorkspaceSidebar` into focused selector hooks (`useSelectedIds`, `useConversationState`, `useChatInputActions`, `useSidebarActions`) to minimize re-renders
- **CSS animation perf**: Replace `height`/`box-shadow` animations with `transform`/`opacity` across session bars, agent bars, and dictation pulse; replace `transition: all` with explicit property list; add `will-change` hints
- **Virtuoso + ResizeObserver**: Reduce overscan buffer (2000/2000 → 400/800), flip ratio to favor downward scroll; add RAF debounce to `ResizeObserver` in `PierreDiffEditor`
- **Store write guards**: Skip no-op `clearInputSuggestion` calls; early-return in `clearInputSuggestion` when already cleared

## Test plan

- [x] All 1375 tests pass (`npx vitest run`)
- [x] ESLint: 0 errors (34 pre-existing warnings)
- [x] TypeScript build passes (`npm run build`)
- [ ] Manual: `make dev` → open conversation → send messages → verify rendering, scroll history loads, budget panel updates
- [ ] Manual: fast trackpad scrolling in long conversations — verify no blank flashing
- [ ] Manual: check dictation pulse, session active indicator, and agent working indicator animations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)