### PR TITLE
Fix: rust-action typo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary
- `dtolnay/rust-action` doesn't exist — should be `dtolnay/rust-toolchain` (matching ci.yml)
- This caused all 4 build-tauri jobs to fail at setup

## Test plan
- [ ] Merge this, then re-run the release flow
- [ ] All build-tauri matrix jobs should pass the "Setup Rust" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)