### PR TITLE
feat: enable sound effects by default

### DIFF
--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -68,7 +68,7 @@ export const SETTINGS_DEFAULTS = {
   confirmCloseActiveTab: true,
   confirmArchiveDirtySession: true,
   desktopNotifications: true,
-  soundEffects: false,
+  soundEffects: true,
   soundEffectType: 'chime',
   sendWithEnter: true,
   suggestionsEnabled: true,


### PR DESCRIPTION
## Summary
- Changes the default value for `soundEffects` from `false` to `true` in the settings store
- New/clean installs will now have sound effects enabled out of the box
- Existing users' persisted preferences are unaffected

## Test plan
- [ ] Verify sound effects toggle is enabled by default on a fresh install (clear persisted settings)
- [ ] Verify existing users with sound effects disabled retain their preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)