### PR TITLE
fix: update outbound links from chatml.dev to chatml.com

### DIFF
--- a/src/components/layout/FullContentLayout.tsx
+++ b/src/components/layout/FullContentLayout.tsx
@@ -90,7 +90,7 @@ export function FullContentLayout({
                   <span className="ml-auto text-xs text-muted-foreground">⌘/</span>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => window.open('https://docs.chatml.dev', '_blank')}>
+                <DropdownMenuItem onClick={() => window.open('https://docs.chatml.com', '_blank')}>
                   <BookOpen className="size-4" />
                   Documentation
                   <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />

--- a/src/components/navigation/TopBar.tsx
+++ b/src/components/navigation/TopBar.tsx
@@ -295,7 +295,7 @@ export function TopBar({
               Session Manager
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => window.open('https://docs.chatml.dev', '_blank')}>
+            <DropdownMenuItem onClick={() => window.open('https://docs.chatml.com', '_blank')}>
               <BookOpen className="size-4" />
               Documentation
               <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />

--- a/src/components/settings/AppSettingsMenu.tsx
+++ b/src/components/settings/AppSettingsMenu.tsx
@@ -175,13 +175,13 @@ export function AppSettingsMenu({
           Check for Updates
         </DropdownMenuItem>
 
-        <DropdownMenuItem onClick={() => window.open('https://docs.chatml.dev', '_blank')}>
+        <DropdownMenuItem onClick={() => window.open('https://docs.chatml.com', '_blank')}>
           <BookOpen className="size-4" />
           Documentation
           <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />
         </DropdownMenuItem>
 
-        <DropdownMenuItem onClick={() => window.open('https://chatml.dev/changelog', '_blank')}>
+        <DropdownMenuItem onClick={() => window.open('https://chatml.com/changelog', '_blank')}>
           <FileText className="size-4" />
           Changelog
           <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />

--- a/src/components/settings/sections/AboutSettings.tsx
+++ b/src/components/settings/sections/AboutSettings.tsx
@@ -118,7 +118,7 @@ export function AboutSettings() {
       {/* Links */}
       <div className="py-4 space-y-3">
         <a
-          href="https://docs.chatml.dev"
+          href="https://docs.chatml.com"
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center justify-between py-2 text-sm hover:text-foreground text-muted-foreground transition-colors"
@@ -127,7 +127,7 @@ export function AboutSettings() {
           <ExternalLink className="w-3.5 h-3.5" />
         </a>
         <a
-          href="https://chatml.dev/changelog"
+          href="https://chatml.com/changelog"
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center justify-between py-2 text-sm hover:text-foreground text-muted-foreground transition-colors"


### PR DESCRIPTION
## Summary
- Updated all outbound URLs from `chatml.dev` to `chatml.com` across Settings, TopBar, and FullContentLayout menus
- Affects documentation links (`docs.chatml.com`) and changelog links (`chatml.com/changelog`)
- 4 files changed, 6 URLs corrected

## Test plan
- [ ] Open Settings → About and verify Documentation and Changelog links open `chatml.com`
- [ ] Verify help menu links in TopBar and FullContentLayout point to `chatml.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)