### PR TITLE
fix: default to diff mode when opening files from Changes panel

### DIFF
--- a/src/components/files/CodeViewer.tsx
+++ b/src/components/files/CodeViewer.tsx
@@ -39,7 +39,8 @@ function isMarkdownFile(filename: string): boolean {
   return ext === 'md' || ext === 'mdx';
 }
 
-function getDefaultViewMode(filename: string): ViewMode {
+function getDefaultViewMode(filename: string, hasOldContent?: boolean): ViewMode {
+  if (hasOldContent) return 'diff';
   return isMarkdownFile(filename) ? 'rendered' : 'code';
 }
 
@@ -55,13 +56,13 @@ export const CodeViewer = memo(function CodeViewer({
   scrollToLine,
   onChange,
 }: CodeViewerProps) {
-  const [viewMode, setViewMode] = useState<ViewMode>(getDefaultViewMode(filename));
+  const [viewMode, setViewMode] = useState<ViewMode>(getDefaultViewMode(filename, typeof oldContent === 'string'));
 
   // Reset view mode when switching files
   const [prevFilename, setPrevFilename] = useState(filename);
   if (prevFilename !== filename) {
     setPrevFilename(filename);
-    setViewMode(getDefaultViewMode(filename));
+    setViewMode(getDefaultViewMode(filename, typeof oldContent === 'string'));
   }
 
   const isMarkdown = isMarkdownFile(filename);


### PR DESCRIPTION
## Summary
- Files clicked in the Changes panel now open in diff mode by default instead of code viewer mode
- `CodeViewer.getDefaultViewMode()` now checks for `oldContent` and returns `'diff'` when present
- Also fixes the file-switch reset path so switching between diff tabs stays in diff mode

## Test plan
- [ ] Click a modified file in the Changes panel → opens in diff mode
- [ ] Click "Diff" toggle to deselect → switches to code view; click again → back to diff
- [ ] Open a file from the Files panel (not Changes) → defaults to code view
- [ ] Open a markdown file → defaults to rendered view

🤖 Generated with [Claude Code](https://claude.com/claude-code)