### PR TITLE
feat: add .mcp.json trust gating for workspace MCP server configs

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -108,6 +108,9 @@ if (structuredOutputSchema) {
 // Target branch for PR base and sync operations
 const targetBranch = getArg("--target-branch");
 
+// Skip loading .mcp.json from workspace root (security: untrusted repo MCP config)
+const skipDotMcp = hasFlag("--skip-dot-mcp");
+
 // MCP servers configuration file (JSON array of server configs from backend)
 const mcpServersFilePath = getArg("--mcp-servers-file");
 
@@ -1591,18 +1594,23 @@ async function main(): Promise<void> {
     const mergedMcpServers: Record<string, McpServerConfig> = { chatml: chatmlMcp };
 
     // Load .mcp.json from worktree root (project-level config)
-    try {
-      const dotMcpPath = `${cwd}/.mcp.json`;
-      const dotMcpContent = readFileSync(dotMcpPath, "utf-8");
-      const dotMcpConfig = JSON.parse(dotMcpContent) as { mcpServers?: Record<string, McpServerConfig> };
-      if (dotMcpConfig.mcpServers) {
-        for (const [name, config] of Object.entries(dotMcpConfig.mcpServers)) {
-          mergedMcpServers[name] = config;
-          debug(`Loaded MCP server from .mcp.json: ${name}`);
+    // Gated by --skip-dot-mcp flag to prevent untrusted repos from executing commands
+    if (!skipDotMcp) {
+      try {
+        const dotMcpPath = `${cwd}/.mcp.json`;
+        const dotMcpContent = readFileSync(dotMcpPath, "utf-8");
+        const dotMcpConfig = JSON.parse(dotMcpContent) as { mcpServers?: Record<string, McpServerConfig> };
+        if (dotMcpConfig.mcpServers) {
+          for (const [name, config] of Object.entries(dotMcpConfig.mcpServers)) {
+            mergedMcpServers[name] = config;
+            debug(`Loaded MCP server from .mcp.json: ${name}`);
+          }
         }
+      } catch {
+        // .mcp.json doesn't exist or is invalid — that's fine
       }
-    } catch {
-      // .mcp.json doesn't exist or is invalid — that's fine
+    } else {
+      debug("Skipping .mcp.json loading (--skip-dot-mcp flag set)");
     }
 
     // Load user-configured MCP servers from backend (via temp file)

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -332,6 +332,14 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 		procOpts.McpServersJSON = mcpJSON
 	}
 
+	// Check .mcp.json trust for this workspace — skip loading unless explicitly trusted.
+	// Also respect the global "never load" kill switch.
+	neverLoadDotMcp, _, _ := m.store.GetSetting(ctx, "never-load-dot-mcp")
+	dotMcpTrust, _, _ := m.store.GetSetting(ctx, "dot-mcp-trust:"+session.WorkspaceID)
+	if neverLoadDotMcp == "true" || dotMcpTrust != "trusted" {
+		procOpts.SkipDotMcp = true
+	}
+
 	// Build programmatic agent definitions from workspace settings
 	agentsJSON := BuildAgentDefinitions(ctx, m.store.GetSetting, session.WorkspaceID, sessionWithWs.EffectiveTargetBranch())
 	if agentsJSON != "" {
@@ -1769,6 +1777,14 @@ func (m *Manager) ResumeConversation(ctx context.Context, convID string) error {
 		logger.Manager.Errorf("Failed to load MCP servers for resume %s: %v", convID, err)
 	}
 	opts.McpServersJSON = mcpServersJSON
+
+	// Check .mcp.json trust for this workspace — skip loading unless explicitly trusted.
+	// Also respect the global "never load" kill switch.
+	neverLoadDotMcp, _, _ := m.store.GetSetting(ctx, "never-load-dot-mcp")
+	dotMcpTrust, _, _ := m.store.GetSetting(ctx, "dot-mcp-trust:"+session.WorkspaceID)
+	if neverLoadDotMcp == "true" || dotMcpTrust != "trusted" {
+		opts.SkipDotMcp = true
+	}
 
 	// Build programmatic agent definitions from workspace settings
 	if sessionWithWs != nil {

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -56,6 +56,7 @@ type ProcessOptions struct {
 	Model               string // Model name override
 	FallbackModel       string // Fallback model name
 	TargetBranch        string // Target branch for PR base and sync (e.g. "origin/develop")
+	SkipDotMcp          bool              // Skip loading .mcp.json from workspace root (untrusted repo)
 	EnvVars             map[string]string // Custom environment variables to inject
 	McpServersJSON      string            // JSON array of MCP server configs
 	AgentsJSON          string            // JSON object of programmatic agent definitions (SDK 0.2.62+)
@@ -304,6 +305,9 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	}
 	if opts.TargetBranch != "" {
 		args = append(args, "--target-branch", opts.TargetBranch)
+	}
+	if opts.SkipDotMcp {
+		args = append(args, "--skip-dot-mcp")
 	}
 
 	// Spawn the Node agent runner

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -1158,3 +1158,60 @@ func TestProcess_EndTurnAndTakePending_AlreadyIdle(t *testing.T) {
 	assert.Nil(t, pending, "should return nil when already idle")
 	assert.False(t, p.IsInActiveTurn())
 }
+
+// ============================================================================
+// SkipDotMcp flag tests
+// ============================================================================
+
+func TestNewProcessWithOptions_SkipDotMcp(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "test-skip-dot-mcp",
+		Workdir:        "/tmp",
+		ConversationID: "conv-skip",
+		SkipDotMcp:     true,
+	}
+
+	p := NewProcessWithOptions(opts)
+
+	assert.Contains(t, p.cmd.Args, "--skip-dot-mcp", "args should contain --skip-dot-mcp when SkipDotMcp is true")
+}
+
+func TestNewProcessWithOptions_NoSkipDotMcp(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "test-no-skip-dot-mcp",
+		Workdir:        "/tmp",
+		ConversationID: "conv-no-skip",
+		SkipDotMcp:     false,
+	}
+
+	p := NewProcessWithOptions(opts)
+
+	assert.NotContains(t, p.cmd.Args, "--skip-dot-mcp", "args should NOT contain --skip-dot-mcp when SkipDotMcp is false")
+}
+
+func TestNewProcessWithOptions_SkipDotMcpPreservedInOptions(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "test-opts-preserve",
+		Workdir:        "/tmp",
+		ConversationID: "conv-preserve",
+		SkipDotMcp:     true,
+	}
+
+	p := NewProcessWithOptions(opts)
+	retrievedOpts := p.Options()
+
+	assert.True(t, retrievedOpts.SkipDotMcp, "SkipDotMcp should be preserved in Options()")
+}
+
+func TestNewProcessWithOptions_SkipDotMcpDefaultFalse(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "test-default",
+		Workdir:        "/tmp",
+		ConversationID: "conv-default",
+	}
+
+	p := NewProcessWithOptions(opts)
+
+	assert.False(t, p.Options().SkipDotMcp, "SkipDotMcp should default to false")
+	assert.NotContains(t, p.cmd.Args, "--skip-dot-mcp")
+}

--- a/backend/server/dot_mcp_trust_handlers_test.go
+++ b/backend/server/dot_mcp_trust_handlers_test.go
@@ -1,0 +1,439 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// GetDotMcpTrust
+// ============================================================================
+
+func TestGetDotMcpTrust_Unknown(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-trust", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "unknown", response["status"])
+}
+
+func TestGetDotMcpTrust_Trusted(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.SetSetting(ctx, "dot-mcp-trust:ws-1", "trusted"))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-trust", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "trusted", response["status"])
+}
+
+func TestGetDotMcpTrust_Denied(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.SetSetting(ctx, "dot-mcp-trust:ws-1", "denied"))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-trust", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "denied", response["status"])
+}
+
+func TestGetDotMcpTrust_InvalidValueReturnsUnknown(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	// Store an invalid value — should be treated as unknown
+	require.NoError(t, s.SetSetting(ctx, "dot-mcp-trust:ws-1", "garbage"))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-trust", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "unknown", response["status"])
+}
+
+func TestGetDotMcpTrust_WorkspaceIsolation(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.SetSetting(ctx, "dot-mcp-trust:ws-1", "trusted"))
+	// ws-2 has no trust setting
+
+	// ws-1 should be trusted
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-trust", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+	h.GetDotMcpTrust(w, req)
+	var resp1 map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp1))
+	assert.Equal(t, "trusted", resp1["status"])
+
+	// ws-2 should be unknown
+	req2 := httptest.NewRequest("GET", "/api/repos/ws-2/dot-mcp-trust", nil)
+	req2 = withChiContext(req2, map[string]string{"id": "ws-2"})
+	w2 := httptest.NewRecorder()
+	h.GetDotMcpTrust(w2, req2)
+	var resp2 map[string]string
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp2))
+	assert.Equal(t, "unknown", resp2["status"])
+}
+
+// ============================================================================
+// SetDotMcpTrust
+// ============================================================================
+
+func TestSetDotMcpTrust_Trusted(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	body, _ := json.Marshal(map[string]string{"status": "trusted"})
+	req := httptest.NewRequest("PUT", "/api/repos/ws-1/dot-mcp-trust", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.SetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "trusted", response["status"])
+
+	// Verify persisted
+	val, found, err := s.GetSetting(ctx, "dot-mcp-trust:ws-1")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "trusted", val)
+}
+
+func TestSetDotMcpTrust_Denied(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	body, _ := json.Marshal(map[string]string{"status": "denied"})
+	req := httptest.NewRequest("PUT", "/api/repos/ws-1/dot-mcp-trust", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.SetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	val, found, err := s.GetSetting(ctx, "dot-mcp-trust:ws-1")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "denied", val)
+}
+
+func TestSetDotMcpTrust_InvalidStatus(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	body, _ := json.Marshal(map[string]string{"status": "maybe"})
+	req := httptest.NewRequest("PUT", "/api/repos/ws-1/dot-mcp-trust", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.SetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSetDotMcpTrust_EmptyStatus(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	body, _ := json.Marshal(map[string]string{"status": ""})
+	req := httptest.NewRequest("PUT", "/api/repos/ws-1/dot-mcp-trust", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.SetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSetDotMcpTrust_InvalidBody(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("PUT", "/api/repos/ws-1/dot-mcp-trust", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.SetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSetDotMcpTrust_OverwriteExisting(t *testing.T) {
+	h, s := setupTestHandlers(t)
+	ctx := context.Background()
+
+	// Start as trusted
+	require.NoError(t, s.SetSetting(ctx, "dot-mcp-trust:ws-1", "trusted"))
+
+	// Revoke to denied
+	body, _ := json.Marshal(map[string]string{"status": "denied"})
+	req := httptest.NewRequest("PUT", "/api/repos/ws-1/dot-mcp-trust", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.SetDotMcpTrust(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	val, _, err := s.GetSetting(ctx, "dot-mcp-trust:ws-1")
+	require.NoError(t, err)
+	assert.Equal(t, "denied", val)
+}
+
+// ============================================================================
+// GetDotMcpInfo
+// ============================================================================
+
+func TestGetDotMcpInfo_NoFile(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	repoDir := t.TempDir()
+	createTestRepo(t, s, "ws-1", repoDir)
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-info", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, false, response["exists"])
+	servers := response["servers"].([]interface{})
+	assert.Empty(t, servers)
+}
+
+func TestGetDotMcpInfo_WithStdioServers(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	repoDir := t.TempDir()
+	createTestRepo(t, s, "ws-1", repoDir)
+
+	mcpConfig := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"test-server": map[string]interface{}{
+				"type":    "stdio",
+				"command": "npx",
+			},
+		},
+	}
+	data, _ := json.Marshal(mcpConfig)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".mcp.json"), data, 0644))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-info", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, true, response["exists"])
+
+	servers := response["servers"].([]interface{})
+	require.Len(t, servers, 1)
+
+	server := servers[0].(map[string]interface{})
+	assert.Equal(t, "test-server", server["name"])
+	assert.Equal(t, "stdio", server["type"])
+	assert.Equal(t, "npx", server["command"])
+}
+
+func TestGetDotMcpInfo_MultipleServers(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	repoDir := t.TempDir()
+	createTestRepo(t, s, "ws-1", repoDir)
+
+	mcpConfig := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"stdio-server": map[string]interface{}{
+				"type":    "stdio",
+				"command": "echo",
+			},
+			"sse-server": map[string]interface{}{
+				"type": "sse",
+				"url":  "http://localhost:3000",
+			},
+		},
+	}
+	data, _ := json.Marshal(mcpConfig)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".mcp.json"), data, 0644))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-info", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, true, response["exists"])
+
+	servers := response["servers"].([]interface{})
+	assert.Len(t, servers, 2)
+}
+
+func TestGetDotMcpInfo_DefaultsToStdioType(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	repoDir := t.TempDir()
+	createTestRepo(t, s, "ws-1", repoDir)
+
+	// Server config without explicit type — should default to "stdio"
+	mcpConfig := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"implicit-stdio": map[string]interface{}{
+				"command": "echo",
+			},
+		},
+	}
+	data, _ := json.Marshal(mcpConfig)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".mcp.json"), data, 0644))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-info", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	servers := response["servers"].([]interface{})
+	require.Len(t, servers, 1)
+	server := servers[0].(map[string]interface{})
+	assert.Equal(t, "stdio", server["type"])
+}
+
+func TestGetDotMcpInfo_InvalidJSON(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	repoDir := t.TempDir()
+	createTestRepo(t, s, "ws-1", repoDir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".mcp.json"), []byte("not json"), 0644))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-info", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, true, response["exists"])
+	servers := response["servers"].([]interface{})
+	assert.Empty(t, servers)
+}
+
+func TestGetDotMcpInfo_RepoNotFound(t *testing.T) {
+	h, _ := setupTestHandlers(t)
+
+	req := httptest.NewRequest("GET", "/api/repos/nonexistent/dot-mcp-info", nil)
+	req = withChiContext(req, map[string]string{"id": "nonexistent"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpInfo(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetDotMcpInfo_EmptyMcpServers(t *testing.T) {
+	h, s := setupTestHandlers(t)
+
+	repoDir := t.TempDir()
+	createTestRepo(t, s, "ws-1", repoDir)
+
+	mcpConfig := map[string]interface{}{
+		"mcpServers": map[string]interface{}{},
+	}
+	data, _ := json.Marshal(mcpConfig)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".mcp.json"), data, 0644))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-1/dot-mcp-info", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-1"})
+	w := httptest.NewRecorder()
+
+	h.GetDotMcpInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, true, response["exists"])
+	servers := response["servers"].([]interface{})
+	assert.Empty(t, servers)
+}

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -186,6 +186,10 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 		// MCP server config endpoints
 		r.Get("/{id}/mcp-servers", h.GetMcpServers)
 		r.Put("/{id}/mcp-servers", h.SetMcpServers)
+		// Workspace .mcp.json trust endpoints
+		r.Get("/{id}/dot-mcp-trust", h.GetDotMcpTrust)
+		r.Put("/{id}/dot-mcp-trust", h.SetDotMcpTrust)
+		r.Get("/{id}/dot-mcp-info", h.GetDotMcpInfo)
 		// Scripts config endpoints
 		r.Get("/{id}/config", h.GetWorkspaceConfig)
 		r.Put("/{id}/config", h.UpdateWorkspaceConfig)
@@ -238,6 +242,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	r.Put("/api/settings/action-templates", h.SetActionTemplates)
 	r.Get("/api/settings/claude-auth-status", h.GetClaudeAuthStatus)
 	r.Get("/api/settings/claude-env", h.GetClaudeEnv)
+	r.Get("/api/settings/never-load-dot-mcp", h.GetNeverLoadDotMcp)
+	r.Put("/api/settings/never-load-dot-mcp", h.SetNeverLoadDotMcp)
 
 	// Attachment endpoints
 	r.Get("/api/attachments/{attachmentId}/data", h.GetAttachmentData)

--- a/backend/server/settings_handlers.go
+++ b/backend/server/settings_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/chatml/chatml-backend/agent"
@@ -632,4 +633,147 @@ func (h *Handlers) SetEnabledAgents(w http.ResponseWriter, r *http.Request) {
 // GetAvailableAgents returns metadata about all built-in agents for the settings UI.
 func (h *Handlers) GetAvailableAgents(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, agent.AvailableAgents())
+}
+
+// GetNeverLoadDotMcp returns the global "never load .mcp.json" setting.
+func (h *Handlers) GetNeverLoadDotMcp(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	raw, _, err := h.store.GetSetting(ctx, "never-load-dot-mcp")
+	if err != nil {
+		writeInternalError(w, "failed to get never-load-dot-mcp setting", err)
+		return
+	}
+	writeJSON(w, map[string]bool{"enabled": raw == "true"})
+}
+
+// SetNeverLoadDotMcp updates the global "never load .mcp.json" setting.
+func (h *Handlers) SetNeverLoadDotMcp(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+	value := "false"
+	if body.Enabled {
+		value = "true"
+	}
+	if err := h.store.SetSetting(ctx, "never-load-dot-mcp", value); err != nil {
+		writeInternalError(w, "failed to save never-load-dot-mcp setting", err)
+		return
+	}
+	writeJSON(w, map[string]bool{"enabled": body.Enabled})
+}
+
+// settingKeyDotMcpTrust returns the settings key for .mcp.json trust status in a workspace.
+func settingKeyDotMcpTrust(workspaceID string) string {
+	return "dot-mcp-trust:" + workspaceID
+}
+
+// GetDotMcpTrust returns the .mcp.json trust status for a workspace.
+func (h *Handlers) GetDotMcpTrust(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	repoID := chi.URLParam(r, "id")
+
+	raw, found, err := h.store.GetSetting(ctx, settingKeyDotMcpTrust(repoID))
+	if err != nil {
+		writeInternalError(w, "failed to get dot-mcp trust status", err)
+		return
+	}
+
+	status := "unknown"
+	if found && (raw == "trusted" || raw == "denied") {
+		status = raw
+	}
+
+	writeJSON(w, map[string]string{"status": status})
+}
+
+// SetDotMcpTrust updates the .mcp.json trust status for a workspace.
+func (h *Handlers) SetDotMcpTrust(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	repoID := chi.URLParam(r, "id")
+
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	if body.Status != "trusted" && body.Status != "denied" {
+		writeValidationError(w, "status must be \"trusted\" or \"denied\"")
+		return
+	}
+
+	if err := h.store.SetSetting(ctx, settingKeyDotMcpTrust(repoID), body.Status); err != nil {
+		writeInternalError(w, "failed to save dot-mcp trust status", err)
+		return
+	}
+
+	writeJSON(w, map[string]string{"status": body.Status})
+}
+
+// DotMcpServerInfo describes a single server entry from a .mcp.json file.
+type DotMcpServerInfo struct {
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Command string `json:"command,omitempty"`
+}
+
+// GetDotMcpInfo checks whether a .mcp.json file exists in the workspace and returns its server list.
+func (h *Handlers) GetDotMcpInfo(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	repoID := chi.URLParam(r, "id")
+
+	repo, err := h.store.GetRepo(ctx, repoID)
+	if err != nil {
+		writeInternalError(w, "failed to get repo", err)
+		return
+	}
+	if repo == nil {
+		http.Error(w, "repo not found", http.StatusNotFound)
+		return
+	}
+
+	dotMcpPath := repo.Path + "/.mcp.json"
+	data, err := os.ReadFile(dotMcpPath)
+	if err != nil {
+		// File doesn't exist or is unreadable
+		writeJSON(w, map[string]interface{}{"exists": false, "servers": []DotMcpServerInfo{}})
+		return
+	}
+
+	var config struct {
+		McpServers map[string]struct {
+			Type    string `json:"type"`
+			Command string `json:"command"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		writeJSON(w, map[string]interface{}{"exists": true, "servers": []DotMcpServerInfo{}})
+		return
+	}
+
+	servers := make([]DotMcpServerInfo, 0, len(config.McpServers))
+	for name, s := range config.McpServers {
+		serverType := s.Type
+		if serverType == "" {
+			serverType = "stdio"
+		}
+		servers = append(servers, DotMcpServerInfo{
+			Name:    name,
+			Type:    serverType,
+			Command: s.Command,
+		})
+	}
+
+	slices.SortFunc(servers, func(a, b DotMcpServerInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	writeJSON(w, map[string]interface{}{"exists": true, "servers": servers})
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,7 @@ import { useFontSize } from '@/hooks/useFontSize';
 import { useReviewTrigger } from '@/hooks/useReviewTrigger';
 import { useMenuState } from '@/hooks/useMenuState';
 import { useMessagePrefetch } from '@/hooks/useMessagePrefetch';
+import { useDotMcpTrustCheck } from '@/hooks/useDotMcpTrustCheck';
 import { PierreWarmup } from '@/components/shared/PierreWarmup';
 import { useToast } from '@/components/ui/toast';
 import {
@@ -182,6 +183,9 @@ export default function Home() {
   const selectedSession = selectedSessionId
     ? sessions.find((s) => s.id === selectedSessionId)
     : null;
+
+  // ─── .mcp.json Trust Check ───────────────────────────────────────────
+  useDotMcpTrustCheck(workspaces, selectedWorkspaceId, dialogRef);
 
   // ─── Onboarding Window Size ───────────────────────────────────────────
   useOnboardingFlow(isInOnboarding, authLoading);

--- a/src/components/dialogs/DotMcpTrustDialog.tsx
+++ b/src/components/dialogs/DotMcpTrustDialog.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import type { DotMcpServerInfo } from '@/lib/api';
+
+interface DotMcpTrustDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceName: string;
+  servers: DotMcpServerInfo[];
+  onAllow: () => void;
+  onDeny: () => void;
+}
+
+export function DotMcpTrustDialog({
+  open,
+  onOpenChange,
+  workspaceName,
+  servers,
+  onAllow,
+  onDeny,
+}: DotMcpTrustDialogProps) {
+  const stdioServers = servers.filter((s) => s.type === 'stdio');
+  const hasStdio = stdioServers.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="sm:max-w-lg"
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Workspace MCP servers detected</DialogTitle>
+          <DialogDescription>
+            <span className="font-medium text-foreground">{workspaceName}</span> contains a{' '}
+            <code className="text-xs bg-muted px-1 py-0.5 rounded">.mcp.json</code> file that
+            defines MCP servers.
+            {hasStdio && ' Some of these servers will execute commands on your system.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2 py-2">
+          {servers.map((server) => (
+            <div
+              key={server.name}
+              className={`rounded-md border px-3 py-2 text-sm ${
+                server.type === 'stdio'
+                  ? 'border-orange-500/30 bg-orange-500/5'
+                  : 'border-border bg-muted/30'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{server.name}</span>
+                <span className="text-xs text-muted-foreground uppercase">{server.type}</span>
+              </div>
+              {server.command && (
+                <div className="mt-1 font-mono text-xs text-muted-foreground truncate">
+                  {server.command}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {hasStdio && (
+          <p className="text-xs text-orange-600 dark:text-orange-400">
+            Stdio servers run shell commands under your user account. Only allow this if you trust
+            the repository.
+          </p>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={onDeny}>
+            Deny
+          </Button>
+          <Button onClick={onAllow}>Allow</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dialogs/__tests__/DotMcpTrustDialog.test.tsx
+++ b/src/components/dialogs/__tests__/DotMcpTrustDialog.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DotMcpTrustDialog } from '../DotMcpTrustDialog';
+import type { DotMcpServerInfo } from '@/lib/api';
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  workspaceName: 'My Project',
+  servers: [] as DotMcpServerInfo[],
+  onAllow: vi.fn(),
+  onDeny: vi.fn(),
+};
+
+describe('DotMcpTrustDialog', () => {
+  it('renders title and workspace name', () => {
+    render(<DotMcpTrustDialog {...defaultProps} />);
+
+    expect(screen.getByText('Workspace MCP servers detected')).toBeInTheDocument();
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+  });
+
+  it('renders Allow and Deny buttons', () => {
+    render(<DotMcpTrustDialog {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Allow' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeInTheDocument();
+  });
+
+  it('displays stdio server with command', () => {
+    const servers: DotMcpServerInfo[] = [
+      { name: 'test-server', type: 'stdio', command: 'npx -y @mcp/test' },
+    ];
+
+    render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
+
+    expect(screen.getByText('test-server')).toBeInTheDocument();
+    expect(screen.getByText('stdio')).toBeInTheDocument();
+    expect(screen.getByText('npx -y @mcp/test')).toBeInTheDocument();
+  });
+
+  it('displays SSE server without command', () => {
+    const servers: DotMcpServerInfo[] = [
+      { name: 'sse-server', type: 'sse' },
+    ];
+
+    render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
+
+    expect(screen.getByText('sse-server')).toBeInTheDocument();
+    expect(screen.getByText('sse')).toBeInTheDocument();
+  });
+
+  it('displays multiple servers', () => {
+    const servers: DotMcpServerInfo[] = [
+      { name: 'server-a', type: 'stdio', command: 'echo' },
+      { name: 'server-b', type: 'http' },
+    ];
+
+    render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
+
+    expect(screen.getByText('server-a')).toBeInTheDocument();
+    expect(screen.getByText('server-b')).toBeInTheDocument();
+  });
+
+  it('shows warning when stdio servers are present', () => {
+    const servers: DotMcpServerInfo[] = [
+      { name: 'cmd-server', type: 'stdio', command: 'rm -rf /' },
+    ];
+
+    render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
+
+    expect(screen.getByText(/run shell commands/i)).toBeInTheDocument();
+    expect(screen.getByText(/trust the repository/i)).toBeInTheDocument();
+  });
+
+  it('does not show stdio warning when only non-stdio servers', () => {
+    const servers: DotMcpServerInfo[] = [
+      { name: 'safe-server', type: 'sse' },
+    ];
+
+    render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
+
+    expect(screen.queryByText(/run shell commands/i)).not.toBeInTheDocument();
+  });
+
+  it('calls onAllow when Allow is clicked', async () => {
+    const onAllow = vi.fn();
+    const user = userEvent.setup();
+
+    render(<DotMcpTrustDialog {...defaultProps} onAllow={onAllow} />);
+
+    await user.click(screen.getByRole('button', { name: 'Allow' }));
+    expect(onAllow).toHaveBeenCalledOnce();
+  });
+
+  it('calls onDeny when Deny is clicked', async () => {
+    const onDeny = vi.fn();
+    const user = userEvent.setup();
+
+    render(<DotMcpTrustDialog {...defaultProps} onDeny={onDeny} />);
+
+    await user.click(screen.getByRole('button', { name: 'Deny' }));
+    expect(onDeny).toHaveBeenCalledOnce();
+  });
+
+  it('does not render when open is false', () => {
+    render(<DotMcpTrustDialog {...defaultProps} open={false} />);
+
+    expect(screen.queryByText('Workspace MCP servers detected')).not.toBeInTheDocument();
+  });
+
+  it('mentions .mcp.json in description', () => {
+    render(<DotMcpTrustDialog {...defaultProps} />);
+
+    expect(screen.getByText('.mcp.json')).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/DialogManager.tsx
+++ b/src/components/layout/DialogManager.tsx
@@ -13,10 +13,12 @@ import { GitHubReposDialog } from '@/components/dialogs/GitHubReposDialog';
 import { CloseTabConfirmDialog } from '@/components/dialogs/CloseTabConfirmDialog';
 import { CloseFileConfirmDialog } from '@/components/dialogs/CloseFileConfirmDialog';
 import { KeyboardShortcutsDialog } from '@/components/dialogs/KeyboardShortcutsDialog';
+import { DotMcpTrustDialog } from '@/components/dialogs/DotMcpTrustDialog';
 import { FilePicker } from '@/components/dialogs/FilePicker';
 import { WorkspaceSearch } from '@/components/dialogs/WorkspaceSearch';
 import { CommandPalette } from '@/components/dialogs/CommandPalette';
-import type { RepoDTO } from '@/lib/api';
+import type { RepoDTO, DotMcpServerInfo } from '@/lib/api';
+import { setDotMcpTrust } from '@/lib/api';
 
 interface DialogManagerProps {
   selectedWorkspaceId: string | null;
@@ -65,6 +67,12 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
   const [showCloneFromUrl, setShowCloneFromUrl] = useState(false);
   const [showGitHubRepos, setShowGitHubRepos] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [dotMcpTrustState, setDotMcpTrustState] = useState<{
+    open: boolean;
+    workspaceId: string;
+    workspaceName: string;
+    servers: DotMcpServerInfo[];
+  }>({ open: false, workspaceId: '', workspaceName: '', servers: [] });
 
   // Listen for open-settings events from other components (e.g. auth error display)
   useEffect(() => {
@@ -113,6 +121,28 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
     setShowSettings(true);
   }, [expandWorkspace]);
 
+  const showDotMcpTrust = useCallback((workspaceId: string, workspaceName: string, servers: DotMcpServerInfo[]) => {
+    setDotMcpTrustState({ open: true, workspaceId, workspaceName, servers });
+  }, []);
+
+  const handleDotMcpAllow = useCallback(async () => {
+    try {
+      await setDotMcpTrust(dotMcpTrustState.workspaceId, 'trusted');
+      setDotMcpTrustState((s) => ({ ...s, open: false }));
+    } catch (err) {
+      console.error('Failed to save .mcp.json trust status:', err);
+    }
+  }, [dotMcpTrustState.workspaceId]);
+
+  const handleDotMcpDeny = useCallback(async () => {
+    try {
+      await setDotMcpTrust(dotMcpTrustState.workspaceId, 'denied');
+      setDotMcpTrustState((s) => ({ ...s, open: false }));
+    } catch (err) {
+      console.error('Failed to save .mcp.json trust status:', err);
+    }
+  }, [dotMcpTrustState.workspaceId]);
+
   // Expose dialog openers to parent via ref
   useImperativeHandle(ref, () => ({
     openSettings,
@@ -123,7 +153,8 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
     showGitHubRepos: () => setShowGitHubRepos(true),
     showShortcuts: () => setShowShortcuts(true),
     openWorkspaceSettings,
-  }), [openSettings, closeSettings, openWorkspaceSettings]);
+    showDotMcpTrust,
+  }), [openSettings, closeSettings, openWorkspaceSettings, showDotMcpTrust]);
 
   return (
     <>
@@ -200,6 +231,16 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
 
       {/* Command Palette (Cmd+K) */}
       <CommandPalette />
+
+      {/* .mcp.json Trust Dialog */}
+      <DotMcpTrustDialog
+        open={dotMcpTrustState.open}
+        onOpenChange={(open) => setDotMcpTrustState((s) => ({ ...s, open }))}
+        workspaceName={dotMcpTrustState.workspaceName}
+        servers={dotMcpTrustState.servers}
+        onAllow={handleDotMcpAllow}
+        onDeny={handleDotMcpDeny}
+      />
     </>
   );
 });
@@ -214,4 +255,5 @@ export type DialogManagerHandles = {
   showGitHubRepos: () => void;
   showShortcuts: () => void;
   openWorkspaceSettings: (workspaceId: string) => void;
+  showDotMcpTrust: (workspaceId: string, workspaceName: string, servers: DotMcpServerInfo[]) => void;
 };

--- a/src/components/settings/sections/AdvancedSettings.tsx
+++ b/src/components/settings/sections/AdvancedSettings.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Switch } from '@/components/ui/switch';
 import { SettingsRow } from '../shared/SettingsRow';
 import { SettingsGroup } from '../shared/SettingsGroup';
 
@@ -145,6 +146,21 @@ export function AdvancedSettings() {
 
       <SettingsGroup label="Environment">
         <EnvSection />
+      </SettingsGroup>
+
+      <SettingsGroup label="Security">
+        <SettingsRow
+          settingId="neverLoadDotMcp"
+          title="Block workspace MCP configs"
+          description="Never auto-load .mcp.json from workspace repositories. Prevents repo-provided MCP servers from running commands."
+          isModified={useSettingsStore((s) => s.neverLoadDotMcp) !== SETTINGS_DEFAULTS.neverLoadDotMcp}
+          onReset={() => useSettingsStore.getState().setNeverLoadDotMcp(SETTINGS_DEFAULTS.neverLoadDotMcp)}
+        >
+          <Switch
+            checked={useSettingsStore((s) => s.neverLoadDotMcp)}
+            onCheckedChange={useSettingsStore((s) => s.setNeverLoadDotMcp)}
+          />
+        </SettingsRow>
       </SettingsGroup>
 
       <SettingsGroup label="Configuration">

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -350,6 +350,16 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
     categoryLabel: 'Advanced',
   },
 
+  // ── Advanced: Security ──
+  {
+    id: 'neverLoadDotMcp',
+    title: 'Block workspace MCP configs',
+    description: 'Never auto-load .mcp.json from workspace repositories. Prevents repo-provided MCP servers from running commands.',
+    keywords: ['mcp', 'trust', 'security', 'workspace', 'block', 'json', 'server', 'untrusted'],
+    category: 'advanced',
+    categoryLabel: 'Advanced',
+  },
+
   // ── Advanced: Configuration ──
   {
     id: 'exportSettings',

--- a/src/hooks/__tests__/useDotMcpTrustCheck.test.ts
+++ b/src/hooks/__tests__/useDotMcpTrustCheck.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+// ---- Mocks ----
+
+const mockGetDotMcpInfo = vi.fn();
+const mockGetDotMcpTrust = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  getDotMcpInfo: (...args: unknown[]) => mockGetDotMcpInfo(...args),
+  getDotMcpTrust: (...args: unknown[]) => mockGetDotMcpTrust(...args),
+}));
+
+import { useDotMcpTrustCheck } from '../useDotMcpTrustCheck';
+import type { Workspace } from '@/lib/types';
+
+const mockWorkspaces: Workspace[] = [
+  {
+    id: 'ws-1',
+    name: 'My Project',
+    path: '/tmp/my-project',
+    defaultBranch: 'main',
+    remote: 'origin',
+    branchPrefix: 'github',
+    customPrefix: '',
+    createdAt: new Date().toISOString(),
+  },
+];
+
+const mockShowDotMcpTrust = vi.fn();
+const mockDialogRef = {
+  current: {
+    openSettings: vi.fn(),
+    closeSettings: vi.fn(),
+    showAddWorkspace: vi.fn(),
+    showCreateFromPR: vi.fn(),
+    showCloneFromUrl: vi.fn(),
+    showGitHubRepos: vi.fn(),
+    showShortcuts: vi.fn(),
+    openWorkspaceSettings: vi.fn(),
+    showDotMcpTrust: mockShowDotMcpTrust,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useSettingsStore.setState({ neverLoadDotMcp: false });
+});
+
+describe('useDotMcpTrustCheck', () => {
+  it('shows trust dialog when .mcp.json exists and trust is unknown', async () => {
+    mockGetDotMcpInfo.mockResolvedValue({
+      exists: true,
+      servers: [{ name: 'test', type: 'stdio', command: 'echo' }],
+    });
+    mockGetDotMcpTrust.mockResolvedValue({ status: 'unknown' });
+
+    renderHook(() =>
+      useDotMcpTrustCheck(mockWorkspaces, 'ws-1', mockDialogRef)
+    );
+
+    await waitFor(() => {
+      expect(mockShowDotMcpTrust).toHaveBeenCalledWith(
+        'ws-1',
+        'My Project',
+        [{ name: 'test', type: 'stdio', command: 'echo' }]
+      );
+    });
+  });
+
+  it('does not show dialog when no .mcp.json exists', async () => {
+    mockGetDotMcpInfo.mockResolvedValue({ exists: false, servers: [] });
+
+    renderHook(() =>
+      useDotMcpTrustCheck(mockWorkspaces, 'ws-1', mockDialogRef)
+    );
+
+    await waitFor(() => {
+      expect(mockGetDotMcpInfo).toHaveBeenCalledWith('ws-1');
+    });
+
+    expect(mockGetDotMcpTrust).not.toHaveBeenCalled();
+    expect(mockShowDotMcpTrust).not.toHaveBeenCalled();
+  });
+
+  it('does not show dialog when trust is already trusted', async () => {
+    mockGetDotMcpInfo.mockResolvedValue({
+      exists: true,
+      servers: [{ name: 'test', type: 'stdio', command: 'echo' }],
+    });
+    mockGetDotMcpTrust.mockResolvedValue({ status: 'trusted' });
+
+    renderHook(() =>
+      useDotMcpTrustCheck(mockWorkspaces, 'ws-1', mockDialogRef)
+    );
+
+    await waitFor(() => {
+      expect(mockGetDotMcpTrust).toHaveBeenCalledWith('ws-1');
+    });
+
+    expect(mockShowDotMcpTrust).not.toHaveBeenCalled();
+  });
+
+  it('does not show dialog when trust is already denied', async () => {
+    mockGetDotMcpInfo.mockResolvedValue({
+      exists: true,
+      servers: [{ name: 'test', type: 'stdio', command: 'echo' }],
+    });
+    mockGetDotMcpTrust.mockResolvedValue({ status: 'denied' });
+
+    renderHook(() =>
+      useDotMcpTrustCheck(mockWorkspaces, 'ws-1', mockDialogRef)
+    );
+
+    await waitFor(() => {
+      expect(mockGetDotMcpTrust).toHaveBeenCalledWith('ws-1');
+    });
+
+    expect(mockShowDotMcpTrust).not.toHaveBeenCalled();
+  });
+
+  it('does not check when neverLoadDotMcp is true', async () => {
+    useSettingsStore.setState({ neverLoadDotMcp: true });
+
+    renderHook(() =>
+      useDotMcpTrustCheck(mockWorkspaces, 'ws-1', mockDialogRef)
+    );
+
+    // Give time for any async operations
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockGetDotMcpInfo).not.toHaveBeenCalled();
+    expect(mockShowDotMcpTrust).not.toHaveBeenCalled();
+  });
+
+  it('does not check when workspaceId is null', async () => {
+    renderHook(() =>
+      useDotMcpTrustCheck(mockWorkspaces, null, mockDialogRef)
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockGetDotMcpInfo).not.toHaveBeenCalled();
+  });
+
+  it('only checks each workspace once per mount', async () => {
+    mockGetDotMcpInfo.mockResolvedValue({ exists: false, servers: [] });
+
+    const { rerender } = renderHook(
+      ({ wsId }) => useDotMcpTrustCheck(mockWorkspaces, wsId, mockDialogRef),
+      { initialProps: { wsId: 'ws-1' as string | null } }
+    );
+
+    await waitFor(() => {
+      expect(mockGetDotMcpInfo).toHaveBeenCalledTimes(1);
+    });
+
+    // Re-render with same workspace — should not check again
+    rerender({ wsId: 'ws-1' });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockGetDotMcpInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show dialog when servers list is empty', async () => {
+    mockGetDotMcpInfo.mockResolvedValue({ exists: true, servers: [] });
+
+    renderHook(() =>
+      useDotMcpTrustCheck(mockWorkspaces, 'ws-1', mockDialogRef)
+    );
+
+    await waitFor(() => {
+      expect(mockGetDotMcpInfo).toHaveBeenCalledWith('ws-1');
+    });
+
+    expect(mockGetDotMcpTrust).not.toHaveBeenCalled();
+    expect(mockShowDotMcpTrust).not.toHaveBeenCalled();
+  });
+
+  it('handles API errors gracefully', async () => {
+    mockGetDotMcpInfo.mockRejectedValue(new Error('Network error'));
+
+    renderHook(() =>
+      useDotMcpTrustCheck(mockWorkspaces, 'ws-1', mockDialogRef)
+    );
+
+    // Should not throw or show dialog
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockShowDotMcpTrust).not.toHaveBeenCalled();
+  });
+
+  it('falls back to unknown workspace name when not found', async () => {
+    mockGetDotMcpInfo.mockResolvedValue({
+      exists: true,
+      servers: [{ name: 'test', type: 'stdio', command: 'echo' }],
+    });
+    mockGetDotMcpTrust.mockResolvedValue({ status: 'unknown' });
+
+    // Use a workspace ID not in the workspaces array
+    renderHook(() =>
+      useDotMcpTrustCheck([], 'ws-unknown', mockDialogRef)
+    );
+
+    await waitFor(() => {
+      expect(mockShowDotMcpTrust).toHaveBeenCalledWith(
+        'ws-unknown',
+        'Unknown workspace',
+        expect.any(Array)
+      );
+    });
+  });
+});

--- a/src/hooks/useDotMcpTrustCheck.ts
+++ b/src/hooks/useDotMcpTrustCheck.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { getDotMcpInfo, getDotMcpTrust } from '@/lib/api';
+import { useSettingsStore } from '@/stores/settingsStore';
+import type { DialogManagerHandles } from '@/components/layout/DialogManager';
+import type { Workspace } from '@/lib/types';
+
+/**
+ * Checks .mcp.json trust status when the selected workspace changes.
+ * Shows the trust dialog if an untrusted .mcp.json is detected.
+ */
+export function useDotMcpTrustCheck(
+  workspaces: Workspace[],
+  selectedWorkspaceId: string | null,
+  dialogRef: React.RefObject<DialogManagerHandles | null>
+) {
+  const checkedWorkspaces = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!selectedWorkspaceId) return;
+    if (checkedWorkspaces.current.has(selectedWorkspaceId)) return;
+
+    const neverLoad = useSettingsStore.getState().neverLoadDotMcp;
+    if (neverLoad) return;
+
+    checkedWorkspaces.current.add(selectedWorkspaceId);
+
+    (async () => {
+      try {
+        const info = await getDotMcpInfo(selectedWorkspaceId);
+        if (!info.exists || info.servers.length === 0) return;
+
+        const trust = await getDotMcpTrust(selectedWorkspaceId);
+        if (trust.status !== 'unknown') return;
+
+        const workspace = workspaces.find((w) => w.id === selectedWorkspaceId);
+        dialogRef.current?.showDotMcpTrust(
+          selectedWorkspaceId,
+          workspace?.name ?? 'Unknown workspace',
+          info.servers
+        );
+      } catch {
+        // Allow re-check on next workspace select
+        checkedWorkspaces.current.delete(selectedWorkspaceId);
+      }
+    })();
+  }, [selectedWorkspaceId, workspaces, dialogRef]);
+}

--- a/src/lib/__tests__/api.dotMcpTrust.test.ts
+++ b/src/lib/__tests__/api.dotMcpTrust.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../__mocks__/server';
+import { getDotMcpInfo, getDotMcpTrust, setDotMcpTrust } from '../api';
+
+const API_BASE = 'http://localhost:9876';
+
+describe('Dot MCP Trust API', () => {
+  // =========================================================================
+  // getDotMcpInfo
+  // =========================================================================
+
+  describe('getDotMcpInfo', () => {
+    it('returns info when .mcp.json exists with servers', async () => {
+      const mockResponse = {
+        exists: true,
+        servers: [
+          { name: 'test-server', type: 'stdio', command: 'npx' },
+          { name: 'sse-server', type: 'sse' },
+        ],
+      };
+
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/dot-mcp-info`, () => {
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await getDotMcpInfo('ws-1');
+      expect(result.exists).toBe(true);
+      expect(result.servers).toHaveLength(2);
+      expect(result.servers[0]).toEqual({ name: 'test-server', type: 'stdio', command: 'npx' });
+    });
+
+    it('returns exists=false when no .mcp.json', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/dot-mcp-info`, () => {
+          return HttpResponse.json({ exists: false, servers: [] });
+        })
+      );
+
+      const result = await getDotMcpInfo('ws-1');
+      expect(result.exists).toBe(false);
+      expect(result.servers).toEqual([]);
+    });
+
+    it('handles server error', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/dot-mcp-info`, () => {
+          return new HttpResponse(null, { status: 500 });
+        })
+      );
+
+      await expect(getDotMcpInfo('ws-1')).rejects.toThrow();
+    });
+  });
+
+  // =========================================================================
+  // getDotMcpTrust
+  // =========================================================================
+
+  describe('getDotMcpTrust', () => {
+    it('returns unknown status', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/dot-mcp-trust`, () => {
+          return HttpResponse.json({ status: 'unknown' });
+        })
+      );
+
+      const result = await getDotMcpTrust('ws-1');
+      expect(result.status).toBe('unknown');
+    });
+
+    it('returns trusted status', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/dot-mcp-trust`, () => {
+          return HttpResponse.json({ status: 'trusted' });
+        })
+      );
+
+      const result = await getDotMcpTrust('ws-1');
+      expect(result.status).toBe('trusted');
+    });
+
+    it('returns denied status', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/dot-mcp-trust`, () => {
+          return HttpResponse.json({ status: 'denied' });
+        })
+      );
+
+      const result = await getDotMcpTrust('ws-1');
+      expect(result.status).toBe('denied');
+    });
+
+    it('handles server error', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/dot-mcp-trust`, () => {
+          return new HttpResponse(null, { status: 500 });
+        })
+      );
+
+      await expect(getDotMcpTrust('ws-1')).rejects.toThrow();
+    });
+  });
+
+  // =========================================================================
+  // setDotMcpTrust
+  // =========================================================================
+
+  describe('setDotMcpTrust', () => {
+    it('sets trusted status', async () => {
+      let capturedBody: unknown = null;
+
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/dot-mcp-trust`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ status: 'trusted' });
+        })
+      );
+
+      await setDotMcpTrust('ws-1', 'trusted');
+      expect(capturedBody).toEqual({ status: 'trusted' });
+    });
+
+    it('sets denied status', async () => {
+      let capturedBody: unknown = null;
+
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/dot-mcp-trust`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ status: 'denied' });
+        })
+      );
+
+      await setDotMcpTrust('ws-1', 'denied');
+      expect(capturedBody).toEqual({ status: 'denied' });
+    });
+
+    it('sends request to correct workspace endpoint', async () => {
+      let capturedWorkspaceId: string | undefined;
+
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/dot-mcp-trust`, async ({ params }) => {
+          capturedWorkspaceId = params.workspaceId as string;
+          return HttpResponse.json({ status: 'trusted' });
+        })
+      );
+
+      await setDotMcpTrust('my-workspace-123', 'trusted');
+      expect(capturedWorkspaceId).toBe('my-workspace-123');
+    });
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2201,6 +2201,57 @@ export async function setMcpServers(workspaceId: string, servers: McpServerConfi
 }
 
 // =========================================================================
+// Workspace .mcp.json Trust
+// =========================================================================
+
+export interface DotMcpServerInfo {
+  name: string;
+  type: string;
+  command?: string;
+}
+
+export interface DotMcpInfoResponse {
+  exists: boolean;
+  servers: DotMcpServerInfo[];
+}
+
+export interface DotMcpTrustResponse {
+  status: 'unknown' | 'trusted' | 'denied';
+}
+
+export async function getDotMcpInfo(workspaceId: string): Promise<DotMcpInfoResponse> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/dot-mcp-info`);
+  return handleResponse<DotMcpInfoResponse>(res);
+}
+
+export async function getDotMcpTrust(workspaceId: string): Promise<DotMcpTrustResponse> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/dot-mcp-trust`);
+  return handleResponse<DotMcpTrustResponse>(res);
+}
+
+export async function setDotMcpTrust(workspaceId: string, status: 'trusted' | 'denied'): Promise<void> {
+  await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/dot-mcp-trust`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+}
+
+export async function getNeverLoadDotMcp(): Promise<boolean> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/never-load-dot-mcp`);
+  const data = await handleResponse<{ enabled: boolean }>(res);
+  return data.enabled;
+}
+
+export async function setNeverLoadDotMcp(enabled: boolean): Promise<void> {
+  await fetchWithAuth(`${getApiBase()}/api/settings/never-load-dot-mcp`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+  });
+}
+
+// =========================================================================
 // AI Agents Configuration
 // =========================================================================
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -95,6 +95,8 @@ export const SETTINGS_DEFAULTS = {
   branchSyncBanner: true,
   deleteBranchOnArchive: false,
   archiveOnMerge: false,
+  // Security
+  neverLoadDotMcp: false,
   // Account
   strictPrivacy: false,
   // Sidebar
@@ -133,6 +135,8 @@ interface SettingsState {
   archiveOnMerge: boolean;
   // Claude Code settings
   autoApproveSafeCommands: boolean;
+  // Security settings
+  neverLoadDotMcp: boolean;
   // Account settings
   strictPrivacy: boolean;
   // UI state
@@ -205,6 +209,7 @@ interface SettingsState {
   setDeleteBranchOnArchive: (value: boolean) => void;
   setArchiveOnMerge: (value: boolean) => void;
   setAutoApproveSafeCommands: (value: boolean) => void;
+  setNeverLoadDotMcp: (value: boolean) => void;
   setStrictPrivacy: (value: boolean) => void;
   setZenMode: (value: boolean) => void;
   setSidebarBottomPanelMinimized: (value: boolean) => void;
@@ -301,6 +306,13 @@ export const useSettingsStore = create<SettingsState>()(
       setDeleteBranchOnArchive: (value) => set({ deleteBranchOnArchive: value }),
       setArchiveOnMerge: (value) => set({ archiveOnMerge: value }),
       setAutoApproveSafeCommands: (value) => set({ autoApproveSafeCommands: value }),
+      setNeverLoadDotMcp: (value) => {
+        set({ neverLoadDotMcp: value });
+        // Sync to backend so agent manager respects the global kill switch
+        import('@/lib/api').then(({ setNeverLoadDotMcp }) => {
+          setNeverLoadDotMcp(value).catch(() => {});
+        });
+      },
       setStrictPrivacy: (value) => set({ strictPrivacy: value }),
       setZenMode: (value) => set({ zenMode: value }),
       setSidebarBottomPanelMinimized: (value) => set({ sidebarBottomPanelMinimized: value }),


### PR DESCRIPTION
Fixes #797

## Summary

- Adds a security layer that prevents workspace `.mcp.json` files from automatically loading MCP servers without explicit user consent
- When a workspace contains a `.mcp.json`, a trust dialog prompts the user to Allow or Deny before any servers are started
- Includes a global "Block workspace MCP configs" toggle in Advanced Settings as a kill switch

### Changes

**Agent runner (`agent-runner/src/index.ts`)**
- New `--skip-dot-mcp` flag to conditionally skip `.mcp.json` loading

**Backend (`backend/`)**
- Per-workspace trust setting (`dot-mcp-trust:<workspaceId>`) checked in `manager.go` for both `StartConversation` and `ResumeConversation`
- Global `never-load-dot-mcp` setting that overrides per-workspace trust
- REST endpoints: `GET/PUT /api/repos/{id}/dot-mcp-trust`, `GET /api/repos/{id}/dot-mcp-info`, `GET/PUT /api/settings/never-load-dot-mcp`
- Deterministic server ordering in `GetDotMcpInfo` response

**Frontend (`src/`)**
- `useDotMcpTrustCheck` hook — checks trust status on workspace select, shows dialog for unknown trust
- `DotMcpTrustDialog` — non-dismissable dialog showing server names/types/commands with Allow/Deny
- Error handling on trust API callbacks (dialog stays open on failure)
- Failed trust checks allow re-checking on next workspace select
- Settings toggle syncs to backend for server-side enforcement

## Bug fixes included

- **Race condition**: workspace was marked as checked before async API call completed — failed checks are now retried
- **Global kill switch bypass**: `neverLoadDotMcp` only suppressed the dialog, not backend loading — now enforced server-side
- **Dialog dismiss**: Escape/overlay click left trust as "unknown" with no re-prompt — dialog is now non-dismissable
- **Missing error handling**: trust API failures silently closed dialog — now keeps dialog open on error
- **Non-deterministic ordering**: Go map iteration produced shuffled server lists — now sorted by name

## Test plan

- [ ] Open a workspace with a `.mcp.json` file — trust dialog should appear
- [ ] Click Allow — sessions should load MCP servers from `.mcp.json`
- [ ] Click Deny — sessions should skip `.mcp.json` servers
- [ ] Toggle "Block workspace MCP configs" in Advanced Settings — all workspaces should skip `.mcp.json` regardless of trust
- [ ] Kill backend while dialog is open, click Allow — dialog should stay open (error handling)
- [ ] Navigate away and back to workspace with failed check — dialog should re-appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)