### PR TITLE
style: fix cargo fmt for sidecar PATH resolution

### DIFF
--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -199,7 +199,10 @@ pub fn spawn_sidecar(app: &tauri::AppHandle, state: &Arc<AppState>) -> AppResult
         {
             let user_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !user_path.is_empty() {
-                log::info!("Resolved user PATH for sidecar ({} entries)", user_path.matches(':').count() + 1);
+                log::info!(
+                    "Resolved user PATH for sidecar ({} entries)",
+                    user_path.matches(':').count() + 1
+                );
                 sidecar_command = sidecar_command.env("PATH", &user_path);
             }
         }


### PR DESCRIPTION
## Summary
- Fix `cargo fmt` formatting on the `log::info!` macro in the PATH resolution block

## Test plan
- [ ] CI passes (Tauri Format check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)