### PR TITLE
feat: make template actions insert as instruction attachments

### DIFF
--- a/src/components/conversation/AttachmentCard.tsx
+++ b/src/components/conversation/AttachmentCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { X, File, FileText, FileCode, Image, FileJson, Terminal, FileType, type LucideIcon } from 'lucide-react';
+import { X, File, FileText, FileCode, Image, FileJson, Terminal, FileType, ScrollText, type LucideIcon } from 'lucide-react';
 import type { Attachment } from '@/lib/types';
 import { getFileCategory, getAttachmentSubtitle } from '@/lib/attachments';
 import { cn } from '@/lib/utils';
@@ -35,8 +35,9 @@ export function AttachmentCard({ attachment, onRemove, onClick, readOnly = false
   // Determine file path for category detection - use path if available, otherwise fall back to name
   const filePath = attachment.path || attachment.name;
   const category = useMemo(() => getFileCategory(filePath), [filePath]);
-  const Icon = CATEGORY_ICONS[category] || FileType;
-  const subtitle = getAttachmentSubtitle(attachment);
+  const isInstruction = attachment.isInstruction;
+  const Icon = isInstruction ? ScrollText : (CATEGORY_ICONS[category] || FileType);
+  const subtitle = isInstruction ? 'Instructions' : getAttachmentSubtitle(attachment);
 
   // CSS truncate on the span handles ellipsis; full name shown via title tooltip
   const displayName = attachment.name;
@@ -44,8 +45,11 @@ export function AttachmentCard({ attachment, onRemove, onClick, readOnly = false
   return (
     <div
       className={cn(
-        'group relative flex items-center gap-2 rounded-md border border-border bg-muted/50 px-2.5 py-1.5',
-        'hover:bg-muted/80 transition-colors',
+        'group relative flex items-center gap-2 rounded-md border px-2.5 py-1.5',
+        isInstruction
+          ? 'border-purple-500/30 bg-purple-500/10 hover:bg-purple-500/15'
+          : 'border-border bg-muted/50 hover:bg-muted/80',
+        'transition-colors',
         'min-w-0 max-w-[220px]',
         onClick && 'cursor-pointer'
       )}
@@ -54,7 +58,7 @@ export function AttachmentCard({ attachment, onRemove, onClick, readOnly = false
       onMouseLeave={() => setIsHovered(false)}
     >
       {/* Icon */}
-      <div className="flex-shrink-0 text-muted-foreground">
+      <div className={cn('flex-shrink-0', isInstruction ? 'text-purple-500' : 'text-muted-foreground')}>
         <Icon className="h-4 w-4" />
       </div>
 

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback, useMemo, Fragment } from 'rea
 import { useAppStore } from '@/stores/appStore';
 import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, approvePlan } from '@/lib/api';
 import { markPlanModeExited } from '@/hooks/useWebSocket';
+import { useAppEventListener } from '@/lib/custom-events';
 import { useShortcut } from '@/hooks/useShortcut';
 import { Button } from '@/components/ui/button';
 import {
@@ -625,6 +626,22 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       unlistenLeave = safeUnlisten(unlistenLeave);
     };
   }, []);
+
+  // Listen for compose-action events (e.g., Fix All review, Add to Chat)
+  // Inserts text and/or instruction attachments into the composer without auto-submitting.
+  useAppEventListener('compose-action', ({ text, attachments: incoming }) => {
+    // Only set text if the composer is empty to avoid overwriting a user's draft
+    if (text) {
+      const existing = plateInputRef.current?.getText() ?? '';
+      if (!existing.trim()) {
+        plateInputRef.current?.setText(text);
+      }
+    }
+    if (incoming && incoming.length > 0) {
+      setAttachments(prev => [...prev, ...incoming]);
+    }
+    plateInputRef.current?.focus();
+  });
 
   // Handler for toggling plan mode - also notifies the backend
   const handlePlanModeToggle = useCallback(async () => {

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -16,12 +16,13 @@ import {
   getWorkspaceActionTemplates,
   type AttachmentDTO,
 } from '@/lib/api';
-import { ACTION_TEMPLATES, fetchMergedActionTemplates } from '@/lib/action-templates';
+import { ACTION_TEMPLATES, ACTION_TEMPLATE_NAMES, fetchMergedActionTemplates } from '@/lib/action-templates';
+import type { ActionTemplateKey } from '@/lib/action-templates';
 import { dispatchAppEvent, useAppEventListener } from '@/lib/custom-events';
 import { formatCIFailureMessage } from '@/lib/check-utils';
 import { useToast } from '@/components/ui/toast';
 import { copyToClipboard, openInApp } from '@/lib/tauri';
-import { cn } from '@/lib/utils';
+import { cn, toBase64 } from '@/lib/utils';
 import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog';
 import { useArchiveSession } from '@/hooks/useArchiveSession';
 import { PRHoverCard } from '@/components/shared/PRHoverCard';
@@ -68,16 +69,6 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { getAppById, getAppName, CATEGORY_LABELS } from '@/lib/openApps';
 import type { AppCategory } from '@/lib/openApps';
 import { getAppIcon } from '@/components/icons/AppIcons';
-
-/** Encode a UTF-8 string to base64, safe for non-Latin1 characters. */
-function toBase64(text: string): string {
-  const bytes = new TextEncoder().encode(text);
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
 
 // ---------------------------------------------------------------------------
 // Review type options for the split button popover
@@ -175,35 +166,39 @@ export function SessionToolbarContent() {
   }, [selectedConversationId, showWarning, showError, updateConversation, setStreaming, isAgentWorking]);
 
   // Wrapper that adds a user bubble + sends template content as attachment
-  const handleActionWithBubbleAndTemplate = useCallback((content: string, templateContent: string) => {
+  const handleActionWithBubbleAndTemplate = useCallback((content: string, templateContent: string, templateKey?: ActionTemplateKey) => {
     if (isAgentWorking) return;
     if (!selectedConversationId) {
       showWarning('No active conversation');
       return;
     }
-    // User bubble shows only the short instruction
+
+    // Create template attachment (before addMessage so it appears in the bubble)
+    const attachmentName = templateKey ? ACTION_TEMPLATE_NAMES[templateKey] : 'Action Instructions';
+    const templateAttachment: AttachmentDTO = {
+      id: crypto.randomUUID(),
+      type: 'file',
+      name: attachmentName,
+      mimeType: 'text/markdown',
+      size: new Blob([templateContent]).size,
+      lineCount: templateContent.split('\n').length,
+      base64Data: toBase64(templateContent),
+      preview: templateContent.slice(0, 200),
+      isInstruction: true,
+    };
+
+    // User bubble shows the short instruction + instruction attachment card
     addMessage({
       id: crypto.randomUUID(),
       conversationId: selectedConversationId,
       role: 'user',
       content,
       timestamp: new Date().toISOString(),
+      attachments: [templateAttachment],
     });
     window.dispatchEvent(new CustomEvent('chat-message-submitted'));
     updateConversation(selectedConversationId, { status: 'active' });
     setStreaming(selectedConversationId, true);
-
-    // Create template attachment
-    const templateAttachment: AttachmentDTO = {
-      id: crypto.randomUUID(),
-      type: 'file',
-      name: 'action-instructions.md',
-      mimeType: 'text/markdown',
-      size: new Blob([templateContent]).size,
-      lineCount: templateContent.split('\n').length,
-      base64Data: toBase64(templateContent),
-      preview: templateContent.slice(0, 200),
-    };
 
     sendConversationMessage(selectedConversationId, content, [templateAttachment]).catch((error) => {
       console.error('Failed to send action message:', error);
@@ -233,11 +228,11 @@ export function SessionToolbarContent() {
     }
     fetchMergedActionTemplates(selectedWorkspaceId, getGlobalActionTemplates, getWorkspaceActionTemplates)
       .then((templates) => {
-        handleActionWithBubbleAndTemplate(message, templates['sync-branch']);
+        handleActionWithBubbleAndTemplate(message, templates['sync-branch'], 'sync-branch');
         dispatchAppEvent('branch-sync-accepted');
       })
       .catch(() => {
-        handleActionWithBubbleAndTemplate(message, ACTION_TEMPLATES['sync-branch']);
+        handleActionWithBubbleAndTemplate(message, ACTION_TEMPLATES['sync-branch'], 'sync-branch');
         dispatchAppEvent('branch-sync-accepted');
       });
   }, [selectedWorkspaceId, selectedConversationId, isAgentWorking, handleActionWithBubbleAndTemplate]);

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -3,10 +3,12 @@
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useSelectedIds, useFileTabState, useTodoState, useFileCommentStats, useReviewComments } from '@/stores/selectors';
-import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, createConversation, updateReviewComment as apiUpdateReviewComment, ApiError, ErrorCode, type FileChangeDTO, type BranchStatsDTO } from '@/lib/api';
+import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, updateReviewComment as apiUpdateReviewComment, ApiError, ErrorCode, type FileChangeDTO, type BranchStatsDTO } from '@/lib/api';
 import { getDiffFromCache, setDiffInCache, invalidateDiffCache } from '@/lib/diffCache';
 import { getSessionData, setSessionData, invalidateSessionData } from '@/lib/sessionDataCache';
 import { formatReviewFeedback } from '@/lib/formatReviewFeedback';
+import { dispatchAppEvent } from '@/lib/custom-events';
+import type { Attachment } from '@/lib/types';
 import { FileTree, FileIcon, type FileNode, type FileTreeHandle } from '@/components/files/FileTree';
 import { TodoPanel } from '@/components/panels/TodoPanel';
 import { BudgetStatusPanel } from '@/components/panels/BudgetStatusPanel';
@@ -66,7 +68,7 @@ import {
   Eye,
   EyeOff,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn, toBase64 } from '@/lib/utils';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import type { FileTab } from '@/lib/types';
@@ -489,23 +491,28 @@ export function ChangesPanel() {
     sendConversationMessage(selectedConversationId, content).catch(console.error);
   }, [selectedConversationId]);
 
-  // Send unresolved review comments as feedback to AI via a dedicated review conversation
-  const handleSendFeedback = useCallback(async () => {
-    if (!selectedWorkspaceId || !selectedSessionId) return;
+  // Send unresolved review comments as feedback — opens in composer so user can add context
+  const handleSendFeedback = useCallback(() => {
+    const feedbackText = formatReviewFeedback(reviewComments);
+    if (!feedbackText) return;
 
-    const message = formatReviewFeedback(reviewComments);
-    if (!message) return;
+    const attachment: Attachment = {
+      id: `review-feedback-${Date.now()}`,
+      type: 'file',
+      name: 'Review Feedback',
+      mimeType: 'text/markdown',
+      size: new Blob([feedbackText]).size,
+      lineCount: feedbackText.split('\n').length,
+      base64Data: toBase64(feedbackText),
+      preview: feedbackText.slice(0, 200),
+      isInstruction: true,
+    };
 
-    try {
-      await createConversation(selectedWorkspaceId, selectedSessionId, {
-        type: 'review',
-        message,
-      });
-    } catch (error) {
-      // TODO: Show a toast notification once a toast library is added
-      console.error('Failed to send review feedback:', error);
-    }
-  }, [selectedWorkspaceId, selectedSessionId, reviewComments]);
+    dispatchAppEvent('compose-action', {
+      text: 'Fix the following review feedback',
+      attachments: [attachment],
+    });
+  }, [reviewComments]);
 
   // Resolve all unresolved review comments
   const updateReviewComment = useAppStore((s) => s.updateReviewComment);

--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -9,6 +9,7 @@ import {
   Info,
   CheckCircle2,
   MessageSquare,
+  MessageSquarePlus,
   FileCode,
   ChevronRight,
   ChevronDown,
@@ -18,7 +19,7 @@ import {
   List,
   ListTree,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn, toBase64 } from '@/lib/utils';
 import {
   Tooltip,
   TooltipContent,
@@ -37,7 +38,8 @@ import {
   listReviewComments,
   updateReviewComment as apiUpdateReviewComment,
 } from '@/lib/api';
-import type { ReviewComment } from '@/lib/types';
+import type { Attachment, ReviewComment } from '@/lib/types';
+import { dispatchAppEvent } from '@/lib/custom-events';
 
 type CommentSeverity = 'error' | 'warning' | 'info' | 'suggestion';
 
@@ -403,6 +405,38 @@ export function ReviewPanel({ workspaceId, sessionId, onFileSelect, onSendFeedba
   );
 }
 
+/** Create an instruction attachment from a review comment. */
+function commentToAttachment(comment: ReviewComment): Attachment {
+  const content = [
+    `## Review Comment: ${comment.title || comment.content.split('\n')[0]}`,
+    '',
+    `**File:** \`${comment.filePath}:${comment.lineNumber}\``,
+    `**Severity:** ${comment.severity || 'info'}`,
+    '',
+    comment.content,
+  ].join('\n');
+
+  return {
+    id: `review-${comment.id}-${Date.now()}`,
+    type: 'file',
+    name: 'Review Comment',
+    mimeType: 'text/markdown',
+    size: new Blob([content]).size,
+    lineCount: content.split('\n').length,
+    base64Data: toBase64(content),
+    preview: content.slice(0, 200),
+    isInstruction: true,
+  };
+}
+
+function handleAddToChat(comment: ReviewComment) {
+  const attachment = commentToAttachment(comment);
+  dispatchAppEvent('compose-action', {
+    text: `Fix this review comment in ${comment.filePath}:${comment.lineNumber}`,
+    attachments: [attachment],
+  });
+}
+
 function ReviewCommentCard({
   comment,
   onNavigate,
@@ -480,6 +514,24 @@ function ReviewCommentCard({
           </div>
         </div>
         <div className="flex items-center gap-0.5 shrink-0">
+          {!isResolved && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-5 w-5 p-0 hover:bg-foreground/10"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleAddToChat(comment);
+                  }}
+                >
+                  <MessageSquarePlus className="h-3 w-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Add to chat</TooltipContent>
+            </Tooltip>
+          )}
           {isResolved ? (
             <Button
               variant="ghost"

--- a/src/components/shared/PrimaryActionButton/index.tsx
+++ b/src/components/shared/PrimaryActionButton/index.tsx
@@ -25,7 +25,7 @@ interface PrimaryActionButtonProps {
   workspaceId: string | null;
   session: WorktreeSession | null | undefined;
   onSendMessage: (content: string) => void;
-  onSendMessageWithTemplate: (content: string, templateContent: string) => void;
+  onSendMessageWithTemplate: (content: string, templateContent: string, templateKey: ActionTemplateKey) => void;
   onFixIssues?: () => void;
   onArchiveSession?: (sessionId: string) => void;
   // Optional: pass pre-fetched data to avoid duplicate fetches
@@ -142,8 +142,8 @@ export function PrimaryActionButton({
   const handleSendWithTemplate = useCallback((content: string, actionType: PrimaryActionType) => {
     const templateKey = getTemplateKey(actionType);
     const templateContent = templateKey ? mergedTemplates[templateKey] : null;
-    if (templateContent) {
-      onSendMessageWithTemplate(content, templateContent);
+    if (templateContent && templateKey) {
+      onSendMessageWithTemplate(content, templateContent, templateKey);
     } else {
       onSendMessage(content);
     }

--- a/src/lib/action-templates.ts
+++ b/src/lib/action-templates.ts
@@ -115,6 +115,18 @@ export function getTemplateKey(actionType: string): ActionTemplateKey | null {
   return ACTION_TYPE_TO_TEMPLATE[actionType] ?? null;
 }
 
+/**
+ * Human-readable display names for template attachments.
+ */
+export const ACTION_TEMPLATE_NAMES: Record<ActionTemplateKey, string> = {
+  'resolve-conflicts': 'Resolve Conflicts Instructions',
+  'fix-issues': 'Fix Issues Instructions',
+  'continue-operation': 'Continue Operation Instructions',
+  'sync-branch': 'Sync Branch Instructions',
+  'create-pr': 'Create PR Instructions',
+  'merge-pr': 'Merge PR Instructions',
+};
+
 const VALID_MODES: Set<string> = new Set<string>(['append', 'replace']);
 
 /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -960,6 +960,7 @@ export interface AttachmentDTO {
   height?: number;
   base64Data?: string;
   preview?: string;
+  isInstruction?: boolean; // Frontend-only: not persisted by the backend
 }
 
 export interface ToolUsageDTO {

--- a/src/lib/custom-events.ts
+++ b/src/lib/custom-events.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import type { Attachment } from '@/lib/types';
 
 /**
  * Typed custom event map. Add new events here for compile-time safety
@@ -11,6 +12,8 @@ export interface AppCustomEventMap {
   'branch-sync-rejected': void;
   'git-create-pr': void;
   'chat-message-submitted': void;
+  /** Insert text and/or instruction attachments into the composer without auto-submitting */
+  'compose-action': { text: string; attachments?: Attachment[] };
 }
 
 type EventDetail<K extends keyof AppCustomEventMap> =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -223,6 +223,7 @@ export interface Attachment {
   height?: number;           // For images
   base64Data?: string;       // Loaded on demand before send
   preview?: string;          // Text preview (first N chars)
+  isInstruction?: boolean;   // Frontend-only: visual distinction for template/instruction attachments (not persisted by backend)
 }
 
 // SuggestionPill = A clickable suggestion option

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,6 +9,16 @@ export function cn(...inputs: ClassValue[]) {
  * Convert an absolute file path to a path relative to the worktree root.
  * Returns the original path if it's not under the worktree or if worktreePath is not provided.
  */
+/** Encode a UTF-8 string to base64, safe for non-Latin1 characters. */
+export function toBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 export function toRelativePath(absolutePath: string, worktreePath: string | undefined | null): string {
   if (!worktreePath || !absolutePath) return absolutePath;
 


### PR DESCRIPTION
## Summary

- Template actions (sync branch, fix issues, create PR, etc.) now render as **instruction attachment cards** with purple styling in user message bubbles, making it clear what instructions were sent to the agent
- Added **"Add to Chat" button** on individual review comments, letting users send specific comments to the composer with an instruction attachment
- **Review feedback** now opens in the composer (instead of auto-creating a review conversation), so users can add context before sending
- Extracted shared `toBase64` utility to `src/lib/utils.ts` (was duplicated in 3 files)
- Used typed `useAppEventListener` hook for compose-action events instead of raw `addEventListener`
- Protected composer from silently overwriting user drafts when compose-action fires

## Test plan

- [ ] Trigger a template action (e.g., sync branch) and verify the user bubble shows a purple instruction attachment card
- [ ] Click "Add to Chat" on a review comment and verify it populates the composer with text + instruction attachment
- [ ] Click "Fix All" in the review panel and verify feedback appears in the composer
- [ ] Type a draft message, then click "Add to Chat" — verify the draft text is preserved and only attachments are added
- [ ] Verify attachment cards show correct icon (ScrollText) and "Instructions" subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)