### PR TITLE
Fix settings module scrolling issue

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -333,7 +333,7 @@ export function SettingsPage({
           </Button>
         </div>
 
-        <ScrollArea className="flex-1">
+        <ScrollArea className="flex-1 min-h-0">
           <div className="py-2 px-2">
             {/* Sidebar Title */}
             <div className="px-1 pt-1 pb-2">
@@ -523,7 +523,7 @@ export function SettingsPage({
         {/* Spacer to match toolbar height */}
         <div className="h-10 shrink-0" />
 
-        <ScrollArea className="flex-1">
+        <ScrollArea className="flex-1 min-h-0">
           <div className="max-w-2xl mx-auto py-8 px-8">
             {/* Hidden focusable element for keyboard focus management */}
             <h2 ref={contentRef} tabIndex={-1} className="sr-only">


### PR DESCRIPTION
## Summary
- Adds `min-h-0` to both `ScrollArea` components in `SettingsPage.tsx` (sidebar nav and content area)
- Fixes a CSS flexbox issue where `min-height: auto` (the default) prevented ScrollArea from being constrained to its allocated space, causing content to be clipped instead of scrollable

## Test plan
- [ ] Open Settings and resize window so content overflows — verify the content area scrolls
- [ ] Verify the sidebar nav scrolls when many workspaces are listed
- [ ] Test in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)