### PR TITLE
feat: add project memory file management

### DIFF
--- a/backend/agent/memory.go
+++ b/backend/agent/memory.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ClaudeMemoryDir returns the path to the Claude SDK auto-memory directory
+// for the given working directory. The SDK convention is:
+//
+//	~/.claude/projects/<encoded-cwd>/memory/
+//
+// where <encoded-cwd> replaces "/" and " " with "-".
+func ClaudeMemoryDir(cwd string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	encoded := encodePathForClaude(cwd)
+	return filepath.Join(homeDir, ".claude", "projects", encoded, "memory"), nil
+}
+
+// encodePathForClaude encodes a filesystem path using the same convention as
+// the Claude Agent SDK: replace path separators and spaces with hyphens.
+// Example: "/Users/foo/my project" → "-Users-foo-my-project"
+func encodePathForClaude(p string) string {
+	p = strings.ReplaceAll(p, string(os.PathSeparator), "-")
+	p = strings.ReplaceAll(p, " ", "-")
+	return p
+}

--- a/backend/server/memory_handlers.go
+++ b/backend/server/memory_handlers.go
@@ -1,0 +1,234 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chatml/chatml-backend/agent"
+	"github.com/go-chi/chi/v5"
+)
+
+// MemoryFileInfo represents a memory file's metadata (for listing).
+type MemoryFileInfo struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+// MemoryFile represents a memory file with its content.
+type MemoryFile struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
+	Size    int64  `json:"size"`
+}
+
+// SaveMemoryFileRequest is the request body for creating/updating a memory file.
+type SaveMemoryFileRequest struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
+}
+
+// maxMemoryFileSize is the maximum allowed size for memory files (1MB).
+var maxMemoryFileSize int64 = 1 * 1024 * 1024
+
+// ListMemoryFiles returns all .md files in the workspace's Claude memory directory.
+func (h *Handlers) ListMemoryFiles(w http.ResponseWriter, r *http.Request) {
+	memDir, err := h.resolveMemoryDir(w, r)
+	if err != nil {
+		return // error already written
+	}
+
+	entries, err := os.ReadDir(memDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSON(w, []MemoryFileInfo{})
+			return
+		}
+		writeInternalError(w, "failed to read memory directory", err)
+		return
+	}
+
+	files := []MemoryFileInfo{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, MemoryFileInfo{
+			Name: entry.Name(),
+			Size: info.Size(),
+		})
+	}
+
+	writeJSON(w, files)
+}
+
+// GetMemoryFile returns the content of a specific memory file.
+func (h *Handlers) GetMemoryFile(w http.ResponseWriter, r *http.Request) {
+	memDir, err := h.resolveMemoryDir(w, r)
+	if err != nil {
+		return
+	}
+
+	name := r.URL.Query().Get("name")
+	if !isValidMemoryFileName(name) {
+		writeValidationError(w, "invalid file name: must be a .md file without path separators")
+		return
+	}
+
+	fullPath := filepath.Join(memDir, name)
+
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeNotFound(w, "memory file")
+			return
+		}
+		writeInternalError(w, "failed to stat memory file", err)
+		return
+	}
+
+	if info.Size() > maxMemoryFileSize {
+		writeValidationError(w, "file exceeds maximum size limit")
+		return
+	}
+
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		writeInternalError(w, "failed to read memory file", err)
+		return
+	}
+
+	writeJSON(w, MemoryFile{
+		Name:    name,
+		Content: string(content),
+		Size:    info.Size(),
+	})
+}
+
+// SaveMemoryFile creates or updates a memory file.
+func (h *Handlers) SaveMemoryFile(w http.ResponseWriter, r *http.Request) {
+	memDir, err := h.resolveMemoryDir(w, r)
+	if err != nil {
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxMemoryFileSize+4096)
+
+	var req SaveMemoryFileRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	if !isValidMemoryFileName(req.Name) {
+		writeValidationError(w, "invalid file name: must be a .md file without path separators")
+		return
+	}
+
+	if int64(len(req.Content)) > maxMemoryFileSize {
+		writeValidationError(w, "content exceeds maximum size limit")
+		return
+	}
+
+	// Create the memory directory if it doesn't exist
+	if err := os.MkdirAll(memDir, 0755); err != nil {
+		writeInternalError(w, "failed to create memory directory", err)
+		return
+	}
+
+	fullPath := filepath.Join(memDir, req.Name)
+
+	if err := os.WriteFile(fullPath, []byte(req.Content), 0644); err != nil {
+		writeInternalError(w, "failed to write memory file", err)
+		return
+	}
+
+	writeJSON(w, map[string]bool{"success": true})
+}
+
+// DeleteMemoryFile deletes a memory file.
+func (h *Handlers) DeleteMemoryFile(w http.ResponseWriter, r *http.Request) {
+	memDir, err := h.resolveMemoryDir(w, r)
+	if err != nil {
+		return
+	}
+
+	name := r.URL.Query().Get("name")
+	if !isValidMemoryFileName(name) {
+		writeValidationError(w, "invalid file name: must be a .md file without path separators")
+		return
+	}
+
+	fullPath := filepath.Join(memDir, name)
+
+	if _, err := os.Stat(fullPath); err != nil {
+		if os.IsNotExist(err) {
+			writeNotFound(w, "memory file")
+			return
+		}
+		writeInternalError(w, "failed to stat memory file", err)
+		return
+	}
+
+	if err := os.Remove(fullPath); err != nil {
+		writeInternalError(w, "failed to delete memory file", err)
+		return
+	}
+
+	writeJSON(w, map[string]bool{"success": true})
+}
+
+// resolveMemoryDir looks up the repo from the route and returns the Claude memory directory path.
+// On error it writes the HTTP response and returns an error.
+func (h *Handlers) resolveMemoryDir(w http.ResponseWriter, r *http.Request) (string, error) {
+	ctx := r.Context()
+	repoID := chi.URLParam(r, "id")
+
+	repo, err := h.store.GetRepo(ctx, repoID)
+	if err != nil {
+		writeDBError(w, err)
+		return "", err
+	}
+	if repo == nil {
+		writeNotFound(w, "workspace")
+		return "", os.ErrNotExist
+	}
+
+	memDir, err := agent.ClaudeMemoryDir(repo.Path)
+	if err != nil {
+		writeInternalError(w, "failed to resolve memory directory", err)
+		return "", err
+	}
+
+	return memDir, nil
+}
+
+// isValidMemoryFileName validates that a file name is safe:
+// - must end in .md
+// - must not contain path separators or ".."
+// - must not be empty
+func isValidMemoryFileName(name string) bool {
+	if name == "" {
+		return false
+	}
+	if !strings.HasSuffix(name, ".md") {
+		return false
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return false
+	}
+	// Ensure the name is just a filename, not a path
+	if filepath.Base(name) != name {
+		return false
+	}
+	return true
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -178,6 +178,11 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		r.Get("/{id}/issues", h.ListIssues)
 		r.With(searchRateLimiter).Get("/{id}/issues/search", h.SearchIssues)
 		r.Get("/{id}/issues/{number}", h.GetIssueDetails)
+		// Memory file endpoints (workspace-level)
+		r.Get("/{id}/memory", h.ListMemoryFiles)
+		r.Get("/{id}/memory/file", h.GetMemoryFile)
+		r.Put("/{id}/memory/file", h.SaveMemoryFile)
+		r.Delete("/{id}/memory/file", h.DeleteMemoryFile)
 		// MCP server config endpoints
 		r.Get("/{id}/mcp-servers", h.GetMcpServers)
 		r.Put("/{id}/mcp-servers", h.SetMcpServers)

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -24,6 +24,7 @@ import {
   X,
   ChevronDown,
   FolderOpen,
+  Brain,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { isMacOS } from '@/lib/platform';
@@ -90,6 +91,7 @@ const workspaceSubPages: WorkspaceSubPage[] = [
   { id: 'review', label: 'Review', icon: <Eye className="w-3.5 h-3.5" /> },
   { id: 'actions', label: 'Actions', icon: <Zap className="w-3.5 h-3.5" /> },
   { id: 'agents', label: 'AI Agents', icon: <Bot className="w-3.5 h-3.5" /> },
+  { id: 'memory', label: 'Memory', icon: <Brain className="w-3.5 h-3.5" /> },
 ];
 
 export function SettingsPage({

--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -51,6 +51,7 @@ import { Switch } from '@/components/ui/switch';
 import { SettingsGroup } from './shared/SettingsGroup';
 import { SettingsRow } from './shared/SettingsRow';
 import type { WorkspaceSettingsSection } from './settingsRegistry';
+import { MemorySettings } from './sections/MemorySettings';
 
 /**
  * Standalone content component for rendering workspace settings sections.
@@ -91,6 +92,9 @@ export function WorkspaceSettingsContent({ workspaceId, section }: {
       )}
       {section === 'agents' && (
         <WorkspaceAgentSettings workspaceId={workspaceId} />
+      )}
+      {section === 'memory' && (
+        <MemorySettings workspaceId={workspaceId} />
       )}
     </>
   );

--- a/src/components/settings/sections/MemorySettings.tsx
+++ b/src/components/settings/sections/MemorySettings.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toast';
+import { Plus, Trash2, RefreshCw } from 'lucide-react';
+import {
+  listMemoryFiles,
+  getMemoryFile,
+  saveMemoryFile,
+  deleteMemoryFile,
+  type MemoryFileInfo,
+} from '@/lib/api';
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+export function MemorySettings({ workspaceId }: { workspaceId: string }) {
+  const [files, setFiles] = useState<MemoryFileInfo[]>([]);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [content, setContent] = useState('');
+  const [savedContent, setSavedContent] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [newFileName, setNewFileName] = useState('');
+  const { error: showError } = useToast();
+
+  const loadFiles = useCallback(async () => {
+    try {
+      const data = await listMemoryFiles(workspaceId);
+      setFiles(data);
+      return data;
+    } catch {
+      // Memory directory may not exist yet — treat as empty
+      setFiles([]);
+      return [];
+    }
+  }, [workspaceId]);
+
+  const loadFileContent = useCallback(async (name: string) => {
+    try {
+      const file = await getMemoryFile(workspaceId, name);
+      setContent(file.content);
+      setSavedContent(file.content);
+      setSelectedFile(name);
+    } catch {
+      showError(`Failed to load ${name}`);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId]);
+
+  useEffect(() => {
+    setLoading(true);
+    loadFiles().then((data) => {
+      // Auto-select MEMORY.md if it exists
+      const memoryFile = data.find((f) => f.name === 'MEMORY.md');
+      if (memoryFile) {
+        loadFileContent('MEMORY.md');
+      }
+    }).finally(() => setLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId]);
+
+  const handleRefresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await loadFiles();
+      if (selectedFile) {
+        const stillExists = data.find((f) => f.name === selectedFile);
+        if (stillExists) {
+          await loadFileContent(selectedFile);
+        } else {
+          setSelectedFile(null);
+          setContent('');
+          setSavedContent('');
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [loadFiles, loadFileContent, selectedFile]);
+
+  const handleSave = useCallback(async () => {
+    if (!selectedFile) return;
+    setSaving(true);
+    try {
+      await saveMemoryFile(workspaceId, selectedFile, content);
+      setSavedContent(content);
+      await loadFiles();
+    } catch {
+      showError('Failed to save memory file');
+    } finally {
+      setSaving(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, selectedFile, content, loadFiles]);
+
+  const handleCreate = useCallback(async () => {
+    const name = newFileName.trim();
+    if (!name) return;
+    const fileName = name.endsWith('.md') ? name : `${name}.md`;
+    try {
+      await saveMemoryFile(workspaceId, fileName, '');
+      setNewFileName('');
+      setCreating(false);
+      await loadFiles();
+      await loadFileContent(fileName);
+    } catch {
+      showError('Failed to create memory file');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, newFileName, loadFiles, loadFileContent]);
+
+  const handleDelete = useCallback(async (name: string) => {
+    if (!window.confirm(`Delete ${name}?`)) return;
+    try {
+      await deleteMemoryFile(workspaceId, name);
+      if (selectedFile === name) {
+        setSelectedFile(null);
+        setContent('');
+        setSavedContent('');
+      }
+      await loadFiles();
+    } catch {
+      showError('Failed to delete memory file');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, selectedFile, loadFiles]);
+
+  const handleCreateMemory = useCallback(async () => {
+    try {
+      await saveMemoryFile(workspaceId, 'MEMORY.md', '');
+      await loadFiles();
+      await loadFileContent('MEMORY.md');
+    } catch {
+      showError('Failed to create MEMORY.md');
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, loadFiles, loadFileContent]);
+
+  const hasChanges = content !== savedContent;
+
+  if (loading && files.length === 0) {
+    return (
+      <div>
+        <h2 className="text-xl font-semibold mb-1">Project Memory</h2>
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-xl font-semibold">Project Memory</h2>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={handleRefresh}
+          disabled={loading}
+          title="Refresh"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground mb-6">
+        Memory files are loaded into the agent&apos;s context for every conversation.
+        They persist preferences, coding conventions, and project-specific knowledge across sessions.
+        Use the <code className="text-xs bg-muted px-1 py-0.5 rounded">/remember</code> command in chat to save memories.
+      </p>
+
+      {files.length === 0 && !creating ? (
+        <div className="border rounded-md p-6 text-center">
+          <p className="text-sm text-muted-foreground mb-3">
+            No memory files yet. Create MEMORY.md to get started.
+          </p>
+          <Button size="sm" onClick={handleCreateMemory}>
+            Create MEMORY.md
+          </Button>
+        </div>
+      ) : (
+        <>
+          {/* File list */}
+          <div className="border rounded-md divide-y mb-4">
+            {files.map((file) => (
+              <div
+                key={file.name}
+                className={`flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-muted/50 transition-colors ${
+                  selectedFile === file.name ? 'bg-muted' : ''
+                }`}
+                onClick={() => {
+                  if (hasChanges && !window.confirm('Discard unsaved changes?')) return;
+                  loadFileContent(file.name);
+                }}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-sm font-medium truncate">{file.name}</span>
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {formatSize(file.size)}
+                  </span>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete(file.name);
+                  }}
+                  title={`Delete ${file.name}`}
+                >
+                  <Trash2 className="w-3.5 h-3.5 text-muted-foreground" />
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          {/* New file input */}
+          {creating ? (
+            <div className="flex items-center gap-2 mb-4">
+              <Input
+                className="text-sm"
+                placeholder="filename.md"
+                value={newFileName}
+                onChange={(e) => setNewFileName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreate();
+                  if (e.key === 'Escape') {
+                    setCreating(false);
+                    setNewFileName('');
+                  }
+                }}
+                autoFocus
+              />
+              <Button size="sm" onClick={handleCreate} disabled={!newFileName.trim()}>
+                Create
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => { setCreating(false); setNewFileName(''); }}
+              >
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              className="mb-4"
+              onClick={() => setCreating(true)}
+            >
+              <Plus className="w-3.5 h-3.5 mr-1.5" />
+              New File
+            </Button>
+          )}
+
+          {/* Editor */}
+          {selectedFile && (
+            <div>
+              <div className="text-sm font-medium text-muted-foreground mb-2">
+                Editing: {selectedFile}
+              </div>
+              <Textarea
+                className="text-sm min-h-[300px] font-mono"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+              />
+              {hasChanges && (
+                <div className="mt-3 flex justify-end">
+                  <Button size="sm" disabled={saving} onClick={handleSave}>
+                    {saving ? 'Saving...' : 'Save'}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -10,7 +10,7 @@ export type SettingsCategory =
   | 'advanced'
   | 'about';
 
-export type WorkspaceSettingsSection = 'repository' | 'review' | 'actions' | 'agents';
+export type WorkspaceSettingsSection = 'repository' | 'review' | 'actions' | 'agents' | 'memory';
 
 export type SettingsView =
   | { type: 'app'; category: SettingsCategory }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1986,6 +1986,51 @@ export async function setCustomInstructions(instructions: string): Promise<void>
   await handleVoidResponse(res, 'Failed to save custom instructions');
 }
 
+// ==================== Memory API ====================
+
+export interface MemoryFileInfo {
+  name: string;
+  size: number;
+}
+
+export interface MemoryFileDTO {
+  name: string;
+  content: string;
+  size: number;
+}
+
+export async function listMemoryFiles(workspaceId: string): Promise<MemoryFileInfo[]> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/memory`);
+  return handleResponse<MemoryFileInfo[]>(res);
+}
+
+export async function getMemoryFile(workspaceId: string, name: string): Promise<MemoryFileDTO> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/memory/file?name=${encodeURIComponent(name)}`
+  );
+  return handleResponse<MemoryFileDTO>(res);
+}
+
+export async function saveMemoryFile(workspaceId: string, name: string, content: string): Promise<void> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/memory/file`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, content }),
+    }
+  );
+  await handleVoidResponse(res, 'Failed to save memory file');
+}
+
+export async function deleteMemoryFile(workspaceId: string, name: string): Promise<void> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/memory/file?name=${encodeURIComponent(name)}`,
+    { method: 'DELETE' }
+  );
+  await handleVoidResponse(res, 'Failed to delete memory file');
+}
+
 // ==================== Scripts API ====================
 
 import type { ChatMLConfig, ScriptRun } from '@/lib/types';

--- a/src/stores/slashCommandStore.ts
+++ b/src/stores/slashCommandStore.ts
@@ -101,6 +101,18 @@ const BUILTIN_COMMANDS: UnifiedSlashCommand[] = [
     executionType: 'prompt',
     execute: (ctx) => ctx.setMessage('Explain '),
   },
+  {
+    id: 'builtin:remember',
+    trigger: 'remember',
+    label: 'Remember',
+    description: 'Save something to project memory across sessions',
+    keywords: ['memory', 'save', 'note', 'persist', 'remember'],
+    icon: Sparkles,
+    source: 'builtin',
+    executionType: 'prompt',
+    available: requiresSession,
+    execute: (ctx) => ctx.setMessage('Save the following to your project memory (in MEMORY.md): '),
+  },
 
   // Git commands (fire actions)
   {


### PR DESCRIPTION
## Summary

- **Backend**: REST API endpoints (`GET/PUT/DELETE`) for managing Claude's auto-memory files at `~/.claude/projects/<encoded-cwd>/memory/`, with path traversal protection, symlink filtering, `.md`-only validation, and `MaxBytesReader` body size limits
- **Frontend**: New "Memory" section in workspace settings with file list, inline editor, create/delete actions, unsaved changes confirmation, and error-resilient loading states
- **Slash command**: `/remember` command to quickly save memories from chat

## Test plan

- [ ] Open workspace settings → Memory tab, verify files from `~/.claude/projects/.../memory/` are listed
- [ ] Create a new memory file, verify it appears on disk
- [ ] Edit and save a file, verify content persists
- [ ] Switch files with unsaved changes, verify confirmation dialog appears
- [ ] Delete a file, verify confirmation and removal
- [ ] Use `/remember` in chat, verify memory is saved
- [ ] Test with no memory directory yet (fresh workspace) — should show "Create MEMORY.md" prompt
- [ ] Verify large file uploads are rejected (>1MB body limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)