### PR TITLE
Fix: auto-tag workflow dispatches release build

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -6,10 +6,11 @@ on:
     branches: [main]
 
 jobs:
-  tag:
+  tag-and-release:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
     permissions:
       contents: write
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,10 +19,26 @@ jobs:
         id: version
         run: |
           BRANCH="${{ github.event.pull_request.head.ref }}"
-          VERSION="${BRANCH#release/}"
-          echo "tag=$VERSION" >> $GITHUB_OUTPUT
+          TAG="${BRANCH#release/}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create and push tag
         run: |
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Trigger release workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: 'main',
+              inputs: {
+                version: '${{ steps.version.outputs.version }}'
+              }
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 0.1.0)'
+        required: true
 
 env:
   CARGO_INCREMENTAL: 0
@@ -21,9 +25,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get version from tag
+      - name: Get version
         id: get-version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create release
         id: create-release


### PR DESCRIPTION
## Summary
- Tags created by `GITHUB_TOKEN` don't trigger other workflows (GitHub security limitation)
- Auto-tag workflow now dispatches `release.yml` via `workflow_dispatch` with the version as input
- Release workflow accepts version from both tag push (`GITHUB_REF`) and dispatch input

## How it works now
1. `make release VERSION=x.y.z` → creates `release/vx.y.z` branch + PR
2. Merge the PR → auto-tag-release creates `vx.y.z` tag AND dispatches the Release workflow
3. Release workflow builds, signs, notarizes, and publishes

## Test plan
- [ ] Merge this PR
- [ ] Delete the stale v0.1.0 release and tag
- [ ] Run `make release VERSION=0.1.0` to test the full flow
- [ ] Verify Release workflow triggers and builds assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)