### PR TITLE
Remove icons from Code Review sidebar tab

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import { useSelectedIds, useFileTabState, useTodoState, useFileCommentStats, useReviewComments, useSessionActivityState } from '@/stores/selectors';
+import { useSelectedIds, useFileTabState, useTodoState, useFileCommentStats, useReviewComments } from '@/stores/selectors';
 import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, createConversation, updateReviewComment as apiUpdateReviewComment, ApiError, ErrorCode, type FileChangeDTO, type BranchStatsDTO } from '@/lib/api';
 import { getDiffFromCache, setDiffInCache, invalidateDiffCache } from '@/lib/diffCache';
 import { getSessionData, setSessionData, invalidateSessionData } from '@/lib/sessionDataCache';
@@ -112,8 +112,6 @@ export function ChangesPanel() {
   const { agentTodos } = useTodoState(selectedConversationId, selectedSessionId);
   const commentStats = useFileCommentStats(selectedSessionId);
   const reviewComments = useReviewComments(selectedSessionId);
-  const sessionActivityState = useSessionActivityState(selectedSessionId ?? '');
-  const isAgentWorking = sessionActivityState === 'working';
   const sessions = useAppStore((s) => s.sessions);
   const workspaces = useAppStore((s) => s.workspaces);
   const updateSession = useAppStore((s) => s.updateSession);
@@ -742,7 +740,6 @@ export function ChangesPanel() {
         changesCount={branchStats?.totalFiles || changes?.length || 0}
         reviewCount={unresolvedCount}
         menuContext={menuContext}
-        isAgentWorking={isAgentWorking}
       />
 
       {/* Always-mounted resizable layout — bottom panel uses collapsible API to avoid remounting */}
@@ -892,7 +889,7 @@ export function ChangesPanel() {
 // Top panel tabs configuration (all tabs always visible)
 const TOP_TABS_CONFIG: Record<AllTopPanelTab, { label: string; shortcutId?: string; icon?: React.ComponentType<{ className?: string }> }> = {
   changes: { label: 'Changes', shortcutId: 'sidebarChangesTab' },
-  review: { label: 'Code Review', shortcutId: 'sidebarReviewTab', icon: Eye },
+  review: { label: 'Code Review', shortcutId: 'sidebarReviewTab' },
   checks: { label: 'Checks', shortcutId: 'sidebarChecksTab' },
   files: { label: 'Files', shortcutId: 'sidebarFilesTab' },
 };
@@ -1146,14 +1143,12 @@ function TopPanelTabs({
   changesCount,
   reviewCount,
   menuContext,
-  isAgentWorking,
 }: {
   selectedTab: string;
   setSelectedTab: (tab: string) => void;
   changesCount: number;
   reviewCount: number;
   menuContext: TopPanelMenuContext;
-  isAgentWorking: boolean;
 }) {
   const topTabOrder = useSettingsStore((s) => s.topTabOrder);
   const setTopTabOrder = useSettingsStore((s) => s.setTopTabOrder);
@@ -1213,9 +1208,9 @@ function TopPanelTabs({
                   }
                   shortcutId={TOP_TABS_CONFIG[tabId].shortcutId}
                   icon={(() => {
-                    const IconComponent = tabId === 'review' && isAgentWorking ? Loader2 : TOP_TABS_CONFIG[tabId].icon;
+                    const IconComponent = TOP_TABS_CONFIG[tabId].icon;
                     if (!IconComponent) return undefined;
-                    return <IconComponent className={cn("size-3", tabId === 'review' && isAgentWorking && "animate-spin")} />;
+                    return <IconComponent className="size-3" />;
                   })()}
                 />
               ))}


### PR DESCRIPTION
## Summary
- Remove the Eye icon and spinning Loader2 icon from the "Code Review" tab in the session secondary sidebar
- Clean up the now-unused `isAgentWorking` prop from `TopPanelTabs` and the `useSessionActivityState` hook
- Simplify the tab icon rendering logic

## Test plan
- [ ] Open a session with the secondary sidebar visible
- [ ] Confirm the "Code Review" tab shows only the label text, no icon
- [ ] Trigger agent work and confirm no spinner appears on the tab
- [ ] Confirm other tabs (Changes, Checks, Files) render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)