### PR TITLE
fix: remove RegisteredCustomThemes preload to avoid duplicate theme registration

### DIFF
--- a/src/lib/pierrePreload.ts
+++ b/src/lib/pierrePreload.ts
@@ -13,7 +13,6 @@
 import {
   ResolvedThemes,
   ResolvedLanguages,
-  RegisteredCustomThemes,
 } from '@pierre/diffs';
 import { normalizeTheme } from 'shiki';
 import type { LanguageRegistration } from '@shikijs/types';
@@ -36,17 +35,6 @@ if (!ResolvedThemes.has('pierre-light')) {
     'pierre-light',
     normalizeTheme(pierreLightRaw as Parameters<typeof normalizeTheme>[0]),
   );
-}
-
-// Also override the registered loaders so any code path that bypasses the
-// ResolvedThemes cache still gets static data instead of a failing import().
-if (!RegisteredCustomThemes.has('pierre-dark')) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  RegisteredCustomThemes.set('pierre-dark', () => Promise.resolve(pierreDarkRaw as any));
-}
-if (!RegisteredCustomThemes.has('pierre-light')) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  RegisteredCustomThemes.set('pierre-light', () => Promise.resolve(pierreLightRaw as any));
 }
 
 // --- Languages: statically import grammars for the languages we use ---


### PR DESCRIPTION
## Summary
- Removes `RegisteredCustomThemes` writes from `pierrePreload.ts` that conflicted with `@pierre/diffs`' own `SharedHighlight.registerCustomTheme()` calls during module init
- The `ResolvedThemes` entries alone are sufficient to bypass dynamic imports in Tauri builds
- Fixes console error: `SharedHighlight.registerCustomTheme: theme name already registered "pierre-dark"`

## Test plan
- [ ] Open the app and verify no "theme name already registered" console error
- [ ] Open a file/diff and verify Pierre renders with correct dark/light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)