### PR TITLE
fix: filter broken aliases in vscode-icons addCollection

### DIFF
--- a/src/lib/vscodeIcons.ts
+++ b/src/lib/vscodeIcons.ts
@@ -367,11 +367,25 @@ _usedIcons.add('default-file');
 _usedIcons.add('default-folder');
 _usedIcons.add('default-folder-opened');
 
+// Filter aliases to only those we reference, and pull in their parent icons.
+// Broken alias targets (pointing to filtered-out icons) cause addCollection to
+// silently discard the entire icon set.
+const { aliases: _allAliases, icons: _allIcons, ...iconsMeta } = vscodeIconsData;
+const _filteredAliases: Record<string, { parent: string }> = {};
+if (_allAliases) {
+  for (const [name, alias] of Object.entries(_allAliases) as [string, { parent: string }][]) {
+    if (_usedIcons.has(name)) {
+      _filteredAliases[name] = alias;
+      _usedIcons.add(alias.parent); // ensure the target icon is included
+    }
+  }
+}
 addCollection({
-  ...vscodeIconsData,
+  ...iconsMeta,
   icons: Object.fromEntries(
-    Object.entries(vscodeIconsData.icons).filter(([name]) => _usedIcons.has(name)),
+    Object.entries(_allIcons).filter(([name]) => _usedIcons.has(name)),
   ),
+  ...(Object.keys(_filteredAliases).length > 0 ? { aliases: _filteredAliases } : {}),
 });
 
 /**


### PR DESCRIPTION
## Summary
- **Root cause**: `addCollection({...vscodeIconsData, icons: filtered})` spread the full `aliases` property, which contained entries (`file-type-makefile` → `file-type-gnu`, `file-type-oxlint` → `file-type-oxc`) pointing to parent icons excluded by our subset filter. Iconify's `addCollection` silently discards the **entire** icon set when any alias target is missing — so zero icons were registered.
- **Fix**: Destructure out `aliases`, filter to only those we reference in our mappings, and pull their parent icons into the filter set so targets are always present.

## Test plan
- [x] Verified with Node.js test: `getIcon('vscode-icons:file-type-js-official')` returns `FOUND` after fix (was `NOT FOUND` before)
- [x] Verified alias resolution works: `getIcon('vscode-icons:file-type-makefile')` resolves through alias to `file-type-gnu`
- [x] `npm run build` passes cleanly
- [ ] Verify icons render in Tauri release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)