### PR TITLE
fix: spawn terminal as login shell and validate CWD

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "chatml"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -6498,9 +6498,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-pty"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f171506c49f603fd9c15b819e78b31a0016a447cfff8260af97801236930d1d"
+checksum = "5da8233d3c7b3581ff7da274d32b9145396da9d68bd16cedbbcb9a6908438be6"
 dependencies = [
  "portable-pty",
  "serde",

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -38,6 +38,13 @@ async function getShellFallbackChain(): Promise<string[]> {
   return defaults;
 }
 
+// On macOS/Linux, spawn shells as login shells so they read profile files
+// (e.g. ~/.zprofile, ~/.bash_profile) which set up PATH, Homebrew, etc.
+// This matches the behavior of Terminal.app, iTerm2, and other macOS terminals.
+function getShellArgs(): string[] {
+  return detectPlatform() === 'windows' ? [] : ['-l'];
+}
+
 // Terminal theme matching the app's dark theme
 const terminalTheme = {
   background: '#0f1111', // matches --background in dark mode
@@ -167,7 +174,24 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
         if (cleanupCalled) return;
 
         const shellChain = await getShellFallbackChain();
+        const shellArgs = getShellArgs();
+        let cwd = initialWorkspacePathRef.current || undefined;
         let lastError: unknown = null;
+
+        // Validate CWD exists — if not, fall back to no CWD (inherits parent process CWD).
+        // A non-existent CWD would cause ALL shell fallbacks to fail.
+        if (cwd) {
+          try {
+            const meta = await invoke<{ isDirectory: boolean }>('read_file_metadata', { path: cwd });
+            if (!meta.isDirectory) {
+              console.warn(`[PTY] CWD "${cwd}" is not a directory, falling back`);
+              cwd = undefined;
+            }
+          } catch {
+            console.warn(`[PTY] CWD "${cwd}" does not exist or is inaccessible, falling back`);
+            cwd = undefined;
+          }
+        }
 
         for (const shell of shellChain) {
           if (cleanupCalled) return;
@@ -175,10 +199,10 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
           try {
             // spawnPty is truly async — rejects if spawn fails,
             // enabling the fallback chain to catch and try the next shell
-            const pty = await spawnPty(shell, [], {
+            const pty = await spawnPty(shell, shellArgs, {
               cols: terminal.cols || 80,
               rows: terminal.rows || 24,
-              cwd: initialWorkspacePathRef.current || undefined,
+              cwd,
             });
 
             if (cleanupCalled) {


### PR DESCRIPTION
## Summary
- Spawn shells with `-l` (login) flag on macOS/Linux so profile files (~/.zprofile, ~/.bash_profile) are sourced — matches Terminal.app and iTerm2 behavior, ensuring PATH, Homebrew, and other env vars are available
- Validate workspace CWD exists and is a directory before PTY creation, falling back gracefully to parent process CWD instead of failing all shell fallbacks
- Bump `tauri-plugin-pty` from 0.1.1 to 0.2.1

## Test plan
- [ ] Open a terminal session in a valid workspace — shell should have full PATH (e.g. `which brew` works)
- [ ] Open a terminal for a workspace whose directory was deleted — should fall back gracefully instead of failing
- [ ] Verify terminal works on both macOS and Windows (Windows should not get `-l` flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)