### PR TITLE
Fix: make auto-tag workflow idempotent

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Create and push tag
         run: |
+          git tag -d "${{ steps.version.outputs.tag }}" 2>/dev/null || true
+          git push origin ":refs/tags/${{ steps.version.outputs.tag }}" 2>/dev/null || true
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 


### PR DESCRIPTION
## Summary
- Delete existing remote tag before creating so re-runs don't fail with "tag already exists"
- This happened with v0.1.0: first auto-tag created the tag, release workflow failed (rust-action typo), second auto-tag couldn't overwrite the stale tag

## Test plan
- [ ] Merge this, then merge a release PR — auto-tag should succeed even if a stale tag exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)