### PR TITLE
Add actionable-only filter for code review feedback

### DIFF
--- a/src/components/settings/sections/ReviewSettings.tsx
+++ b/src/components/settings/sections/ReviewSettings.tsx
@@ -3,9 +3,13 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/toast';
 import { getGlobalReviewPrompts, setGlobalReviewPrompts, getGlobalPRTemplate, setGlobalPRTemplate } from '@/lib/api';
 import { REVIEW_PROMPTS, REVIEW_TYPE_META } from '@/hooks/useReviewTrigger';
+import { useSettingsStore, SETTINGS_DEFAULTS } from '@/stores/settingsStore';
+import { SettingsRow } from '../shared/SettingsRow';
+import { SettingsGroup } from '../shared/SettingsGroup';
 
 function OverridableBadge() {
   return (
@@ -16,6 +20,8 @@ function OverridableBadge() {
 }
 
 export function ReviewSettings() {
+  const reviewActionableOnly = useSettingsStore((s) => s.reviewActionableOnly);
+  const setReviewActionableOnly = useSettingsStore((s) => s.setReviewActionableOnly);
   const [prompts, setPrompts] = useState<Record<string, string>>({});
   const [saved, setSaved] = useState<Record<string, string>>({});
   const [prTemplate, setPRTemplate] = useState('');
@@ -73,7 +79,23 @@ export function ReviewSettings() {
         Per-workspace and per-session overrides can be set in their respective settings.
       </p>
 
-      <div data-setting-id="reviewPrompts" className="space-y-5">
+      <SettingsGroup label="Review Preferences">
+        <SettingsRow
+          settingId="reviewActionableOnly"
+          title="Actionable feedback only"
+          description="Only include actionable review comments (errors, warnings, suggestions). Hides informational and positive feedback."
+          isModified={reviewActionableOnly !== SETTINGS_DEFAULTS.reviewActionableOnly}
+          onReset={() => setReviewActionableOnly(SETTINGS_DEFAULTS.reviewActionableOnly)}
+        >
+          <Switch
+            checked={reviewActionableOnly}
+            onCheckedChange={setReviewActionableOnly}
+            aria-label="Actionable feedback only"
+          />
+        </SettingsRow>
+      </SettingsGroup>
+
+      <div data-setting-id="reviewPrompts" className="space-y-5 mt-6">
         {REVIEW_TYPE_META.map(({ key, label, placeholder }) => (
           <div key={key}>
             <label className="text-sm font-medium block mb-1.5">{label}</label>

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -256,6 +256,14 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
     categoryLabel: 'Review & PRs',
   },
   {
+    id: 'reviewActionableOnly',
+    title: 'Actionable feedback only',
+    description: 'Only include actionable review comments (errors, warnings, suggestions). Hides informational and positive feedback.',
+    keywords: ['review', 'feedback', 'actionable', 'info', 'informational', 'positive', 'noise', 'filter', 'severity'],
+    category: 'review',
+    categoryLabel: 'Review & PRs',
+  },
+  {
     id: 'prTemplate',
     title: 'PR Description Prompt',
     description: 'Custom instructions for AI-generated PR descriptions',

--- a/src/hooks/__tests__/useReviewTrigger.test.ts
+++ b/src/hooks/__tests__/useReviewTrigger.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/__mocks__/server';
 import { useReviewTrigger } from '../useReviewTrigger';
 import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
 
 const API_BASE = 'http://localhost:9876';
 
@@ -276,6 +277,149 @@ describe('useReviewTrigger', () => {
 
       const streamingState = useAppStore.getState().streamingState['new-review-conv'];
       expect(streamingState?.isStreaming).toBe(true);
+    });
+  });
+
+  describe('actionable-only feedback preference', () => {
+    it('excludes actionable-only instruction by default (store defaults to false)', async () => {
+      // Verify the store default is false so this test breaks loudly if the default changes
+      expect(useSettingsStore.getState().reviewActionableOnly).toBe(false);
+
+      let requestBody: Record<string, unknown> | null = null;
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`, async ({ request }) => {
+          requestBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'conv-default',
+            sessionId: 'session-1',
+            type: 'review',
+            name: 'Code Review',
+            status: 'active',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        })
+      );
+
+      // Do NOT set reviewActionableOnly — rely on store default (false)
+      setupSelectedContext();
+      renderHook(() => useReviewTrigger());
+
+      await act(async () => {
+        dispatchStartReview('quick');
+      });
+
+      expect(requestBody).not.toBeNull();
+      expect(requestBody!.message).not.toContain('Only report actionable findings');
+    });
+
+    it('includes actionable-only instruction when reviewActionableOnly is explicitly true', async () => {
+      let requestBody: Record<string, unknown> | null = null;
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`, async ({ request }) => {
+          requestBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'conv-actionable',
+            sessionId: 'session-1',
+            type: 'review',
+            name: 'Code Review',
+            status: 'active',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        })
+      );
+
+      useSettingsStore.setState({ reviewActionableOnly: true });
+
+      setupSelectedContext();
+      renderHook(() => useReviewTrigger());
+
+      await act(async () => {
+        dispatchStartReview('quick');
+      });
+
+      expect(requestBody).not.toBeNull();
+      expect(requestBody!.message).toContain('Only report actionable findings');
+    });
+
+    it('excludes actionable-only instruction when reviewActionableOnly is false', async () => {
+      let requestBody: Record<string, unknown> | null = null;
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`, async ({ request }) => {
+          requestBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'conv-all-feedback',
+            sessionId: 'session-1',
+            type: 'review',
+            name: 'Code Review',
+            status: 'active',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        })
+      );
+
+      useSettingsStore.setState({ reviewActionableOnly: false });
+
+      setupSelectedContext();
+      renderHook(() => useReviewTrigger());
+
+      await act(async () => {
+        dispatchStartReview('deep');
+      });
+
+      expect(requestBody).not.toBeNull();
+      expect(requestBody!.message).not.toContain('Only report actionable findings');
+    });
+
+    it('places actionable-only instruction before custom overrides so user overrides take precedence', async () => {
+      let requestBody: Record<string, unknown> | null = null;
+
+      // Mock both the conversation creation and the review prompt overrides
+      server.use(
+        http.get(`${API_BASE}/api/settings/review-prompts`, () => {
+          return HttpResponse.json({ prompts: { quick: 'Custom global override' } });
+        }),
+        http.get(`${API_BASE}/api/repos/:workspaceId/settings/review-prompts`, () => {
+          return HttpResponse.json({ prompts: {} });
+        }),
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`, async ({ request }) => {
+          requestBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 'conv-override',
+            sessionId: 'session-1',
+            type: 'review',
+            name: 'Code Review',
+            status: 'active',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        })
+      );
+
+      useSettingsStore.setState({ reviewActionableOnly: true });
+
+      setupSelectedContext();
+      renderHook(() => useReviewTrigger());
+
+      await act(async () => {
+        dispatchStartReview('quick');
+      });
+
+      // The handler chain is: dispatch → fetchMergedOverrides → createConversation.
+      // act() may not resolve the full chain, so wait for the request to complete.
+      await waitFor(() => {
+        expect(requestBody).not.toBeNull();
+      });
+
+      const message = requestBody!.message as string;
+      // Actionable instruction should appear before custom override
+      const actionableIndex = message.indexOf('Only report actionable findings');
+      const overrideIndex = message.indexOf('Custom global override');
+      expect(actionableIndex).toBeGreaterThan(-1);
+      expect(overrideIndex).toBeGreaterThan(-1);
+      expect(actionableIndex).toBeLessThan(overrideIndex);
     });
   });
 

--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -11,6 +11,9 @@ import { useSettingsStore } from '@/stores/settingsStore';
 const MARKDOWN_INSTRUCTION =
   '\nWhen writing comment content, use Markdown formatting for detailed comments that include code examples, lists, or structured explanations (use fenced code blocks for code, bullet lists for multiple points, **bold** for emphasis). Keep simple one-sentence comments as plain text.';
 
+const ACTIONABLE_ONLY_INSTRUCTION =
+  '\n\nIMPORTANT: Only report actionable findings. Every comment must identify something that needs to be changed, fixed, or improved. Do NOT include positive feedback, praise, or purely informational observations like "Good implementation", "Nice pattern", "Well structured", or "This looks correct". If a file has no actionable issues, skip it silently.';
+
 const REVIEW_PROMPTS: Record<string, string> = {
   quick:
     'Review the changes in this session. Use get_workspace_diff to see what changed, then use add_review_comment to leave inline comments. Focus on bugs, errors, and obvious issues. Be concise.' + MARKDOWN_INSTRUCTION,
@@ -90,12 +93,18 @@ export function useReviewTrigger() {
         // Use base prompt without overrides
       }
 
-      const message = extra
-        ? `${basePrompt}\n\nAdditional instructions:\n${extra}`
-        : basePrompt;
-
       try {
-        const { reviewModel } = useSettingsStore.getState();
+        const { reviewModel, reviewActionableOnly } = useSettingsStore.getState();
+
+        let prompt = basePrompt;
+        if (reviewActionableOnly) {
+          prompt += ACTIONABLE_ONLY_INSTRUCTION;
+        }
+
+        const message = extra
+          ? `${prompt}\n\nAdditional instructions:\n${extra}`
+          : prompt;
+
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
           type: 'review',
           message,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -86,6 +86,7 @@ export const SETTINGS_DEFAULTS = {
   maxThinkingTokens: 16000,
   showThinkingBlocks: true,
   reviewModel: 'claude-opus-4-6',
+  reviewActionableOnly: false,
   defaultPlanMode: false,
   autoApproveSafeCommands: true,
   // Git
@@ -116,6 +117,7 @@ interface SettingsState {
   suggestionsEnabled: boolean;
   autoSubmitPillSuggestion: boolean;
   reviewModel: string;
+  reviewActionableOnly: boolean; // Only include actionable feedback (errors/warnings/suggestions) in code reviews
   defaultPlanMode: boolean;
   autoConvertLongText: boolean;
   showChatCost: boolean;
@@ -189,6 +191,7 @@ interface SettingsState {
   setSuggestionsEnabled: (value: boolean) => void;
   setAutoSubmitPillSuggestion: (value: boolean) => void;
   setReviewModel: (value: string) => void;
+  setReviewActionableOnly: (value: boolean) => void;
   setDefaultPlanMode: (value: boolean) => void;
   setAutoConvertLongText: (value: boolean) => void;
   setShowChatCost: (value: boolean) => void;
@@ -283,6 +286,7 @@ export const useSettingsStore = create<SettingsState>()(
       setSuggestionsEnabled: (value) => set({ suggestionsEnabled: value }),
       setAutoSubmitPillSuggestion: (value) => set({ autoSubmitPillSuggestion: value }),
       setReviewModel: (value) => set({ reviewModel: value }),
+      setReviewActionableOnly: (value) => set({ reviewActionableOnly: value }),
       setDefaultPlanMode: (value) => set({ defaultPlanMode: value }),
       setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),
       setShowChatCost: (value) => set({ showChatCost: value }),


### PR DESCRIPTION
## Summary

- Adds a **reviewActionableOnly** setting that filters code review output to only actionable comments (errors, warnings, suggestions), hiding informational and positive feedback
- Defaults to **off** so existing users retain current behavior
- Appends filtering instruction to review prompts before custom overrides, so user overrides take precedence

## Changes Made

- **settingsStore.ts** — Added `reviewActionableOnly` field (default `false`) and setter
- **useReviewTrigger.ts** — Appends `ACTIONABLE_ONLY_INSTRUCTION` to review prompts when setting is enabled
- **ReviewSettings.tsx** — Added toggle switch in a new "Review Preferences" settings group
- **settingsRegistry.ts** — Registered the new setting for search/discovery
- **useReviewTrigger.test.ts** — Added 4 tests covering default behavior, explicit on/off, and ordering with custom overrides

## Test Plan

- [x] `npx vitest run src/hooks/__tests__/useReviewTrigger.test.ts` — all 18 tests pass
- [ ] Manual: open Settings → Review & PRs → verify "Actionable feedback only" toggle appears
- [ ] Manual: toggle on, run a review, confirm only actionable comments appear
- [ ] Manual: toggle off, run a review, confirm all feedback types appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)