### PR TITLE
fix: handle fish shell PATH format in sidecar

### DIFF
--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -193,15 +193,27 @@ pub fn spawn_sidecar(app: &tauri::AppHandle, state: &Arc<AppState>) -> AppResult
     // /usr/local/bin, or an nvm/fnm-managed path. Resolve the user's login shell PATH.
     {
         let shell_path = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        let is_fish = shell_path.ends_with("/fish");
+
+        // Fish shell outputs $PATH as space-separated list; other shells use colon-separated.
+        // Use a printf that always produces colon-separated output regardless of shell.
+        let path_cmd = if is_fish {
+            // In fish, $PATH is a list. Use string join to produce colon-separated output.
+            "string join : $PATH"
+        } else {
+            "echo $PATH"
+        };
+
         if let Ok(output) = Command::new(&shell_path)
-            .args(["-l", "-c", "echo $PATH"])
+            .args(["-l", "-c", path_cmd])
             .output()
         {
             let user_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !user_path.is_empty() {
                 log::info!(
-                    "Resolved user PATH for sidecar ({} entries)",
-                    user_path.matches(':').count() + 1
+                    "Resolved user PATH for sidecar ({} entries, shell={})",
+                    user_path.matches(':').count() + 1,
+                    shell_path
                 );
                 sidecar_command = sidecar_command.env("PATH", &user_path);
             }


### PR DESCRIPTION
## Summary
- Fish shell outputs `$PATH` as a space-separated list instead of colon-separated, causing the Go backend sidecar to fail finding `git` and `node`
- Detect fish shell and use `string join : $PATH` to produce correct colon-separated PATH format

## Implementation Details
- Added fish shell detection via `shell_path.ends_with("/fish")`
- Fish uses `string join : $PATH` to convert its list-type PATH to colon-separated format
- Other shells continue using `echo $PATH` unchanged
- Added shell name to the log message for easier debugging

## Test Plan
- [ ] Run `make dev` with `$SHELL` set to fish — verify backend can find `git` and `node`
- [ ] Run `make dev` with `$SHELL` set to zsh — verify no regression
- [ ] Verify branches load and messages send successfully

## Notes
Without this fix, all git and agent operations fail with `executable file not found in $PATH` for fish shell users.