### PR TITLE
fix: add OAuth beta header for Anthropic API authentication

### DIFF
--- a/backend/ai/generate.go
+++ b/backend/ai/generate.go
@@ -12,12 +12,13 @@ import (
 )
 
 const (
-	defaultModel  = "claude-sonnet-4-6"
-	haikuModel    = "claude-haiku-4-5-20251001"
-	anthropicURL  = "https://api.anthropic.com/v1/messages"
-	apiVersion    = "2023-06-01"
-	maxTokens     = 1024
-	clientTimeout = 60 * time.Second
+	defaultModel    = "claude-sonnet-4-6"
+	haikuModel      = "claude-haiku-4-5-20251001"
+	anthropicURL    = "https://api.anthropic.com/v1/messages"
+	apiVersion      = "2023-06-01"
+	oauthBetaHeader = "oauth-2025-04-20" // Required when authenticating with OAuth tokens
+	maxTokens       = 1024
+	clientTimeout   = 60 * time.Second
 )
 
 // Client is the Anthropic implementation of the Provider interface.
@@ -28,6 +29,7 @@ type Client struct {
 	httpClient *http.Client
 	model      string
 	apiURL     string // Override for testing; defaults to anthropicURL
+	isOAuth    bool   // When true, include the oauth beta header in requests
 }
 
 // AuthHeader returns the HTTP header name used for authentication (for testing).
@@ -38,6 +40,16 @@ func (c *Client) AuthValue() string { return c.authValue }
 
 // Name returns the provider name.
 func (c *Client) Name() string { return "anthropic" }
+
+// setCommonHeaders sets authentication, API version, and beta headers on an HTTP request.
+func (c *Client) setCommonHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(c.authHeader, c.authValue)
+	req.Header.Set("anthropic-version", apiVersion)
+	if c.isOAuth {
+		req.Header.Set("anthropic-beta", oauthBetaHeader)
+	}
+}
 
 // NewClient creates a new AI client using an API key (x-api-key header).
 // Returns nil if apiKey is empty.
@@ -55,6 +67,7 @@ func NewClient(apiKey string) *Client {
 }
 
 // NewClientWithOAuth creates a new AI client using an OAuth access token (Authorization: Bearer header).
+// The Anthropic API requires the "anthropic-beta: oauth-2025-04-20" header for OAuth authentication.
 // Returns nil if token is empty.
 func NewClientWithOAuth(accessToken string) *Client {
 	if accessToken == "" {
@@ -66,6 +79,7 @@ func NewClientWithOAuth(accessToken string) *Client {
 		httpClient: &http.Client{Timeout: clientTimeout},
 		model:      defaultModel,
 		apiURL:     anthropicURL,
+		isOAuth:    true,
 	}
 }
 
@@ -186,9 +200,7 @@ func (c *Client) GeneratePRDescription(ctx context.Context, req GeneratePRReques
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set(c.authHeader, c.authValue)
-	httpReq.Header.Set("anthropic-version", apiVersion)
+	c.setCommonHeaders(httpReq)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -308,9 +320,7 @@ func (c *Client) GenerateConversationSummary(ctx context.Context, req GenerateSu
 		return "", fmt.Errorf("creating request: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set(c.authHeader, c.authValue)
-	httpReq.Header.Set("anthropic-version", apiVersion)
+	c.setCommonHeaders(httpReq)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -378,9 +388,7 @@ func (c *Client) GenerateSessionTitle(ctx context.Context, userMessage string) (
 		return "", fmt.Errorf("creating request: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set(c.authHeader, c.authValue)
-	httpReq.Header.Set("anthropic-version", apiVersion)
+	c.setCommonHeaders(httpReq)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -569,9 +577,7 @@ func (c *Client) GenerateSessionSummary(ctx context.Context, req GenerateSession
 		return "", fmt.Errorf("creating request: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set(c.authHeader, c.authValue)
-	httpReq.Header.Set("anthropic-version", apiVersion)
+	c.setCommonHeaders(httpReq)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -765,9 +771,7 @@ func (c *Client) GenerateInputSuggestion(ctx context.Context, req SuggestionRequ
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set(c.authHeader, c.authValue)
-	httpReq.Header.Set("anthropic-version", apiVersion)
+	c.setCommonHeaders(httpReq)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {

--- a/backend/ai/generate_test.go
+++ b/backend/ai/generate_test.go
@@ -121,8 +121,10 @@ func TestNewClientWithOAuth_ValidToken(t *testing.T) {
 
 func TestNewClientWithOAuth_SendsBearerHeader(t *testing.T) {
 	var capturedAuthHeader string
+	var capturedBetaHeader string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedAuthHeader = r.Header.Get("Authorization")
+		capturedBetaHeader = r.Header.Get("anthropic-beta")
 		// x-api-key should NOT be set when using OAuth
 		assert.Empty(t, r.Header.Get("x-api-key"), "x-api-key should not be set for OAuth client")
 
@@ -145,6 +147,7 @@ func TestNewClientWithOAuth_SendsBearerHeader(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Fix login bug", title)
 	assert.Equal(t, "Bearer sk-ant-oat01-test-token", capturedAuthHeader)
+	assert.Equal(t, "oauth-2025-04-20", capturedBetaHeader, "OAuth clients must send the oauth beta header")
 }
 
 func TestNewClient_SendsApiKeyHeader(t *testing.T) {
@@ -153,6 +156,8 @@ func TestNewClient_SendsApiKeyHeader(t *testing.T) {
 		capturedApiKey = r.Header.Get("x-api-key")
 		// Authorization should NOT be set when using API key
 		assert.Empty(t, r.Header.Get("Authorization"), "Authorization should not be set for API key client")
+		// OAuth beta header should NOT be set when using API key
+		assert.Empty(t, r.Header.Get("anthropic-beta"), "anthropic-beta should not be set for API key client")
 
 		resp := anthropicResponse{
 			Content: []struct {


### PR DESCRIPTION
## Summary
- The Anthropic Messages API requires `anthropic-beta: oauth-2025-04-20` when authenticating with OAuth tokens — without it, the API returns 401 "OAuth authentication is currently not supported"
- This was silently breaking all Go backend AI features (session titles, PR descriptions, conversation/session summaries, input suggestions) for users authenticating via OAuth (i.e., most release builds)
- Added `isOAuth` flag to the AI client and a centralized `setCommonHeaders()` method that conditionally includes the beta header

## Root Cause
The Claude Code SDK includes this header (`OAUTH_BETA_HEADER = "oauth-2025-04-20"`) but our Go backend never sent it. API key authentication (`x-api-key`) doesn't need this header, which is why it worked during development when `ANTHROPIC_API_KEY` was set.

## Test plan
- [x] All existing backend tests pass (72 AI tests, full suite green)
- [x] Updated `TestNewClientWithOAuth_SendsBearerHeader` to verify the beta header IS sent
- [x] Updated `TestNewClient_SendsApiKeyHeader` to verify the beta header is NOT sent
- [x] Manually verified: `curl` with OAuth token + beta header returns 200, without returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)