### PR TITLE
feat: add Import from Claude button for env vars in settings

### DIFF
--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -237,6 +237,7 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	r.Get("/api/settings/action-templates", h.GetActionTemplates)
 	r.Put("/api/settings/action-templates", h.SetActionTemplates)
 	r.Get("/api/settings/claude-auth-status", h.GetClaudeAuthStatus)
+	r.Get("/api/settings/claude-env", h.GetClaudeEnv)
 
 	// Attachment endpoints
 	r.Get("/api/attachments/{attachmentId}/data", h.GetAttachmentData)

--- a/backend/server/settings_handlers.go
+++ b/backend/server/settings_handlers.go
@@ -477,6 +477,25 @@ func (h *Handlers) GetClaudeAuthStatus(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// GetClaudeEnv reads ~/.claude/settings.json and returns the env vars defined there.
+// Returns an empty map if the file does not exist.
+func (h *Handlers) GetClaudeEnv(w http.ResponseWriter, r *http.Request) {
+	settings, err := ai.ReadClaudeCodeSettings()
+	if err != nil {
+		writeInternalError(w, "failed to read Claude settings", err)
+		return
+	}
+
+	env := map[string]string{}
+	if settings != nil && settings.Env != nil {
+		env = settings.Env
+	}
+
+	writeJSON(w, map[string]interface{}{
+		"env": env,
+	})
+}
+
 // settingKeyMcpServers returns the settings key for MCP servers in a workspace
 func settingKeyMcpServers(workspaceID string) string {
 	return "mcp-servers:" + workspaceID

--- a/backend/server/settings_handlers_test.go
+++ b/backend/server/settings_handlers_test.go
@@ -952,3 +952,59 @@ func TestGetClaudeAuthStatus_CliCredentialsFallbackToFile(t *testing.T) {
 	assert.Equal(t, true, result["hasCliCredentials"])
 	assert.Equal(t, "claude_subscription", result["credentialSource"])
 }
+
+func TestGetClaudeEnv_NoFile(t *testing.T) {
+	h, st := setupTestHandlers(t)
+	defer st.Close()
+
+	// HOME points to temp dir with no .claude/settings.json
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	req := httptest.NewRequest("GET", "/api/settings/claude-env", nil)
+	w := httptest.NewRecorder()
+	h.GetClaudeEnv(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	env, ok := result["env"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Empty(t, env)
+}
+
+func TestGetClaudeEnv_WithEnvVars(t *testing.T) {
+	h, st := setupTestHandlers(t)
+	defer st.Close()
+
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+
+	settings := `{
+		"env": {
+			"CLAUDE_CODE_USE_BEDROCK": "true",
+			"AWS_PROFILE": "core-dev",
+			"AWS_REGION": "us-east-1"
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(settings), 0o600))
+	t.Setenv("HOME", dir)
+
+	req := httptest.NewRequest("GET", "/api/settings/claude-env", nil)
+	w := httptest.NewRecorder()
+	h.GetClaudeEnv(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	env, ok := result["env"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "true", env["CLAUDE_CODE_USE_BEDROCK"])
+	assert.Equal(t, "core-dev", env["AWS_PROFILE"])
+	assert.Equal(t, "us-east-1", env["AWS_REGION"])
+}

--- a/src/components/settings/sections/AdvancedSettings.tsx
+++ b/src/components/settings/sections/AdvancedSettings.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { FolderOpen, ExternalLink, Download, Upload } from 'lucide-react';
 import { openFolderDialog } from '@/lib/tauri';
-import { getWorkspacesBasePath, setWorkspacesBasePath, getEnvSettings, setEnvSettings } from '@/lib/api';
+import { getWorkspacesBasePath, setWorkspacesBasePath, getEnvSettings, setEnvSettings, getClaudeEnv } from '@/lib/api';
 import { useToast } from '@/components/ui/toast';
 import { useSettingsStore, SETTINGS_DEFAULTS } from '@/stores/settingsStore';
 import { useTheme } from 'next-themes';
@@ -312,8 +312,10 @@ function EnvSection() {
   const [envVars, setEnvVarsLocal] = useState('');
   const [savedEnvVars, setSavedEnvVars] = useState('');
   const [saving, setSaving] = useState(false);
+  const [importing, setImporting] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const toasts = useToast();
 
   useEffect(() => {
     getEnvSettings()
@@ -342,6 +344,76 @@ function EnvSection() {
       setSaving(false);
     }
   }, [envVars, hasUnsavedChanges]);
+
+  const handleImportFromClaude = useCallback(async () => {
+    setImporting(true);
+    setSaveError(null);
+    try {
+      const claudeEnv = await getClaudeEnv();
+      const claudeKeys = Object.keys(claudeEnv);
+
+      if (claudeKeys.length === 0) {
+        toasts.info('No environment variables found in ~/.claude/settings.json');
+        return;
+      }
+
+      // Parse existing vars into a map so we can detect overwrites
+      const existingMap: Record<string, string> = {};
+      for (const line of envVars.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const eqIdx = trimmed.indexOf('=');
+        if (eqIdx > 0) {
+          existingMap[trimmed.substring(0, eqIdx).trim()] = trimmed.substring(eqIdx + 1);
+        }
+      }
+
+      // Track what actually changes
+      let added = 0;
+      let overwritten = 0;
+      const remaining = new Set(claudeKeys);
+
+      // Rebuild lines: update existing var lines in-place, preserve comments/blanks
+      const lines = envVars.split('\n');
+      const updatedLines = lines.map((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) return line; // preserve comments and blanks
+        const eqIdx = trimmed.indexOf('=');
+        if (eqIdx <= 0) return line;
+        const key = trimmed.substring(0, eqIdx).trim();
+        if (remaining.has(key)) {
+          remaining.delete(key);
+          if (existingMap[key] !== claudeEnv[key]) {
+            overwritten++;
+          }
+          return `${key}=${claudeEnv[key]}`;
+        }
+        return line;
+      });
+
+      // Append new vars that didn't exist yet
+      for (const key of remaining) {
+        added++;
+        updatedLines.push(`${key}=${claudeEnv[key]}`);
+      }
+
+      setEnvVarsLocal(updatedLines.join('\n'));
+
+      // Build a descriptive toast
+      const parts: string[] = [];
+      if (added > 0) parts.push(`${added} added`);
+      if (overwritten > 0) parts.push(`${overwritten} updated`);
+      if (parts.length === 0) {
+        toasts.info('All Claude env vars already match — no changes made');
+      } else {
+        toasts.success(`Imported from Claude settings: ${parts.join(', ')}`);
+      }
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to import Claude env vars');
+    } finally {
+      setImporting(false);
+    }
+  }, [envVars, toasts]);
 
   return (
     <SettingsRow
@@ -373,7 +445,17 @@ function EnvSection() {
       />
 
       <div className="flex items-center justify-between mt-3">
-        <div>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            disabled={importing || loading}
+            onClick={handleImportFromClaude}
+          >
+            <Download className="w-3.5 h-3.5" />
+            {importing ? 'Importing...' : 'Import from Claude'}
+          </Button>
           <p className="text-xs text-muted-foreground">
             One per line:{' '}
             <code className="px-1 py-0.5 bg-muted rounded text-xs font-mono">VAR_NAME=value</code>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1580,6 +1580,12 @@ export async function getEnvSettings(): Promise<string> {
   return data.envVars;
 }
 
+export async function getClaudeEnv(): Promise<Record<string, string>> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/claude-env`);
+  const data = await handleResponse<{ env: Record<string, string> }>(res);
+  return data.env;
+}
+
 export async function setEnvSettings(envVars: string): Promise<void> {
   const res = await fetchWithAuth(
     `${getApiBase()}/api/settings/env`,


### PR DESCRIPTION
## Summary
- Adds `GET /api/settings/claude-env` backend endpoint that reads env vars from `~/.claude/settings.json`
- Adds "Import from Claude" button in Advanced Settings → Environment Variables section
- Import merges intelligently: preserves comments/blank lines, updates existing vars in-place, appends new ones
- Toast accurately reports how many vars were added vs updated (or "no changes" if everything already matches)

## Test plan
- [ ] Verify import with no `~/.claude/settings.json` shows info toast
- [ ] Verify import with env vars merges correctly and preserves existing comments
- [ ] Verify toast shows accurate counts (e.g. "2 added, 1 updated")
- [ ] Verify importing when all vars already match shows "no changes" info toast
- [ ] Run `cd backend && go test ./...` — new tests for the endpoint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)