### PR TITLE
feat: add AWS Bedrock auth error detection and notifications

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -169,6 +169,13 @@ const fallbackModel = getArg("--fallback-model");
 const sdkDebug = hasFlag("--sdk-debug");
 const sdkDebugFile = getArg("--sdk-debug-file");
 
+// Bedrock diagnostic logging — appears in Go backend stderr logs
+if (process.env.CLAUDE_CODE_USE_BEDROCK === "true") {
+  console.error(`[Bedrock] Enabled. AWS_PROFILE=${process.env.AWS_PROFILE ? "(set)" : "(unset)"}, AWS_REGION=${process.env.AWS_REGION || "(unset)"}`);
+  console.error(`[Bedrock] ANTHROPIC_DEFAULT_SONNET_MODEL=${process.env.ANTHROPIC_DEFAULT_SONNET_MODEL || "(unset)"}`);
+  console.error(`[Bedrock] ANTHROPIC_DEFAULT_HAIKU_MODEL=${process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL || "(unset)"}`);
+}
+
 // Instructions (e.g., from conversation summaries)
 import { readFileSync, writeFileSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
@@ -1821,7 +1828,7 @@ async function main(): Promise<void> {
               if (detectAuthError(errorText)) {
                 emit({
                   type: "auth_error",
-                  message: "Authentication failed. Your OAuth token may have expired or your API key is invalid. Check your API key in Settings > Claude Code.",
+                  message: getAuthErrorMessage(),
                 });
                 // Auth errors are fatal — break out to stop the session
                 stopMainLoop();
@@ -1876,6 +1883,7 @@ async function main(): Promise<void> {
 }
 
 const AUTH_ERROR_PATTERNS = [
+  // Anthropic API patterns
   "authentication_error",
   "oauth token has expired",
   "oauth token expired",
@@ -1887,11 +1895,28 @@ const AUTH_ERROR_PATTERNS = [
   "request unauthorized",
   "unauthorized request",
   "token has been revoked",
+  // AWS Bedrock patterns
+  "expiredtoken",
+  "expired token",
+  "the security token included in the request is expired",
+  "accessdeniedexception: unable to locate credentials",
+  "accessdeniedexception: unable to assume role",
+  "accessdeniedexception: expired",
+  "unable to locate credentials",
+  "could not resolve credentials",
+  "invalid identity token",
 ];
 
 function detectAuthError(text: string): boolean {
   const lower = text.toLowerCase();
   return AUTH_ERROR_PATTERNS.some((p) => lower.includes(p));
+}
+
+function getAuthErrorMessage(): string {
+  if (process.env.CLAUDE_CODE_USE_BEDROCK === "true") {
+    return "AWS credentials expired or invalid. Run 'aws sso login' (or your configured auth refresh command) in a terminal, then retry.";
+  }
+  return "Authentication failed. Your OAuth token may have expired or your API key is invalid. Check your API key in Settings > Claude Code.";
 }
 
 function handleMessage(message: SDKMessage): void {
@@ -2232,7 +2257,7 @@ function handleMessage(message: SDKMessage): void {
         if (detectAuthError(errorText)) {
           emit({
             type: "auth_error",
-            message: "Authentication failed. Your OAuth token may have expired or your API key is invalid. Check your API key in Settings > Claude Code.",
+            message: getAuthErrorMessage(),
           });
         }
       }
@@ -2584,7 +2609,7 @@ main().catch(async (err) => {
   if (detectAuthError(errorMessage)) {
     emit({
       type: "auth_error",
-      message: "Authentication failed. Your OAuth token may have expired or your API key is invalid. Check your API key in Settings > Claude Code.",
+      message: getAuthErrorMessage(),
     });
   }
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1029,7 +1029,31 @@ export function useWebSocket(enabled: boolean = true) {
         }
         break;
 
-      case 'auth_status':
+      case 'auth_status': {
+        // Show notification when SDK is authenticating (e.g., AWS SSO browser flow)
+        const isAuthenticating = event?.isAuthenticating;
+        if (isAuthenticating) {
+          window.dispatchEvent(new CustomEvent('agent-notification', {
+            detail: {
+              title: 'Authenticating',
+              message: event?.output?.[0] || 'Authenticating with provider...',
+              type: 'info',
+              conversationId,
+            }
+          }));
+        } else if (event?.error) {
+          window.dispatchEvent(new CustomEvent('agent-notification', {
+            detail: {
+              title: 'Authentication failed',
+              message: String(event.error),
+              type: 'error',
+              conversationId,
+            }
+          }));
+        }
+        break;
+      }
+
       case 'status_update':
         // Diagnostic — no UI action needed
         break;


### PR DESCRIPTION
## Summary
- Add AWS Bedrock-specific patterns to auth error detection (expired tokens, missing credentials, AccessDeniedException variants, invalid identity tokens)
- Show context-aware auth error messages — Bedrock users see `aws sso login` guidance, Anthropic API users see the existing API key message
- Surface `auth_status` SDK events as user-facing notifications (info toast for SSO flows, error toast on failure)
- Add Bedrock diagnostic logging on agent-runner startup for easier debugging

## Test plan
- [ ] Verify Bedrock auth errors (expired SSO token) show the new Bedrock-specific message
- [ ] Verify Anthropic API auth errors still show the existing message
- [ ] Verify `auth_status` events with `isAuthenticating: true` show an info notification
- [ ] Verify `auth_status` events with `error` show an error notification
- [ ] Verify Bedrock diagnostic logs appear in backend stderr when `CLAUDE_CODE_USE_BEDROCK=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)