### PR TITLE
Improve comment card colors and styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -957,8 +957,15 @@ code.hljs { padding: 3px 5px; }
   border-radius: 2px;
 }
 
+.comment-gutter-info {
+  background-color: #94a3b8;  /* slate-400 */
+  width: 4px !important;
+  margin-left: 3px;
+  border-radius: 2px;
+}
+
 .comment-gutter-suggestion {
-  background-color: #3b82f6;
+  background-color: #a855f7;  /* purple-500 */
   width: 4px !important;
   margin-left: 3px;
   border-radius: 2px;

--- a/src/components/comments/CommentThread.tsx
+++ b/src/components/comments/CommentThread.tsx
@@ -69,9 +69,9 @@ function SeverityIcon({ severity }: { severity?: 'error' | 'warning' | 'suggesti
     case 'warning':
       return <AlertTriangle className="w-4 h-4 text-text-warning shrink-0" />;
     case 'info':
-      return <Info className="w-4 h-4 text-text-info shrink-0" />;
+      return <Info className="w-4 h-4 text-slate-400 shrink-0" />;
     case 'suggestion':
-      return <Lightbulb className="w-4 h-4 text-text-info shrink-0" />;
+      return <Lightbulb className="w-4 h-4 text-purple-500 shrink-0" />;
     default:
       return null;
   }
@@ -87,9 +87,9 @@ function getSeverityBorderClass(severity?: 'error' | 'warning' | 'suggestion' | 
     case 'warning':
       return 'border-l-yellow-500';
     case 'info':
-      return 'border-l-blue-500';
+      return 'border-l-slate-300 dark:border-l-slate-500';
     case 'suggestion':
-      return 'border-l-blue-500';
+      return 'border-l-purple-500';
     default:
       return 'border-l-muted-foreground/50';
   }

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -260,7 +260,7 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
         <Button
           variant={filter === 'info' ? 'secondary' : 'ghost'}
           size="sm"
-          className={cn('h-5 text-xs px-1.5', filter === 'info' ? 'text-text-info' : 'text-muted-foreground')}
+          className={cn('h-5 text-xs px-1.5', filter === 'info' ? 'text-slate-500 dark:text-slate-400' : 'text-muted-foreground')}
           onClick={() => setFilter('info')}
         >
           <Info className="h-3 w-3 mr-0.5" />
@@ -435,18 +435,34 @@ function ReviewCommentCard({
     suggestion: MessageSquare,
   }[severity];
 
-  const severityColor = {
-    error: 'text-text-error bg-red-500/10 border-red-500/20',
-    warning: 'text-text-warning bg-yellow-500/10 border-yellow-500/20',
-    info: 'text-text-info bg-blue-500/10 border-blue-500/20',
-    suggestion: 'text-purple-500 bg-purple-500/10 border-purple-500/20',
+  const severityStyles = {
+    error: {
+      card: 'bg-red-500/10 border-red-500/20',
+      icon: 'text-text-error',
+      title: 'font-medium text-text-error',
+    },
+    warning: {
+      card: 'bg-amber-50 border-amber-200 dark:bg-amber-500/10 dark:border-amber-500/20',
+      icon: 'text-amber-600 dark:text-amber-400',
+      title: 'font-semibold text-foreground',
+    },
+    info: {
+      card: 'bg-slate-100/60 border-slate-200 dark:bg-slate-500/8 dark:border-slate-400/20',
+      icon: 'text-slate-400',
+      title: 'font-medium text-muted-foreground',
+    },
+    suggestion: {
+      card: 'bg-purple-500/10 border-purple-500/20',
+      icon: 'text-purple-500',
+      title: 'font-medium text-purple-500',
+    },
   }[severity];
 
   return (
     <div
       className={cn(
         'rounded-lg border p-2 transition-colors cursor-pointer',
-        isResolved ? 'bg-muted/40 border-border/50' : severityColor
+        isResolved ? 'bg-muted/40 border-border/50' : severityStyles?.card
       )}
       onClick={onNavigate}
     >
@@ -455,11 +471,11 @@ function ReviewCommentCard({
         {isResolved ? (
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0 mt-0.5 text-green-500" />
         ) : (
-          <SeverityIcon className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+          <SeverityIcon className={cn('h-3.5 w-3.5 shrink-0 mt-0.5', severityStyles?.icon)} />
         )}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5 min-w-0">
-            <span className={cn('font-medium text-xs leading-tight truncate', isResolved && 'text-muted-foreground')}>{title}</span>
+            <span className={cn('text-xs leading-tight truncate', isResolved ? 'font-medium text-muted-foreground' : severityStyles?.title)}>{title}</span>
             {isResolved && <ResolutionBadge type={comment.resolutionType} />}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Restructure ReviewCommentCard severity styling to separate card, icon, and title concerns — warning titles are now **bold foreground** (black in light, white in dark) instead of hard-to-read yellow text
- Info cards use **neutral slate/gray tones** to reduce color fatigue in long review lists, while remaining clearly distinct from handled/resolved cards (which use 50% opacity + green checkmark + line-through)
- Fix suggestion severity incorrectly using blue instead of purple in CommentThread (icon color and border were same as info)

## Test plan
- [ ] Open a session with code review comments of all severity types (error, warning, info, suggestion)
- [ ] Verify warning cards show bold black title in light mode, bold white title in dark mode, with amber icon/accents
- [ ] Verify info cards use neutral gray/slate tones in both light and dark mode
- [ ] Resolve a few comments and confirm handled cards (faded, green checkmark, line-through) are visually distinct from info cards
- [ ] Check filter bar: info button active state uses gray, not blue
- [ ] Verify error and suggestion cards are unchanged (red and purple respectively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)