### PR TITLE
Add resolution type to review comments and fix review UX

### DIFF
--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -374,19 +374,20 @@ type FileTab struct {
 
 // ReviewComment represents an inline code review comment
 type ReviewComment struct {
-	ID         string     `json:"id"`
-	SessionID  string     `json:"sessionId"`
-	FilePath   string     `json:"filePath"`
-	LineNumber int        `json:"lineNumber"`
-	Title      string     `json:"title,omitempty"`
-	Content    string     `json:"content"`
-	Source     string     `json:"source"` // "claude" or "user"
-	Author     string     `json:"author"` // Display name
-	Severity   string     `json:"severity,omitempty"` // "error", "warning", "suggestion", "info"
-	CreatedAt  time.Time  `json:"createdAt"`
-	Resolved   bool       `json:"resolved"`
-	ResolvedAt *time.Time `json:"resolvedAt,omitempty"`
-	ResolvedBy string     `json:"resolvedBy,omitempty"`
+	ID             string     `json:"id"`
+	SessionID      string     `json:"sessionId"`
+	FilePath       string     `json:"filePath"`
+	LineNumber     int        `json:"lineNumber"`
+	Title          string     `json:"title,omitempty"`
+	Content        string     `json:"content"`
+	Source         string     `json:"source"` // "claude" or "user"
+	Author         string     `json:"author"` // Display name
+	Severity       string     `json:"severity,omitempty"` // "error", "warning", "suggestion", "info"
+	CreatedAt      time.Time  `json:"createdAt"`
+	Resolved       bool       `json:"resolved"`
+	ResolvedAt     *time.Time `json:"resolvedAt,omitempty"`
+	ResolvedBy     string     `json:"resolvedBy,omitempty"`
+	ResolutionType string     `json:"resolutionType,omitempty"` // "fixed" or "ignored"
 }
 
 // ReviewCommentSource constants
@@ -401,6 +402,12 @@ const (
 	CommentSeverityWarning    = "warning"
 	CommentSeveritySuggestion = "suggestion"
 	CommentSeverityInfo       = "info"
+)
+
+// ReviewCommentResolution constants
+const (
+	CommentResolutionFixed   = "fixed"
+	CommentResolutionIgnored = "ignored"
 )
 
 // CommentStats represents per-file comment statistics

--- a/backend/server/review_comment_handlers.go
+++ b/backend/server/review_comment_handlers.go
@@ -168,11 +168,12 @@ func (h *Handlers) GetReviewCommentStats(w http.ResponseWriter, r *http.Request)
 }
 
 type UpdateReviewCommentRequest struct {
-	Title      *string `json:"title,omitempty"`
-	Content    *string `json:"content,omitempty"`
-	Severity   *string `json:"severity,omitempty"`
-	Resolved   *bool   `json:"resolved,omitempty"`
-	ResolvedBy *string `json:"resolvedBy,omitempty"`
+	Title          *string `json:"title,omitempty"`
+	Content        *string `json:"content,omitempty"`
+	Severity       *string `json:"severity,omitempty"`
+	Resolved       *bool   `json:"resolved,omitempty"`
+	ResolvedBy     *string `json:"resolvedBy,omitempty"`
+	ResolutionType *string `json:"resolutionType,omitempty"`
 }
 
 func (h *Handlers) UpdateReviewComment(w http.ResponseWriter, r *http.Request) {
@@ -218,6 +219,14 @@ func (h *Handlers) UpdateReviewComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate resolution type if provided
+	if req.ResolutionType != nil && *req.ResolutionType != "" &&
+		*req.ResolutionType != models.CommentResolutionFixed &&
+		*req.ResolutionType != models.CommentResolutionIgnored {
+		writeValidationError(w, "resolutionType must be 'fixed' or 'ignored'")
+		return
+	}
+
 	if err := h.store.UpdateReviewComment(ctx, commentID, func(c *models.ReviewComment) {
 		if req.Title != nil {
 			c.Title = *req.Title
@@ -236,9 +245,14 @@ func (h *Handlers) UpdateReviewComment(w http.ResponseWriter, r *http.Request) {
 				if req.ResolvedBy != nil {
 					c.ResolvedBy = *req.ResolvedBy
 				}
+				// Only apply resolutionType when resolving
+				if req.ResolutionType != nil {
+					c.ResolutionType = *req.ResolutionType
+				}
 			} else {
 				c.ResolvedAt = nil
 				c.ResolvedBy = ""
+				c.ResolutionType = ""
 			}
 		}
 	}); err != nil {

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -324,6 +324,8 @@ func (s *SQLiteStore) runMigrations() error {
 	_, _ = s.db.Exec(`ALTER TABLE sessions ADD COLUMN pr_title TEXT NOT NULL DEFAULT ''`)
 	// Add checkpoint_uuid column to messages (ignore error if already exists)
 	_, _ = s.db.Exec(`ALTER TABLE messages ADD COLUMN checkpoint_uuid TEXT DEFAULT NULL`)
+	// Add resolution_type column to review_comments (ignore error if already exists)
+	_, _ = s.db.Exec(`ALTER TABLE review_comments ADD COLUMN resolution_type TEXT DEFAULT ''`)
 	return nil
 }
 
@@ -2042,11 +2044,11 @@ func (s *SQLiteStore) AddReviewComment(ctx context.Context, comment *models.Revi
 	}
 
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO review_comments (id, session_id, file_path, line_number, title, content, source, author, severity, created_at, resolved)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO review_comments (id, session_id, file_path, line_number, title, content, source, author, severity, created_at, resolved, resolution_type)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		comment.ID, comment.SessionID, comment.FilePath, comment.LineNumber,
 		comment.Title, comment.Content, comment.Source, comment.Author, severity,
-		comment.CreatedAt, boolToInt(comment.Resolved))
+		comment.CreatedAt, boolToInt(comment.Resolved), comment.ResolutionType)
 	if err != nil {
 		return fmt.Errorf("AddReviewComment: %w", err)
 	}
@@ -2059,15 +2061,16 @@ func (s *SQLiteStore) GetReviewComment(ctx context.Context, id string) (*models.
 	var resolved int
 	var resolvedAt sql.NullTime
 	var resolvedBy sql.NullString
+	var resolutionType sql.NullString
 
 	var title sql.NullString
 
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, session_id, file_path, line_number, title, content, source, author, severity, created_at, resolved, resolved_at, resolved_by
+		SELECT id, session_id, file_path, line_number, title, content, source, author, severity, created_at, resolved, resolved_at, resolved_by, resolution_type
 		FROM review_comments WHERE id = ?`, id).Scan(
 		&comment.ID, &comment.SessionID, &comment.FilePath, &comment.LineNumber,
 		&title, &comment.Content, &comment.Source, &comment.Author, &severity,
-		&comment.CreatedAt, &resolved, &resolvedAt, &resolvedBy)
+		&comment.CreatedAt, &resolved, &resolvedAt, &resolvedBy, &resolutionType)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -2088,13 +2091,16 @@ func (s *SQLiteStore) GetReviewComment(ctx context.Context, id string) (*models.
 	if resolvedBy.Valid {
 		comment.ResolvedBy = resolvedBy.String
 	}
+	if resolutionType.Valid {
+		comment.ResolutionType = resolutionType.String
+	}
 
 	return &comment, nil
 }
 
 func (s *SQLiteStore) ListReviewComments(ctx context.Context, sessionID string) ([]*models.ReviewComment, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, session_id, file_path, line_number, title, content, source, author, severity, created_at, resolved, resolved_at, resolved_by
+		SELECT id, session_id, file_path, line_number, title, content, source, author, severity, created_at, resolved, resolved_at, resolved_by, resolution_type
 		FROM review_comments WHERE session_id = ?
 		ORDER BY file_path, line_number`, sessionID)
 	if err != nil {
@@ -2110,11 +2116,12 @@ func (s *SQLiteStore) ListReviewComments(ctx context.Context, sessionID string) 
 		var resolved int
 		var resolvedAt sql.NullTime
 		var resolvedBy sql.NullString
+		var resolutionType sql.NullString
 
 		if err := rows.Scan(
 			&comment.ID, &comment.SessionID, &comment.FilePath, &comment.LineNumber,
 			&title, &comment.Content, &comment.Source, &comment.Author, &severity,
-			&comment.CreatedAt, &resolved, &resolvedAt, &resolvedBy); err != nil {
+			&comment.CreatedAt, &resolved, &resolvedAt, &resolvedBy, &resolutionType); err != nil {
 			return nil, fmt.Errorf("ListReviewComments scan: %w", err)
 		}
 
@@ -2131,6 +2138,9 @@ func (s *SQLiteStore) ListReviewComments(ctx context.Context, sessionID string) 
 		if resolvedBy.Valid {
 			comment.ResolvedBy = resolvedBy.String
 		}
+		if resolutionType.Valid {
+			comment.ResolutionType = resolutionType.String
+		}
 
 		comments = append(comments, &comment)
 	}
@@ -2142,7 +2152,7 @@ func (s *SQLiteStore) ListReviewComments(ctx context.Context, sessionID string) 
 
 func (s *SQLiteStore) ListReviewCommentsForFile(ctx context.Context, sessionID, filePath string) ([]*models.ReviewComment, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, session_id, file_path, line_number, title, content, source, author, severity, created_at, resolved, resolved_at, resolved_by
+		SELECT id, session_id, file_path, line_number, title, content, source, author, severity, created_at, resolved, resolved_at, resolved_by, resolution_type
 		FROM review_comments WHERE session_id = ? AND file_path = ?
 		ORDER BY line_number`, sessionID, filePath)
 	if err != nil {
@@ -2158,11 +2168,12 @@ func (s *SQLiteStore) ListReviewCommentsForFile(ctx context.Context, sessionID, 
 		var resolved int
 		var resolvedAt sql.NullTime
 		var resolvedBy sql.NullString
+		var resolutionType sql.NullString
 
 		if err := rows.Scan(
 			&comment.ID, &comment.SessionID, &comment.FilePath, &comment.LineNumber,
 			&title, &comment.Content, &comment.Source, &comment.Author, &severity,
-			&comment.CreatedAt, &resolved, &resolvedAt, &resolvedBy); err != nil {
+			&comment.CreatedAt, &resolved, &resolvedAt, &resolvedBy, &resolutionType); err != nil {
 			return nil, fmt.Errorf("ListReviewCommentsForFile scan: %w", err)
 		}
 
@@ -2178,6 +2189,9 @@ func (s *SQLiteStore) ListReviewCommentsForFile(ctx context.Context, sessionID, 
 		}
 		if resolvedBy.Valid {
 			comment.ResolvedBy = resolvedBy.String
+		}
+		if resolutionType.Valid {
+			comment.ResolutionType = resolutionType.String
 		}
 
 		comments = append(comments, &comment)
@@ -2243,9 +2257,9 @@ func (s *SQLiteStore) UpdateReviewComment(ctx context.Context, id string, update
 
 	_, err = s.db.ExecContext(ctx, `
 		UPDATE review_comments SET
-			title = ?, content = ?, severity = ?, resolved = ?, resolved_at = ?, resolved_by = ?
+			title = ?, content = ?, severity = ?, resolved = ?, resolved_at = ?, resolved_by = ?, resolution_type = ?
 		WHERE id = ?`,
-		comment.Title, comment.Content, severity, boolToInt(comment.Resolved), resolvedAt, resolvedBy, id)
+		comment.Title, comment.Content, severity, boolToInt(comment.Resolved), resolvedAt, resolvedBy, comment.ResolutionType, id)
 	if err != nil {
 		return fmt.Errorf("UpdateReviewComment: %w", err)
 	}

--- a/src/components/comments/CommentThread.tsx
+++ b/src/components/comments/CommentThread.tsx
@@ -1,25 +1,34 @@
 'use client';
 
 /**
- * CommentThread - Inline comment display for Monaco view zones
+ * CommentThread - Inline comment display for Pierre diff annotations
  *
  * Displays a review comment with:
  * - Author and timestamp
  * - Severity indicator (error/warning/info/suggestion)
- * - Markdown content
- * - Resolve/delete actions
+ * - Markdown content (compact prose rendering)
+ * - Resolution dropdown (Fixed/Ignored) and status badge
+ * - Delete action for user-created comments
  */
 
 import { memo, useCallback } from 'react';
-import { AlertCircle, AlertTriangle, Info, Lightbulb, CheckCircle2, Circle, Trash2 } from 'lucide-react';
+import { AlertCircle, AlertTriangle, Info, Lightbulb, CheckCircle2, Circle, MinusCircle, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ResolutionBadge } from '@/components/comments/ResolutionBadge';
 import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
+import { PROSE_CLASSES_COMPACT } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 import type { ReviewComment } from '@/lib/types';
 
 interface CommentThreadProps {
   comment: ReviewComment;
-  onResolve: (id: string, resolved: boolean) => void;
+  onResolve: (id: string, resolved: boolean, resolutionType?: 'fixed' | 'ignored') => void;
   onDelete?: (id: string) => void;
 }
 
@@ -29,7 +38,6 @@ interface CommentThreadProps {
 function formatRelativeTime(isoTimestamp: string): string {
   try {
     const date = new Date(isoTimestamp);
-    // Check for Invalid Date
     if (isNaN(date.getTime())) {
       return 'unknown';
     }
@@ -88,6 +96,21 @@ function getSeverityBorderClass(severity?: 'error' | 'warning' | 'suggestion' | 
 }
 
 /**
+ * Status badge showing open/resolved state for inline comment threads.
+ */
+function StatusBadge({ comment }: { comment: ReviewComment }) {
+  if (comment.resolved) {
+    return <ResolutionBadge type={comment.resolutionType} size="sm" />;
+  }
+
+  return (
+    <span className="inline-flex items-center text-xs px-1.5 py-0 rounded-full border font-medium shrink-0 bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/30">
+      Open
+    </span>
+  );
+}
+
+/**
  * CommentThread component - memoized for performance in view zones.
  */
 export const CommentThread = memo(function CommentThread({
@@ -95,15 +118,19 @@ export const CommentThread = memo(function CommentThread({
   onResolve,
   onDelete,
 }: CommentThreadProps) {
-  const handleResolve = useCallback(() => {
-    onResolve(comment.id, !comment.resolved);
-  }, [comment.id, comment.resolved, onResolve]);
+  const handleResolveAs = useCallback((resolutionType: 'fixed' | 'ignored') => {
+    onResolve(comment.id, true, resolutionType);
+  }, [comment.id, onResolve]);
+
+  const handleUnresolve = useCallback(() => {
+    onResolve(comment.id, false);
+  }, [comment.id, onResolve]);
 
   const handleDelete = useCallback(() => {
     onDelete?.(comment.id);
   }, [comment.id, onDelete]);
 
-  const borderClass = getSeverityBorderClass(comment.severity);
+  const borderClass = comment.resolved ? 'border-l-muted-foreground/30' : getSeverityBorderClass(comment.severity);
 
   return (
     <div
@@ -122,26 +149,43 @@ export const CommentThread = memo(function CommentThread({
           <span className="text-muted-foreground text-xs shrink-0">
             {formatRelativeTime(comment.createdAt)}
           </span>
-          {comment.resolved && (
-            <span className="text-xs text-text-success shrink-0">
-              Resolved
-            </span>
-          )}
+          <StatusBadge comment={comment} />
         </div>
         <div className="flex items-center gap-1 shrink-0">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 w-6 p-0"
-            onClick={handleResolve}
-            title={comment.resolved ? 'Mark as unresolved' : 'Mark as resolved'}
-          >
-            {comment.resolved ? (
+          {comment.resolved ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 p-0"
+              onClick={handleUnresolve}
+              title="Mark as open"
+            >
               <CheckCircle2 className="w-4 h-4 text-text-success" />
-            ) : (
-              <Circle className="w-4 h-4 text-muted-foreground" />
-            )}
-          </Button>
+            </Button>
+          ) : (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  title="Resolve comment"
+                >
+                  <Circle className="w-4 h-4 text-muted-foreground" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuItem onClick={() => handleResolveAs('fixed')}>
+                  <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+                  Mark as Fixed
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleResolveAs('ignored')}>
+                  <MinusCircle className="h-3.5 w-3.5 text-muted-foreground" />
+                  Mark as Ignored
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
           {/* Only show delete for user-created comments */}
           {comment.source === 'user' && onDelete && (
             <Button
@@ -157,8 +201,8 @@ export const CommentThread = memo(function CommentThread({
         </div>
       </div>
 
-      {/* Content - rendered as markdown */}
-      <div className="prose prose-sm dark:prose-invert max-w-none text-sm text-foreground/90 break-words [&_pre]:my-1 [&_pre]:bg-muted/50 [&_pre]:text-xs [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1">
+      {/* Content - rendered as compact markdown */}
+      <div className={cn(PROSE_CLASSES_COMPACT, 'text-foreground/90 break-words')}>
         <CachedMarkdown cacheKey={`review-comment:${comment.id}`} content={comment.content} />
       </div>
     </div>

--- a/src/components/comments/ResolutionBadge.tsx
+++ b/src/components/comments/ResolutionBadge.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@/lib/utils';
+
+const RESOLUTION_STYLES = {
+  fixed: 'bg-green-500/15 text-green-600 dark:text-green-400 border-green-500/30',
+  ignored: 'bg-muted text-muted-foreground border-border',
+} as const;
+
+const SIZE_CLASSES = {
+  xs: 'text-2xs px-1 py-0',
+  sm: 'text-xs px-1.5 py-0',
+} as const;
+
+interface ResolutionBadgeProps {
+  type?: 'fixed' | 'ignored';
+  /** xs for card lists, sm for inline threads */
+  size?: 'xs' | 'sm';
+}
+
+export function ResolutionBadge({ type, size = 'xs' }: ResolutionBadgeProps) {
+  const resolvedType = type || 'fixed';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border font-medium capitalize shrink-0',
+        SIZE_CLASSES[size],
+        RESOLUTION_STYLES[resolvedType]
+      )}
+    >
+      {resolvedType}
+    </span>
+  );
+}

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -824,14 +824,14 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   }, [fileTabs, selectFileTab, updateFileTab]);
 
   // Handle resolving/unresolving a review comment
-  const handleResolveComment = useCallback(async (commentId: string, resolved: boolean) => {
+  const handleResolveComment = useCallback(async (commentId: string, resolved: boolean, resolutionType?: 'fixed' | 'ignored') => {
     if (!selectedWorkspaceId || !selectedSessionId) return;
     try {
       const updatedComment = await updateReviewComment(
         selectedWorkspaceId,
         selectedSessionId,
         commentId,
-        { resolved, resolvedBy: resolved ? 'You' : undefined }
+        { resolved, resolvedBy: resolved ? 'You' : undefined, resolutionType }
       );
       updateReviewCommentInStore(selectedSessionId, commentId, updatedComment);
     } catch (error) {

--- a/src/components/files/CodeViewer.tsx
+++ b/src/components/files/CodeViewer.tsx
@@ -20,7 +20,7 @@ interface CodeViewerProps {
   /** Review comments to display in diff view */
   comments?: ReviewComment[];
   /** Callback when a comment is resolved/unresolved */
-  onResolveComment?: (id: string, resolved: boolean) => void;
+  onResolveComment?: (id: string, resolved: boolean, resolutionType?: 'fixed' | 'ignored') => void;
   /** Callback when a comment is deleted */
   onDeleteComment?: (id: string) => void;
   /** Callback when a user creates a new comment on a diff line */

--- a/src/components/files/PierreDiffEditor.tsx
+++ b/src/components/files/PierreDiffEditor.tsx
@@ -28,7 +28,7 @@ interface PierreDiffEditorProps {
   newContent: string;
   filename: string;
   comments?: ReviewComment[];
-  onResolveComment?: (id: string, resolved: boolean) => void;
+  onResolveComment?: (id: string, resolved: boolean, resolutionType?: 'fixed' | 'ignored') => void;
   onDeleteComment?: (id: string) => void;
   onCreateComment?: (lineNumber: number, content: string) => void;
   /** Line number to scroll to (e.g. from review comment click) */

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -11,6 +11,7 @@ import { FileTree, FileIcon, type FileNode, type FileTreeHandle } from '@/compon
 import { TodoPanel } from '@/components/panels/TodoPanel';
 import { BudgetStatusPanel } from '@/components/panels/BudgetStatusPanel';
 import { ChecksPanel, type ChecksPanelHandle } from '@/components/panels/ChecksPanel';
+import { useToast } from '@/components/ui/toast';
 
 
 import { McpServersPanel } from '@/components/panels/McpServersPanel';
@@ -112,6 +113,7 @@ export function ChangesPanel() {
   const { agentTodos } = useTodoState(selectedConversationId, selectedSessionId);
   const commentStats = useFileCommentStats(selectedSessionId);
   const reviewComments = useReviewComments(selectedSessionId);
+  const { error: showError } = useToast();
   const sessions = useAppStore((s) => s.sessions);
   const workspaces = useAppStore((s) => s.workspaces);
   const updateSession = useAppStore((s) => s.updateSession);
@@ -535,22 +537,31 @@ export function ChangesPanel() {
     const unresolved = comments.filter((c) => !c.resolved);
     if (unresolved.length === 0) return;
 
-    // Optimistically resolve all
+    // Optimistically resolve all as "fixed"
     for (const comment of unresolved) {
       updateReviewComment(selectedSessionId, comment.id, {
         resolved: true,
         resolvedBy: 'user',
+        resolutionType: 'fixed',
       });
     }
 
-    // Fire API calls (best-effort, no rollback for bulk)
-    for (const comment of unresolved) {
-      apiUpdateReviewComment(selectedWorkspaceId, selectedSessionId, comment.id, {
-        resolved: true,
-        resolvedBy: 'user',
-      }).catch(console.error);
+    // Fire API calls and report failures
+    const results = await Promise.allSettled(
+      unresolved.map((comment) =>
+        apiUpdateReviewComment(selectedWorkspaceId, selectedSessionId, comment.id, {
+          resolved: true,
+          resolvedBy: 'user',
+          resolutionType: 'fixed',
+        })
+      )
+    );
+
+    const failedCount = results.filter((r) => r.status === 'rejected').length;
+    if (failedCount > 0) {
+      showError(`Failed to resolve ${failedCount} comment${failedCount > 1 ? 's' : ''}`);
     }
-  }, [selectedWorkspaceId, selectedSessionId, updateReviewComment]);
+  }, [selectedWorkspaceId, selectedSessionId, updateReviewComment, showError]);
 
   // Fetch files from session's worktree when session changes.
   // Decoupled from tab visibility so data is ready when the user switches tabs.

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -9,11 +9,11 @@ import {
   Info,
   CheckCircle2,
   MessageSquare,
-  Clock,
   FileCode,
   ChevronRight,
   ChevronDown,
-  Check,
+  Circle,
+  MinusCircle,
   Loader2,
   List,
   ListTree,
@@ -24,6 +24,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ResolutionBadge } from '@/components/comments/ResolutionBadge';
 import { formatTimeAgo } from '@/lib/format';
 import { useAppStore } from '@/stores/appStore';
 import {
@@ -103,8 +110,10 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
       return c.severity === filter;
     });
 
-    // Sort by severity priority (error > warning > suggestion > info), then by line number
+    // Sort: unresolved first, then by severity priority, file path, line number
     return filtered.sort((a, b) => {
+      // Resolved comments go to the bottom
+      if (a.resolved !== b.resolved) return a.resolved ? 1 : -1;
       const aPriority = SEVERITY_PRIORITY[a.severity || 'info'] ?? 3;
       const bPriority = SEVERITY_PRIORITY[b.severity || 'info'] ?? 3;
       if (aPriority !== bPriority) return aPriority - bPriority;
@@ -139,26 +148,53 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
     suggestion: unresolvedComments.filter((c) => c.severity === 'suggestion').length,
   };
 
-  const handleResolve = useCallback(
-    async (commentId: string) => {
+  const handleResolveAs = useCallback(
+    async (commentId: string, resolutionType: 'fixed' | 'ignored') => {
       if (!workspaceId || !sessionId) return;
 
       // Optimistically update the store immediately
       updateReviewComment(sessionId, commentId, {
         resolved: true,
         resolvedBy: 'user',
+        resolutionType,
       });
 
       try {
         await apiUpdateReviewComment(workspaceId, sessionId, commentId, {
           resolved: true,
           resolvedBy: 'user',
+          resolutionType,
         });
       } catch {
         // Revert optimistic update on failure
         updateReviewComment(sessionId, commentId, {
           resolved: false,
           resolvedBy: undefined,
+          resolutionType: undefined,
+        });
+      }
+    },
+    [workspaceId, sessionId, updateReviewComment]
+  );
+
+  const handleUnresolve = useCallback(
+    async (commentId: string) => {
+      if (!workspaceId || !sessionId) return;
+
+      updateReviewComment(sessionId, commentId, {
+        resolved: false,
+        resolvedBy: undefined,
+        resolutionType: undefined,
+      });
+
+      try {
+        await apiUpdateReviewComment(workspaceId, sessionId, commentId, {
+          resolved: false,
+        });
+      } catch {
+        updateReviewComment(sessionId, commentId, {
+          resolved: true,
+          resolvedBy: 'user',
         });
       }
     },
@@ -326,8 +362,8 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
                             key={comment.id}
                             comment={comment}
                             onNavigate={() => onFileSelect?.(comment.filePath, comment.lineNumber)}
-                            onResolve={() => handleResolve(comment.id)}
-                            isResolved={comment.resolved}
+                            onResolveAs={(type) => handleResolveAs(comment.id, type)}
+                            onUnresolve={() => handleUnresolve(comment.id)}
                           />
                         ))}
                       </div>
@@ -341,8 +377,7 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
                   key={comment.id}
                   comment={comment}
                   onNavigate={() => onFileSelect?.(comment.filePath, comment.lineNumber)}
-                  onResolve={() => handleResolve(comment.id)}
-                  isResolved={comment.resolved}
+                  onResolveAs={(type) => handleResolveAs(comment.id, type)}
                   showFilePath
                 />
               ))
@@ -371,17 +406,18 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
 function ReviewCommentCard({
   comment,
   onNavigate,
-  onResolve,
-  isResolved,
+  onResolveAs,
+  onUnresolve,
   showFilePath,
 }: {
   comment: ReviewComment;
   onNavigate: () => void;
-  onResolve?: () => void;
-  isResolved?: boolean;
+  onResolveAs?: (type: 'fixed' | 'ignored') => void;
+  onUnresolve?: () => void;
   showFilePath?: boolean;
 }) {
   const title = comment.title || comment.content.split('\n')[0];
+  const isResolved = comment.resolved;
 
   // Refresh relative timestamps every 60s
   const [, setTick] = useState(0);
@@ -410,43 +446,70 @@ function ReviewCommentCard({
     <div
       className={cn(
         'rounded-lg border p-2 transition-colors cursor-pointer',
-        isResolved ? 'opacity-50 border-border bg-surface-1' : severityColor
+        isResolved ? 'bg-muted/40 border-border/50' : severityColor
       )}
       onClick={onNavigate}
     >
       {/* Header row */}
-      <div className="flex items-start gap-2">
+      <div className="flex items-start gap-2 min-w-0">
         {isResolved ? (
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0 mt-0.5 text-green-500" />
         ) : (
           <SeverityIcon className="h-3.5 w-3.5 shrink-0 mt-0.5" />
         )}
         <div className="flex-1 min-w-0">
-          <div className={cn('font-medium text-xs leading-tight', isResolved && 'line-through')}>{title}</div>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className={cn('font-medium text-xs leading-tight truncate', isResolved && 'text-muted-foreground')}>{title}</span>
+            {isResolved && <ResolutionBadge type={comment.resolutionType} />}
+          </div>
         </div>
         <div className="flex items-center gap-0.5 shrink-0">
-          {!isResolved && (
+          {isResolved ? (
             <Button
               variant="ghost"
               size="sm"
-              className="h-5 w-5 p-0 hover:bg-green-500/20 hover:text-green-500"
+              className="h-5 w-5 p-0 hover:bg-foreground/10"
               onClick={(e) => {
                 e.stopPropagation();
-                onResolve?.();
+                onUnresolve?.();
               }}
-              title="Resolve comment"
+              title="Mark as open"
             >
-              <Check className="h-3 w-3" />
+              <CheckCircle2 className="h-3 w-3 text-green-500" />
             </Button>
+          ) : (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-5 w-5 p-0 hover:bg-foreground/10"
+                  onClick={(e) => e.stopPropagation()}
+                  title="Resolve comment"
+                >
+                  <Circle className="h-3 w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40" onClick={(e) => e.stopPropagation()}>
+                <DropdownMenuItem onClick={() => onResolveAs?.('fixed')}>
+                  <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+                  Mark as Fixed
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onResolveAs?.('ignored')}>
+                  <MinusCircle className="h-3.5 w-3.5 text-muted-foreground" />
+                  Mark as Ignored
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
       </div>
 
       {/* Footer row - location and time */}
-      <div className="flex items-center gap-2 mt-1 ml-5.5 text-2xs text-muted-foreground">
+      <div className="flex items-center gap-2 mt-1 ml-5.5 text-2xs text-muted-foreground min-w-0">
         {comment.lineNumber > 0 && (
           <span
-            className="truncate"
+            className="truncate min-w-0"
             title={showFilePath ? `${comment.filePath}:${comment.lineNumber}` : undefined}
           >
             {showFilePath
@@ -455,8 +518,7 @@ function ReviewCommentCard({
             }
           </span>
         )}
-        <span className="ml-auto flex items-center gap-0.5 shrink-0">
-          <Clock className="h-2.5 w-2.5" />
+        <span className="ml-auto shrink-0">
           {formatTimeAgo(comment.createdAt)}
         </span>
       </div>

--- a/src/components/panels/__tests__/ReviewPanel.test.tsx
+++ b/src/components/panels/__tests__/ReviewPanel.test.tsx
@@ -362,7 +362,7 @@ describe('ReviewPanel', () => {
         }),
         http.patch(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/comments/:commentId`, () => {
           patchCalled = true;
-          return HttpResponse.json(makeComment({ id: 'c-resolve-1', resolved: true, resolvedBy: 'user' }));
+          return HttpResponse.json(makeComment({ id: 'c-resolve-1', resolved: true, resolvedBy: 'user', resolutionType: 'fixed' }));
         })
       );
 
@@ -372,9 +372,12 @@ describe('ReviewPanel', () => {
         expect(screen.getByText('To resolve')).toBeInTheDocument();
       });
 
-      // Find and click the resolve button (checkmark icon)
+      // Find and click the resolve dropdown trigger, then select "Mark as Fixed"
       const resolveButton = screen.getByTitle('Resolve comment');
       await user.click(resolveButton);
+
+      const fixedOption = await screen.findByText('Mark as Fixed');
+      await user.click(fixedOption);
 
       await waitFor(() => {
         expect(patchCalled).toBe(true);
@@ -399,8 +402,12 @@ describe('ReviewPanel', () => {
         expect(screen.getByText('Will fail resolve')).toBeInTheDocument();
       });
 
+      // Open dropdown and select "Mark as Fixed"
       const resolveButton = screen.getByTitle('Resolve comment');
       await user.click(resolveButton);
+
+      const fixedOption = await screen.findByText('Mark as Fixed');
+      await user.click(fixedOption);
 
       // After API failure, the optimistic update should be reverted
       await waitFor(() => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1405,6 +1405,7 @@ export interface ReviewCommentDTO {
   resolved: boolean;
   resolvedAt?: string;
   resolvedBy?: string;
+  resolutionType?: 'fixed' | 'ignored';
 }
 
 export interface CommentStatsDTO {
@@ -1463,7 +1464,7 @@ export async function updateReviewComment(
   workspaceId: string,
   sessionId: string,
   commentId: string,
-  data: { resolved?: boolean; resolvedBy?: string }
+  data: { resolved?: boolean; resolvedBy?: string; resolutionType?: 'fixed' | 'ignored' }
 ): Promise<ReviewCommentDTO> {
   const res = await fetchWithAuth(
     `${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/comments/${commentId}`,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -26,6 +26,9 @@ export const GIT_STATUS_POLL_INTERVAL_MS = 30000; // 30 seconds
 // Shared Tailwind prose classes for markdown content rendering
 export const PROSE_CLASSES = 'prose prose-base dark:prose-invert max-w-none text-base leading-relaxed prose-p:my-3 prose-pre:my-2 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:font-semibold prose-headings:my-2 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-ul:marker:text-primary prose-ol:marker:text-primary';
 
+// Compact prose classes for inline comment threads and smaller markdown areas
+export const PROSE_CLASSES_COMPACT = 'prose prose-sm dark:prose-invert max-w-none text-sm leading-normal prose-p:my-1 prose-pre:my-1 prose-pre:bg-muted/50 prose-pre:border prose-pre:border-border/50 prose-pre:text-xs prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-headings:font-semibold prose-headings:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5 prose-ul:marker:text-primary prose-ol:marker:text-primary';
+
 // Tool rendering constants
 export const TOOL_TARGET_TRUNCATE = 60;
 export const TOOL_COMMAND_TRUNCATE = 80;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -675,6 +675,7 @@ export interface ReviewComment {
   resolved: boolean;
   resolvedAt?: string;
   resolvedBy?: string;
+  resolutionType?: 'fixed' | 'ignored';
 }
 
 // Comment statistics per file


### PR DESCRIPTION
## Summary
- Add `resolutionType` field (`fixed` / `ignored`) to review comments across backend model, SQLite store, API handlers, and frontend types
- Fix backend bug: `resolutionType` can now only be set when `resolved=true`, preventing inconsistent state
- Extract shared `ResolutionBadge` component from duplicate implementations in `ReviewPanel` and `CommentThread`
- Replace single-item dropdown with plain button for re-opening resolved comments in `CommentThread`
- Add re-open capability for resolved comments in `ReviewPanel` (was missing)
- Add error toast for bulk resolve failures in `ChangesPanel` using `Promise.allSettled`
- Add compact prose classes constant for inline comment markdown rendering
- Sort review comments with unresolved first, then by severity

## Test plan
- [ ] Resolve a comment as "Fixed" — verify badge shows "fixed" and backend stores `resolutionType`
- [ ] Resolve a comment as "Ignored" — verify badge shows "ignored"
- [ ] Re-open a resolved comment from the inline diff view (CommentThread) — verify single click works (no dropdown)
- [ ] Re-open a resolved comment from the Review sidebar panel — verify checkmark button works
- [ ] Bulk resolve all comments — verify toast appears if backend is unreachable
- [ ] Send `{ resolutionType: "fixed" }` without `resolved: true` to the API — verify it is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)