### PR TITLE
fix: align code review dropdown menu items

### DIFF
--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -1282,17 +1282,14 @@ function TopPanelTabs({
                 <CheckCheck className="size-4" />
                 Resolve All
               </DropdownMenuItem>
-              <DropdownMenuCheckboxItem
-                checked={menuContext.showResolved}
-                onCheckedChange={menuContext.onToggleShowResolved}
-              >
+              <DropdownMenuItem onSelect={menuContext.onToggleShowResolved}>
                 {menuContext.showResolved ? (
                   <EyeOff className="size-4" />
                 ) : (
                   <Eye className="size-4" />
                 )}
-                Show Resolved
-              </DropdownMenuCheckboxItem>
+                {menuContext.showResolved ? 'Hide Resolved' : 'Show Resolved'}
+              </DropdownMenuItem>
             </>
           )}
         </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- Replace `DropdownMenuCheckboxItem` with `DropdownMenuItem` for the "Show Resolved" toggle in the Code Review tab's dropdown menu
- Fixes icon misalignment caused by the checkbox item's extra `pl-8` left padding vs `px-2` on regular items
- Toggle state is now communicated via icon swap (Eye/EyeOff) and label text ("Show Resolved"/"Hide Resolved")

## Test plan
- [ ] Open a PR with code review comments
- [ ] Click the `...` menu on the Code Review tab
- [ ] Verify all menu items (Search Files, Resolve All, Show/Hide Resolved) have aligned icons
- [ ] Click "Show Resolved" — verify it toggles to "Hide Resolved" with EyeOff icon
- [ ] Click again — verify it toggles back to "Show Resolved" with Eye icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)