### PR TITLE
fix: resolve Pierre syntax highlighting in Tauri release builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  transpilePackages: [],
+  transpilePackages: ['@pierre/diffs', '@shikijs/core', '@shikijs/engine-javascript', '@shikijs/langs'],
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@shikijs/langs": "^3.22.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@iconify-json/vscode-icons": "^1.2.40",
     "@iconify/react": "^6.0.2",
     "@pierre/diffs": "^1.0.11",
+    "@shikijs/langs": "^3.22.0",
     "@platejs/combobox": "^52.0.15",
     "@platejs/mention": "^52.0.15",
     "@platejs/slash-command": "^52.0.15",

--- a/src/components/conversation/tool-details/CodeViewerDetail.tsx
+++ b/src/components/conversation/tool-details/CodeViewerDetail.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { memo, useMemo, useState, useCallback } from 'react';
-import { File as PierreFile } from '@pierre/diffs/react';
-import type { FileContents, FileOptions } from '@pierre/diffs/react';
+import { File as PierreFile } from '@/lib/pierre';
+import type { FileContents, FileOptions } from '@/lib/pierre';
 import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
 import { FileCode, WrapText } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/src/components/conversation/tool-details/EditToolDetail.tsx
+++ b/src/components/conversation/tool-details/EditToolDetail.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { memo, useMemo, useState, useCallback } from 'react';
-import { FileDiff } from '@pierre/diffs/react';
-import type { FileContents } from '@pierre/diffs/react';
-import type { FileDiffMetadata } from '@pierre/diffs';
-import { parseDiffFromFile } from '@pierre/diffs';
+import { FileDiff, parseDiffFromFile } from '@/lib/pierre';
+import type { FileContents, FileDiffMetadata } from '@/lib/pierre';
 import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
 import { FileCode, Rows, SplitSquareHorizontal, WrapText } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/src/components/conversation/tool-details/WorkspaceDiffDetail.tsx
+++ b/src/components/conversation/tool-details/WorkspaceDiffDetail.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { memo, useMemo, useState, useEffect, useCallback, useRef } from 'react';
-import { FileDiff } from '@pierre/diffs/react';
-import type { FileContents } from '@pierre/diffs/react';
-import type { FileDiffMetadata } from '@pierre/diffs';
-import { parseDiffFromFile } from '@pierre/diffs';
+import { FileDiff, parseDiffFromFile } from '@/lib/pierre';
+import type { FileContents, FileDiffMetadata } from '@/lib/pierre';
 import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
 import {
   ChevronRight,

--- a/src/components/files/PierreDiffEditor.tsx
+++ b/src/components/files/PierreDiffEditor.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { memo, useMemo, useDeferredValue, useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
-import { FileDiff } from '@pierre/diffs/react';
-import type { FileContents, DiffLineAnnotation } from '@pierre/diffs/react';
-import type { FileDiffOptions, FileDiffMetadata, OnDiffLineClickProps } from '@pierre/diffs';
-import { parseDiffFromFile } from '@pierre/diffs';
+import { FileDiff, parseDiffFromFile } from '@/lib/pierre';
+import type { FileContents, DiffLineAnnotation, FileDiffOptions, FileDiffMetadata, OnDiffLineClickProps } from '@/lib/pierre';
 import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
 import { FileCode, Rows, SplitSquareHorizontal, WrapText } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/src/components/files/PierreEditor.tsx
+++ b/src/components/files/PierreEditor.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { memo, useState, useMemo, useCallback } from 'react';
-import { File as PierreFile } from '@pierre/diffs/react';
-import type { FileContents, FileOptions } from '@pierre/diffs/react';
+import { File as PierreFile } from '@/lib/pierre';
+import type { FileContents, FileOptions } from '@/lib/pierre';
 import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
 import { FileCode, Eye, WrapText } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/src/components/shared/PierreWarmup.tsx
+++ b/src/components/shared/PierreWarmup.tsx
@@ -1,14 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { File as PierreFile } from '@pierre/diffs/react';
-import type { FileContents, FileOptions } from '@pierre/diffs/react';
+import { File as PierreFile } from '@/lib/pierre';
+import type { FileContents, FileOptions } from '@/lib/pierre';
 import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
-
-// Pre-load Pierre themes and common language grammars statically so they're
-// bundled at build time — avoids dynamic import() calls that fail in Tauri
-// release builds (same pattern as vscodeIcons.ts addCollection fix).
-import '@/lib/pierrePreload';
 
 const PIERRE_THEMES = { dark: 'pierre-dark', light: 'pierre-light' } as const;
 

--- a/src/lib/pierre.ts
+++ b/src/lib/pierre.ts
@@ -1,0 +1,27 @@
+/**
+ * Barrel module for Pierre (@pierre/diffs).
+ *
+ * The side-effect import of pierrePreload ensures that themes and language
+ * grammars are pre-populated in Pierre's internal Maps before any component
+ * tries to render. This prevents dynamic import() calls that fail in Tauri
+ * release builds.
+ *
+ * All Pierre consumers should import from '@/lib/pierre' instead of
+ * '@pierre/diffs' or '@pierre/diffs/react' directly.
+ */
+import '@/lib/pierrePreload';
+
+// ⚠️ DO NOT import from '@pierre/diffs' or '@pierre/diffs/react' directly.
+// Add new exports here so the pierrePreload side-effect always runs first.
+
+// React components
+export { File, FileDiff } from '@pierre/diffs/react';
+
+// Types from react entry
+export type { FileContents, FileOptions, DiffLineAnnotation } from '@pierre/diffs/react';
+
+// Utilities from main entry
+export { parseDiffFromFile } from '@pierre/diffs';
+
+// Types from main entry
+export type { FileDiffOptions, FileDiffMetadata, OnDiffLineClickProps } from '@pierre/diffs';


### PR DESCRIPTION
## Summary

- **Fix syntax highlighting broken in Tauri release builds** — `@pierre/diffs` uses dynamic `import()` to load Shiki themes and language grammars, which fails in bundled Tauri apps
- Centralize all Pierre imports through a barrel module (`src/lib/pierre.ts`) that guarantees static preloading runs before any component renders
- Add `@shikijs/langs` as an explicit dependency and to `transpilePackages`

## Changes Made

- **`src/lib/pierre.ts`** (new) — Barrel module that re-exports Pierre components/types with a side-effect import of `pierrePreload`, ensuring themes and grammars are pre-populated
- **`next.config.ts`** — Added `@pierre/diffs`, `@shikijs/core`, `@shikijs/engine-javascript`, `@shikijs/langs` to `transpilePackages`
- **`package.json`** — Added `@shikijs/langs` as an explicit dependency (was transitive)
- **6 component files** — Updated imports from `@pierre/diffs/react` and `@pierre/diffs` to `@/lib/pierre`
- **`PierreWarmup.tsx`** — Removed redundant explicit `pierrePreload` import (now handled by barrel)

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds
- [ ] `make dev` — verify syntax highlighting works in diff views and code viewers
- [ ] Tauri release build — verify syntax highlighting works (the actual bug scenario)


🤖 Generated with [Claude Code](https://claude.com/claude-code)