### PR TITLE
feat: unified MCP servers panel with source tracking

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -181,7 +181,7 @@ if (process.env.CLAUDE_CODE_USE_BEDROCK === "true") {
 
 // Instructions (e.g., from conversation summaries)
 import { readFileSync, writeFileSync, unlinkSync } from "fs";
-import { tmpdir } from "os";
+import { tmpdir, homedir } from "os";
 import { join } from "path";
 let instructions: string | undefined;
 {
@@ -332,6 +332,9 @@ let queryRef: Query | null = null;
 
 // Track current session ID
 let currentSessionId: string | undefined = undefined;
+
+// MCP server source tracking — maps server name to its origin for the UI
+let mcpServerSources: Record<string, string> = {};
 
 // Pending user question requests (for AskUserQuestion tool)
 const ASK_USER_QUESTION_HOOK_TIMEOUT_S = 86400; // 24 hours — lets users take as long as they need
@@ -1597,8 +1600,10 @@ async function main(): Promise<void> {
     // Create ChatML MCP server
     const chatmlMcp = createChatMLMcpServer({ context: workspaceContext });
 
-    // Build merged MCP servers map: built-in + .mcp.json + user-configured
+    // Build merged MCP servers map: built-in + .mcp.json + claude-cli + user-configured
+    // Merge priority (later wins): builtin → dot-mcp → claude-cli-user → claude-cli-project → chatml
     const mergedMcpServers: Record<string, McpServerConfig> = { chatml: chatmlMcp };
+    mcpServerSources = { chatml: "builtin" };
 
     // Load .mcp.json from worktree root (project-level config)
     // Gated by --skip-dot-mcp flag to prevent untrusted repos from executing commands
@@ -1610,6 +1615,7 @@ async function main(): Promise<void> {
         if (dotMcpConfig.mcpServers) {
           for (const [name, config] of Object.entries(dotMcpConfig.mcpServers)) {
             mergedMcpServers[name] = config;
+            mcpServerSources[name] = "dot-mcp";
             debug(`Loaded MCP server from .mcp.json: ${name}`);
           }
         }
@@ -1618,6 +1624,42 @@ async function main(): Promise<void> {
       }
     } else {
       debug("Skipping .mcp.json loading (--skip-dot-mcp flag set)");
+    }
+
+    // Load Claude Code CLI user-level MCP servers (~/.claude/settings.json)
+    // Always trusted — this is the user's own global config
+    try {
+      const userSettingsPath = join(homedir(), ".claude", "settings.json");
+      const userSettingsContent = readFileSync(userSettingsPath, "utf-8");
+      const userSettings = JSON.parse(userSettingsContent) as { mcpServers?: Record<string, McpServerConfig> };
+      if (userSettings.mcpServers) {
+        for (const [name, config] of Object.entries(userSettings.mcpServers)) {
+          mergedMcpServers[name] = config;
+          mcpServerSources[name] = "claude-cli-user";
+          debug(`Loaded MCP server from ~/.claude/settings.json: ${name}`);
+        }
+      }
+    } catch {
+      // ~/.claude/settings.json doesn't exist or is invalid — that's fine
+    }
+
+    // Load Claude Code CLI project-level MCP servers (<cwd>/.claude/settings.json)
+    // Gated by same trust mechanism as .mcp.json
+    if (!skipDotMcp) {
+      try {
+        const projectSettingsPath = join(cwd, ".claude", "settings.json");
+        const projectSettingsContent = readFileSync(projectSettingsPath, "utf-8");
+        const projectSettings = JSON.parse(projectSettingsContent) as { mcpServers?: Record<string, McpServerConfig> };
+        if (projectSettings.mcpServers) {
+          for (const [name, config] of Object.entries(projectSettings.mcpServers)) {
+            mergedMcpServers[name] = config;
+            mcpServerSources[name] = "claude-cli-project";
+            debug(`Loaded MCP server from .claude/settings.json: ${name}`);
+          }
+        }
+      } catch {
+        // .claude/settings.json doesn't exist or is invalid — that's fine
+      }
     }
 
     // Load user-configured MCP servers from backend (via temp file)
@@ -1654,6 +1696,10 @@ async function main(): Promise<void> {
               url: server.url,
               headers: server.headers || {},
             };
+            mcpServerSources[server.name] = "chatml";
+          } else {
+            debug(`Skipped user MCP server with unsupported config: ${server.name} (${server.type})`);
+            continue;
           }
           debug(`Loaded user MCP server: ${server.name} (${server.type})`);
         }
@@ -2305,6 +2351,7 @@ function handleMessage(message: SDKMessage): void {
           model: initMsg.model,
           tools: initMsg.tools,
           mcpServers: initMsg.mcp_servers,
+          mcpServerSources,
           slashCommands: initMsg.slash_commands,
           skills: initMsg.skills,
           plugins: initMsg.plugins,

--- a/backend/server/settings_handlers.go
+++ b/backend/server/settings_handlers.go
@@ -717,14 +717,16 @@ func (h *Handlers) SetDotMcpTrust(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]string{"status": body.Status})
 }
 
-// DotMcpServerInfo describes a single server entry from a .mcp.json file.
+// DotMcpServerInfo describes a single server entry from a project-level MCP config file.
 type DotMcpServerInfo struct {
 	Name    string `json:"name"`
 	Type    string `json:"type"`
 	Command string `json:"command,omitempty"`
+	Source  string `json:"source,omitempty"` // "dot-mcp" or "claude-cli-project"
 }
 
-// GetDotMcpInfo checks whether a .mcp.json file exists in the workspace and returns its server list.
+// GetDotMcpInfo checks whether project-level MCP config files exist in the workspace
+// and returns their combined server list. Checks both .mcp.json and .claude/settings.json.
 func (h *Handlers) GetDotMcpInfo(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	repoID := chi.URLParam(r, "id")
@@ -739,36 +741,71 @@ func (h *Handlers) GetDotMcpInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Use a map to dedup — later sources (claude-cli-project) override earlier (dot-mcp),
+	// matching the agent-runner merge priority.
+	serverMap := make(map[string]DotMcpServerInfo)
+	anyExists := false
+
+	// Check .mcp.json
 	dotMcpPath := repo.Path + "/.mcp.json"
-	data, err := os.ReadFile(dotMcpPath)
-	if err != nil {
-		// File doesn't exist or is unreadable
+	if data, err := os.ReadFile(dotMcpPath); err == nil {
+		anyExists = true
+		var config struct {
+			McpServers map[string]struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"mcpServers"`
+		}
+		if err := json.Unmarshal(data, &config); err == nil {
+			for name, s := range config.McpServers {
+				serverType := s.Type
+				if serverType == "" {
+					serverType = "stdio"
+				}
+				serverMap[name] = DotMcpServerInfo{
+					Name:    name,
+					Type:    serverType,
+					Command: s.Command,
+					Source:  "dot-mcp",
+				}
+			}
+		}
+	}
+
+	// Check .claude/settings.json for mcpServers
+	claudeSettingsPath := repo.Path + "/.claude/settings.json"
+	if data, err := os.ReadFile(claudeSettingsPath); err == nil {
+		var config struct {
+			McpServers map[string]struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"mcpServers"`
+		}
+		if err := json.Unmarshal(data, &config); err == nil && len(config.McpServers) > 0 {
+			anyExists = true
+			for name, s := range config.McpServers {
+				serverType := s.Type
+				if serverType == "" {
+					serverType = "stdio"
+				}
+				serverMap[name] = DotMcpServerInfo{
+					Name:    name,
+					Type:    serverType,
+					Command: s.Command,
+					Source:  "claude-cli-project",
+				}
+			}
+		}
+	}
+
+	if !anyExists {
 		writeJSON(w, map[string]interface{}{"exists": false, "servers": []DotMcpServerInfo{}})
 		return
 	}
 
-	var config struct {
-		McpServers map[string]struct {
-			Type    string `json:"type"`
-			Command string `json:"command"`
-		} `json:"mcpServers"`
-	}
-	if err := json.Unmarshal(data, &config); err != nil {
-		writeJSON(w, map[string]interface{}{"exists": true, "servers": []DotMcpServerInfo{}})
-		return
-	}
-
-	servers := make([]DotMcpServerInfo, 0, len(config.McpServers))
-	for name, s := range config.McpServers {
-		serverType := s.Type
-		if serverType == "" {
-			serverType = "stdio"
-		}
-		servers = append(servers, DotMcpServerInfo{
-			Name:    name,
-			Type:    serverType,
-			Command: s.Command,
-		})
+	servers := make([]DotMcpServerInfo, 0, len(serverMap))
+	for _, s := range serverMap {
+		servers = append(servers, s)
 	}
 
 	slices.SortFunc(servers, func(a, b DotMcpServerInfo) int {

--- a/src/components/dialogs/DotMcpTrustDialog.tsx
+++ b/src/components/dialogs/DotMcpTrustDialog.tsx
@@ -9,6 +9,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { ShieldAlert, Terminal, Globe } from 'lucide-react';
 import type { DotMcpServerInfo } from '@/lib/api';
 
 interface DotMcpTrustDialogProps {
@@ -20,6 +22,17 @@ interface DotMcpTrustDialogProps {
   onDeny: () => void;
 }
 
+function sourceLabel(source?: string): string {
+  switch (source) {
+    case 'claude-cli-project':
+      return '.claude/settings.json';
+    case 'dot-mcp':
+      return '.mcp.json';
+    default:
+      return '.mcp.json';
+  }
+}
+
 export function DotMcpTrustDialog({
   open,
   onOpenChange,
@@ -28,8 +41,14 @@ export function DotMcpTrustDialog({
   onAllow,
   onDeny,
 }: DotMcpTrustDialogProps) {
-  const stdioServers = servers.filter((s) => s.type === 'stdio');
-  const hasStdio = stdioServers.length > 0;
+  const hasStdio = servers.some((s) => s.type === 'stdio');
+  const hasMcpJson = servers.some((s) => !s.source || s.source === 'dot-mcp');
+  const hasClaudeSettings = servers.some((s) => s.source === 'claude-cli-project');
+
+  // Build description of which config files were found
+  const configFiles: string[] = [];
+  if (hasMcpJson || (!hasMcpJson && !hasClaudeSettings)) configFiles.push('.mcp.json');
+  if (hasClaudeSettings) configFiles.push('.claude/settings.json');
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -40,51 +59,83 @@ export function DotMcpTrustDialog({
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
         <DialogHeader>
-          <DialogTitle>Workspace MCP servers detected</DialogTitle>
-          <DialogDescription>
-            <span className="font-medium text-foreground">{workspaceName}</span> contains a{' '}
-            <code className="text-xs bg-muted px-1 py-0.5 rounded">.mcp.json</code> file that
-            defines MCP servers.
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldAlert className="w-5 h-5 text-orange-500 shrink-0" />
+            Project MCP servers detected
+          </DialogTitle>
+          <DialogDescription className="pt-1">
+            <span className="font-medium text-foreground">{workspaceName}</span>{' '}
+            contains {configFiles.length === 1 ? 'a ' : ''}
+            {configFiles.map((f, i) => (
+              <span key={f}>
+                {i > 0 && ' and '}
+                <code className="text-xs bg-muted px-1 py-0.5 rounded">{f}</code>
+              </span>
+            ))}{' '}
+            {configFiles.length === 1 ? 'file' : 'files'} that{' '}
+            {configFiles.length === 1 ? 'defines' : 'define'} MCP servers.
             {hasStdio && ' Some of these servers will execute commands on your system.'}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-2 py-2">
-          {servers.map((server) => (
-            <div
-              key={server.name}
-              className={`rounded-md border px-3 py-2 text-sm ${
-                server.type === 'stdio'
-                  ? 'border-orange-500/30 bg-orange-500/5'
-                  : 'border-border bg-muted/30'
-              }`}
-            >
-              <div className="flex items-center justify-between">
-                <span className="font-medium">{server.name}</span>
-                <span className="text-xs text-muted-foreground uppercase">{server.type}</span>
-              </div>
-              {server.command && (
-                <div className="mt-1 font-mono text-xs text-muted-foreground truncate">
-                  {server.command}
+        <ScrollArea className="max-h-[240px]">
+          <div className="space-y-2 py-3">
+            {servers.map((server) => {
+              const isStdio = server.type === 'stdio';
+              const TypeIcon = isStdio ? Terminal : Globe;
+
+              return (
+                <div
+                  key={`${server.name}-${server.source}`}
+                  className={`rounded-md border px-3 py-2.5 text-sm ${
+                    isStdio
+                      ? 'border-orange-500/30 bg-orange-500/5'
+                      : 'border-border bg-muted/30'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <TypeIcon className={`w-3.5 h-3.5 shrink-0 ${isStdio ? 'text-orange-500' : 'text-muted-foreground'}`} />
+                    <span className="font-medium flex-1 truncate">{server.name}</span>
+                    <span className="text-[10px] text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded">
+                      {sourceLabel(server.source)}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground uppercase">{server.type}</span>
+                  </div>
+                  {server.command && (
+                    <div className="mt-1.5 ml-5.5 font-mono text-xs text-muted-foreground truncate">
+                      {server.command}
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          ))}
-        </div>
+              );
+            })}
+          </div>
+        </ScrollArea>
 
         {hasStdio && (
-          <p className="text-xs text-orange-600 dark:text-orange-400">
-            Stdio servers run shell commands under your user account. Only allow this if you trust
-            the repository.
-          </p>
+          <div className="flex items-start gap-2 rounded-md bg-orange-500/5 border border-orange-500/20 px-3 py-2.5">
+            <Terminal className="w-3.5 h-3.5 text-orange-500 shrink-0 mt-0.5" />
+            <p className="text-xs text-orange-600 dark:text-orange-400">
+              Stdio servers run shell commands under your user account. Only allow this if you trust
+              the repository.
+            </p>
+          </div>
         )}
 
-        <DialogFooter className="gap-2 sm:gap-0">
-          <Button variant="outline" onClick={onDeny}>
-            Deny
-          </Button>
-          <Button onClick={onAllow}>Allow</Button>
-        </DialogFooter>
+        <div className="border-t border-border/50 pt-4">
+          <DialogFooter className="gap-3 sm:gap-3">
+            <Button
+              variant="outline"
+              onClick={onDeny}
+              className="flex-1 text-destructive hover:text-destructive hover:bg-destructive/10 border-destructive/30"
+            >
+              Deny
+            </Button>
+            <Button onClick={onAllow} className="flex-1">
+              Allow
+            </Button>
+          </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dialogs/__tests__/DotMcpTrustDialog.test.tsx
+++ b/src/components/dialogs/__tests__/DotMcpTrustDialog.test.tsx
@@ -17,7 +17,7 @@ describe('DotMcpTrustDialog', () => {
   it('renders title and workspace name', () => {
     render(<DotMcpTrustDialog {...defaultProps} />);
 
-    expect(screen.getByText('Workspace MCP servers detected')).toBeInTheDocument();
+    expect(screen.getByText('Project MCP servers detected')).toBeInTheDocument();
     expect(screen.getByText('My Project')).toBeInTheDocument();
   });
 
@@ -30,7 +30,7 @@ describe('DotMcpTrustDialog', () => {
 
   it('displays stdio server with command', () => {
     const servers: DotMcpServerInfo[] = [
-      { name: 'test-server', type: 'stdio', command: 'npx -y @mcp/test' },
+      { name: 'test-server', type: 'stdio', command: 'npx -y @mcp/test', source: 'dot-mcp' },
     ];
 
     render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
@@ -42,7 +42,7 @@ describe('DotMcpTrustDialog', () => {
 
   it('displays SSE server without command', () => {
     const servers: DotMcpServerInfo[] = [
-      { name: 'sse-server', type: 'sse' },
+      { name: 'sse-server', type: 'sse', source: 'dot-mcp' },
     ];
 
     render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
@@ -53,8 +53,8 @@ describe('DotMcpTrustDialog', () => {
 
   it('displays multiple servers', () => {
     const servers: DotMcpServerInfo[] = [
-      { name: 'server-a', type: 'stdio', command: 'echo' },
-      { name: 'server-b', type: 'http' },
+      { name: 'server-a', type: 'stdio', command: 'echo', source: 'dot-mcp' },
+      { name: 'server-b', type: 'http', source: 'dot-mcp' },
     ];
 
     render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
@@ -65,7 +65,7 @@ describe('DotMcpTrustDialog', () => {
 
   it('shows warning when stdio servers are present', () => {
     const servers: DotMcpServerInfo[] = [
-      { name: 'cmd-server', type: 'stdio', command: 'rm -rf /' },
+      { name: 'cmd-server', type: 'stdio', command: 'rm -rf /', source: 'dot-mcp' },
     ];
 
     render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
@@ -76,7 +76,7 @@ describe('DotMcpTrustDialog', () => {
 
   it('does not show stdio warning when only non-stdio servers', () => {
     const servers: DotMcpServerInfo[] = [
-      { name: 'safe-server', type: 'sse' },
+      { name: 'safe-server', type: 'sse', source: 'dot-mcp' },
     ];
 
     render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
@@ -107,12 +107,26 @@ describe('DotMcpTrustDialog', () => {
   it('does not render when open is false', () => {
     render(<DotMcpTrustDialog {...defaultProps} open={false} />);
 
-    expect(screen.queryByText('Workspace MCP servers detected')).not.toBeInTheDocument();
+    expect(screen.queryByText('Project MCP servers detected')).not.toBeInTheDocument();
   });
 
   it('mentions .mcp.json in description', () => {
     render(<DotMcpTrustDialog {...defaultProps} />);
 
     expect(screen.getByText('.mcp.json')).toBeInTheDocument();
+  });
+
+  it('shows source badges for servers from different configs', () => {
+    const servers: DotMcpServerInfo[] = [
+      { name: 'mcp-server', type: 'stdio', command: 'echo', source: 'dot-mcp' },
+      { name: 'claude-server', type: 'sse', source: 'claude-cli-project' },
+    ];
+
+    render(<DotMcpTrustDialog {...defaultProps} servers={servers} />);
+
+    // Source badges should show the config file origin
+    // .mcp.json appears in description and badge; .claude/settings.json in description and badge
+    expect(screen.getAllByText('.mcp.json').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('.claude/settings.json').length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/components/panels/McpServersPanel.tsx
+++ b/src/components/panels/McpServersPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { useMcpServers } from '@/stores/selectors';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMcpServers, useMcpServerSources } from '@/stores/selectors';
 import { useAppStore } from '@/stores/appStore';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -31,12 +31,11 @@ import {
   Plus,
   Pencil,
   Trash2,
-  Settings2,
   Wrench,
   Minus,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { McpServerStatus, McpServerConfig } from '@/lib/types';
+import type { McpServerStatus, McpServerConfig, McpServerSource } from '@/lib/types';
 
 const STATUS_CONFIG = {
   connected: {
@@ -71,6 +70,24 @@ const STATUS_CONFIG = {
   },
 } as const;
 
+const SOURCE_BADGE_CONFIG: Record<string, { label: string; className: string }> = {
+  builtin: { label: 'Built-in', className: 'bg-muted text-muted-foreground' },
+  'dot-mcp': { label: '.mcp.json', className: 'bg-blue-500/10 text-blue-600 dark:text-blue-400' },
+  'claude-cli-user': { label: 'Claude Code', className: 'bg-purple-500/10 text-purple-600 dark:text-purple-400' },
+  'claude-cli-project': { label: 'Claude Code (Project)', className: 'bg-purple-500/10 text-purple-600 dark:text-purple-400' },
+  chatml: { label: 'ChatML', className: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' },
+};
+
+interface UnifiedServer {
+  name: string;
+  status: McpServerStatus['status'];
+  source: McpServerSource | string;
+  toolCount?: number;
+  isEditable: boolean;
+  configIndex?: number; // index into mcpServerConfigs for editable servers
+  config?: McpServerConfig;
+}
+
 const EMPTY_SERVER: McpServerConfig = {
   name: '',
   type: 'stdio',
@@ -88,13 +105,13 @@ export function McpServersPanel() {
   const fetchMcpServerConfigs = useAppStore((s) => s.fetchMcpServerConfigs);
   const saveMcpServerConfigs = useAppStore((s) => s.saveMcpServerConfigs);
   const mcpToolsByServer = useAppStore((s) => s.mcpToolsByServer);
+  const mcpServerSources = useMcpServerSources();
 
-  const [showConfig, setShowConfig] = useState(false);
   const [editingServer, setEditingServer] = useState<McpServerConfig | null>(null);
   const [editingIndex, setEditingIndex] = useState<number>(-1);
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  // Load configs when workspace changes (needed for both status and config views)
+  // Load configs when workspace changes
   useEffect(() => {
     if (workspaceId) {
       fetchMcpServerConfigs(workspaceId);
@@ -139,98 +156,108 @@ export function McpServersPanel() {
     setDialogOpen(false);
   }, [workspaceId, mcpServerConfigs, editingIndex, saveMcpServerConfigs]);
 
-  // Build a status lookup from runtime status
-  const statusMap = new Map<string, McpServerStatus>();
-  for (const s of mcpServers) {
-    statusMap.set(s.name, s);
-  }
+  // Build unified server list
+  const unifiedServers = useMemo(() => {
+    const servers: UnifiedServer[] = [];
+    const seen = new Set<string>();
 
-  const hasContent = mcpServers.length > 0 || mcpServerConfigs.length > 0;
+    // Runtime status map
+    const statusMap = new Map<string, McpServerStatus>();
+    for (const s of mcpServers) {
+      statusMap.set(s.name, s);
+    }
+
+    // Config index map for editable servers
+    const configIndexMap = new Map<string, number>();
+    for (let i = 0; i < mcpServerConfigs.length; i++) {
+      configIndexMap.set(mcpServerConfigs[i].name, i);
+    }
+
+    // Add runtime servers first (these are actively connected/failed/pending)
+    for (const server of mcpServers) {
+      seen.add(server.name);
+      const source = mcpServerSources[server.name] || 'builtin';
+      const isEditable = source === 'chatml';
+      const configIdx = configIndexMap.get(server.name);
+      servers.push({
+        name: server.name,
+        status: server.status,
+        source,
+        toolCount: mcpToolsByServer[server.name]?.length,
+        isEditable,
+        configIndex: isEditable ? configIdx : undefined,
+        config: configIdx != null ? mcpServerConfigs[configIdx] : undefined,
+      });
+    }
+
+    // Add configured ChatML servers not in runtime status as "idle"
+    for (let i = 0; i < mcpServerConfigs.length; i++) {
+      const config = mcpServerConfigs[i];
+      if (!seen.has(config.name)) {
+        seen.add(config.name);
+        servers.push({
+          name: config.name,
+          status: 'idle',
+          source: 'chatml',
+          isEditable: true,
+          configIndex: i,
+          config,
+        });
+      }
+    }
+
+    return servers;
+  }, [mcpServers, mcpServerConfigs, mcpServerSources, mcpToolsByServer]);
+
+  const hasContent = unifiedServers.length > 0;
 
   return (
     <div className="h-full flex flex-col">
-      {/* Header with toggle */}
+      {/* Header */}
       <div className="flex items-center justify-between px-2 py-1.5 border-b border-border/50">
-        <button
-          className={cn(
-            'flex items-center gap-1.5 text-xs font-medium transition-colors',
-            showConfig ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
-          )}
-          onClick={() => setShowConfig(!showConfig)}
+        <span className="text-xs font-medium text-muted-foreground">
+          MCP Servers
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={handleAdd}
+          disabled={!workspaceId}
+          title="Add ChatML MCP server"
         >
-          <Settings2 className="w-3.5 h-3.5" />
-          Configure
-        </button>
-        {showConfig && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 w-6 p-0"
-            onClick={handleAdd}
-            disabled={!workspaceId}
-          >
-            <Plus className="w-3.5 h-3.5" />
-          </Button>
-        )}
+          <Plus className="w-3.5 h-3.5" />
+        </Button>
       </div>
 
       <ScrollArea className="flex-1">
-        {showConfig ? (
-          // Configuration view
-          <div className="p-2 space-y-1">
-            {mcpConfigLoading && mcpServerConfigs.length === 0 && (
-              <p className="text-xs text-muted-foreground text-center py-4">Loading...</p>
-            )}
-            {!mcpConfigLoading && mcpServerConfigs.length === 0 && (
-              <EmptyState
-                icon={Server}
-                title="No MCP servers configured"
-                description="Add servers to extend agent capabilities"
-              />
-            )}
-            {mcpServerConfigs.map((config, i) => {
-              const status = statusMap.get(config.name);
-              return (
-                <ConfigRow
-                  key={`${config.name}-${i}`}
-                  config={config}
-                  status={status}
-                  toolCount={mcpToolsByServer[config.name]?.length}
-                  onEdit={() => handleEdit(config, i)}
-                  onDelete={() => handleDelete(i)}
-                  onToggle={() => handleToggle(i)}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          // Runtime status view — shows live servers + configured idle ones
-          <div className="p-2 space-y-1">
-            {!hasContent && (
-              <EmptyState
-                icon={Server}
-                title="No MCP servers"
-                description="Servers will appear when agent starts"
-              />
-            )}
-            {mcpServers.map((server) => (
-              <StatusRow
-                key={server.name}
-                server={server}
-                toolCount={mcpToolsByServer[server.name]?.length}
-              />
-            ))}
-            {/* Show configured servers that aren't in runtime status as "idle" */}
-            {mcpServerConfigs
-              .filter((c) => c.enabled && !statusMap.has(c.name))
-              .map((config) => (
-                <StatusRow
-                  key={`idle-${config.name}`}
-                  server={{ name: config.name, status: 'idle' }}
-                />
-              ))}
-          </div>
-        )}
+        <div className="p-2 space-y-1">
+          {mcpConfigLoading && !hasContent && (
+            <p className="text-xs text-muted-foreground text-center py-4">Loading...</p>
+          )}
+          {!mcpConfigLoading && !hasContent && (
+            <EmptyState
+              icon={Server}
+              title="No MCP servers"
+              description="Servers will appear when agent starts"
+            />
+          )}
+          {unifiedServers.map((server) => (
+            <ServerRow
+              key={server.name}
+              server={server}
+              onEdit={server.isEditable && server.configIndex != null && server.config
+                ? () => handleEdit(server.config!, server.configIndex!)
+                : undefined}
+              onDelete={server.isEditable && server.configIndex != null
+                ? () => handleDelete(server.configIndex!)
+                : undefined}
+              onToggle={server.isEditable && server.configIndex != null
+                ? () => handleToggle(server.configIndex!)
+                : undefined}
+            />
+          ))}
+        </div>
       </ScrollArea>
 
       {/* Edit/Add dialog */}
@@ -246,82 +273,83 @@ export function McpServersPanel() {
   );
 }
 
-function StatusRow({ server, toolCount }: { server: McpServerStatus; toolCount?: number }) {
-  const config = STATUS_CONFIG[server.status as keyof typeof STATUS_CONFIG] || STATUS_CONFIG.pending;
-  const Icon = config.icon;
-
+function SourceBadge({ source }: { source: string }) {
+  const badge = SOURCE_BADGE_CONFIG[source] || SOURCE_BADGE_CONFIG.builtin;
   return (
-    <div
-      className={cn(
-        'flex items-center gap-2 px-2 py-1.5 rounded-md',
-        config.bgColor
-      )}
-    >
-      <Icon className={cn('w-3.5 h-3.5 shrink-0', config.color)} />
-      <span className="text-sm font-medium flex-1 truncate">{server.name}</span>
-      {toolCount != null && toolCount > 0 && (
-        <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground" title={`${toolCount} tools`}>
-          <Wrench className="w-2.5 h-2.5" />
-          {toolCount}
-        </span>
-      )}
-      <span className={cn('text-xs', config.color)}>{config.label}</span>
-    </div>
+    <span className={cn('text-[9px] font-medium px-1.5 py-0.5 rounded-full whitespace-nowrap', badge.className)}>
+      {badge.label}
+    </span>
   );
 }
 
-function ConfigRow({
-  config,
-  status,
-  toolCount,
+function ServerRow({
+  server,
   onEdit,
   onDelete,
   onToggle,
 }: {
-  config: McpServerConfig;
-  status?: McpServerStatus;
-  toolCount?: number;
-  onEdit: () => void;
-  onDelete: () => void;
-  onToggle: () => void;
+  server: UnifiedServer;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onToggle?: () => void;
 }) {
-  const statusConfig = status ? STATUS_CONFIG[status.status] : null;
-  const StatusIcon = statusConfig?.icon;
+  const statusConfig = STATUS_CONFIG[server.status as keyof typeof STATUS_CONFIG] || STATUS_CONFIG.pending;
+  const StatusIcon = statusConfig.icon;
+  const isDisabled = server.config && !server.config.enabled;
 
   return (
-    <div className="flex items-center gap-2 px-2 py-1.5 rounded-md bg-muted/30 group">
-      <Switch
-        checked={config.enabled}
-        onCheckedChange={onToggle}
-        className="scale-75"
-      />
+    <div className={cn(
+      'flex items-center gap-2 px-2 py-1.5 rounded-md group',
+      statusConfig.bgColor
+    )}>
+      {/* Toggle switch for editable servers */}
+      {onToggle ? (
+        <Switch
+          checked={server.config?.enabled ?? true}
+          onCheckedChange={onToggle}
+          className="scale-75 shrink-0"
+        />
+      ) : (
+        <StatusIcon className={cn('w-3.5 h-3.5 shrink-0', statusConfig.color)} />
+      )}
+
+      {/* Server info */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
-          <span className={cn('text-sm font-medium truncate', !config.enabled && 'text-muted-foreground')}>
-            {config.name}
+          <span className={cn('text-sm font-medium truncate', isDisabled && 'text-muted-foreground')}>
+            {server.name}
           </span>
-          {StatusIcon && (
-            <StatusIcon className={cn('w-3 h-3 shrink-0', statusConfig?.color)} />
+          {onToggle && (
+            <StatusIcon className={cn('w-3 h-3 shrink-0', statusConfig.color)} />
           )}
-          {toolCount != null && toolCount > 0 && (
-            <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground" title={`${toolCount} tools`}>
+          {server.toolCount != null && server.toolCount > 0 && (
+            <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground" title={`${server.toolCount} tools`}>
               <Wrench className="w-2.5 h-2.5" />
-              {toolCount}
+              {server.toolCount}
             </span>
           )}
         </div>
-        <span className="text-[10px] text-muted-foreground">
-          {config.type === 'stdio' ? config.command : config.url}
-        </span>
+        <div className="flex items-center gap-1.5 mt-0.5">
+          <SourceBadge source={server.source} />
+          <span className={cn('text-xs', statusConfig.color)}>{statusConfig.label}</span>
+        </div>
       </div>
-      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-        <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={onEdit}>
-          <Pencil className="w-3 h-3" />
-        </Button>
-        <Button variant="ghost" size="sm" className="h-6 w-6 p-0 text-text-error" onClick={onDelete}>
-          <Trash2 className="w-3 h-3" />
-        </Button>
-      </div>
+
+      {/* Edit/delete controls for ChatML servers */}
+      {(onEdit || onDelete) && (
+        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+          {onEdit && (
+            <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={onEdit}>
+              <Pencil className="w-3 h-3" />
+            </Button>
+          )}
+          {onDelete && (
+            <Button variant="ghost" size="sm" className="h-6 w-6 p-0 text-text-error" onClick={onDelete}>
+              <Trash2 className="w-3 h-3" />
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/panels/__tests__/McpServersPanel.test.tsx
+++ b/src/components/panels/__tests__/McpServersPanel.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { McpServersPanel } from '../McpServersPanel';
 import { useAppStore } from '@/stores/appStore';
 
@@ -19,6 +18,7 @@ describe('McpServersPanel', () => {
       mcpServerConfigs: [],
       mcpConfigLoading: false,
       mcpToolsByServer: {},
+      mcpServerSources: {},
       fetchMcpServerConfigs: fetchMcpServerConfigsMock,
       saveMcpServerConfigs: saveMcpServerConfigsMock,
     });
@@ -71,44 +71,44 @@ describe('McpServersPanel', () => {
   });
 
   // --------------------------------------------------------------------------
-  // Configure toggle
+  // Unified view with source badges
   // --------------------------------------------------------------------------
 
-  it('shows Configure button', () => {
+  it('shows source badges for servers', () => {
+    useAppStore.setState({
+      mcpServers: [
+        { name: 'chatml', status: 'connected' },
+        { name: 'tauri', status: 'connected' },
+      ],
+      mcpServerSources: {
+        chatml: 'builtin',
+        tauri: 'dot-mcp',
+      },
+    });
+
     render(<McpServersPanel />);
-    expect(screen.getByText('Configure')).toBeInTheDocument();
+
+    expect(screen.getByText('Built-in')).toBeInTheDocument();
+    expect(screen.getByText('.mcp.json')).toBeInTheDocument();
   });
 
-  it('toggles to config view', async () => {
-    const user = userEvent.setup();
-    render(<McpServersPanel />);
-
-    await user.click(screen.getByText('Configure'));
-
-    expect(screen.getByText('No MCP servers configured')).toBeInTheDocument();
-  });
-
-  it('shows configured servers in config view', async () => {
+  it('shows configured servers in unified view', () => {
     useAppStore.setState({
       mcpServerConfigs: [
         { name: 'my-server', type: 'stdio', command: 'npx', enabled: true },
       ],
     });
 
-    const user = userEvent.setup();
     render(<McpServersPanel />);
 
-    await user.click(screen.getByText('Configure'));
-
     expect(screen.getByText('my-server')).toBeInTheDocument();
-    expect(screen.getByText('npx')).toBeInTheDocument();
   });
 
   // --------------------------------------------------------------------------
-  // Idle servers in status view
+  // Idle servers
   // --------------------------------------------------------------------------
 
-  it('shows idle servers in status view', () => {
+  it('shows idle servers from config', () => {
     useAppStore.setState({
       mcpServers: [],
       mcpServerConfigs: [
@@ -122,7 +122,7 @@ describe('McpServersPanel', () => {
     expect(screen.getByText('Idle')).toBeInTheDocument();
   });
 
-  it('disabled servers not shown as idle', () => {
+  it('shows disabled servers with toggle off', () => {
     useAppStore.setState({
       mcpServers: [],
       mcpServerConfigs: [
@@ -132,9 +132,8 @@ describe('McpServersPanel', () => {
 
     render(<McpServersPanel />);
 
-    // Disabled servers should not appear in the status view
-    expect(screen.queryByText('disabled-server')).not.toBeInTheDocument();
-    expect(screen.queryByText('Idle')).not.toBeInTheDocument();
+    // Disabled servers still appear in unified view (with toggle switch off)
+    expect(screen.getByText('disabled-server')).toBeInTheDocument();
   });
 
   // --------------------------------------------------------------------------
@@ -153,6 +152,37 @@ describe('McpServersPanel', () => {
 
     expect(screen.getByText('github')).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  // --------------------------------------------------------------------------
+  // Edit controls only for ChatML servers
+  // --------------------------------------------------------------------------
+
+  it('shows edit controls for ChatML-managed servers', () => {
+    useAppStore.setState({
+      mcpServers: [{ name: 'my-server', status: 'connected' }],
+      mcpServerConfigs: [
+        { name: 'my-server', type: 'stdio', command: 'npx', enabled: true },
+      ],
+      mcpServerSources: { 'my-server': 'chatml' },
+    });
+
+    render(<McpServersPanel />);
+
+    // ChatML servers should have a toggle switch
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  it('does not show edit controls for external servers', () => {
+    useAppStore.setState({
+      mcpServers: [{ name: 'chatml', status: 'connected' }],
+      mcpServerSources: { chatml: 'builtin' },
+    });
+
+    render(<McpServersPanel />);
+
+    // Built-in servers should not have edit controls
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
   });
 
   // --------------------------------------------------------------------------

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -405,6 +405,10 @@ export function useWebSocket(enabled: boolean = true) {
           }
           store.setMcpToolsByServer(toolsByServer);
         }
+        // Extract MCP server source origins
+        if (event?.mcpServerSources && typeof event.mcpServerSources === 'object') {
+          store.setMcpServerSources(event.mcpServerSources as Record<string, string>);
+        }
         break;
 
       case 'assistant_text':
@@ -1377,11 +1381,14 @@ export function useWebSocket(enabled: boolean = true) {
           return;
         }
 
-        // Handle init event for MCP server status
+        // Handle init event for MCP server status and source tracking
         if (data.type === 'init') {
           const payload = data.payload as Record<string, unknown> | undefined;
           if (payload?.mcpServers && Array.isArray(payload.mcpServers)) {
             getStore().setMcpServers(payload.mcpServers);
+          }
+          if (payload?.mcpServerSources && typeof payload.mcpServerSources === 'object') {
+            getStore().setMcpServerSources(payload.mcpServerSources as Record<string, string>);
           }
           return;
         }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2208,6 +2208,7 @@ export interface DotMcpServerInfo {
   name: string;
   type: string;
   command?: string;
+  source?: string; // 'dot-mcp' | 'claude-cli-project'
 }
 
 export interface DotMcpInfoResponse {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -311,6 +311,7 @@ export interface AgentEvent {
   model?: string;
   tools?: string[];
   mcpServers?: McpServerStatus[];
+  mcpServerSources?: Record<string, McpServerSource>;
   slashCommands?: string[];
   skills?: string[];
   plugins?: PluginInfo[];
@@ -425,10 +426,14 @@ export interface AgentEvent {
   maxAttempts?: number;
 }
 
+// MCP server source — where the server configuration originated
+export type McpServerSource = 'builtin' | 'dot-mcp' | 'claude-cli-user' | 'claude-cli-project' | 'chatml';
+
 // MCP server status
 export interface McpServerStatus {
   name: string;
   status: 'connected' | 'failed' | 'needs-auth' | 'pending' | 'idle';
+  source?: McpServerSource;
 }
 
 // MCP server configuration (user-managed)

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -244,6 +244,7 @@ interface AppState {
   mcpServerConfigs: McpServerConfig[];
   mcpConfigLoading: boolean;
   mcpToolsByServer: Record<string, string[]>; // server name → tool names
+  mcpServerSources: Record<string, string>;   // server name → source origin
 
   // Checkpoint timeline state
   checkpoints: CheckpointInfo[];
@@ -479,6 +480,7 @@ interface AppState {
   updateMcpServerStatus: (serverName: string, status: McpServerStatus['status']) => void;
   removeMcpServer: (serverName: string) => void;
   setMcpToolsByServer: (tools: Record<string, string[]>) => void;
+  setMcpServerSources: (sources: Record<string, string>) => void;
   fetchMcpServerConfigs: (workspaceId: string) => Promise<void>;
   saveMcpServerConfigs: (workspaceId: string, configs: McpServerConfig[]) => Promise<void>;
 
@@ -564,6 +566,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   mcpServerConfigs: [],
   mcpConfigLoading: false,
   mcpToolsByServer: {},
+  mcpServerSources: {},
   checkpoints: [],
   pendingCheckpointUuid: {},
   contextUsage: {},
@@ -2158,6 +2161,7 @@ updateFileTabContent: (id, content) => set((state) => ({
     mcpServers: state.mcpServers.filter((s) => s.name !== serverName),
   })),
   setMcpToolsByServer: (tools) => set({ mcpToolsByServer: tools }),
+  setMcpServerSources: (sources) => set({ mcpServerSources: sources }),
   fetchMcpServerConfigs: async (workspaceId) => {
     set({ mcpConfigLoading: true });
     try {

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -381,6 +381,12 @@ export const useFileChanges = () => useAppStore((s) => s.fileChanges);
  */
 export const useMcpServers = () => useAppStore((s) => s.mcpServers);
 
+/**
+ * MCP server source origins (server name → source).
+ * Use in: McpServersPanel
+ */
+export const useMcpServerSources = () => useAppStore((s) => s.mcpServerSources);
+
 // ============================================================================
 // Review Comments State
 // ============================================================================


### PR DESCRIPTION
## Summary
- **Unified MCP panel**: Replaces the split status/config toggle with a single view showing all servers (built-in, `.mcp.json`, Claude Code CLI, ChatML) with color-coded source badges
- **Claude Code CLI server loading**: Agent-runner now reads MCP servers from `~/.claude/settings.json` (user-level, always trusted) and `<cwd>/.claude/settings.json` (project-level, gated by dot-mcp trust)
- **Source tracking**: Server origins flow from agent-runner → WebSocket → frontend store, enabling per-source UI (edit controls only for ChatML-managed servers)
- **Bug fixes**: Consistent source naming (`claude-cli-project` everywhere), dedup for duplicate server names across config files, no phantom source entries for invalid configs, dead ternary cleanup, unused selector wired up

## Test plan
- [x] Frontend tests pass (24/24 — DotMcpTrustDialog + McpServersPanel)
- [x] Go backend builds cleanly
- [ ] Manual: verify MCP panel shows source badges for servers from different origins
- [ ] Manual: verify trust dialog correctly labels `.mcp.json` vs `.claude/settings.json` servers
- [ ] Manual: verify edit/delete controls only appear on ChatML-managed servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)