### PR TITLE
fix: guard against null commits in FileHistoryPanel

### DIFF
--- a/src/components/panels/FileHistoryPanel.tsx
+++ b/src/components/panels/FileHistoryPanel.tsx
@@ -81,7 +81,7 @@ export function FileHistoryPanel() {
     try {
       const data = await getFileCommitHistory(selectedWorkspaceId, selectedSessionId, currentFilePath);
       if (isMountedRef.current) {
-        setCommits(data.commits);
+        setCommits(data.commits ?? []);
       }
     } catch (err) {
       if (isMountedRef.current) {


### PR DESCRIPTION
## Summary
- The file history API can return `null` for the `commits` field, causing a `TypeError: null is not an object (evaluating 'commits.length')` crash in `FileHistoryPanel`
- Added a nullish coalescing fallback (`?? []`) when setting commits state to ensure it's always an array

## Test plan
- [ ] Open the file history panel and verify it loads without errors
- [ ] Confirm that files with no commit history show the empty state instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)