### PR TITLE
Fix API key detection and improve onboarding for Claude subscriptions

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1965,13 +1965,21 @@ func (m *Manager) newAIClient() ai.Provider {
 		return ai.NewClient(apiKey)
 	}
 
-	// Source 3: Claude Code OAuth token from macOS Keychain
+	// Source 3: Claude Code OAuth token from OS keychain
 	token, err := ai.ReadClaudeCodeOAuthToken()
 	if err != nil {
-		logger.Manager.Debugf("No Claude Code OAuth token available: %v", err)
-		return nil
+		logger.Manager.Debugf("No Claude Code OAuth token from keychain: %v", err)
+
+		// Source 4: Credentials file fallback (~/.claude/.credentials.json)
+		token, err = ai.ReadClaudeCodeCredentialsFile()
+		if err != nil {
+			logger.Manager.Debugf("No Claude Code credentials file available: %v", err)
+			return nil
+		}
+		logger.Manager.Debugf("Using OAuth token from Claude Code credentials file")
+	} else {
+		logger.Manager.Debugf("Using OAuth token from Claude Code keychain")
 	}
-	logger.Manager.Debugf("Using OAuth token from Claude Code keychain")
 	return ai.NewClientWithOAuth(token)
 }
 

--- a/backend/ai/credentials_file.go
+++ b/backend/ai/credentials_file.go
@@ -1,0 +1,47 @@
+package ai
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ReadClaudeCodeCredentialsFile reads Claude Code OAuth credentials from
+// ~/.claude/.credentials.json. This serves as a fallback when keychain/
+// secret-service access fails (e.g., due to ACL restrictions in release builds).
+func ReadClaudeCodeCredentialsFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+
+	path := filepath.Join(home, ".claude", ".credentials.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading credentials file: %w", err)
+	}
+
+	var creds claudeCodeCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return "", fmt.Errorf("parsing credentials JSON: %w", err)
+	}
+
+	if creds.ClaudeAiOAuth == nil {
+		return "", fmt.Errorf("no claudeAiOauth field in credentials file")
+	}
+
+	if creds.ClaudeAiOAuth.AccessToken == "" {
+		return "", fmt.Errorf("empty access token in credentials file")
+	}
+
+	if creds.ClaudeAiOAuth.ExpiresAt > 0 {
+		expiresAt := time.UnixMilli(creds.ClaudeAiOAuth.ExpiresAt)
+		if time.Now().After(expiresAt) {
+			return "", fmt.Errorf("OAuth token expired at %s", expiresAt.Format(time.RFC3339))
+		}
+	}
+
+	return creds.ClaudeAiOAuth.AccessToken, nil
+}

--- a/backend/ai/credentials_file_test.go
+++ b/backend/ai/credentials_file_test.go
@@ -1,0 +1,137 @@
+package ai
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadClaudeCodeCredentialsFile_ValidNonExpired(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+
+	futureMs := time.Now().Add(1 * time.Hour).UnixMilli()
+	creds := fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-valid","expiresAt":%d}}`, futureMs)
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), []byte(creds), 0o600))
+
+	// Override HOME so ReadClaudeCodeCredentialsFile resolves to our temp dir
+	t.Setenv("HOME", dir)
+
+	token, err := ReadClaudeCodeCredentialsFile()
+	require.NoError(t, err)
+	assert.Equal(t, "sk-ant-oat01-valid", token)
+}
+
+func TestReadClaudeCodeCredentialsFile_Expired(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+
+	pastMs := time.Now().Add(-1 * time.Hour).UnixMilli()
+	creds := fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-expired","expiresAt":%d}}`, pastMs)
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), []byte(creds), 0o600))
+
+	t.Setenv("HOME", dir)
+
+	_, err := ReadClaudeCodeCredentialsFile()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestReadClaudeCodeCredentialsFile_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	_, err := ReadClaudeCodeCredentialsFile()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reading credentials file")
+}
+
+func TestReadClaudeCodeCredentialsFile_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), []byte("not-json"), 0o600))
+
+	t.Setenv("HOME", dir)
+
+	_, err := ReadClaudeCodeCredentialsFile()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing credentials JSON")
+}
+
+func TestReadClaudeCodeCredentialsFile_MissingOAuthField(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), []byte(`{"mcpOAuth":{}}`), 0o600))
+
+	t.Setenv("HOME", dir)
+
+	_, err := ReadClaudeCodeCredentialsFile()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no claudeAiOauth")
+}
+
+func TestReadClaudeCodeCredentialsFile_EmptyAccessToken(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), []byte(`{"claudeAiOauth":{"accessToken":"","expiresAt":0}}`), 0o600))
+
+	t.Setenv("HOME", dir)
+
+	_, err := ReadClaudeCodeCredentialsFile()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty access token")
+}
+
+func TestReadClaudeCodeCredentialsFile_ZeroExpiryMeansNoExpiry(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-no-expiry","expiresAt":0}}`), 0o600))
+
+	t.Setenv("HOME", dir)
+
+	token, err := ReadClaudeCodeCredentialsFile()
+	require.NoError(t, err)
+	assert.Equal(t, "sk-ant-oat01-no-expiry", token)
+}
+
+func TestReadClaudeCodeCredentialsFile_RealWorldStructure(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+
+	futureMs := time.Now().Add(24 * time.Hour).UnixMilli()
+	creds := fmt.Sprintf(`{
+		"claudeAiOauth": {
+			"accessToken": "sk-ant-oat01-k7-4gjpFXlUkIR1xay",
+			"refreshToken": "sk-ant-ort01-BQNHb6wnEKO2w2iW",
+			"expiresAt": %d,
+			"scopes": ["user:inference", "user:profile"],
+			"subscriptionType": "max"
+		},
+		"mcpOAuth": {}
+	}`, futureMs)
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), []byte(creds), 0o600))
+
+	t.Setenv("HOME", dir)
+
+	token, err := ReadClaudeCodeCredentialsFile()
+	require.NoError(t, err)
+	assert.Contains(t, token, "sk-ant-oat01-")
+
+	// Verify the JSON structure was parsed correctly
+	var parsed claudeCodeCredentials
+	require.NoError(t, json.Unmarshal([]byte(creds), &parsed))
+	assert.Equal(t, token, parsed.ClaudeAiOAuth.AccessToken)
+}

--- a/backend/ai/keychain_darwin.go
+++ b/backend/ai/keychain_darwin.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -61,6 +62,14 @@ func extractKeychainPassword(output string) string {
 			// Remove surrounding quotes
 			if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
 				value = value[1 : len(value)-1]
+			}
+			// Handle hex-encoded passwords (e.g., 0x7B22636C...)
+			if strings.HasPrefix(value, "0x") || strings.HasPrefix(value, "0X") {
+				decoded, err := hex.DecodeString(value[2:])
+				if err == nil {
+					return string(decoded)
+				}
+				// If hex decode fails, return the raw value and let JSON parsing catch it
 			}
 			return value
 		}

--- a/backend/ai/keychain_darwin_test.go
+++ b/backend/ai/keychain_darwin_test.go
@@ -44,10 +44,35 @@ func TestExtractKeychainPassword_EmptyOutput(t *testing.T) {
 	assert.Empty(t, result)
 }
 
-func TestExtractKeychainPassword_PasswordWithoutQuotes(t *testing.T) {
-	output := `password: 0x7B22636C61756465416F41757468223A7B7D7D`
+func TestExtractKeychainPassword_HexEncodedSimple(t *testing.T) {
+	// Hex-encode a simple JSON credential
+	cred := `{"claudeAiOauth":{}}`
+	hexStr := "0x" + fmt.Sprintf("%x", []byte(cred))
+	output := "password: " + hexStr
 	result := extractKeychainPassword(output)
-	assert.Equal(t, "0x7B22636C61756465416F41757468223A7B7D7D", result)
+	assert.Equal(t, cred, result)
+}
+
+func TestExtractKeychainPassword_HexEncodedValidCredential(t *testing.T) {
+	// Hex-encode a full credential JSON
+	cred := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-abc","expiresAt":1770776037151}}`
+	hexStr := "0x" + fmt.Sprintf("%x", []byte(cred))
+	output := "password: " + hexStr
+	result := extractKeychainPassword(output)
+	assert.Equal(t, cred, result)
+
+	// Verify it parses as valid JSON
+	var parsed map[string]interface{}
+	err := json.Unmarshal([]byte(result), &parsed)
+	require.NoError(t, err)
+	assert.Contains(t, parsed, "claudeAiOauth")
+}
+
+func TestExtractKeychainPassword_HexDecodeFailureFallsBack(t *testing.T) {
+	// Invalid hex (not valid hex chars) — should return raw value
+	output := `password: 0xNOTHEX`
+	result := extractKeychainPassword(output)
+	assert.Equal(t, "0xNOTHEX", result)
 }
 
 func TestExtractKeychainPassword_PasswordLineWithLeadingWhitespace(t *testing.T) {

--- a/backend/server/settings_handlers.go
+++ b/backend/server/settings_handlers.go
@@ -420,17 +420,36 @@ func (h *Handlers) GetClaudeAuthStatus(w http.ResponseWriter, r *http.Request) {
 	// Check 2: ANTHROPIC_API_KEY environment variable
 	hasEnvKey := os.Getenv("ANTHROPIC_API_KEY") != ""
 
-	// Check 3: Claude Code CLI credentials (validates token contents + expiration)
+	// Check 3: Claude Code CLI credentials via OS keychain (validates token contents + expiration)
 	_, cliErr := ai.ReadClaudeCodeOAuthToken()
 	hasCliCredentials := cliErr == nil
 
+	// Check 4: ~/.claude/.credentials.json file fallback (only if keychain failed)
+	if !hasCliCredentials {
+		_, fileErr := ai.ReadClaudeCodeCredentialsFile()
+		if fileErr == nil {
+			hasCliCredentials = true
+		}
+	}
+
 	configured := hasStoredKey || hasEnvKey || hasCliCredentials
+
+	// Determine the primary credential source for UI display
+	credentialSource := ""
+	if hasStoredKey {
+		credentialSource = "api_key"
+	} else if hasEnvKey {
+		credentialSource = "env_var"
+	} else if hasCliCredentials {
+		credentialSource = "claude_subscription"
+	}
 
 	writeJSON(w, map[string]interface{}{
 		"configured":       configured,
 		"hasStoredKey":     hasStoredKey,
 		"hasEnvKey":        hasEnvKey,
 		"hasCliCredentials": hasCliCredentials,
+		"credentialSource": credentialSource,
 	})
 }
 

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -133,8 +133,8 @@ interface ChatInputProps {
 }
 
 export function ChatInput({ onMessageSubmit }: ChatInputProps) {
-  const claudeAuthConfigured = useClaudeAuthStatus();
-  const authDisabled = claudeAuthConfigured === false;
+  const claudeAuthStatus = useClaudeAuthStatus();
+  const authDisabled = claudeAuthStatus?.configured === false;
   const [message, setMessage] = useState('');
   // Read store defaults once at mount time — these initialize per-conversation
   // state and intentionally don't sync if the user changes settings mid-session.

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -132,7 +132,8 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   );
   const addMessage = useAppStore((s) => s.addMessage);
 
-  const claudeAuthConfigured = useClaudeAuthStatus();
+  const claudeAuthStatus = useClaudeAuthStatus();
+  const claudeAuthConfigured = claudeAuthStatus?.configured ?? null;
 
   // Use messages selector scoped to the selected conversation
   const allConversationMessages = useMessages(selectedConversationId);
@@ -981,7 +982,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
           <div className="flex items-center gap-2">
             <KeyRound className="h-4 w-4 text-amber-500 shrink-0" />
             <span className="text-xs text-amber-200/90">
-              No Anthropic API key configured. Agents cannot run without credentials.
+              No credentials configured. Agents cannot run without an API key or Claude subscription.
             </span>
             <button
               className="ml-auto flex items-center gap-1 text-xs text-amber-300 hover:text-amber-100 transition-colors shrink-0"

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { getClaudeAuthStatus } from '@/lib/api';
+import { DEFAULT_AUTH_STATUS, type ClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
 import { WelcomeStep } from './steps/WelcomeStep';
 import { WorkspacesStep } from './steps/WorkspacesStep';
 import { SessionsStep } from './steps/SessionsStep';
@@ -18,29 +19,21 @@ interface OnboardingWizardProps {
 }
 
 const CONCEPT_STEPS = [WelcomeStep, WorkspacesStep, SessionsStep, ConversationsStep, ShortcutsStep];
+const TOTAL_STEPS = CONCEPT_STEPS.length + 1; // +1 for ApiKeyStep (always shown)
 
 export function OnboardingWizard({ onComplete, onSkip, onOpenSettings }: OnboardingWizardProps) {
   const [currentStep, setCurrentStep] = useState(0);
   const keyboardReady = useRef(false);
-  const [needsApiKey, setNeedsApiKey] = useState<boolean | null>(null);
+  const [authStatus, setAuthStatus] = useState<ClaudeAuthStatus | null>(null);
 
   // Check auth status once when component mounts
   useEffect(() => {
     getClaudeAuthStatus()
-      .then((result) => setNeedsApiKey(!result.configured))
-      .catch(() => setNeedsApiKey(true));
+      .then((result) => setAuthStatus(result))
+      .catch(() => setAuthStatus(DEFAULT_AUTH_STATUS));
   }, []);
 
-  const steps = useMemo(() => {
-    if (needsApiKey) {
-      return [...CONCEPT_STEPS, ApiKeyStep];
-    }
-    return CONCEPT_STEPS;
-  }, [needsApiKey]);
-
-  const totalSteps = steps.length;
-  const isLastStep = currentStep === totalSteps - 1;
-  const isApiKeyStep = needsApiKey && currentStep === totalSteps - 1;
+  const isLastStep = currentStep === TOTAL_STEPS - 1;
 
   const handleNext = useCallback(() => {
     if (isLastStep) {
@@ -85,21 +78,28 @@ export function OnboardingWizard({ onComplete, onSkip, onOpenSettings }: Onboard
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [handleNext, handlePrev, onSkip]);
 
-  const StepComponent = steps[currentStep];
-
   const getButtonLabel = () => {
     if (currentStep === 0) return 'Get Started';
-    if (isApiKeyStep) return 'Open Settings';
-    if (isLastStep) return 'Start Using ChatML';
+    if (isLastStep) {
+      return authStatus?.configured ? 'Start Using ChatML' : 'Open Settings';
+    }
     return 'Next';
   };
 
   const handleButtonClick = () => {
-    if (isApiKeyStep && onOpenSettings) {
+    if (isLastStep && !authStatus?.configured && onOpenSettings) {
       onOpenSettings();
     } else {
       handleNext();
     }
+  };
+
+  const renderStep = () => {
+    if (isLastStep) {
+      return <ApiKeyStep authStatus={authStatus} />;
+    }
+    const StepComponent = CONCEPT_STEPS[currentStep];
+    return <StepComponent />;
   };
 
   return (
@@ -112,13 +112,13 @@ export function OnboardingWizard({ onComplete, onSkip, onOpenSettings }: Onboard
         onClick={onSkip}
         className="absolute top-14 right-6 text-sm text-muted-foreground/70 hover:text-foreground transition-colors z-40"
       >
-        {isApiKeyStep ? 'Skip for now' : 'Skip Onboarding'}
+        {isLastStep && !authStatus?.configured ? 'Skip for now' : 'Skip Onboarding'}
       </button>
 
       {/* Step content — full-size opaque layer prevents GPU cache artifacts from previous step */}
       <div className="absolute inset-0 flex items-center justify-center bg-background z-10" key={currentStep}>
         <div className="w-full max-w-lg px-8 animate-fade-in">
-          <StepComponent />
+          {renderStep()}
         </div>
       </div>
 
@@ -135,7 +135,7 @@ export function OnboardingWizard({ onComplete, onSkip, onOpenSettings }: Onboard
 
         {/* Dot indicators */}
         <div className="flex items-center gap-2">
-          {steps.map((_, index) => (
+          {Array.from({ length: TOTAL_STEPS }, (_, index) => (
             <button
               key={index}
               onClick={() => setCurrentStep(index)}

--- a/src/components/onboarding/steps/ApiKeyStep.tsx
+++ b/src/components/onboarding/steps/ApiKeyStep.tsx
@@ -1,16 +1,57 @@
 'use client';
 
-import { KeyRound, ExternalLink } from 'lucide-react';
+import { KeyRound, ExternalLink, CheckCircle2, Shield } from 'lucide-react';
 import { OnboardingWizardStep } from '../OnboardingWizardStep';
+import type { ClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
 
-export function ApiKeyStep() {
+interface ApiKeyStepProps {
+  authStatus: ClaudeAuthStatus | null;
+}
+
+function getSourceLabel(source: string): string {
+  switch (source) {
+    case 'claude_subscription':
+      return 'Claude subscription credentials found';
+    case 'api_key':
+      return 'API key configured in settings';
+    case 'env_var':
+      return 'API key found in environment';
+    default:
+      return 'Credentials configured';
+  }
+}
+
+export function ApiKeyStep({ authStatus }: ApiKeyStepProps) {
+  const configured = authStatus?.configured ?? false;
+
+  if (configured) {
+    return (
+      <OnboardingWizardStep
+        icon={<Shield className="w-8 h-8 text-emerald-400" />}
+        title="Credentials detected"
+      >
+        <div className="flex items-center gap-2 justify-center text-emerald-400/90 mb-2">
+          <CheckCircle2 className="w-5 h-5" />
+          <span className="font-medium">
+            {getSourceLabel(authStatus?.credentialSource ?? '')}
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground/70">
+          You&apos;re all set to run AI agents. You can change your credentials anytime in Settings.
+        </p>
+      </OnboardingWizardStep>
+    );
+  }
+
   return (
     <OnboardingWizardStep
       icon={<KeyRound className="w-8 h-8 text-primary" />}
-      title="Connect your API key"
+      title="Connect credentials"
     >
       <p>
-        To run AI agents, ChatML needs an <strong className="text-white">Anthropic API key</strong>. You can create one from the Anthropic Console.
+        To run AI agents, ChatML needs either a{' '}
+        <strong className="text-white">Claude subscription</strong> or an{' '}
+        <strong className="text-white">Anthropic API key</strong>.
       </p>
       <a
         href="https://console.anthropic.com/settings/keys"

--- a/src/hooks/useClaudeAuthStatus.ts
+++ b/src/hooks/useClaudeAuthStatus.ts
@@ -2,31 +2,47 @@
 import { useState, useEffect } from 'react';
 import { getClaudeAuthStatus } from '@/lib/api';
 
-let cachedStatus: boolean | null = null;
-const listeners = new Set<(v: boolean) => void>();
+export interface ClaudeAuthStatus {
+  configured: boolean;
+  hasStoredKey: boolean;
+  hasEnvKey: boolean;
+  hasCliCredentials: boolean;
+  credentialSource: string;
+}
 
-function notify(value: boolean) {
+export const DEFAULT_AUTH_STATUS: ClaudeAuthStatus = {
+  configured: false,
+  hasStoredKey: false,
+  hasEnvKey: false,
+  hasCliCredentials: false,
+  credentialSource: '',
+};
+
+let cachedStatus: ClaudeAuthStatus | null = null;
+const listeners = new Set<(v: ClaudeAuthStatus | null) => void>();
+
+function notify(value: ClaudeAuthStatus | null) {
   cachedStatus = value;
   listeners.forEach((fn) => fn(value));
 }
 
 export function refreshClaudeAuthStatus() {
   getClaudeAuthStatus()
-    .then((result) => notify(result.configured))
-    .catch(() => notify(false));
+    .then((result) => notify(result))
+    .catch(() => notify(DEFAULT_AUTH_STATUS));
 }
 
-export function useClaudeAuthStatus() {
-  const [configured, setConfigured] = useState<boolean | null>(cachedStatus);
+export function useClaudeAuthStatus(): ClaudeAuthStatus | null {
+  const [status, setStatus] = useState<ClaudeAuthStatus | null>(cachedStatus);
 
   useEffect(() => {
-    listeners.add(setConfigured);
+    listeners.add(setStatus);
     // Fetch on first subscriber
     if (cachedStatus === null) {
       refreshClaudeAuthStatus();
     }
-    return () => { listeners.delete(setConfigured); };
+    return () => { listeners.delete(setStatus); };
   }, []);
 
-  return configured;
+  return status;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1603,6 +1603,7 @@ export async function getClaudeAuthStatus(): Promise<{
   hasStoredKey: boolean;
   hasEnvKey: boolean;
   hasCliCredentials: boolean;
+  credentialSource: string;
 }> {
   const res = await fetchWithAuth(`${getApiBase()}/api/settings/claude-auth-status`);
   return handleResponse(res);


### PR DESCRIPTION
## Summary

- **Credentials file fallback** — When macOS keychain access fails (e.g., ACL restrictions in release builds), the backend now falls back to reading `~/.claude/.credentials.json`
- **Hex-encoded keychain passwords** — The `security` command sometimes returns passwords in hex format (`0x7B22...`); these are now decoded correctly
- **Onboarding improvements** — The API key step now detects existing credentials and shows a success state with the credential source, instead of always prompting for setup

## Changes Made

- **`backend/agent/manager.go`** — Added credentials file as Source 4 fallback after keychain, consolidated duplicated `NewClientWithOAuth` return paths
- **`backend/ai/keychain_darwin.go`** — Added hex decoding for `0x`-prefixed passwords from macOS `security` output
- **`backend/ai/keychain_darwin_test.go`** — Updated tests for hex-encoded passwords (valid decode, invalid fallback)
- **`backend/ai/credentials_file.go`** *(new)* — Reads and validates OAuth tokens from `~/.claude/.credentials.json`
- **`backend/ai/credentials_file_test.go`** *(new)* — Tests for valid/expired/missing/malformed credential files
- **`backend/server/settings_handlers.go`** — Added credentials file check to auth status endpoint, added `credentialSource` field to response
- **`src/hooks/useClaudeAuthStatus.ts`** — Expanded `ClaudeAuthStatus` interface with all fields, exported `DEFAULT_AUTH_STATUS` constant, fixed fail-closed behavior on network errors
- **`src/components/onboarding/OnboardingWizard.tsx`** — Always show API key step (with success or setup UI), removed dead code (`isApiKeyStep` duplicate of `isLastStep`)
- **`src/components/onboarding/steps/ApiKeyStep.tsx`** — Added credential-detected success state with source label
- **`src/components/conversation/ChatInput.tsx`** / **`ConversationArea.tsx`** — Updated to use new `ClaudeAuthStatus` object
- **`src/lib/api.ts`** — Added `credentialSource` to response type

## Test Plan

- [x] `go test ./ai/...` — all tests pass
- [x] `go build ./...` — backend builds clean
- [ ] Manual: fresh install without API key but with Claude Code CLI login → onboarding shows "Claude subscription credentials found"
- [ ] Manual: no credentials at all → onboarding shows setup prompt with "Open Settings" button
- [ ] Manual: API key in settings → onboarding shows "API key configured in settings"

🤖 Generated with [Claude Code](https://claude.com/claude-code)