### PR TITLE
feat: show toast when app is already on the latest version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@shikijs/langs':
+        specifier: ^3.22.0
+        version: 3.22.0
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.1.18)

--- a/src/hooks/useMenuHandlers.ts
+++ b/src/hooks/useMenuHandlers.ts
@@ -5,6 +5,7 @@ import { useTheme } from 'next-themes';
 import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useUpdateStore } from '@/stores/updateStore';
+import { useToast } from '@/components/ui/toast';
 import { useNavigationStore } from '@/stores/navigationStore';
 import { useTabStore } from '@/stores/tabStore';
 import { ENABLE_BROWSER_TABS } from '@/lib/constants';
@@ -43,10 +44,14 @@ interface MenuHandlersOptions {
  */
 export function useMenuHandlers(options: MenuHandlersOptions) {
   const { resolvedTheme, setTheme } = useTheme();
+  const { info: toastInfo } = useToast();
 
   // Refs for menu-event handler callbacks — prevents safeListen re-registration race condition.
   // Without refs, unstable callbacks cause the useEffect to re-run, tearing down the Tauri
   // listener and asynchronously re-registering it. During the async gap, menu events are lost.
+  const toastInfoRef = useRef(toastInfo);
+  useEffect(() => { toastInfoRef.current = toastInfo; }, [toastInfo]);
+
   const handleNewSessionRef = useRef(options.handleNewSession);
   const handleNewConversationRef = useRef(options.handleNewConversation);
   const handleCloseTabRef = useRef(options.handleCloseTab);
@@ -78,7 +83,11 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
       switch (menuId) {
         // App menu
         case 'check_for_updates':
-          useUpdateStore.getState().checkForUpdates();
+          useUpdateStore.getState().checkForUpdates().then((result) => {
+            if (result === 'up-to-date') {
+              toastInfoRef.current("You're on the latest version");
+            }
+          });
           break;
         case 'settings':
           options.onOpenSettings();

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -9,7 +9,7 @@ interface UpdateState {
   progress: number;
   error: string | null;
 
-  checkForUpdates: () => Promise<void>;
+  checkForUpdates: () => Promise<'up-to-date' | 'available' | null>;
   downloadAndInstall: () => Promise<void>;
   relaunch: () => Promise<void>;
 }
@@ -28,10 +28,10 @@ export const useUpdateStore = create<UpdateState>()((set, get) => ({
   error: null,
 
   checkForUpdates: async () => {
-    if (!isTauri()) return;
+    if (!isTauri()) return null;
 
     const { status } = get();
-    if (status === 'checking' || status === 'downloading') return;
+    if (status === 'checking' || status === 'downloading') return null;
 
     try {
       set({ status: 'checking', error: null });
@@ -41,14 +41,17 @@ export const useUpdateStore = create<UpdateState>()((set, get) => ({
       if (result) {
         pendingUpdate = result;
         set({ status: 'available', version: result.version });
+        return 'available';
       } else {
         pendingUpdate = null;
         set({ status: 'idle', version: null });
+        return 'up-to-date';
       }
     } catch (err) {
       console.debug('Update check failed:', err);
       // Silently return to idle on check failure — not actionable for users
       set({ status: 'idle' });
+      return null;
     }
   },
 


### PR DESCRIPTION
## Summary
- When users click "Check for Updates" and are already up-to-date, display an info toast: "You're on the latest version"
- Changed `checkForUpdates()` return type from `Promise<void>` to `Promise<'up-to-date' | 'available' | null>` to enable callers to react to the result
- Used narrowly-scoped `toastInfoRef` pattern consistent with existing ref conventions in `useMenuHandlers`

## Test plan
- [ ] Click "Check for Updates" when already on the latest version — should see info toast
- [ ] Click "Check for Updates" when an update is available — should show update banner as before (no toast)
- [ ] Verify toast auto-dismisses after ~4 seconds
- [ ] Verify no toast appears when update check fails silently (e.g., offline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)