### PR TITLE
fix: replace display:contents with flex layout to fix WebKit repaint bug

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -1155,7 +1155,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
       )}
 
       {/* Conversation messages — hidden when file tab is active */}
-      <div className={isFileActive ? 'hidden' : 'contents'}>
+      <div className={isFileActive ? 'hidden' : 'flex flex-col flex-1 min-h-0'}>
         {/* Messages */}
         <div className="relative flex-1 min-h-0">
           {/* Chat Search Bar */}


### PR DESCRIPTION
## Summary
- The conversation area wrapper used `display: contents` which triggers a known WebKit rendering bug where paint invalidation is skipped for children after DOM mutations
- This caused the conversation area to intermittently go blank, requiring a mouse scroll to force a repaint
- Replaced `display: contents` with `flex flex-col flex-1 min-h-0` to make the wrapper a proper layout participant while maintaining identical visual layout

## Test plan
- [ ] Open the app, verify conversation area renders correctly
- [ ] Switch between file tabs and conversation view — no blank areas
- [ ] Send messages, receive streaming responses — no blanking
- [ ] Resize the window — layout stays correct
- [ ] Scroll works normally, Virtuoso virtualizes properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)