### PR TITLE
feat: add setting to toggle branch sync banner notifications

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -58,6 +58,7 @@ import { BlockErrorFallback, InlineErrorFallback } from '@/components/shared/Err
 import { BranchSyncBanner } from '@/components/BranchSyncBanner';
 import { InterruptedBanner } from '@/components/conversation/InterruptedBanner';
 import { useBranchSync } from '@/hooks/useBranchSync';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { dispatchAppEvent, useAppEventListener } from '@/lib/custom-events';
 import { useClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
 import { SessionHandoffDialog } from '@/components/conversation/SessionHandoffDialog';
@@ -216,6 +217,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   }, [selectedConversationId, setMessagePage]);
 
   // Branch sync for updating from origin/main
+  const branchSyncBanner = useSettingsStore((s) => s.branchSyncBanner);
   const {
     status: branchSyncStatus,
     dismissed: branchSyncDismissed,
@@ -963,7 +965,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   return (
     <div className="flex-1 min-h-0 flex flex-col bg-chat-background">
       {/* Branch sync banner - shows when origin/main has updates */}
-      {branchSyncStatus && branchSyncStatus.behindBy > 0 && !branchSyncDismissed && (
+      {branchSyncBanner && branchSyncStatus && branchSyncStatus.behindBy > 0 && !branchSyncDismissed && (
         <BranchSyncBanner
           status={branchSyncStatus}
           loading={branchSyncing}

--- a/src/components/settings/sections/GitSettings.tsx
+++ b/src/components/settings/sections/GitSettings.tsx
@@ -16,6 +16,8 @@ function OverridableBadge() {
 }
 
 export function GitSettings() {
+  const branchSyncBanner = useSettingsStore((s) => s.branchSyncBanner);
+  const setBranchSyncBanner = useSettingsStore((s) => s.setBranchSyncBanner);
   const branchPrefixType = useSettingsStore((s) => s.branchPrefixType);
   const setBranchPrefixType = useSettingsStore((s) => s.setBranchPrefixType);
   const customPrefix = useSettingsStore((s) => s.branchPrefixCustom);
@@ -31,6 +33,22 @@ export function GitSettings() {
   return (
     <div>
       <h2 className="text-xl font-semibold mb-5">Git</h2>
+
+      <SettingsGroup label="Sync">
+        <SettingsRow
+          settingId="branchSyncBanner"
+          title="Branch sync notifications"
+          description="Show a banner when your branch is behind the base branch"
+          isModified={branchSyncBanner !== SETTINGS_DEFAULTS.branchSyncBanner}
+          onReset={() => setBranchSyncBanner(SETTINGS_DEFAULTS.branchSyncBanner)}
+        >
+          <Switch
+            checked={branchSyncBanner}
+            onCheckedChange={setBranchSyncBanner}
+            aria-label="Branch sync notifications"
+          />
+        </SettingsRow>
+      </SettingsGroup>
 
       <SettingsGroup label="Branches">
         <SettingsRow

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -218,6 +218,16 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
     categoryLabel: 'Instructions',
   },
 
+  // ── Git: Sync ──
+  {
+    id: 'branchSyncBanner',
+    title: 'Branch sync notifications',
+    description: 'Show a banner when your branch is behind the base branch',
+    keywords: ['branch', 'sync', 'rebase', 'merge', 'banner', 'notification', 'behind'],
+    category: 'git',
+    categoryLabel: 'Git',
+  },
+
   // ── Git: Branches ──
   {
     id: 'branchPrefixType',

--- a/src/hooks/useBranchSync.ts
+++ b/src/hooks/useBranchSync.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getBranchSyncStatus, syncBranch, abortBranchSync, BranchSyncStatusDTO, BranchSyncResultDTO } from '@/lib/api';
 import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
 
 // Cache TTL in milliseconds (30 seconds)
 const SYNC_STATUS_CACHE_TTL = 30_000;
@@ -58,6 +59,9 @@ export function useBranchSync(
   // Check sync status (with cache) - stable reference, no status dependency
   const checkStatus = useCallback(async (force = false) => {
     if (!workspaceId || !sessionId) return;
+
+    // Skip network calls when branch sync banner is disabled in settings
+    if (!useSettingsStore.getState().branchSyncBanner) return;
 
     // Skip if this session was just synced (prevents re-fetch after successful sync)
     if (justSyncedRef.current.has(sessionId)) {
@@ -202,6 +206,17 @@ export function useBranchSync(
       isMountedRef.current = false;
     };
   }, []);
+
+  // Re-check when the setting is toggled ON so the banner appears immediately
+  const branchSyncBanner = useSettingsStore((s) => s.branchSyncBanner);
+  const prevBannerRef = useRef(branchSyncBanner);
+  useEffect(() => {
+    if (branchSyncBanner && !prevBannerRef.current) {
+      checkStatus(true);
+    }
+    prevBannerRef.current = branchSyncBanner;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [branchSyncBanner]);
 
   // Check status on session change only (not on checkStatus change)
   // Deferred via requestIdleCallback so it doesn't block the initial render

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -92,6 +92,7 @@ export const SETTINGS_DEFAULTS = {
   // Git
   branchPrefixType: 'github' as BranchPrefixType,
   branchPrefixCustom: '',
+  branchSyncBanner: true,
   deleteBranchOnArchive: false,
   archiveOnMerge: false,
   // Account
@@ -125,6 +126,7 @@ interface SettingsState {
   theme: ThemeOption; // App theme (system, light, dark)
   fontSize: FontSize;
   // Git settings
+  branchSyncBanner: boolean;
   branchPrefixType: BranchPrefixType;
   branchPrefixCustom: string;
   deleteBranchOnArchive: boolean;
@@ -197,6 +199,7 @@ interface SettingsState {
   setShowChatCost: (value: boolean) => void;
   setTheme: (value: ThemeOption) => void;
   setFontSize: (value: FontSize) => void;
+  setBranchSyncBanner: (value: boolean) => void;
   setBranchPrefixType: (value: BranchPrefixType) => void;
   setBranchPrefixCustom: (value: string) => void;
   setDeleteBranchOnArchive: (value: boolean) => void;
@@ -292,6 +295,7 @@ export const useSettingsStore = create<SettingsState>()(
       setShowChatCost: (value) => set({ showChatCost: value }),
       setTheme: (value) => set({ theme: value }),
       setFontSize: (value) => set({ fontSize: value }),
+      setBranchSyncBanner: (value) => set({ branchSyncBanner: value }),
       setBranchPrefixType: (value) => set({ branchPrefixType: value }),
       setBranchPrefixCustom: (value) => set({ branchPrefixCustom: value }),
       setDeleteBranchOnArchive: (value) => set({ deleteBranchOnArchive: value }),


### PR DESCRIPTION
## Summary

- Adds a **Branch sync notifications** toggle to Git settings, allowing users to hide the "your branch is behind" banner
- Defaults to **enabled** so existing behavior is preserved on upgrade
- Skips network calls when disabled and reactively re-checks when toggled back on

## Changes Made

- **settingsStore.ts** — Added `branchSyncBanner` setting (default: `true`) with getter/setter
- **settingsRegistry.ts** — Registered setting metadata with search keywords
- **GitSettings.tsx** — Added "Sync" settings group with toggle switch
- **useBranchSync.ts** — Early-return in `checkStatus` when disabled; reactive effect to force-check when toggled on
- **ConversationArea.tsx** — Gate banner render on the new setting

## Test Plan

- [ ] Toggle setting OFF in Git settings → banner disappears, no network calls to `/branch-sync`
- [ ] Toggle setting ON → banner appears immediately if branch is behind
- [ ] Fresh install defaults to ON (banner shows as before)
- [ ] Existing users who haven't changed the setting see no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)