### PR TITLE
feat: add shared dev GitHub OAuth App for contributors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,12 @@
 # Get your API key at: https://console.anthropic.com/settings/keys
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# GitHub OAuth Configuration (optional — enables PR creation and CI/CD monitoring)
-# Create a GitHub OAuth App at: https://github.com/settings/developers
-# Set the Authorization callback URL to: chatml://oauth/callback
-# Note: Community contributors need their own GitHub OAuth App
-GITHUB_CLIENT_ID=your_github_client_id
-GITHUB_CLIENT_SECRET=your_github_client_secret
-NEXT_PUBLIC_GITHUB_CLIENT_ID=your_github_client_id
+# GitHub OAuth (shared development app — works out of the box)
+# These are credentials for a public dev-only OAuth App (separate from production).
+# Production builds use separate credentials injected via GitHub Actions secrets.
+GITHUB_CLIENT_ID=Ov23linEv8yjPM9K6bWa
+GITHUB_CLIENT_SECRET=bb3a749da6a9910285a01af5da23199f24cdac6b
+NEXT_PUBLIC_GITHUB_CLIENT_ID=Ov23linEv8yjPM9K6bWa
 
 # Linear OAuth Configuration (optional — enables issue tracking integration)
 # Create a Linear OAuth App at: https://linear.app/settings/api/applications

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to ChatML! This guide will help you 
    ```bash
    cp .env.example .env
    ```
-   Edit `.env` with your API keys and OAuth credentials (see [OAuth Setup](#oauth-setup) below).
+   Edit `.env` with your Anthropic API key. GitHub OAuth works out of the box (see [OAuth Setup](#oauth-setup)).
 
 3. **Start development**
    ```bash
@@ -58,16 +58,17 @@ npm run build              # TypeScript type checking + build
 
 ## OAuth Setup
 
-ChatML integrates with GitHub and Linear via OAuth. For development, you need your own OAuth apps.
+ChatML integrates with GitHub and Linear via OAuth.
 
-### GitHub OAuth App
+### GitHub OAuth
 
-1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
-2. Click "New OAuth App"
-3. Set **Authorization callback URL** to: `chatml://oauth/callback`
-4. Copy the Client ID and Client Secret to your `.env` file
+`.env.example` ships with a shared development OAuth App — just `cp .env.example .env` and GitHub OAuth works out of the box. No setup needed.
 
-### Linear OAuth App
+The dev OAuth App is separate from production. Production credentials are injected at build time via GitHub Actions secrets.
+
+### Linear OAuth
+
+Linear requires your own OAuth app:
 
 1. Go to [Linear API Applications](https://linear.app/settings/api/applications)
 2. Create a new application


### PR DESCRIPTION
## Summary
- Ship a dedicated dev-only GitHub OAuth App's credentials in `.env.example` so contributors get working OAuth out of the box with just `cp .env.example .env`
- Simplify `CONTRIBUTING.md` OAuth setup section — no more "create your own OAuth app" instructions for GitHub
- Production builds are unaffected (separate credentials via GitHub Actions secrets + `-ldflags`)

## Test plan
- [ ] `cp .env.example .env && make dev`
- [ ] Sign in with GitHub — full OAuth flow completes via `chatml://oauth/callback`
- [ ] Verify production release workflow still uses GitHub Actions secrets (no changes to `release.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)