### PR TITLE
Fix message rendering order by tracking active turn state

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -390,13 +390,9 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 	return conv, nil
 }
 
-// handleConversationOutput processes output from the agent process.
-// Note: Uses the app-level context so background work is cancelled on shutdown.
-// Store errors are logged but not propagated since this is async processing.
-// flushPendingUserMessage takes any deferred user message from the process and
-// persists it to the database. Returns true if a message was flushed.
-func (m *Manager) flushPendingUserMessage(ctx context.Context, convID string, proc *Process) bool {
-	pending := proc.TakePendingUserMessage()
+// storePendingUserMessage persists a previously-deferred user message to the DB.
+// Returns false if pending is nil (nothing to store).
+func (m *Manager) storePendingUserMessage(ctx context.Context, convID string, pending *models.Message) bool {
 	if pending == nil {
 		return false
 	}
@@ -411,6 +407,9 @@ func (m *Manager) flushPendingUserMessage(ctx context.Context, convID string, pr
 	return true
 }
 
+// handleConversationOutput processes output from the agent process.
+// Note: Uses the app-level context so background work is cancelled on shutdown.
+// Store errors are logged but not propagated since this is async processing.
 func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	ctx := m.ctx
 	var currentAssistantMessage string
@@ -594,6 +593,8 @@ outer:
 				}
 				isThinking = false
 
+				// Mark that a turn is actively producing output (for user message deferral logic)
+				proc.SetInActiveTurn(true)
 				// Track that the process produced user-visible output (for zero-output detection)
 				proc.SetProducedOutput()
 				currentAssistantMessage += event.Content
@@ -606,6 +607,7 @@ outer:
 				markSnapshotDirty()
 
 			case EventTypeToolStart:
+				proc.SetInActiveTurn(true)
 				entry := ActiveToolEntry{
 					ID:        event.ID,
 					Tool:      event.Tool,
@@ -655,6 +657,7 @@ outer:
 				markSnapshotDirty()
 
 			case EventTypeThinkingStart:
+				proc.SetInActiveTurn(true)
 				// Seal previous thinking block if any
 				if thinkingBlockStart != nil && currentThinkingText != "" {
 					thinkingBlocks = append(thinkingBlocks, thinkingBlock{content: currentThinkingText, timestamp: *thinkingBlockStart})
@@ -1094,10 +1097,14 @@ outer:
 					currentAssistantMessage = ""
 				}
 
-				// Flush deferred user message (sent during active turn).
+				// Atomically clear the active turn flag and take any deferred
+				// user message. This must be atomic so a concurrent
+				// SendConversationMessage cannot slip a new message between
+				// clearing the flag and flushing the old deferred one.
 				// Must happen AFTER storing the assistant message so the DB
-				// position ordering is correct: [assistant_N, user_N+1].
-				m.flushPendingUserMessage(ctx, convID, proc)
+				// position ordering is correct: [assistant_N, queued_user_N+1].
+				pending := proc.EndTurnAndTakePending()
+				m.storePendingUserMessage(ctx, convID, pending)
 
 				// Reset per-turn accumulation state
 				currentThinking = ""
@@ -1294,9 +1301,11 @@ outer:
 		}
 	}
 
-	// Flush any remaining deferred user message so it is not lost when the
-	// process exits without a turn_complete event (e.g. crash, forced stop).
-	m.flushPendingUserMessage(ctx, convID, proc)
+	// Atomically clear active turn flag and flush any remaining deferred user
+	// message so it is not lost when the process exits without a turn_complete
+	// event (e.g. crash, forced stop).
+	pending := proc.EndTurnAndTakePending()
+	m.storePendingUserMessage(ctx, convID, pending)
 
 	// Clear snapshot on process exit — but only if this process is still the current
 	// one in the map. If a new process has already been started (via SendConversationMessage),
@@ -1582,13 +1591,15 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 	}
 
 	// Store user message with attachments.
-	// When the process was restarted (or freshly started), there is no pending
-	// assistant turn, so the user message can be stored immediately with the
-	// correct position. When the process is already running, the agent may be
-	// mid-turn streaming a response — storing now would give this message a
-	// position before the assistant response, breaking chronological order on
-	// reload. Defer storage until the current turn completes (flushed in
-	// handleConversationOutput).
+	// Three cases:
+	//  1. needsRestart=true  — process was restarted/freshly started, no active turn.
+	//     Store immediately so the user message precedes the assistant response.
+	//  2. needsRestart=false, process idle between turns — store immediately.
+	//     Same reasoning as case 1.
+	//  3. needsRestart=false, process mid-turn (inActiveTurn=true) — defer storage
+	//     until the current turn completes. The assistant response for the current
+	//     turn is stored first, then this queued user message is flushed after it.
+	//     This preserves chronological order: [assistant_N, queued_user_N+1].
 	msg := models.Message{
 		ID:          uuid.New().String()[:8],
 		Role:        "user",
@@ -1596,7 +1607,12 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 		Attachments: attachments,
 		Timestamp:   time.Now(),
 	}
-	if needsRestart {
+	// StoreOrDeferMessage atomically checks inActiveTurn and either defers
+	// (returns false) or signals store-now (returns true). Short-circuits
+	// when needsRestart is true — the process was just created (proc = newProc
+	// above), so inActiveTurn is false and pendingUserMessage is nil by default.
+	storeNow := needsRestart || proc.StoreOrDeferMessage(&msg)
+	if storeNow {
 		if err := m.store.AddMessageToConversation(ctx, convID, msg); err != nil {
 			logger.Manager.Errorf("Failed to store user message for conv %s: %v", convID, err)
 		}
@@ -1605,8 +1621,6 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 				logger.Manager.Errorf("Failed to save attachments: %v", err)
 			}
 		}
-	} else {
-		proc.SetPendingUserMessage(&msg)
 	}
 
 	// Send to process with attachments

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -80,7 +80,8 @@ type Process struct {
 	opts               ProcessOptions // Original options for restart
 	lastStderrLines    []string      // Ring buffer of last N stderr lines for crash diagnostics
 	sawErrorEvent      bool          // Whether the agent emitted an error/auth_error event
-	producedOutput     bool          // Whether any assistant text was emitted during this process lifetime
+	producedOutput     bool            // Whether any assistant text was emitted during this process lifetime
+	inActiveTurn       bool            // Whether the agent is currently processing a turn (producing output)
 	pendingUserMessage *models.Message // User message deferred until turn completes (correct DB position ordering)
 }
 
@@ -783,6 +784,55 @@ func (p *Process) ProducedOutput() bool {
 	return p.producedOutput
 }
 
+// SetInActiveTurn marks whether the agent is currently processing a turn.
+// Set to true when the first output event of a turn arrives (assistant_text,
+// tool_start, thinking_start). Set to false when a turn-ending event fires
+// (turn_complete, complete, result) or when the process exits.
+func (p *Process) SetInActiveTurn(active bool) {
+	p.mu.Lock()
+	p.inActiveTurn = active
+	p.mu.Unlock()
+}
+
+// IsInActiveTurn returns whether the agent is currently processing a turn.
+func (p *Process) IsInActiveTurn() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.inActiveTurn
+}
+
+// StoreOrDeferMessage atomically checks whether the process is in an active turn.
+// If active, the message is deferred (stored as pending) and false is returned.
+// If idle, true is returned and the caller should store the message immediately.
+// This atomic check-and-set prevents a TOCTOU race between checking inActiveTurn
+// and setting pendingUserMessage.
+func (p *Process) StoreOrDeferMessage(msg *models.Message) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.inActiveTurn {
+		if p.pendingUserMessage != nil {
+			logger.Process.Warnf("Overwriting pending user message %s with %s — previous message will be lost",
+				p.pendingUserMessage.ID, msg.ID)
+		}
+		p.pendingUserMessage = msg
+		return false
+	}
+	return true
+}
+
+// EndTurnAndTakePending atomically clears the active turn flag and returns
+// the pending user message (if any). This prevents a race where a concurrent
+// SendConversationMessage sees inActiveTurn=false and stores a new message
+// before the old deferred message is flushed.
+func (p *Process) EndTurnAndTakePending() *models.Message {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.inActiveTurn = false
+	msg := p.pendingUserMessage
+	p.pendingUserMessage = nil
+	return msg
+}
+
 // SetRunningForTest sets the running flag. Intended for testing only.
 func (p *Process) SetRunningForTest(running bool) {
 	p.mu.Lock()
@@ -852,21 +902,6 @@ func (p *Process) SetOptionsPlanMode(enabled bool) {
 	defer p.mu.Unlock()
 	p.opts.PlanMode = enabled
 	p.planModeActive = enabled
-}
-
-// SetPendingUserMessage stores a user message to be flushed to the DB after
-// the current assistant turn completes. This ensures correct position ordering
-// when a user submits a message while the agent is still streaming.
-// If a pending message already exists (rapid double-send), the old message is
-// logged as a warning — this should not happen in normal UI flow.
-func (p *Process) SetPendingUserMessage(msg *models.Message) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.pendingUserMessage != nil {
-		logger.Process.Warnf("Overwriting pending user message %s with %s — previous message will be lost",
-			p.pendingUserMessage.ID, msg.ID)
-	}
-	p.pendingUserMessage = msg
 }
 
 // TakePendingUserMessage returns and clears the pending user message.

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/chatml/chatml-backend/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1040,4 +1041,120 @@ func TestNewProcessWithOptions_Effort(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "Expected --effort high in args: %v", args)
+}
+
+func TestProcess_InActiveTurn_DefaultFalse(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+	assert.False(t, p.IsInActiveTurn())
+}
+
+func TestProcess_InActiveTurn_SetAndGet(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+
+	p.SetInActiveTurn(true)
+	assert.True(t, p.IsInActiveTurn())
+
+	p.SetInActiveTurn(false)
+	assert.False(t, p.IsInActiveTurn())
+}
+
+func TestProcess_StoreOrDeferMessage_WhenIdle(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+	// inActiveTurn defaults to false (idle)
+
+	msg := &models.Message{ID: "msg-1", Role: "user", Content: "hello"}
+	storeNow := p.StoreOrDeferMessage(msg)
+
+	assert.True(t, storeNow, "should return true when process is idle")
+	// No pending message should be set
+	assert.Nil(t, p.TakePendingUserMessage(), "should not defer message when idle")
+}
+
+func TestProcess_StoreOrDeferMessage_WhenActive(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+	p.SetInActiveTurn(true)
+
+	msg := &models.Message{ID: "msg-1", Role: "user", Content: "hello"}
+	storeNow := p.StoreOrDeferMessage(msg)
+
+	assert.False(t, storeNow, "should return false when process is in active turn")
+	// Message should be deferred as pending
+	pending := p.TakePendingUserMessage()
+	require.NotNil(t, pending)
+	assert.Equal(t, "msg-1", pending.ID)
+}
+
+func TestProcess_StoreOrDeferMessage_ConcurrentAccess(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+
+	// Run concurrent set/check operations and track results to verify
+	// that every call either deferred or returned store-now.
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	storeCount := 0
+	deferCount := 0
+
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			p.SetInActiveTurn(true)
+		}()
+		go func(id int) {
+			defer wg.Done()
+			msg := &models.Message{ID: fmt.Sprintf("msg-%d", id), Role: "user", Content: "test"}
+			if p.StoreOrDeferMessage(msg) {
+				mu.Lock()
+				storeCount++
+				mu.Unlock()
+			} else {
+				mu.Lock()
+				deferCount++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Every call must have returned a definitive result
+	assert.Equal(t, 100, storeCount+deferCount, "every StoreOrDeferMessage call must return store or defer")
+}
+
+func TestProcess_StoreOrDeferMessage_TransitionFromActiveToIdle(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+
+	// Simulate active turn
+	p.SetInActiveTurn(true)
+	msg1 := &models.Message{ID: "msg-1", Role: "user", Content: "queued during turn"}
+	assert.False(t, p.StoreOrDeferMessage(msg1), "should defer during active turn")
+
+	// Simulate turn ending — atomically clear flag and take pending
+	pending := p.EndTurnAndTakePending()
+	require.NotNil(t, pending)
+	assert.Equal(t, "msg-1", pending.ID)
+	assert.False(t, p.IsInActiveTurn(), "should be idle after EndTurnAndTakePending")
+
+	// Now idle — next message should be stored immediately
+	msg2 := &models.Message{ID: "msg-2", Role: "user", Content: "new prompt"}
+	assert.True(t, p.StoreOrDeferMessage(msg2), "should store immediately when idle")
+	assert.Nil(t, p.TakePendingUserMessage(), "should not have pending message")
+}
+
+func TestProcess_EndTurnAndTakePending_NoPending(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+	p.SetInActiveTurn(true)
+
+	// End turn with no deferred message
+	pending := p.EndTurnAndTakePending()
+	assert.Nil(t, pending, "should return nil when no message was deferred")
+	assert.False(t, p.IsInActiveTurn(), "should be idle after EndTurnAndTakePending")
+}
+
+func TestProcess_EndTurnAndTakePending_AlreadyIdle(t *testing.T) {
+	p := NewProcess("test-id", "/tmp", "conv-123")
+	// Already idle (default state)
+
+	pending := p.EndTurnAndTakePending()
+	assert.Nil(t, pending, "should return nil when already idle")
+	assert.False(t, p.IsInActiveTurn())
 }


### PR DESCRIPTION
## Summary

- Fixes user messages appearing before the assistant response they interrupted, breaking chronological order on page reload
- Adds an `inActiveTurn` flag on `Process` with atomic `StoreOrDeferMessage` / `EndTurnAndTakePending` operations to eliminate TOCTOU races
- Removes dead code (`SetPendingUserMessage`, `flushPendingUserMessage`) superseded by the new atomic operations

## Changes Made

- **backend/agent/process.go** — Added `inActiveTurn` field, `SetInActiveTurn`, `IsInActiveTurn`, `StoreOrDeferMessage` (atomic check-and-defer), and `EndTurnAndTakePending` (atomic clear-and-flush). Removed unused `SetPendingUserMessage`.
- **backend/agent/manager.go** — Turn-start events (`assistant_text`, `tool_start`, `thinking_start`) set `inActiveTurn=true`. Turn-end uses `EndTurnAndTakePending` for atomic flag-clear + pending-message extraction. `SendConversationMessage` uses `StoreOrDeferMessage` to atomically decide store-now vs defer. Removed `flushPendingUserMessage` wrapper, added `storePendingUserMessage` helper.
- **backend/agent/process_test.go** — Tests for all new methods: idle/active deferral, concurrent access with result counting, `EndTurnAndTakePending` with/without pending messages, active-to-idle transition.

## Test Plan

- [x] `go test -race ./agent/` — all tests pass, no races detected
- [x] `go test ./...` — full backend test suite passes
- [x] `go build ./...` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)