### PR TITLE
fix: handle network errors in Linear auth and consistent error logging

### DIFF
--- a/backend/server/linear_auth_handlers.go
+++ b/backend/server/linear_auth_handlers.go
@@ -132,11 +132,31 @@ func (h *LinearAuthHandlers) RestoreFromStore(ctx context.Context) {
 		return
 	}
 
-	encRefresh, _, _ := h.store.GetSetting(ctx, settingLinearRefreshToken)
-	refreshToken, _ := crypto.Decrypt(encRefresh)
+	encRefresh, _, err := h.store.GetSetting(ctx, settingLinearRefreshToken)
+	var refreshToken string
+	if err != nil {
+		logger.Linear.Warnf("Failed to load Linear refresh token setting: %v", err)
+	} else if encRefresh != "" {
+		refreshToken, err = crypto.Decrypt(encRefresh)
+		if err != nil {
+			logger.Linear.Warnf("Failed to decrypt Linear refresh token: %v", err)
+		}
+	}
 
-	expiryStr, _, _ := h.store.GetSetting(ctx, settingLinearTokenExpiry)
-	expiresAt, _ := time.Parse(time.RFC3339, expiryStr)
+	expiryStr, _, err := h.store.GetSetting(ctx, settingLinearTokenExpiry)
+	var expiresAt time.Time
+	if err != nil {
+		logger.Linear.Warnf("Failed to load Linear token expiry setting: %v", err)
+	} else if expiryStr != "" {
+		expiresAt, err = time.Parse(time.RFC3339, expiryStr)
+		if err != nil {
+			logger.Linear.Warnf("Failed to parse Linear token expiry %q: %v", expiryStr, err)
+		}
+	}
+	// If expiry is zero/missing, set to now to force an immediate refresh
+	if expiresAt.IsZero() {
+		expiresAt = time.Now()
+	}
 
 	tokens := &linear.TokenSet{
 		AccessToken:  accessToken,
@@ -147,8 +167,10 @@ func (h *LinearAuthHandlers) RestoreFromStore(ctx context.Context) {
 	h.linearClient.SetTokens(tokens)
 
 	// Restore user info
-	encUser, found, _ := h.store.GetSetting(ctx, settingLinearUser)
-	if found {
+	encUser, found, err := h.store.GetSetting(ctx, settingLinearUser)
+	if err != nil {
+		logger.Linear.Warnf("Failed to load Linear user setting: %v", err)
+	} else if found {
 		userJSON, err := crypto.Decrypt(encUser)
 		if err == nil {
 			var user linear.User
@@ -185,25 +207,7 @@ func PersistLinearTokens(ctx context.Context, s *store.SQLiteStore, tokens *line
 
 // persistTokens encrypts and stores tokens + user in the settings table.
 func (h *LinearAuthHandlers) persistTokens(ctx context.Context, tokens *linear.TokenSet, user *linear.User) error {
-	encAccess, err := crypto.Encrypt(tokens.AccessToken)
-	if err != nil {
-		return err
-	}
-	if err := h.store.SetSetting(ctx, settingLinearAccessToken, encAccess); err != nil {
-		return err
-	}
-
-	if tokens.RefreshToken != "" {
-		encRefresh, err := crypto.Encrypt(tokens.RefreshToken)
-		if err != nil {
-			return err
-		}
-		if err := h.store.SetSetting(ctx, settingLinearRefreshToken, encRefresh); err != nil {
-			return err
-		}
-	}
-
-	if err := h.store.SetSetting(ctx, settingLinearTokenExpiry, tokens.ExpiresAt.Format(time.RFC3339)); err != nil {
+	if err := PersistLinearTokens(ctx, h.store, tokens); err != nil {
 		return err
 	}
 

--- a/src/lib/__tests__/linearAuth.test.ts
+++ b/src/lib/__tests__/linearAuth.test.ts
@@ -21,6 +21,9 @@ beforeEach(async () => {
   // Clear sessionStorage between tests
   sessionStorage.clear();
 
+  // Set Linear client ID for tests (guard requires it)
+  vi.stubEnv('NEXT_PUBLIC_LINEAR_CLIENT_ID', 'test_linear_client_id');
+
   // Re-import to reset module-level state (pendingOAuthState, pendingCodeVerifier)
   vi.resetModules();
 
@@ -38,6 +41,21 @@ afterEach(() => {
 describe('LINEAR_STATE_PREFIX', () => {
   it('is "linear:"', () => {
     expect(linearAuth.LINEAR_STATE_PREFIX).toBe('linear:');
+  });
+});
+
+describe('isLinearConfigured', () => {
+  it('returns true when client ID is set', () => {
+    expect(linearAuth.isLinearConfigured).toBe(true);
+  });
+
+  it('returns false when client ID is empty', async () => {
+    vi.stubEnv('NEXT_PUBLIC_LINEAR_CLIENT_ID', '');
+    vi.resetModules();
+    vi.doMock('@/lib/tauri', () => ({ isTauri: () => false }));
+    vi.doMock('@/lib/api', () => ({ getApiBase: () => API_BASE }));
+    const mod = await import('../linearAuth');
+    expect(mod.isLinearConfigured).toBe(false);
   });
 });
 
@@ -66,6 +84,18 @@ describe('cancelLinearOAuthFlow', () => {
 });
 
 describe('startLinearOAuthFlow', () => {
+  it('throws when client ID is not configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_LINEAR_CLIENT_ID', '');
+    vi.resetModules();
+    vi.doMock('@/lib/tauri', () => ({ isTauri: () => false }));
+    vi.doMock('@/lib/api', () => ({ getApiBase: () => API_BASE }));
+    const mod = await import('../linearAuth');
+
+    await expect(mod.startLinearOAuthFlow())
+      .rejects
+      .toThrow('Linear integration is not configured for this build.');
+  });
+
   it('opens a browser window with correct OAuth params', async () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
 
@@ -239,6 +269,43 @@ describe('getLinearAuthStatus', () => {
     expect(status.authenticated).toBe(false);
     expect(status.user).toBeUndefined();
   });
+
+  it('returns unauthenticated on non-OK response', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    server.use(
+      http.get(`${API_BASE}/api/auth/linear/status`, () => {
+        return new HttpResponse('Internal Server Error', { status: 500 });
+      }),
+    );
+
+    const status = await linearAuth.getLinearAuthStatus();
+    expect(status.authenticated).toBe(false);
+    expect(status.user).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith('[Linear Auth] Status check failed:', 500);
+
+    errorSpy.mockRestore();
+  });
+
+  it('returns unauthenticated on network error', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    server.use(
+      http.get(`${API_BASE}/api/auth/linear/status`, () => {
+        return HttpResponse.error();
+      }),
+    );
+
+    const status = await linearAuth.getLinearAuthStatus();
+    expect(status.authenticated).toBe(false);
+    expect(status.user).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[Linear Auth] Status check failed:',
+      expect.any(Error),
+    );
+
+    errorSpy.mockRestore();
+  });
 });
 
 describe('linearLogout', () => {
@@ -254,5 +321,40 @@ describe('linearLogout', () => {
 
     await linearAuth.linearLogout();
     expect(logoutCalled).toBe(true);
+  });
+
+  it('logs error on non-OK response but does not throw', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    server.use(
+      http.post(`${API_BASE}/api/auth/linear/logout`, () => {
+        return new HttpResponse('Internal Server Error', { status: 500 });
+      }),
+    );
+
+    // Should not throw
+    await linearAuth.linearLogout();
+    expect(errorSpy).toHaveBeenCalledWith('[Linear Auth] Logout failed:', 500);
+
+    errorSpy.mockRestore();
+  });
+
+  it('does not throw on network error', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    server.use(
+      http.post(`${API_BASE}/api/auth/linear/logout`, () => {
+        return HttpResponse.error();
+      }),
+    );
+
+    // Should not throw
+    await linearAuth.linearLogout();
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[Linear Auth] Logout failed:',
+      expect.any(Error),
+    );
+
+    errorSpy.mockRestore();
   });
 });

--- a/src/lib/linearAuth.ts
+++ b/src/lib/linearAuth.ts
@@ -16,6 +16,9 @@ const LINEAR_CLIENT_ID = process.env.NEXT_PUBLIC_LINEAR_CLIENT_ID || '';
 const LINEAR_REDIRECT_URI = 'chatml://oauth/callback';
 const LINEAR_SCOPES = 'read';
 
+/** Whether Linear OAuth is configured (client ID available at build time). */
+export const isLinearConfigured = LINEAR_CLIENT_ID !== '';
+
 // State prefix for routing callbacks
 export const LINEAR_STATE_PREFIX = 'linear:';
 
@@ -59,6 +62,10 @@ export function cancelLinearOAuthFlow(): void {
 
 /** Start the Linear OAuth flow with PKCE. Opens browser to Linear authorization page. */
 export async function startLinearOAuthFlow(): Promise<void> {
+  if (!LINEAR_CLIENT_ID) {
+    throw new Error('Linear integration is not configured for this build.');
+  }
+
   const random = generateRandomString(32);
   pendingOAuthState = LINEAR_STATE_PREFIX + random;
   pendingCodeVerifier = generateRandomString(32);
@@ -161,11 +168,27 @@ export async function handleLinearOAuthCallback(url: string): Promise<{ user: Li
 
 /** Check Linear auth status from backend. */
 export async function getLinearAuthStatus(): Promise<LinearAuthStatus> {
-  const res = await fetch(`${getApiBase()}/api/auth/linear/status`);
-  return res.json();
+  try {
+    const res = await fetch(`${getApiBase()}/api/auth/linear/status`);
+    if (!res.ok) {
+      console.error('[Linear Auth] Status check failed:', res.status);
+      return { authenticated: false };
+    }
+    return res.json();
+  } catch (err) {
+    console.error('[Linear Auth] Status check failed:', err);
+    return { authenticated: false };
+  }
 }
 
 /** Logout from Linear. */
 export async function linearLogout(): Promise<void> {
-  await fetch(`${getApiBase()}/api/auth/linear/logout`, { method: 'POST' });
+  try {
+    const res = await fetch(`${getApiBase()}/api/auth/linear/logout`, { method: 'POST' });
+    if (!res.ok) {
+      console.error('[Linear Auth] Logout failed:', res.status);
+    }
+  } catch (err) {
+    console.error('[Linear Auth] Logout failed:', err);
+  }
 }


### PR DESCRIPTION
## Summary

- Wrap `getLinearAuthStatus()` and `linearLogout()` fetch calls in try/catch to gracefully handle network errors (DNS failure, offline, etc.) instead of letting them propagate as unhandled rejections
- Log `GetSetting` error for user restore in `RestoreFromStore`, consistent with how refresh token and expiry errors are already handled
- Add tests for network error scenarios in both `getLinearAuthStatus` and `linearLogout`

## Test plan

- [x] `npx vitest run src/lib/__tests__/linearAuth.test.ts` — 21 tests pass (including 2 new network error tests)
- [x] `go build ./...` — backend builds cleanly
- [x] `go test ./server/` — Go server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)