### PR TITLE
fix: prevent false-positive @mention pills in log/paste content

### DIFF
--- a/src/components/conversation/MentionText.tsx
+++ b/src/components/conversation/MentionText.tsx
@@ -8,8 +8,9 @@ interface MentionTextProps {
   className?: string;
 }
 
-// Regex pattern to match @filepath mentions (supports paths with slashes, dots, hyphens, underscores)
-const MENTION_PATTERN = /@([\w./-]+)/g;
+// Regex pattern to match @filepath mentions. Lookbehind ensures @ is not preceded by a word character,
+// aligning with MentionPlugin's triggerPreviousCharPattern which requires start-of-input, whitespace, or quote.
+const MENTION_PATTERN = /(?<!\w)@([\w./-]+)/g;
 
 /**
  * Renders text content with @mentions styled as pills.

--- a/src/components/conversation/__tests__/MentionText.test.tsx
+++ b/src/components/conversation/__tests__/MentionText.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MentionText } from '../MentionText';
+
+describe('MentionText', () => {
+  describe('legitimate mentions (should render pills)', () => {
+    it('renders mention at start of string', () => {
+      const { container } = render(<MentionText content="@src/Button.tsx" />);
+      const pill = container.querySelector('.inline-flex');
+      expect(pill).toBeInTheDocument();
+      expect(pill).toHaveTextContent('Button.tsx');
+    });
+
+    it('renders mention preceded by space', () => {
+      const { container } = render(
+        <MentionText content="Fix @src/Button.tsx please" />
+      );
+      const pill = container.querySelector('.inline-flex');
+      expect(pill).toBeInTheDocument();
+      expect(pill).toHaveTextContent('Button.tsx');
+    });
+
+    it('renders mention preceded by double quote', () => {
+      const { container } = render(
+        <MentionText content='Check "@src/Button.tsx" now' />
+      );
+      const pill = container.querySelector('.inline-flex');
+      expect(pill).toBeInTheDocument();
+      expect(pill).toHaveTextContent('Button.tsx');
+    });
+
+    it('renders mention preceded by single quote', () => {
+      const { container } = render(
+        <MentionText content="Check '@src/Button.tsx' now" />
+      );
+      const pill = container.querySelector('.inline-flex');
+      expect(pill).toBeInTheDocument();
+      expect(pill).toHaveTextContent('Button.tsx');
+    });
+
+    it('renders multiple mentions', () => {
+      const { container } = render(
+        <MentionText content="@src/a.ts and @src/b.ts" />
+      );
+      const pills = container.querySelectorAll('.inline-flex');
+      expect(pills).toHaveLength(2);
+      expect(pills[0]).toHaveTextContent('a.ts');
+      expect(pills[1]).toHaveTextContent('b.ts');
+    });
+
+    it('renders mention after newline', () => {
+      const { container } = render(
+        <MentionText content={'line1\n@src/file.ts'} />
+      );
+      const pill = container.querySelector('.inline-flex');
+      expect(pill).toBeInTheDocument();
+      expect(pill).toHaveTextContent('file.ts');
+    });
+  });
+
+  describe('false positives (should NOT render pills)', () => {
+    it('does not match pnpm path with @ in package name', () => {
+      const { container } = render(
+        <MentionText content="node_modules/.pnpm/next@16.1.6_babel" />
+      );
+      const pills = container.querySelectorAll('.inline-flex');
+      expect(pills).toHaveLength(0);
+    });
+
+    it('does not match pnpm path with multiple @ symbols', () => {
+      const { container } = render(
+        <MentionText content="core@7.29.0_react-dom@19.2.4_react@19.2.4" />
+      );
+      const pills = container.querySelectorAll('.inline-flex');
+      expect(pills).toHaveLength(0);
+    });
+
+    it('does not match email-like patterns', () => {
+      const { container } = render(
+        <MentionText content="user@example.com" />
+      );
+      const pills = container.querySelectorAll('.inline-flex');
+      expect(pills).toHaveLength(0);
+    });
+
+    it('does not match stack trace @ separator', () => {
+      const { container } = render(
+        <MentionText content="FileHistoryPanel@http://localhost:3100" />
+      );
+      const pills = container.querySelectorAll('.inline-flex');
+      expect(pills).toHaveLength(0);
+    });
+
+    it('does not match full pnpm dependency string from log', () => {
+      const content =
+        'node_modules/.pnpm/next@16.1.6_babel+core@7.29.0_react-dom@19.2.4_react@19.2.4__react-dom@19.2.4/node_modules/react-dom/cjs/react-dom-client.development.js';
+      const { container } = render(<MentionText content={content} />);
+      const pills = container.querySelectorAll('.inline-flex');
+      expect(pills).toHaveLength(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('renders plain text without @ as plain span', () => {
+      render(<MentionText content="No mentions here" />);
+      expect(screen.getByText('No mentions here')).toBeInTheDocument();
+    });
+
+    it('handles empty string', () => {
+      const { container } = render(<MentionText content="" />);
+      expect(container.querySelector('.inline-flex')).not.toBeInTheDocument();
+    });
+
+    it('does not match bare @ with no path after it', () => {
+      const { container } = render(<MentionText content="@ " />);
+      const pills = container.querySelectorAll('.inline-flex');
+      expect(pills).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds negative lookbehind `(?<!\w)` to `MentionText` regex so `@` preceded by a word character is no longer rendered as a mention pill
- Fixes false positives for pnpm dependency paths (`next@16.1.6`), email addresses (`user@example.com`), and stack traces (`Component@http://...`)
- Adds comprehensive test suite covering legitimate mentions, false-positive cases, and edge cases

## Test plan
- [ ] Run `npm run test` — new MentionText tests should pass
- [ ] Paste a log containing pnpm paths into a conversation and verify no spurious mention pills appear
- [ ] Verify legitimate `@file` mentions still render as pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)