### PR TITLE
Fix toolbar content disappearing when overlay views unmount

### DIFF
--- a/src/hooks/useMainToolbarContent.ts
+++ b/src/hooks/useMainToolbarContent.ts
@@ -1,9 +1,24 @@
-import { useEffect, useRef } from 'react';
+import { type MutableRefObject, useEffect, useRef } from 'react';
 import { useUIStore, type ToolbarConfig } from '@/stores/uiStore';
+
+// Track mounted instances so unmount can restore the previous toolbar config
+// instead of clearing to null (fixes overlay views like Settings clobbering
+// the toolbar of the still-mounted view beneath them).
+// Stored on globalThis so the stack survives HMR module re-evaluation.
+const STACK_KEY = '__useMainToolbarContent_stack__';
+
+type StackEntry = { id: symbol; configRef: MutableRefObject<ToolbarConfig> };
+
+function getStack(): StackEntry[] {
+  if (!(globalThis as Record<string, unknown>)[STACK_KEY]) {
+    (globalThis as Record<string, unknown>)[STACK_KEY] = [];
+  }
+  return (globalThis as Record<string, unknown>)[STACK_KEY] as StackEntry[];
+}
 
 /**
  * Sets the MainToolbar's dynamic content (Flutter AppBar-style).
- * Config is applied on mount / update and cleared on unmount.
+ * Config is applied on mount / update and restored on unmount.
  *
  * @example
  * useMainToolbarContent({
@@ -15,19 +30,35 @@ import { useUIStore, type ToolbarConfig } from '@/stores/uiStore';
  */
 export function useMainToolbarContent(config: ToolbarConfig) {
   const configRef = useRef(config);
+  const entryRef = useRef<StackEntry | null>(null);
 
   useEffect(() => {
     configRef.current = config;
   });
 
-  // Apply on mount and clear on unmount
+  // Register on mount, restore previous on unmount
   useEffect(() => {
+    const stack = getStack();
+    const entry: StackEntry = { id: Symbol(), configRef };
+    entryRef.current = entry;
+    stack.push(entry);
     useUIStore.getState().setToolbarConfig(configRef.current);
-    return () => useUIStore.getState().setToolbarConfig(null);
+
+    return () => {
+      const s = getStack();
+      const idx = s.findIndex((e) => e.id === entry.id);
+      if (idx !== -1) s.splice(idx, 1);
+      const prev = s[s.length - 1];
+      useUIStore.getState().setToolbarConfig(prev ? prev.configRef.current : null);
+    };
   }, []);
 
-  // Sync config updates when the caller's memoized config changes
+  // Sync config updates only when this instance is the topmost
   useEffect(() => {
-    useUIStore.getState().setToolbarConfig(config);
+    const stack = getStack();
+    const top = stack[stack.length - 1];
+    if (top && entryRef.current && top.id === entryRef.current.id) {
+      useUIStore.getState().setToolbarConfig(config);
+    }
   }, [config]);
 }


### PR DESCRIPTION
## Summary

- `useMainToolbarContent` cleared the toolbar config to `null` on unmount, causing the underlying view's toolbar to vanish when an overlay (e.g. Settings) was closed
- Replaced clear-on-unmount with a stack-based approach that restores the previous view's config
- Guarded the config-sync effect so only the topmost instance applies updates, preventing background views from clobbering the overlay's toolbar

## Changes Made

- **`src/hooks/useMainToolbarContent.ts`** — Added a `globalThis`-backed stack (`getStack()`) to track mounted instances; mount pushes an entry, unmount splices it out and restores the previous entry's config; sync effect now checks topmost before applying

## Test Plan

- [ ] Open a session, confirm toolbar content renders correctly
- [ ] Open Settings (overlay), confirm Settings toolbar appears
- [ ] Close Settings, confirm the session toolbar is restored (not blank)
- [ ] Navigate between sessions, confirm toolbar updates correctly
- [ ] `npm run build` — build succeeds (pre-existing Tauri module errors unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)