### PR TITLE
Fix: update updater pubkey and endpoint URL

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,9 +56,9 @@
       }
     },
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcyQTNBMzJBNjQ0ODgwOEMKUldTTWdFaGtLcU9qY21ldENlYWZweHlKYWswTTdIeHJNNHNKMURaTnU1MzVzWGJqR3gwWlMrUDMK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDA3MjIwMzg2RjQ0MUE0RjIKUldUeXBFSDBoZ01pQndRNVpUUUsvbHF1cUFZeFYwYVZtOUVMUU5pbVpMVmcreERTaFdScTU5aEoK",
       "endpoints": [
-        "https://github.com/chatml/app/releases/latest/download/latest.json"
+        "https://github.com/chatml/chatml/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"


### PR DESCRIPTION
## Summary
- Update updater signing pubkey to match regenerated key pair
- Fix endpoint URL from `chatml/app` to `chatml/chatml`

## Test plan
- [ ] Merge, then `make release VERSION=0.1.0` → release build should pass updater signing step

🤖 Generated with [Claude Code](https://claude.com/claude-code)