### PR TITLE
feat: add GitHub CLI status check to settings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@shikijs/langs':
+        specifier: ^3.22.0
+        version: 3.22.0
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.1.18)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "chatml"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "argon2",
  "base64 0.22.1",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -467,6 +467,79 @@ pub fn check_prerequisites() -> PrerequisitesResult {
     }
 }
 
+/// Status of GitHub CLI installation and authentication
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GhCliStatus {
+    pub installed: bool,
+    pub version: Option<String>,
+    pub authenticated: bool,
+    pub username: Option<String>,
+}
+
+/// Check GitHub CLI installation and authentication status.
+/// Uses the user's login shell PATH to find `gh`.
+#[tauri::command]
+pub fn check_gh_auth_status() -> GhCliStatus {
+    let user_path = sidecar::resolve_user_path();
+
+    // Check if gh is installed
+    let version_output = Command::new("gh")
+        .args(["--version"])
+        .env("PATH", &user_path)
+        .output();
+
+    let version = match version_output {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            // Parse version from "gh version 2.40.1 (2024-01-01)" format
+            stdout
+                .split_whitespace()
+                .find(|s| {
+                    s.starts_with('v') || s.chars().next().is_some_and(|c| c.is_ascii_digit())
+                })
+                .map(|v| v.trim_start_matches('v').to_string())
+        }
+        _ => {
+            return GhCliStatus {
+                installed: false,
+                version: None,
+                authenticated: false,
+                username: None,
+            };
+        }
+    };
+
+    // Check authentication: exit code 0 = authenticated, 1 = not
+    let auth_output = Command::new("gh")
+        .args(["auth", "status"])
+        .env("PATH", &user_path)
+        .output();
+
+    let authenticated = matches!(&auth_output, Ok(output) if output.status.success());
+
+    // Get username reliably via the API (works regardless of gh output format)
+    let username = if authenticated {
+        Command::new("gh")
+            .args(["api", "user", "--jq", ".login"])
+            .env("PATH", &user_path)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .filter(|s| !s.is_empty())
+    } else {
+        None
+    };
+
+    GhCliStatus {
+        installed: true,
+        version,
+        authenticated,
+        username,
+    }
+}
+
 /// Count lines in a text file
 #[tauri::command]
 pub fn count_file_lines(path: String) -> Result<usize, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,7 +172,8 @@ pub fn run() {
             commands::detect_installed_apps,
             commands::close_window,
             // System prerequisites
-            commands::check_prerequisites
+            commands::check_prerequisites,
+            commands::check_gh_auth_status
         ])
         .setup(move |app| {
             // Create and set the menu

--- a/src/components/settings/sections/AccountSettings.tsx
+++ b/src/components/settings/sections/AccountSettings.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect, useCallback } from 'react';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { CheckCircle2, LogOut, Loader2 } from 'lucide-react';
@@ -8,6 +9,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { useLinearAuthStore } from '@/stores/linearAuthStore';
 import { logout } from '@/lib/auth';
 import { startLinearOAuthFlow, linearLogout, cancelLinearOAuthFlow } from '@/lib/linearAuth';
+import { checkGhAuthStatus, openUrlInBrowser, type GhCliStatus } from '@/lib/tauri';
 import { SettingsRow } from '../shared/SettingsRow';
 import { SettingsGroup } from '../shared/SettingsGroup';
 
@@ -53,6 +55,39 @@ export function AccountSettings() {
       console.error('Failed to disconnect Linear:', error);
     }
   };
+
+  // GitHub CLI status
+  const [ghStatus, setGhStatus] = useState<GhCliStatus | null>(null);
+  const [ghLoading, setGhLoading] = useState(true);
+  const [ghError, setGhError] = useState(false);
+
+  const recheckGhStatus = useCallback(async () => {
+    setGhLoading(true);
+    setGhError(false);
+    try {
+      const status = await checkGhAuthStatus();
+      if (status === null) {
+        setGhError(true);
+      }
+      setGhStatus(status);
+    } finally {
+      setGhLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    recheckGhStatus();
+  }, [recheckGhStatus]);
+
+  const ghDescription = ghLoading
+    ? 'Checking...'
+    : ghError
+      ? 'Unable to check GitHub CLI status.'
+      : !ghStatus?.installed
+        ? 'GitHub CLI is not installed.'
+        : ghStatus.authenticated && ghStatus.username
+          ? `Authenticated as @${ghStatus.username}`
+          : `Installed${ghStatus.version ? ` (v${ghStatus.version})` : ''} but not authenticated.`;
 
   return (
     <div>
@@ -101,6 +136,45 @@ export function AccountSettings() {
       </SettingsGroup>
 
       <SettingsGroup label="Integrations">
+        {/* GitHub CLI Integration */}
+        <SettingsRow
+          settingId="githubCli"
+          title="GitHub CLI"
+          description={ghDescription}
+          badge={
+            ghLoading
+              ? <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+              : ghStatus?.authenticated
+                ? <CheckCircle2 className="w-4 h-4 text-text-success" />
+                : undefined
+          }
+        >
+          {ghLoading ? (
+            <span />
+          ) : ghError ? (
+            <Button variant="ghost" size="sm" onClick={recheckGhStatus}>
+              Re-check
+            </Button>
+          ) : !ghStatus?.installed ? (
+            <Button variant="outline" size="sm" onClick={() => openUrlInBrowser('https://cli.github.com')}>
+              Install
+            </Button>
+          ) : !ghStatus.authenticated ? (
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={() => openUrlInBrowser('https://cli.github.com/manual/gh_auth_login')}>
+                How to authenticate
+              </Button>
+              <Button variant="ghost" size="sm" onClick={recheckGhStatus}>
+                Re-check
+              </Button>
+            </div>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={recheckGhStatus}>
+              Re-check
+            </Button>
+          )}
+        </SettingsRow>
+
         {/* Linear Integration */}
         <SettingsRow
           settingId="linearIntegration"
@@ -135,20 +209,6 @@ export function AccountSettings() {
               )}
             </div>
           )}
-        </SettingsRow>
-
-        {/* GitHub CLI Integration */}
-        <SettingsRow
-          settingId="githubCli"
-          title="GitHub CLI"
-          description={
-            user
-              ? `Authenticated as @${user.login}`
-              : 'Not connected. Sign in to enable GitHub integration.'
-          }
-          badge={user ? <CheckCircle2 className="w-4 h-4 text-text-success" /> : undefined}
-        >
-          <span />
         </SettingsRow>
       </SettingsGroup>
 

--- a/src/components/settings/sections/__tests__/AccountSettings.test.tsx
+++ b/src/components/settings/sections/__tests__/AccountSettings.test.tsx
@@ -10,6 +10,13 @@ const mockLogout = vi.fn().mockResolvedValue(undefined);
 const mockStartLinearOAuthFlow = vi.fn().mockResolvedValue(undefined);
 const mockLinearLogout = vi.fn().mockResolvedValue(undefined);
 const mockCancelLinearOAuthFlow = vi.fn();
+const mockCheckGhAuthStatus = vi.fn().mockResolvedValue({
+  installed: true,
+  version: '2.40.1',
+  authenticated: true,
+  username: 'jdoe',
+});
+const mockOpenUrlInBrowser = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/lib/auth', () => ({
   logout: (...args: unknown[]) => mockLogout(...args),
@@ -19,6 +26,11 @@ vi.mock('@/lib/linearAuth', () => ({
   startLinearOAuthFlow: (...args: unknown[]) => mockStartLinearOAuthFlow(...args),
   linearLogout: (...args: unknown[]) => mockLinearLogout(...args),
   cancelLinearOAuthFlow: (...args: unknown[]) => mockCancelLinearOAuthFlow(...args),
+}));
+
+vi.mock('@/lib/tauri', () => ({
+  checkGhAuthStatus: (...args: unknown[]) => mockCheckGhAuthStatus(...args),
+  openUrlInBrowser: (...args: unknown[]) => mockOpenUrlInBrowser(...args),
 }));
 
 describe('AccountSettings', () => {

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -304,7 +304,7 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
   {
     id: 'githubCli',
     title: 'GitHub CLI',
-    description: 'GitHub CLI authentication status',
+    description: 'GitHub CLI installation and authentication status',
     keywords: ['github', 'cli', 'auth', 'integration', 'connect'],
     category: 'account',
     categoryLabel: 'Account',

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -426,6 +426,24 @@ export async function checkPrerequisites(): Promise<PrerequisitesResult | null> 
 }
 
 // ============================================
+// GitHub CLI Status Check
+// ============================================
+
+export interface GhCliStatus {
+  installed: boolean;
+  version: string | null;
+  authenticated: boolean;
+  username: string | null;
+}
+
+/**
+ * Check GitHub CLI installation and authentication status.
+ */
+export async function checkGhAuthStatus(): Promise<GhCliStatus | null> {
+  return safeInvoke<GhCliStatus>('check_gh_auth_status');
+}
+
+// ============================================
 // File Attachment Functions
 // ============================================
 


### PR DESCRIPTION
## Summary
- Add `check_gh_auth_status` Tauri command that detects GitHub CLI installation, version, and authentication status
- Use exit code (`gh auth status`) for reliable auth detection and `gh api user --jq .login` for username retrieval — works across all gh versions regardless of stdout/stderr output changes
- Frontend distinguishes Tauri IPC failures from "gh not installed" state, showing appropriate UI for each case
- Add Install, How to authenticate, and Re-check action buttons based on detected state

## Test plan
- [ ] Verify settings page shows correct status when gh is installed and authenticated
- [ ] Verify "not installed" state shows Install button linking to cli.github.com
- [ ] Verify unauthenticated state shows "How to authenticate" and "Re-check" buttons
- [ ] Verify Re-check button refreshes status after user authenticates in terminal
- [ ] Run `npm run lint` — passes with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)