### PR TITLE
Fix: force tauri-action to use npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
+          tauriScript: npx tauri
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}
 


### PR DESCRIPTION
## Summary
tauri-action auto-detects pnpm (likely from corepack on Node 24) even though the project uses npm. All 4 platform builds fail with `running pnpm [...] — pnpm is not recognized`.

Set `tauriScript: npx tauri` to explicitly use npm.

## Test plan
- [ ] Merge, then `make release VERSION=0.1.0` — all build-tauri jobs should use npx tauri

🤖 Generated with [Claude Code](https://claude.com/claude-code)