### PR TITLE
fix: resolve duplicate theme registration error

### DIFF
--- a/src/lib/pierrePreload.ts
+++ b/src/lib/pierrePreload.ts
@@ -40,10 +40,14 @@ if (!ResolvedThemes.has('pierre-light')) {
 
 // Also override the registered loaders so any code path that bypasses the
 // ResolvedThemes cache still gets static data instead of a failing import().
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-RegisteredCustomThemes.set('pierre-dark', () => Promise.resolve(pierreDarkRaw as any));
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-RegisteredCustomThemes.set('pierre-light', () => Promise.resolve(pierreLightRaw as any));
+if (!RegisteredCustomThemes.has('pierre-dark')) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RegisteredCustomThemes.set('pierre-dark', () => Promise.resolve(pierreDarkRaw as any));
+}
+if (!RegisteredCustomThemes.has('pierre-light')) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RegisteredCustomThemes.set('pierre-light', () => Promise.resolve(pierreLightRaw as any));
+}
 
 // --- Languages: statically import grammars for the languages we use ---
 // Each @shikijs/langs/* module default-exports a LanguageRegistration[].


### PR DESCRIPTION
## Summary
- Adds `has()` guards to `RegisteredCustomThemes.set()` calls in `pierrePreload.ts`, preventing the console error `SharedHighlight.registerCustomTheme: theme name already registered "pierre-dark"` that occurs during HMR module re-evaluation
- Matches the existing guard pattern already used for `ResolvedThemes` in the same file

## Test plan
- [ ] Run `npm run dev` and verify no "theme name already registered" console error on page load
- [ ] Verify Pierre syntax highlighting still works correctly for both dark and light themes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)