### PR TITLE
feat: upgrade Claude Agent SDK to 0.2.70, add supportsFastMode

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.62",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.70",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.62",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.62.tgz",
-      "integrity": "sha512-exRJ2djKP6erRpUrtnVf5iXzqeS9dAie9d1ghODZVVXdLqieSqCpaAhZhe0hL1yvP33OL0J5CgT9RAyPzhYY9A==",
+      "version": "0.2.70",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.70.tgz",
+      "integrity": "sha512-ABaB37jWt7dZXfIDHebHv99jX9GIyqc0aSjcz9nxq79eauOpa+64Cah5hx/yzhsWz7m5GEtjbMIZCClTfnRRhg==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -380,7 +380,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.62",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.70",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -980,9 +980,16 @@ function resetRunStats(): void {
 // HOOKS - All hooks are always enabled for comprehensive logging/tracking
 // ============================================================================
 
+// Extract agent_id / agent_type from hook inputs (SDK 0.2.69+ provides these on ALL hooks)
+function extractAgentFields(input: unknown): { agentId?: string; agentType?: string } {
+  const i = input as { agent_id?: string; agent_type?: string };
+  return { agentId: i.agent_id, agentType: i.agent_type };
+}
+
 const preToolUseHook: HookCallback = async (input, toolUseId) => {
   const hookInput = input as PreToolUseHookInput;
-  const agentId = sessionToAgentId.get(hookInput.session_id);
+  const agentFields = extractAgentFields(input);
+  const agentId = sessionToAgentId.get(hookInput.session_id) || agentFields.agentId;
 
   emit({
     type: "hook_pre_tool",
@@ -990,6 +997,7 @@ const preToolUseHook: HookCallback = async (input, toolUseId) => {
     tool: hookInput.tool_name,
     input: hookInput.tool_input,
     sessionId: hookInput.session_id,
+    ...agentFields,
   });
 
   // Capture Task tool descriptions for sub-agent description plumbing (Issue 3)
@@ -1041,6 +1049,7 @@ const postToolUseHook: HookCallback = async (input, toolUseId) => {
     tool: hookInput.tool_name,
     response: responseSummary,
     sessionId: hookInput.session_id,
+    ...extractAgentFields(input),
   });
 
   // When ExitPlanMode completes, the SDK internally changes the permission mode
@@ -1128,6 +1137,7 @@ const postToolUseFailureHook: HookCallback = async (input, toolUseId) => {
     error: hookInput.error,
     isInterrupt: hookInput.is_interrupt,
     sessionId: hookInput.session_id,
+    ...extractAgentFields(input),
   });
 
   // If this is a sub-agent tool, emit a tool_end event with success: false
@@ -1162,6 +1172,7 @@ const notificationHook: HookCallback = async (input) => {
     message: hookInput.message,
     notificationType: hookInput.notification_type,
     sessionId: hookInput.session_id,
+    ...extractAgentFields(input),
   });
   return {};
 };
@@ -1174,6 +1185,7 @@ const sessionStartHook: HookCallback = async (input) => {
     sessionId: hookInput.session_id,
     source: hookInput.source,
     cwd: hookInput.cwd,
+    ...extractAgentFields(input),
   });
   return {};
 };
@@ -1184,6 +1196,7 @@ const sessionEndHook: HookCallback = async (input) => {
     type: "session_ended",
     reason: hookInput.reason,
     sessionId: hookInput.session_id,
+    ...extractAgentFields(input),
   });
   return {};
 };
@@ -1194,6 +1207,7 @@ const stopHook: HookCallback = async (input) => {
     type: "agent_stop",
     stopHookActive: hookInput.stop_hook_active,
     sessionId: hookInput.session_id,
+    ...extractAgentFields(input),
   });
   return {};
 };
@@ -1205,6 +1219,7 @@ const preCompactHook: HookCallback = async (input) => {
     trigger: hookInput.trigger,
     customInstructions: hookInput.custom_instructions,
     sessionId: hookInput.session_id,
+    ...extractAgentFields(input),
   });
   return {};
 };

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -219,6 +219,7 @@ type ModelInfo struct {
 	SupportsEffort           *bool    `json:"supportsEffort,omitempty"`
 	SupportedEffortLevels    []string `json:"supportedEffortLevels,omitempty"`
 	SupportsAdaptiveThinking *bool    `json:"supportsAdaptiveThinking,omitempty"`
+	SupportsFastMode         *bool    `json:"supportsFastMode,omitempty"`
 }
 
 // SlashCmd represents a slash command/skill

--- a/src/hooks/__tests__/useWebSocket.events.test.ts
+++ b/src/hooks/__tests__/useWebSocket.events.test.ts
@@ -467,6 +467,19 @@ describe('useWebSocket — missing event handling', () => {
 
       expect(useAppStore.getState().supportedModels).toEqual(models);
     });
+
+    it('stores supportsFastMode field from SDK models', () => {
+      const models = [
+        { value: 'claude-opus-4-6', displayName: 'Opus 4.6', description: 'Most capable', supportsFastMode: true },
+        { value: 'claude-haiku-4-5', displayName: 'Haiku 4.5', description: 'Fast', supportsFastMode: false },
+      ];
+
+      useAppStore.getState().setSupportedModels(models);
+
+      const stored = useAppStore.getState().supportedModels;
+      expect(stored[0].supportsFastMode).toBe(true);
+      expect(stored[1].supportsFastMode).toBe(false);
+    });
   });
 
   describe('supported_commands event (Group J)', () => {

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1076,6 +1076,7 @@ export function useWebSocket(enabled: boolean = true) {
             supportsEffort?: boolean;
             supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
             supportsAdaptiveThinking?: boolean;
+            supportsFastMode?: boolean;
           }>);
         }
         break;

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -73,6 +73,45 @@ describe('getModelInfo', () => {
     expect(getModelInfo(arn)).toBeUndefined();
   });
 
+  it('returns supportsFastMode from dynamic SDK models', async () => {
+    const { useAppStore } = await import('@/stores/appStore');
+
+    const spy = vi.spyOn(useAppStore, 'getState').mockReturnValue({
+      ...useAppStore.getState(),
+      supportedModels: [
+        {
+          value: 'claude-opus-4-6',
+          displayName: 'Claude Opus 4.6',
+          description: 'Most capable',
+          supportsAdaptiveThinking: true,
+          supportsEffort: true,
+          supportedEffortLevels: ['low', 'medium', 'high', 'max'],
+          supportsFastMode: true,
+        },
+        {
+          value: 'claude-haiku-4-5-20251001',
+          displayName: 'Claude Haiku 4.5',
+          description: 'Fast',
+          supportsAdaptiveThinking: false,
+          supportsEffort: false,
+          supportsFastMode: false,
+        },
+      ],
+    } as ReturnType<typeof useAppStore.getState>);
+
+    try {
+      const opus = getModelInfo('claude-opus-4-6');
+      expect(opus).toBeDefined();
+      expect(opus!.supportsFastMode).toBe(true);
+
+      const haiku = getModelInfo('claude-haiku-4-5-20251001');
+      expect(haiku).toBeDefined();
+      expect(haiku!.supportsFastMode).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('returns correct capabilities for each static model', () => {
     for (const model of MODELS) {
       const info = getModelInfo(model.id);

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -16,6 +16,7 @@ export interface DynamicModelInfo {
   supportsThinking: boolean;
   supportsEffort: boolean;
   supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
+  supportsFastMode?: boolean;
 }
 
 /**
@@ -34,6 +35,7 @@ export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
       supportsThinking: sdkModel.supportsAdaptiveThinking ?? true,
       supportsEffort: sdkModel.supportsEffort ?? false,
       supportedEffortLevels: sdkModel.supportedEffortLevels,
+      supportsFastMode: sdkModel.supportsFastMode,
     };
   }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -290,6 +290,7 @@ interface AppState {
     supportsEffort?: boolean;
     supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
     supportsAdaptiveThinking?: boolean;
+    supportsFastMode?: boolean;
   }>;
   supportedCommands: Array<{ name: string; description: string; argumentHint: string }>;
   accountInfo: Record<string, unknown> | null;


### PR DESCRIPTION
## Summary
- **Upgrade** `@anthropic-ai/claude-agent-sdk` from 0.2.62 to 0.2.70
- **Plumb `agent_id`/`agent_type`** from SDK 0.2.69+ through all hook events via new `extractAgentFields` helper
- **Add `supportsFastMode`** capability flag across the full stack: Go parser (`ModelInfo`), WebSocket event handling, `DynamicModelInfo` interface, and Zustand store

## Test plan
- [ ] Verify `supportsFastMode` is correctly received from SDK and surfaced in `getModelInfo()`
- [ ] Verify `agent_id`/`agent_type` fields appear in hook event emissions
- [ ] Run `npm run test` — models.test.ts and useWebSocket.events.test.ts cover the new fields
- [ ] Run `cd agent-runner && npx tsc --noEmit` — type-checks clean
- [ ] Run `cd backend && go build ./...` — parser changes compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)