### PR TITLE
fix: use credential cascade for AI features in server handlers

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -2031,6 +2031,13 @@ func (m *Manager) newAIClient() ai.Provider {
 	return ai.NewClientWithOAuth(token)
 }
 
+// CreateAIClient returns an AI provider from the best available credential source,
+// or nil if no credentials are configured. This is the public entry point for
+// packages that need an AI client (e.g. server handlers).
+func (m *Manager) CreateAIClient() ai.Provider {
+	return m.newAIClient()
+}
+
 // generateAndApplySessionTitle uses the AI client to generate a session title
 // from the user's first message, then applies it to the conversation and session.
 func (m *Manager) generateAndApplySessionTitle(sessionID, convID, userMessage string) {

--- a/backend/server/conversation_handlers.go
+++ b/backend/server/conversation_handlers.go
@@ -652,8 +652,9 @@ func (h *Handlers) GenerateConversationSummary(w http.ResponseWriter, r *http.Re
 	}
 
 	// Check AI client is available
-	if h.aiClient == nil {
-		writeServiceUnavailable(w, "AI features not configured (missing ANTHROPIC_API_KEY)")
+	aiClient := h.getAIClient()
+	if aiClient == nil {
+		writeServiceUnavailable(w, "AI features not configured (no API key or Claude subscription found)")
 		return
 	}
 
@@ -732,7 +733,7 @@ func (h *Handlers) GenerateConversationSummary(w http.ResponseWriter, r *http.Re
 	// Generate asynchronously
 	go func() {
 		bgCtx := context.Background()
-		result, err := h.aiClient.GenerateConversationSummary(bgCtx, ai.GenerateSummaryRequest{
+		result, err := aiClient.GenerateConversationSummary(bgCtx, ai.GenerateSummaryRequest{
 			ConversationName: conv.Name,
 			Messages:         summaryMessages,
 		})

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -547,6 +547,19 @@ type Handlers struct {
 	scriptRunner     *scripts.Runner
 }
 
+// getAIClient returns an AI provider, checking the static client first,
+// then falling back to the agent manager's multi-source credential cascade
+// (stored API key → env var → Claude Code OAuth token).
+func (h *Handlers) getAIClient() ai.Provider {
+	if h.aiClient != nil {
+		return h.aiClient
+	}
+	if h.agentManager != nil {
+		return h.agentManager.CreateAIClient()
+	}
+	return nil
+}
+
 // GetProviderCapabilities returns the current AI agent provider's capabilities.
 func (h *Handlers) GetProviderCapabilities(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, agent.DefaultProvider())

--- a/backend/server/session_handlers.go
+++ b/backend/server/session_handlers.go
@@ -651,15 +651,17 @@ func (h *Handlers) UpdateSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Trigger archive summary generation when session is being archived
-	if req.Archived != nil && *req.Archived && h.aiClient != nil {
-		// Set generating status synchronously so the frontend sees it immediately
-		if err := h.store.UpdateSession(ctx, id, func(s *models.Session) {
-			s.ArchiveSummaryStatus = models.SummaryStatusGenerating
-		}); err != nil {
-			logger.Error.Errorf("Failed to set generating status for session %s: %v", id, err)
-		} else {
-			session.ArchiveSummaryStatus = models.SummaryStatusGenerating
-			go h.generateArchiveSummary(id)
+	if req.Archived != nil && *req.Archived {
+		if aiClient := h.getAIClient(); aiClient != nil {
+			// Set generating status synchronously so the frontend sees it immediately
+			if err := h.store.UpdateSession(ctx, id, func(s *models.Session) {
+				s.ArchiveSummaryStatus = models.SummaryStatusGenerating
+			}); err != nil {
+				logger.Error.Errorf("Failed to set generating status for session %s: %v", id, err)
+			} else {
+				session.ArchiveSummaryStatus = models.SummaryStatusGenerating
+				go h.generateArchiveSummary(id, aiClient)
+			}
 		}
 	}
 
@@ -710,7 +712,7 @@ func (h *Handlers) UpdateSession(w http.ResponseWriter, r *http.Request) {
 }
 
 // generateArchiveSummary fetches all conversations for a session and generates a combined summary.
-func (h *Handlers) generateArchiveSummary(sessionID string) {
+func (h *Handlers) generateArchiveSummary(sessionID string, aiClient ai.Provider) {
 	bgCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
@@ -775,7 +777,7 @@ func (h *Handlers) generateArchiveSummary(sessionID string) {
 		task = sess.Task
 	}
 
-	result, err := h.aiClient.GenerateSessionSummary(bgCtx, ai.GenerateSessionSummaryRequest{
+	result, err := aiClient.GenerateSessionSummary(bgCtx, ai.GenerateSessionSummaryRequest{
 		SessionName:   sessionName,
 		Task:          task,
 		Conversations: convMessages,


### PR DESCRIPTION
## Summary
- Add `getAIClient()` helper on `Handlers` that falls back to the agent manager's multi-source credential cascade (stored API key → env var → Claude Code OAuth token) when `h.aiClient` is nil
- Pass the resolved AI client into `generateArchiveSummary` to eliminate a TOCTOU race and throwaway client allocation
- Keep `newAIClient` unexported with a thin `CreateAIClient()` public wrapper to limit the API surface of the `agent` package

## Test plan
- [x] All 8 `TestNewAIClient_*` tests pass
- [x] Full `server` package test suite passes
- [x] `go build ./...` succeeds
- [ ] Manual: archive a session without a startup API key but with Claude Code OAuth credentials — verify summary generates

🤖 Generated with [Claude Code](https://claude.com/claude-code)