### PR TITLE
Fix user message bubble rendering above its response

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -953,6 +953,15 @@ outer:
 				}
 
 			case EventTypeTurnComplete, EventTypeComplete, EventTypeResult:
+				// Atomically clear the active turn flag and take any deferred
+				// user message. Store BEFORE the assistant message so the DB
+				// position ordering is: [queued_user_N, assistant_N+1].
+				// This must be atomic so a concurrent SendConversationMessage
+				// cannot slip a new message between clearing the flag and
+				// flushing the old deferred one.
+				pending := proc.EndTurnAndTakePending()
+				m.storePendingUserMessage(ctx, convID, pending)
+
 				// Store accumulated message and reset streaming state.
 				if currentAssistantMessage != "" {
 					// Seal final text segment
@@ -1104,15 +1113,6 @@ outer:
 					currentAssistantMessage = ""
 				}
 
-				// Atomically clear the active turn flag and take any deferred
-				// user message. This must be atomic so a concurrent
-				// SendConversationMessage cannot slip a new message between
-				// clearing the flag and flushing the old deferred one.
-				// Must happen AFTER storing the assistant message so the DB
-				// position ordering is correct: [assistant_N, queued_user_N+1].
-				pending := proc.EndTurnAndTakePending()
-				m.storePendingUserMessage(ctx, convID, pending)
-
 				// Reset per-turn accumulation state
 				currentThinking = ""
 				pendingPlanContent = ""
@@ -1232,6 +1232,12 @@ outer:
 		}
 	}
 
+	// Atomically clear active turn flag and flush any remaining deferred user
+	// message. Store BEFORE the assistant message so the DB position ordering
+	// is: [queued_user_N, assistant_N+1].
+	pendingFinal := proc.EndTurnAndTakePending()
+	m.storePendingUserMessage(ctx, convID, pendingFinal)
+
 	// Store any remaining assistant message (with full enrichment)
 	if currentAssistantMessage != "" {
 		// Seal any in-progress text segment
@@ -1307,12 +1313,6 @@ outer:
 			logger.Manager.Errorf("Failed to store final assistant message for conv %s: %v", convID, err)
 		}
 	}
-
-	// Atomically clear active turn flag and flush any remaining deferred user
-	// message so it is not lost when the process exits without a turn_complete
-	// event (e.g. crash, forced stop).
-	pending := proc.EndTurnAndTakePending()
-	m.storePendingUserMessage(ctx, convID, pending)
 
 	// Clear snapshot on process exit — but only if this process is still the current
 	// one in the map. If a new process has already been started (via SendConversationMessage),
@@ -1604,9 +1604,9 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 	//  2. needsRestart=false, process idle between turns — store immediately.
 	//     Same reasoning as case 1.
 	//  3. needsRestart=false, process mid-turn (inActiveTurn=true) — defer storage
-	//     until the current turn completes. The assistant response for the current
-	//     turn is stored first, then this queued user message is flushed after it.
-	//     This preserves chronological order: [assistant_N, queued_user_N+1].
+	//     until the current turn completes. The queued user message is flushed
+	//     before the assistant response so the user bubble renders first:
+	//     [queued_user_N, assistant_N+1].
 	msg := models.Message{
 		ID:          uuid.New().String()[:8],
 		Role:        "user",

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -187,7 +187,6 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     addMessage,
     setStreaming,
     setQueuedMessage,
-    commitQueuedMessage,
     clearPendingPlanApproval,
     setApprovedPlanContent,
     clearApprovedPlanContent,
@@ -774,14 +773,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       // Compute elapsed time for the stopped run (must read before finalize clears state)
       const startTime = useAppStore.getState().streamingState[selectedConversationId]?.startTime;
       const durationMs = startTime ? Date.now() - startTime : undefined;
-      // Finalize streaming content first, then commit queued message.
-      // Order matters: assistant message must be appended before the queued
-      // user message to maintain correct timeline ordering. Also,
+      // Finalize streaming content and atomically commit any queued user
+      // message before the assistant message so the user bubble renders first.
       // finalizeStreamingMessage checks for queued message to keep
       // isStreaming=true, preventing a visual flash between turns.
       // toolUsage is auto-derived from activeTools inside finalizeStreamingMessage.
-      finalizeStreamingMessage(selectedConversationId, { durationMs });
-      commitQueuedMessage(selectedConversationId);
+      finalizeStreamingMessage(selectedConversationId, { durationMs, commitQueuedFirst: true });
       // Add system message indicating the agent was stopped
       addMessage({
         id: `msg-stopped-${Date.now()}`,
@@ -796,7 +793,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       console.error('Failed to stop conversation:', error);
       showError('Failed to stop conversation. Please try again.');
     }
-  }, [selectedConversationId, isStreaming, commitQueuedMessage, finalizeStreamingMessage, addMessage, updateConversation, showError]);
+  }, [selectedConversationId, isStreaming, finalizeStreamingMessage, addMessage, updateConversation, showError]);
 
   useShortcut('stopAgent', handleStop, { enabled: isStreaming });
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -308,12 +308,11 @@ export function useWebSocket(enabled: boolean = true) {
         if (data.payload === 'idle' && store.streamingState[conversationId]?.isStreaming) {
           const startTime = store.streamingState[conversationId]?.startTime;
           const durationMs = startTime ? Date.now() - startTime : undefined;
-          // Must finalize BEFORE committing queued message so the assistant
-          // message is appended first (correct timeline ordering).
-          // Also: finalizeStreamingMessage checks for queued message to keep
-          // isStreaming=true, preventing a visual flash between turns.
-          store.finalizeStreamingMessage(conversationId, { durationMs });
-          store.commitQueuedMessage(conversationId);
+          // Finalize streaming and commit any queued user message atomically.
+          // commitQueuedFirst places the user message BEFORE the assistant message
+          // so the user bubble appears above its response. Also keeps
+          // isStreaming=true when a queued message exists, preventing visual flash.
+          store.finalizeStreamingMessage(conversationId, { durationMs, commitQueuedFirst: true });
           store.clearAgentTodos(conversationId);
         }
       } else {
@@ -630,14 +629,13 @@ export function useWebSocket(enabled: boolean = true) {
           stderr: t.stderr,
         }));
 
-        // Atomic finalization - creates message and clears streaming/activeTools
+        // Atomic finalization - creates message and clears streaming/activeTools.
+        // commitQueuedFirst places the queued user message BEFORE the assistant message.
         turnStore.finalizeStreamingMessage(conversationId, {
           durationMs: turnDurationMs,
           toolUsage: turnToolUsage.length > 0 ? turnToolUsage : undefined,
+          commitQueuedFirst: true,
         });
-        // Commit queued message to messages array (if any).
-        // Must happen AFTER finalize (which checked for queued to keep isStreaming).
-        turnStore.commitQueuedMessage(conversationId);
         // Explicitly set status to active — finalizeStreamingMessage only clears
         // streaming/activeTools state but does NOT update conversation status.
         // The process is still alive and ready for the next message.
@@ -656,11 +654,9 @@ export function useWebSocket(enabled: boolean = true) {
 
       case 'complete': {
         // Complete event signals the entire conversation ended (stdin closed)
-        // Finalize streaming content first, then commit queued message.
-        // Order matters: assistant message must be appended before the queued
-        // user message to maintain correct timeline ordering.
-        store.finalizeStreamingMessage(conversationId, {});
-        store.commitQueuedMessage(conversationId);
+        // Finalize streaming content and atomically commit any queued user
+        // message before the assistant message so the user bubble renders first.
+        store.finalizeStreamingMessage(conversationId, { commitQueuedFirst: true });
         store.setStreaming(conversationId, false);
         store.clearAgentTodos(conversationId);
         store.clearPendingUserQuestion(conversationId);
@@ -761,10 +757,9 @@ export function useWebSocket(enabled: boolean = true) {
           break;
         }
 
-        // Finalize any partial assistant content before committing the queued
-        // user message — preserves correct timeline ordering.
-        store.finalizeStreamingMessage(conversationId, {});
-        store.commitQueuedMessage(conversationId);
+        // Finalize any partial assistant content and atomically commit any
+        // queued user message before the assistant message.
+        store.finalizeStreamingMessage(conversationId, { commitQueuedFirst: true });
         store.setStreamingError(conversationId, errorMessage);
         // Update conversation status to idle
         store.updateConversation(conversationId, { status: 'idle' });
@@ -971,11 +966,9 @@ export function useWebSocket(enabled: boolean = true) {
       // Group F: Interrupted + User Question Timeout
       // ====================================================================
       case 'interrupted':
-        // Finalize streaming content first, then commit queued message.
-        // Order matters: assistant message must be appended before the queued
-        // user message to maintain correct timeline ordering.
-        store.finalizeStreamingMessage(conversationId, {});
-        store.commitQueuedMessage(conversationId);
+        // Finalize streaming content and atomically commit any queued user
+        // message before the assistant message so the user bubble renders first.
+        store.finalizeStreamingMessage(conversationId, { commitQueuedFirst: true });
         addSystemMessage(conversationId, 'Agent was stopped by user.')
           .then(({ id }) => {
             store.addMessage({
@@ -1183,12 +1176,11 @@ export function useWebSocket(enabled: boolean = true) {
 
       for (const convId of locallyStreaming) {
         if (!serverActiveSet.has(convId)) {
-          // Agent finished while we were disconnected — clear orphaned state
-          store.commitQueuedMessage(convId);
-          store.clearStreamingText(convId);
-          store.clearActiveTools(convId);
+          // Agent finished while we were disconnected — clear orphaned state.
+          // commitQueuedFirst places the user message before any partial
+          // assistant content (consistent with all other finalization paths).
+          store.finalizeStreamingMessage(convId, { commitQueuedFirst: true });
           store.clearThinking(convId);
-          store.clearSubAgents(convId);
           store.updateConversation(convId, { status: 'completed' });
 
           // Reload messages to pick up any assistant responses we missed

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -159,6 +159,18 @@ export interface QueuedMessage {
   timestamp: string;
 }
 
+/** Convert a QueuedMessage into a store Message for a given conversation. */
+function queuedToMessage(queued: QueuedMessage, conversationId: string): Message {
+  return {
+    id: queued.id,
+    conversationId,
+    role: 'user' as const,
+    content: queued.content,
+    attachments: queued.attachments,
+    timestamp: queued.timestamp,
+  };
+}
+
 // Streaming state for conversations
 interface StreamingState {
   text: string; // Legacy: full accumulated text for compatibility
@@ -431,6 +443,7 @@ interface AppState {
       durationMs?: number;
       toolUsage?: ToolUsage[];
       runSummary?: RunSummary;
+      commitQueuedFirst?: boolean;
     }
   ) => void;
 
@@ -1812,8 +1825,10 @@ updateFileTabContent: (id, content) => set((state) => ({
         approvedPlanTimestamp: undefined,
       };
 
-      // If no streaming text, just clear the state
+      // If no streaming text, just clear the state (but still commit queued message if requested)
       if (!streaming?.text) {
+        const queued = metadata.commitQueuedFirst ? state.queuedMessage[conversationId] : null;
+        const convPagination = state.messagePagination[conversationId];
         return {
           streamingState: {
             ...state.streamingState,
@@ -1827,6 +1842,23 @@ updateFileTabContent: (id, content) => set((state) => ({
             ...state.subAgents,
             [conversationId]: [],
           },
+          // Commit queued user message even with no streaming text (e.g. turn_complete after result)
+          ...(queued ? {
+            messagesByConversation: {
+              ...state.messagesByConversation,
+              [conversationId]: [...(state.messagesByConversation[conversationId] ?? []), queuedToMessage(queued, conversationId)],
+            },
+            queuedMessage: { ...state.queuedMessage, [conversationId]: null },
+            ...(convPagination ? {
+              messagePagination: {
+                ...state.messagePagination,
+                [conversationId]: {
+                  ...convPagination,
+                  totalCount: convPagination.totalCount + 1,
+                },
+              },
+            } : {}),
+          } : {}),
         };
       }
 
@@ -1906,11 +1938,19 @@ updateFileTabContent: (id, content) => set((state) => ({
       };
 
       // Atomically: add message AND clear streaming state
+      // When commitQueuedFirst is set, place the queued user message BEFORE the assistant message
+      const queued = metadata.commitQueuedFirst ? state.queuedMessage[conversationId] : null;
+      const existing = state.messagesByConversation[conversationId] ?? [];
+      const updatedMessages = queued
+        ? [...existing, queuedToMessage(queued, conversationId), newMessage]
+        : [...existing, newMessage];
+
+      const convPagination = state.messagePagination[conversationId];
       const { [conversationId]: _removedCp, ...remainingPendingCp } = state.pendingCheckpointUuid;
       return {
         messagesByConversation: {
           ...state.messagesByConversation,
-          [conversationId]: [...(state.messagesByConversation[conversationId] ?? []), newMessage],
+          [conversationId]: updatedMessages,
         },
         streamingState: {
           ...state.streamingState,
@@ -1925,6 +1965,20 @@ updateFileTabContent: (id, content) => set((state) => ({
           [conversationId]: [],
         },
         pendingCheckpointUuid: remainingPendingCp,
+        // Clear queued message if it was committed
+        ...(queued ? {
+          queuedMessage: { ...state.queuedMessage, [conversationId]: null },
+        } : {}),
+        // Keep pagination totalCount in sync when queued message was committed
+        ...(queued && convPagination ? {
+          messagePagination: {
+            ...state.messagePagination,
+            [conversationId]: {
+              ...convPagination,
+              totalCount: convPagination.totalCount + 1,
+            },
+          },
+        } : {}),
       };
     });
   },
@@ -1936,19 +1990,11 @@ updateFileTabContent: (id, content) => set((state) => ({
   commitQueuedMessage: (conversationId) => set((state) => {
     const queued = state.queuedMessage[conversationId];
     if (!queued) return state;
-    const msg: Message = {
-      id: queued.id,
-      conversationId,
-      role: 'user',
-      content: queued.content,
-      attachments: queued.attachments,
-      timestamp: queued.timestamp,
-    };
     const convPagination = state.messagePagination[conversationId];
     return {
       messagesByConversation: {
         ...state.messagesByConversation,
-        [conversationId]: [...(state.messagesByConversation[conversationId] ?? []), msg],
+        [conversationId]: [...(state.messagesByConversation[conversationId] ?? []), queuedToMessage(queued, conversationId)],
       },
       queuedMessage: { ...state.queuedMessage, [conversationId]: null },
       // Keep totalCount in sync (same pattern as addMessage)


### PR DESCRIPTION
## Summary

- When a user sends a message while the agent is mid-turn, the queued user bubble was appearing **below** the assistant response instead of above it
- Reorders both backend DB storage and frontend Zustand state so the queued user message is placed **before** the assistant message
- Fixes a missed call site in the WebSocket reconnect path and deduplicates queued message construction

## Changes Made

- **Backend (`manager.go`)** — Moved `EndTurnAndTakePending` + `storePendingUserMessage` to execute *before* assistant message storage in both the event-loop and process-exit paths
- **Frontend (`appStore.ts`)** — Added `commitQueuedFirst` flag to `finalizeStreamingMessage` that atomically inserts the queued user message before the assistant message in a single state update. Extracted `queuedToMessage` helper to deduplicate the message shape construction across 3 call sites
- **Frontend (`useWebSocket.ts`)** — Migrated all `commitQueuedMessage` call sites to use `finalizeStreamingMessage({ commitQueuedFirst: true })`, including a previously missed reconnect recovery path
- **Frontend (`ChatInput.tsx`)** — Updated stop handler to use the new atomic flag

## Test Plan

- [ ] `npm run lint` — no new errors
- [ ] `npm run build` — succeeds
- [ ] `cd backend && go build ./...` — succeeds
- [ ] Manual: send a user message while the agent is mid-turn, verify the user bubble appears above the assistant response
- [ ] Manual: disconnect/reconnect WebSocket while agent is streaming with a queued message, verify message order is correct after reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)