### PR TITLE
refactor: deduplicate getApiBase and fix conversation state leak

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -81,6 +81,16 @@ export function markPlanModeExited(conversationId: string) {
 }
 
 /**
+ * Clean up module-level state for a conversation that is being removed.
+ * Call this when deleting sessions to prevent stale entries from lingering
+ * in reconcilingConversations and recentlyExitedPlanMode maps.
+ */
+export function cleanupConversationState(conversationId: string) {
+  reconcilingConversations.delete(conversationId);
+  recentlyExitedPlanMode.delete(conversationId);
+}
+
+/**
  * Mark a session as unread and play an in-app sound when a background session
  * has a notable event (turn complete, question, plan approval).
  * Only fires if the conversation belongs to a session that is NOT currently selected.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,15 +15,6 @@ export function getApiBase(): string {
   return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:9876';
 }
 
-/**
- * @deprecated Use `getApiBase()` instead. This static export is evaluated at module
- * load time with the default port and will NOT reflect dynamically allocated ports
- * in Tauri builds. Only kept for backwards compatibility with external consumers.
- */
-export const API_BASE = typeof window !== 'undefined' && (window as Window & { __TAURI__?: unknown }).__TAURI__
-  ? 'http://localhost:9876'  // Default - does NOT update for dynamic ports!
-  : (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:9876');
-
 // Custom error class for API errors
 export class ApiError extends Error {
   public code?: string;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,19 +12,10 @@
  */
 
 import { isTauri, safeListen, safeInvoke } from '@/lib/tauri';
-import { getBackendPortSync } from '@/lib/backend-port';
 import { generateRandomString, generateCodeChallenge } from '@/lib/pkce';
 import { LINEAR_STATE_PREFIX, handleLinearOAuthCallback } from '@/lib/linearAuth';
 import type { LinearUser } from '@/lib/linearAuth';
-
-// Get API base URL dynamically based on the backend port
-function getApiBase(): string {
-  if (typeof window !== 'undefined' && (window as Window & { __TAURI__?: unknown }).__TAURI__) {
-    const port = getBackendPortSync();
-    return `http://localhost:${port}`;
-  }
-  return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:9876';
-}
+import { getApiBase } from '@/lib/api';
 
 // GitHub OAuth configuration
 const GITHUB_CLIENT_ID = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID || '';

--- a/src/lib/backend-port.ts
+++ b/src/lib/backend-port.ts
@@ -100,13 +100,6 @@ export function setBackendPort(port: number): void {
 }
 
 /**
- * Get the API base URL for the backend.
- */
-export function getApiBaseUrl(port: number = getBackendPortSync()): string {
-  return `http://localhost:${port}`;
-}
-
-/**
  * Get the WebSocket URL for the backend.
  */
 export function getWsUrl(port: number = getBackendPortSync()): string {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -33,6 +33,7 @@ import type { StreamingSnapshotDTO, SnapshotSubAgent } from '@/lib/api';
 import { useSettingsStore } from './settingsStore';
 import { refreshPRStatus } from '@/lib/api';
 import { buildTurnConfigLabel } from '@/lib/models';
+import { cleanupConversationState } from '@/hooks/useWebSocket';
 
 // Throttle on-select PR refresh to avoid excessive API calls.
 // Entries are pruned when the map exceeds MAX_PR_REFRESH_ENTRIES to prevent unbounded growth.
@@ -764,6 +765,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       .map((c) => c.id);
     clearScriptOutputBuffers(id);
     clearToolTimeoutsForConversations(sessionConvIds);
+    sessionConvIds.forEach(cleanupConversationState);
 
     set((state) => {
       // Re-derive conv IDs inside set() for consistency with latest state


### PR DESCRIPTION
## Summary

- **Deduplicate `getApiBase()`** — `auth.ts` had its own copy identical to `api.ts`; now imports from `api.ts`
- **Remove dead code** — deprecated `API_BASE` export and unused `getApiBaseUrl()` had no remaining consumers
- **Fix memory leak** — module-level Maps in `useWebSocket.ts` accumulated stale entries when sessions were deleted; added `cleanupConversationState()` called during session deletion

## Changes Made

- **`src/lib/auth.ts`** — Replaced local `getApiBase()` with import from `@/lib/api`
- **`src/lib/api.ts`** — Removed deprecated `API_BASE` static export
- **`src/lib/backend-port.ts`** — Removed unused `getApiBaseUrl()`
- **`src/hooks/useWebSocket.ts`** — Added `cleanupConversationState()` to clear `reconcilingConversations` and `recentlyExitedPlanMode` maps
- **`src/stores/appStore.ts`** — Calls `cleanupConversationState` during session deletion

## Test Plan

- [ ] `npm run lint` — no new warnings
- [ ] `npm run build` — build succeeds
- [ ] Manual: delete a session, confirm no errors in console
- [ ] Manual: OAuth login still works (auth.ts uses shared `getApiBase()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)