### PR TITLE
Remove unused auto-approve safe commands setting

### DIFF
--- a/src/components/settings/sections/AIModelSettings.tsx
+++ b/src/components/settings/sections/AIModelSettings.tsx
@@ -18,14 +18,6 @@ import { useToast } from '@/components/ui/toast';
 import { SettingsRow } from '../shared/SettingsRow';
 import { SettingsGroup } from '../shared/SettingsGroup';
 
-function ComingSoonBadge() {
-  return (
-    <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-2xs font-medium text-muted-foreground">
-      Coming soon
-    </span>
-  );
-}
-
 export function AIModelSettings() {
   const defaultModel = useSettingsStore((s) => s.defaultModel);
   const setDefaultModel = useSettingsStore((s) => s.setDefaultModel);
@@ -140,17 +132,6 @@ export function AIModelSettings() {
             </Select>
           </SettingsRow>
         )}
-      </SettingsGroup>
-
-      <SettingsGroup label="Automation">
-        <SettingsRow
-          title="Auto-approve safe commands"
-          description="Automatically approve read-only commands"
-          badge={<ComingSoonBadge />}
-          className="opacity-60"
-        >
-          <Switch checked={false} disabled aria-label="Auto-approve safe commands" />
-        </SettingsRow>
       </SettingsGroup>
 
       <SettingsGroup label="Authentication">

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -336,34 +336,6 @@ describe('settingsStore', () => {
     });
   });
 
-  describe('autoApproveSafeCommands', () => {
-    beforeEach(() => {
-      useSettingsStore.setState({ autoApproveSafeCommands: true });
-    });
-
-    it('should have a default value of true', () => {
-      const { autoApproveSafeCommands } = useSettingsStore.getState();
-      expect(autoApproveSafeCommands).toBe(true);
-    });
-
-    it('should update autoApproveSafeCommands when setAutoApproveSafeCommands is called', () => {
-      const { setAutoApproveSafeCommands } = useSettingsStore.getState();
-      setAutoApproveSafeCommands(false);
-      expect(useSettingsStore.getState().autoApproveSafeCommands).toBe(false);
-    });
-
-    it('should not affect other settings when setAutoApproveSafeCommands is called', () => {
-      const initialState = useSettingsStore.getState();
-      const { setAutoApproveSafeCommands } = useSettingsStore.getState();
-      setAutoApproveSafeCommands(false);
-      const newState = useSettingsStore.getState();
-      
-      expect(newState.showThinkingBlocks).toBe(initialState.showThinkingBlocks);
-      expect(newState.reviewModel).toBe(initialState.reviewModel);
-      expect(newState.archiveOnMerge).toBe(initialState.archiveOnMerge);
-    });
-  });
-
   describe('strictPrivacy', () => {
     beforeEach(() => {
       useSettingsStore.setState({ strictPrivacy: false });
@@ -388,7 +360,7 @@ describe('settingsStore', () => {
       
       expect(newState.showThinkingBlocks).toBe(initialState.showThinkingBlocks);
       expect(newState.reviewModel).toBe(initialState.reviewModel);
-      expect(newState.autoApproveSafeCommands).toBe(initialState.autoApproveSafeCommands);
+      expect(newState.archiveOnMerge).toBe(initialState.archiveOnMerge);
     });
   });
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -88,7 +88,6 @@ export const SETTINGS_DEFAULTS = {
   reviewModel: 'claude-opus-4-6',
   reviewActionableOnly: false,
   defaultPlanMode: false,
-  autoApproveSafeCommands: true,
   // Git
   branchPrefixType: 'github' as BranchPrefixType,
   branchPrefixCustom: '',
@@ -133,8 +132,6 @@ interface SettingsState {
   branchPrefixCustom: string;
   deleteBranchOnArchive: boolean;
   archiveOnMerge: boolean;
-  // Claude Code settings
-  autoApproveSafeCommands: boolean;
   // Security settings
   neverLoadDotMcp: boolean;
   // Account settings
@@ -208,7 +205,6 @@ interface SettingsState {
   setBranchPrefixCustom: (value: string) => void;
   setDeleteBranchOnArchive: (value: boolean) => void;
   setArchiveOnMerge: (value: boolean) => void;
-  setAutoApproveSafeCommands: (value: boolean) => void;
   setNeverLoadDotMcp: (value: boolean) => void;
   setStrictPrivacy: (value: boolean) => void;
   setZenMode: (value: boolean) => void;
@@ -305,7 +301,6 @@ export const useSettingsStore = create<SettingsState>()(
       setBranchPrefixCustom: (value) => set({ branchPrefixCustom: value }),
       setDeleteBranchOnArchive: (value) => set({ deleteBranchOnArchive: value }),
       setArchiveOnMerge: (value) => set({ archiveOnMerge: value }),
-      setAutoApproveSafeCommands: (value) => set({ autoApproveSafeCommands: value }),
       setNeverLoadDotMcp: (value) => {
         set({ neverLoadDotMcp: value });
         // Sync to backend so agent manager respects the global kill switch


### PR DESCRIPTION
## Summary

- Remove the disabled "Coming soon" auto-approve safe commands placeholder from AI Model Settings
- Clean up related store state, setter, defaults, and tests

## Changes Made

- **AIModelSettings.tsx** — Removed `ComingSoonBadge` component and the "Automation" settings group with disabled switch
- **settingsStore.ts** — Removed `autoApproveSafeCommands` from defaults, interface, and setter
- **settingsStore.test.ts** — Removed `autoApproveSafeCommands` test block; updated `strictPrivacy` isolation test to assert `archiveOnMerge` instead

## Test Plan

- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Settings page renders without the Automation section

🤖 Generated with [Claude Code](https://claude.com/claude-code)