### PR TITLE
fix: send review prompts as instruction attachments

### DIFF
--- a/src/hooks/__tests__/useReviewTrigger.test.ts
+++ b/src/hooks/__tests__/useReviewTrigger.test.ts
@@ -139,7 +139,14 @@ describe('useReviewTrigger', () => {
 
       expect(requestBody).not.toBeNull();
       expect(requestBody!.type).toBe('review');
-      expect(requestBody!.message).toContain('Review the changes');
+      expect(requestBody!.message).toBe('Review: Quick Scan');
+      // Full prompt should be in the instruction attachment
+      const attachments = requestBody!.attachments as Array<Record<string, unknown>>;
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].isInstruction).toBe(true);
+      expect(attachments[0].name).toBe('Quick Scan Instructions');
+      const decoded = atob(attachments[0].base64Data as string);
+      expect(decoded).toContain('Review the changes');
     });
 
     it('sends deep review prompt for type=deep', async () => {
@@ -167,7 +174,10 @@ describe('useReviewTrigger', () => {
       });
 
       expect(requestBody).not.toBeNull();
-      expect(requestBody!.message).toContain('thorough code review');
+      expect(requestBody!.message).toBe('Review: Deep Review');
+      const attachments = requestBody!.attachments as Array<Record<string, unknown>>;
+      const decoded = atob(attachments[0].base64Data as string);
+      expect(decoded).toContain('thorough code review');
     });
 
     it('sends security review prompt for type=security', async () => {
@@ -195,7 +205,10 @@ describe('useReviewTrigger', () => {
       });
 
       expect(requestBody).not.toBeNull();
-      expect(requestBody!.message).toContain('security audit');
+      expect(requestBody!.message).toBe('Review: Security Audit');
+      const attachments = requestBody!.attachments as Array<Record<string, unknown>>;
+      const decoded = atob(attachments[0].base64Data as string);
+      expect(decoded).toContain('security audit');
     });
 
     it('defaults to quick review when no type specified', async () => {
@@ -223,7 +236,10 @@ describe('useReviewTrigger', () => {
       });
 
       expect(requestBody).not.toBeNull();
-      expect(requestBody!.message).toContain('Review the changes');
+      expect(requestBody!.message).toBe('Review: Quick Scan');
+      const attachments = requestBody!.attachments as Array<Record<string, unknown>>;
+      const decoded = atob(attachments[0].base64Data as string);
+      expect(decoded).toContain('Review the changes');
     });
   });
 
@@ -253,7 +269,9 @@ describe('useReviewTrigger', () => {
       const reviewMessages = useAppStore.getState().messagesByConversation['new-review-conv'] ?? [];
       expect(reviewMessages).toHaveLength(1);
       expect(reviewMessages[0].role).toBe('user');
-      expect(reviewMessages[0].content).toContain('Review the changes');
+      expect(reviewMessages[0].content).toBe('Review: Quick Scan');
+      expect(reviewMessages[0].attachments).toHaveLength(1);
+      expect(reviewMessages[0].attachments[0].isInstruction).toBe(true);
     });
 
     it('selects the new conversation', async () => {
@@ -310,7 +328,9 @@ describe('useReviewTrigger', () => {
       });
 
       expect(requestBody).not.toBeNull();
-      expect(requestBody!.message).not.toContain('Only report actionable findings');
+      const attachments0 = requestBody!.attachments as Array<Record<string, unknown>>;
+      const decoded0 = atob(attachments0[0].base64Data as string);
+      expect(decoded0).not.toContain('Only report actionable findings');
     });
 
     it('includes actionable-only instruction when reviewActionableOnly is explicitly true', async () => {
@@ -340,7 +360,9 @@ describe('useReviewTrigger', () => {
       });
 
       expect(requestBody).not.toBeNull();
-      expect(requestBody!.message).toContain('Only report actionable findings');
+      const attachments1 = requestBody!.attachments as Array<Record<string, unknown>>;
+      const decoded1 = atob(attachments1[0].base64Data as string);
+      expect(decoded1).toContain('Only report actionable findings');
     });
 
     it('excludes actionable-only instruction when reviewActionableOnly is false', async () => {
@@ -370,7 +392,9 @@ describe('useReviewTrigger', () => {
       });
 
       expect(requestBody).not.toBeNull();
-      expect(requestBody!.message).not.toContain('Only report actionable findings');
+      const attachments2 = requestBody!.attachments as Array<Record<string, unknown>>;
+      const decoded2 = atob(attachments2[0].base64Data as string);
+      expect(decoded2).not.toContain('Only report actionable findings');
     });
 
     it('places actionable-only instruction before custom overrides so user overrides take precedence', async () => {
@@ -413,10 +437,11 @@ describe('useReviewTrigger', () => {
         expect(requestBody).not.toBeNull();
       });
 
-      const message = requestBody!.message as string;
+      const attachments3 = requestBody!.attachments as Array<Record<string, unknown>>;
+      const decoded3 = atob(attachments3[0].base64Data as string);
       // Actionable instruction should appear before custom override
-      const actionableIndex = message.indexOf('Only report actionable findings');
-      const overrideIndex = message.indexOf('Custom global override');
+      const actionableIndex = decoded3.indexOf('Only report actionable findings');
+      const overrideIndex = decoded3.indexOf('Custom global override');
       expect(actionableIndex).toBeGreaterThan(-1);
       expect(overrideIndex).toBeGreaterThan(-1);
       expect(actionableIndex).toBeLessThan(overrideIndex);

--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -4,9 +4,11 @@ import {
   createConversation,
   getGlobalReviewPrompts,
   getWorkspaceReviewPrompts,
+  type AttachmentDTO,
 } from '@/lib/api';
 import { useSelectedIds } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { toBase64 } from '@/lib/utils';
 
 const MARKDOWN_INSTRUCTION =
   '\nWhen writing comment content, use Markdown formatting for detailed comments that include code examples, lists, or structured explanations (use fenced code blocks for code, bullet lists for multiple points, **bold** for emphasis). Keep simple one-sentence comments as plain text.';
@@ -37,6 +39,10 @@ const REVIEW_TYPE_META: { key: string; label: string; placeholder: string }[] = 
   { key: 'architecture', label: 'Architecture', placeholder: 'e.g., We follow hexagonal architecture' },
   { key: 'premerge', label: 'Pre-merge Check', placeholder: 'e.g., Ensure all TODO comments reference a ticket' },
 ];
+
+const REVIEW_TYPE_LABELS: Record<string, string> = Object.fromEntries(
+  REVIEW_TYPE_META.map(({ key, label }) => [key, label])
+);
 
 /**
  * Fetches global and per-workspace overrides and merges them.
@@ -105,10 +111,28 @@ export function useReviewTrigger() {
           ? `${prompt}\n\nAdditional instructions:\n${extra}`
           : prompt;
 
+        // Build short display text + instruction attachment (matching PrimaryActionButton pattern)
+        const label = REVIEW_TYPE_LABELS[reviewType] || REVIEW_TYPE_LABELS['quick'] || 'Review';
+        const shortContent = `Review: ${label}`;
+        const attachmentName = `${label} Instructions`;
+
+        const templateAttachment: AttachmentDTO = {
+          id: crypto.randomUUID(),
+          type: 'file',
+          name: attachmentName,
+          mimeType: 'text/markdown',
+          size: new Blob([message]).size,
+          lineCount: message.split('\n').length,
+          base64Data: toBase64(message),
+          preview: message.slice(0, 200),
+          isInstruction: true,
+        };
+
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
           type: 'review',
-          message,
+          message: shortContent,
           model: reviewModel,
+          attachments: [templateAttachment],
         });
 
         // Always add the conversation and message to the store, even if the
@@ -131,8 +155,9 @@ export function useReviewTrigger() {
           id: crypto.randomUUID(),
           conversationId: conv.id,
           role: 'user',
-          content: message,
+          content: shortContent,
           timestamp: new Date().toISOString(),
+          attachments: [templateAttachment],
         });
 
         // Always mark streaming so WebSocket reconnection reconciliation


### PR DESCRIPTION
## Summary
- Review button prompts are now sent as instruction attachments instead of inline message content, matching the `PrimaryActionButton` pattern
- Message content shows a short label (e.g. "Review: Quick Scan") for cleaner conversation list display
- Fallback label for unknown review types now correctly uses "Quick Scan" to match the prompt fallback

## Test plan
- [x] Updated all existing `useReviewTrigger` tests to verify attachment structure
- [ ] Manual: trigger each review type and confirm short label appears in conversation list
- [ ] Manual: confirm the agent still receives the full prompt via the attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)