### PR TITLE
feat: add Check for Updates command to Command Palette

### DIFF
--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/command';
 import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { useUpdateStore } from '@/stores/updateStore';
 import { useShortcut } from '@/hooks/useShortcut';
 import { navigate } from '@/lib/navigation';
 import { copyToClipboard } from '@/lib/tauri';
@@ -44,6 +45,7 @@ import {
   ExternalLink,
   Terminal,
   RefreshCw,
+  Download,
   // Review
   Search,
   Shield,
@@ -399,6 +401,14 @@ const COMMANDS: Command[] = [
       const store = useSettingsStore.getState();
       store.setSoundEffects(!store.soundEffects);
     },
+  },
+  {
+    id: 'check-for-updates',
+    category: 'Settings',
+    label: 'Check for Updates',
+    icon: Download,
+    keywords: ['update', 'upgrade', 'version', 'release'],
+    action: () => useUpdateStore.getState().checkForUpdates(),
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds a **Check for Updates** command to the Command Palette (Settings category)
- Triggers the existing `updateStore.checkForUpdates()` — if an update is found, the UpdatePill automatically appears in the toolbar
- Searchable by keywords: update, upgrade, version, release

## Test plan
- [ ] Open Command Palette (`Cmd+K`), type "update", verify the command appears
- [ ] Select the command — verify the update check runs (UpdatePill appears if an update is available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)