### PR TITLE
Fix file tab deferral and diff cache during session switch

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -102,28 +102,28 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   const selectedSessionId = useAppStore((s) => s.selectedSessionId);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
 
-  // Defer file tab rendering on session switch so the tab bar paints first.
-  // Only the active + previous tab mount their editors (max 2), so a single
-  // rAF is sufficient — the previous double-rAF was needed when ALL tabs mounted.
+  // Defer heavy file tab rendering on session switch for instant UI response.
+  // Shadow DOM + Shiki tokenization in the code viewer blocks startTransition;
+  // rendering a placeholder first lets the session switch paint immediately.
+  // We track a deferred session ID that catches up after a double-rAF, and
+  // derive readiness by comparing it to the current selected session.
   const [deferredSessionId, setDeferredSessionId] = useState(selectedSessionId);
   const fileTabsReady = deferredSessionId === selectedSessionId;
 
-  // Track the previously active file tab so we can keep it mounted alongside
-  // the current one. This avoids a visible remount flash when switching tabs.
-  // Uses "setState during render" pattern — React supports this and synchronously
-  // re-renders before committing, avoiding refs (forbidden by React Compiler).
-  const [prevFileTabId, setPrevFileTabId] = useState<string | null>(null);
-  const [trackedFileTabId, setTrackedFileTabId] = useState(selectedFileTabId);
-  if (selectedFileTabId !== trackedFileTabId) {
-    setPrevFileTabId(trackedFileTabId);
-    setTrackedFileTabId(selectedFileTabId);
-  }
-
   useEffect(() => {
-    const rafId = requestAnimationFrame(() => {
-      setDeferredSessionId(selectedSessionId);
+    // Double-rAF ensures the placeholder paints before we re-enable heavy
+    // rendering. A single rAF fires before the paint, so React may batch
+    // both state updates into one render, skipping the placeholder entirely.
+    let innerRafId: number;
+    const outerRafId = requestAnimationFrame(() => {
+      innerRafId = requestAnimationFrame(() => {
+        setDeferredSessionId(selectedSessionId);
+      });
     });
-    return () => cancelAnimationFrame(rafId);
+    return () => {
+      cancelAnimationFrame(outerRafId);
+      cancelAnimationFrame(innerRafId);
+    };
   }, [selectedSessionId]);
   // Session-scoped streaming state for the selected conversation only
   const selectedStreaming = useStreamingState(selectedConversationId);
@@ -1019,17 +1019,15 @@ export function ConversationArea({ children }: ConversationAreaProps) {
         sessionId={selectedSessionId}
       />
 
-      {/* Content Area - The active tab and the previously active tab are mounted
-           to avoid Shiki re-tokenization flash on tab switch. Other tabs are
-           unmounted to keep session switch fast. */}
+      {/* Content Area - File viewer and messages are BOTH rendered but only one is visible.
+           This keeps Pierre's Shadow DOM alive even when viewing a conversation,
+           avoiding expensive Shiki re-tokenization when switching back. */}
 
-      {/* File viewer — active + previous tab mount their editors, hidden when conversation is active */}
+      {/* File viewer — always rendered when tabs exist, hidden when conversation is active */}
       {visibleTabs.length > 0 && (
         <div className={isFileActive ? 'flex-1 min-h-0 relative' : 'hidden'}>
           {visibleTabs.map((tab) => {
             const isActive = tab.id === selectedFileTabId;
-            const isPrevious = tab.id === prevFileTabId && tab.id !== selectedFileTabId;
-            const shouldMount = isActive || isPrevious;
             const tabComments = tab.path === currentFilePath ? fileComments : [];
 
             return (
@@ -1037,103 +1035,100 @@ export function ConversationArea({ children }: ConversationAreaProps) {
                 key={tab.id}
                 className={isActive ? 'h-full' : 'hidden'}
               >
-                {/* Mount the editor for the active tab and the previous tab */}
-                {shouldMount && (
-                  <>
-                    {!fileTabsReady ? (
-                      <div className="h-full flex items-center justify-center">
-                        <div className="flex items-center gap-2 text-muted-foreground">
-                          <Loader2 className="w-4 h-4 animate-spin" />
-                          <span className="text-sm">Loading file...</span>
-                        </div>
+                {!fileTabsReady ? (
+                  isActive ? (
+                    <div className="h-full flex items-center justify-center">
+                      <div className="flex items-center gap-2 text-muted-foreground">
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        <span className="text-sm">Loading file...</span>
                       </div>
-                    ) : tab.loadError ? (
-                      <div className="h-full flex items-center justify-center">
-                        <div className="text-center max-w-md">
-                          <AlertCircle className="w-12 h-12 mx-auto mb-3 text-destructive/50" />
-                          <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
-                          <p className="text-xs text-muted-foreground mb-2">Failed to load file</p>
-                          <p className="text-xs text-destructive/70 mb-3">{tab.loadError}</p>
-                          <button
-                            className="text-xs text-muted-foreground hover:text-foreground transition-colors underline"
-                            onClick={() => updateFileTab(tab.id, {
-                              loadError: undefined,
-                              content: undefined,
-                              diff: undefined,
-                            })}
-                          >
-                            Retry
-                          </button>
-                        </div>
-                      </div>
-                    ) : tab.isBinary ? (
-                      <div className="h-full flex items-center justify-center">
-                        <div className="text-center">
-                          <FileQuestion className="w-12 h-12 mx-auto mb-3 text-muted-foreground/50" />
-                          <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
-                          <p className="text-xs text-muted-foreground">Binary file cannot be displayed</p>
-                        </div>
-                      </div>
-                    ) : tab.isTooLarge ? (
-                      <div className="h-full flex items-center justify-center">
-                        <div className="text-center">
-                          <FileQuestion className="w-12 h-12 mx-auto mb-3 text-muted-foreground/50" />
-                          <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
-                          <p className="text-xs text-muted-foreground">File is too large to display</p>
-                        </div>
-                      </div>
-                    ) : tab.isEmpty ? (
-                      <div className="h-full flex items-center justify-center">
-                        <div className="text-center">
-                          <File className="w-12 h-12 mx-auto mb-3 text-muted-foreground/50" />
-                          <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
-                          <p className="text-xs text-muted-foreground">This file is empty</p>
-                        </div>
-                      </div>
-                    ) : tab.viewMode === 'diff' && tab.diff ? (
-                      <ErrorBoundary
-                        resetKeys={[tab.id]}
-                        section="CodeViewer"
-                        fallback={
-                          <BlockErrorFallback
-                            icon={FileCode}
-                            title="Unable to load diff"
-                            description="There was an error rendering the file diff"
-                          />
-                        }
+                    </div>
+                  ) : null
+                ) : tab.loadError ? (
+                  <div className="h-full flex items-center justify-center">
+                    <div className="text-center max-w-md">
+                      <AlertCircle className="w-12 h-12 mx-auto mb-3 text-destructive/50" />
+                      <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
+                      <p className="text-xs text-muted-foreground mb-2">Failed to load file</p>
+                      <p className="text-xs text-destructive/70 mb-3">{tab.loadError}</p>
+                      <button
+                        className="text-xs text-muted-foreground hover:text-foreground transition-colors underline"
+                        onClick={() => updateFileTab(tab.id, {
+                          loadError: undefined,
+                          content: undefined,
+                          diff: undefined,
+                        })}
                       >
-                        <CodeViewer
-                          content={tab.diff.newContent}
-                          oldContent={tab.diff.oldContent}
-                          filename={tab.name}
-                          isLoading={tab.isLoading}
-                          comments={tabComments}
-                          onResolveComment={handleResolveComment}
-                          onDeleteComment={handleDeleteComment}
-                          onCreateComment={handleCreateComment}
-                          scrollToLine={tab.cursorPosition?.line}
-                        />
-                      </ErrorBoundary>
-                    ) : (
-                      <ErrorBoundary
-                        resetKeys={[tab.id]}
-                        section="CodeViewer"
-                        fallback={
-                          <BlockErrorFallback
-                            icon={FileCode}
-                            title="Unable to load file"
-                            description="There was an error rendering the file content"
-                          />
-                        }
-                      >
-                        <CodeViewer
-                          content={tab.content || ''}
-                          filename={tab.name}
-                          isLoading={tab.isLoading}
-                        />
-                      </ErrorBoundary>
-                    )}
-                  </>
+                        Retry
+                      </button>
+                    </div>
+                  </div>
+                ) : tab.isBinary ? (
+                  <div className="h-full flex items-center justify-center">
+                    <div className="text-center">
+                      <FileQuestion className="w-12 h-12 mx-auto mb-3 text-muted-foreground/50" />
+                      <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
+                      <p className="text-xs text-muted-foreground">Binary file cannot be displayed</p>
+                    </div>
+                  </div>
+                ) : tab.isTooLarge ? (
+                  <div className="h-full flex items-center justify-center">
+                    <div className="text-center">
+                      <FileQuestion className="w-12 h-12 mx-auto mb-3 text-muted-foreground/50" />
+                      <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
+                      <p className="text-xs text-muted-foreground">File is too large to display</p>
+                    </div>
+                  </div>
+                ) : tab.isEmpty ? (
+                  <div className="h-full flex items-center justify-center">
+                    <div className="text-center">
+                      <File className="w-12 h-12 mx-auto mb-3 text-muted-foreground/50" />
+                      <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
+                      <p className="text-xs text-muted-foreground">This file is empty</p>
+                    </div>
+                  </div>
+                ) : tab.viewMode === 'diff' && tab.diff ? (
+                  <ErrorBoundary
+                    resetKeys={[tab.id]}
+                    section="CodeViewer"
+                    fallback={
+                      <BlockErrorFallback
+                        icon={FileCode}
+                        title="Unable to load diff"
+                        description="There was an error rendering the file diff"
+                      />
+                    }
+                  >
+                    <CodeViewer
+                      content={tab.diff.newContent}
+                      oldContent={tab.diff.oldContent}
+                      filename={tab.name}
+                      isLoading={tab.isLoading}
+                      comments={tabComments}
+                      onResolveComment={handleResolveComment}
+                      onDeleteComment={handleDeleteComment}
+                      onCreateComment={handleCreateComment}
+                      scrollToLine={tab.cursorPosition?.line}
+                    />
+                  </ErrorBoundary>
+                ) : (
+                  <ErrorBoundary
+                    resetKeys={[tab.id]}
+                    section="CodeViewer"
+                    fallback={
+                      <BlockErrorFallback
+                        icon={FileCode}
+                        title="Unable to load file"
+                        description="There was an error rendering the file content"
+                      />
+                    }
+                  >
+                    <CodeViewer
+                      content={tab.content || ''}
+                      filename={tab.name}
+                      isLoading={tab.isLoading}
+                    />
+                  </ErrorBoundary>
                 )}
               </div>
             );


### PR DESCRIPTION
## Summary

- **Defer all tabs during session switch**, not just the active one. Previously, background tabs would still render expensive Shiki/Shadow DOM content during the deferral window, partially defeating the performance optimization.
- **Use double-rAF** for the deferral to ensure the placeholder actually paints before heavy rendering begins. A single rAF fires before paint, so React may batch both state updates into one render.
- **Remove previous-tab mount tracking** (`prevFileTabId`/`trackedFileTabId`) — all tabs now stay alive via CSS `hidden`, avoiding re-tokenization on tab switch without the complexity of tracking the previous tab.

## Test plan

- [ ] Switch between sessions with file tabs open — should see loading spinner briefly, then files render
- [ ] Switch between file tabs within a session — no flash or re-tokenization
- [ ] Open diff view tab, switch away and back — diff should still be rendered without delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)