### PR TITLE
fix: correct conversation bubble rendering order for queued messages

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -791,10 +791,10 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       const startTime = useAppStore.getState().streamingState[selectedConversationId]?.startTime;
       const durationMs = startTime ? Date.now() - startTime : undefined;
       // Finalize streaming content and atomically commit any queued user
-      // message before the assistant message so the user bubble renders first.
+      // message after the assistant message so the conversation order is correct.
       // terminal clears remaining queue and forces isStreaming=false.
       // toolUsage is auto-derived from activeTools inside finalizeStreamingMessage.
-      finalizeStreamingMessage(selectedConversationId, { durationMs, commitQueuedFirst: true, terminal: true });
+      finalizeStreamingMessage(selectedConversationId, { durationMs, commitQueued: true, terminal: true });
       // Add system message indicating the agent was stopped
       addMessage({
         id: `msg-stopped-${Date.now()}`,

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -319,10 +319,10 @@ export function useWebSocket(enabled: boolean = true) {
           const startTime = store.streamingState[conversationId]?.startTime;
           const durationMs = startTime ? Date.now() - startTime : undefined;
           // Finalize streaming and commit any queued user message atomically.
-          // commitQueuedFirst places the user message BEFORE the assistant message
-          // so the user bubble appears above its response.
+          // commitQueued commits the user message AFTER the assistant message
+          // so the conversation order is chronologically correct.
           // terminal clears remaining queue and forces isStreaming=false.
-          store.finalizeStreamingMessage(conversationId, { durationMs, commitQueuedFirst: true, terminal: true });
+          store.finalizeStreamingMessage(conversationId, { durationMs, commitQueued: true, terminal: true });
           store.clearAgentTodos(conversationId);
         }
       } else {
@@ -644,11 +644,11 @@ export function useWebSocket(enabled: boolean = true) {
         }));
 
         // Atomic finalization - creates message and clears streaming/activeTools.
-        // commitQueuedFirst places the queued user message BEFORE the assistant message.
+        // commitQueued commits the queued user message AFTER the assistant message.
         turnStore.finalizeStreamingMessage(conversationId, {
           durationMs: turnDurationMs,
           toolUsage: turnToolUsage.length > 0 ? turnToolUsage : undefined,
-          commitQueuedFirst: true,
+          commitQueued: true,
         });
         // Explicitly set status to active — finalizeStreamingMessage only clears
         // streaming/activeTools state but does NOT update conversation status.
@@ -669,9 +669,9 @@ export function useWebSocket(enabled: boolean = true) {
       case 'complete': {
         // Complete event signals the entire conversation ended (stdin closed)
         // Finalize streaming content and atomically commit any queued user
-        // message before the assistant message so the user bubble renders first.
+        // message after the assistant message so the conversation order is correct.
         // terminal clears remaining queue and forces isStreaming=false.
-        store.finalizeStreamingMessage(conversationId, { commitQueuedFirst: true, terminal: true });
+        store.finalizeStreamingMessage(conversationId, { commitQueued: true, terminal: true });
         store.clearAgentTodos(conversationId);
         store.clearPendingUserQuestion(conversationId);
         // Update conversation status to idle (ready for new input)
@@ -774,7 +774,7 @@ export function useWebSocket(enabled: boolean = true) {
         // Finalize any partial assistant content and atomically commit any
         // queued user message before the assistant message.
         // terminal clears remaining queue and forces isStreaming=false.
-        store.finalizeStreamingMessage(conversationId, { commitQueuedFirst: true, terminal: true });
+        store.finalizeStreamingMessage(conversationId, { commitQueued: true, terminal: true });
         store.setStreamingError(conversationId, errorMessage);
         // Update conversation status to idle
         store.updateConversation(conversationId, { status: 'idle' });
@@ -982,9 +982,9 @@ export function useWebSocket(enabled: boolean = true) {
       // ====================================================================
       case 'interrupted':
         // Finalize streaming content and atomically commit any queued user
-        // message before the assistant message so the user bubble renders first.
+        // message after the assistant message so the conversation order is correct.
         // terminal clears remaining queue and forces isStreaming=false.
-        store.finalizeStreamingMessage(conversationId, { commitQueuedFirst: true, terminal: true });
+        store.finalizeStreamingMessage(conversationId, { commitQueued: true, terminal: true });
         addSystemMessage(conversationId, 'Agent was stopped by user.')
           .then(({ id }) => {
             store.addMessage({
@@ -1217,10 +1217,10 @@ export function useWebSocket(enabled: boolean = true) {
       for (const convId of locallyStreaming) {
         if (!serverActiveSet.has(convId)) {
           // Agent finished while we were disconnected — clear orphaned state.
-          // commitQueuedFirst places the user message before any partial
+          // commitQueued commits the user message after any partial
           // assistant content (consistent with all other finalization paths).
           // terminal clears remaining queue and forces isStreaming=false.
-          store.finalizeStreamingMessage(convId, { commitQueuedFirst: true, terminal: true });
+          store.finalizeStreamingMessage(convId, { commitQueued: true, terminal: true });
           store.clearThinking(convId);
           store.updateConversation(convId, { status: 'completed' });
 

--- a/src/stores/__tests__/appStore.queuedMessages.test.ts
+++ b/src/stores/__tests__/appStore.queuedMessages.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useAppStore } from '../appStore';
+
+describe('appStore - queued message ordering', () => {
+  const conversationId = 'conv-test';
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-01T12:00:00Z'));
+
+    // Reset store state
+    useAppStore.setState({
+      messagesByConversation: {},
+      streamingState: {},
+      activeTools: {},
+      queuedMessages: {},
+      subAgents: {},
+      pendingCheckpointUuid: {},
+      messagePagination: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('places queued user message AFTER assistant message on turn_complete', () => {
+    // Set up: user1 already in messages, assistant is streaming, user2 is queued
+    useAppStore.setState({
+      messagesByConversation: {
+        [conversationId]: [
+          {
+            id: 'msg-user1',
+            conversationId,
+            role: 'user',
+            content: 'First user message',
+            timestamp: '2025-07-01T12:00:00Z',
+          },
+        ],
+      },
+      streamingState: {
+        [conversationId]: {
+          text: 'Assistant response to first message.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {
+        [conversationId]: [
+          {
+            id: 'msg-user2',
+            content: 'Second user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:05Z',
+          },
+        ],
+      },
+    });
+
+    // Simulate turn_complete: commitQueued=true, non-terminal
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 5000,
+      commitQueued: true,
+    });
+
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
+    expect(messages).toHaveLength(3);
+    // Order: user1, assistant1, user2
+    expect(messages[0].role).toBe('user');
+    expect(messages[0].content).toBe('First user message');
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[1].content).toBe('Assistant response to first message.');
+    expect(messages[2].role).toBe('user');
+    expect(messages[2].content).toBe('Second user message');
+  });
+
+  it('places queued user message AFTER assistant message on terminal event', () => {
+    useAppStore.setState({
+      messagesByConversation: {
+        [conversationId]: [
+          {
+            id: 'msg-user1',
+            conversationId,
+            role: 'user',
+            content: 'First user message',
+            timestamp: '2025-07-01T12:00:00Z',
+          },
+        ],
+      },
+      streamingState: {
+        [conversationId]: {
+          text: 'Assistant response.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {
+        [conversationId]: [
+          {
+            id: 'msg-user2',
+            content: 'Second user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:05Z',
+          },
+        ],
+      },
+    });
+
+    // Simulate complete/error: commitQueued=true, terminal=true
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      commitQueued: true,
+      terminal: true,
+    });
+
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
+    expect(messages).toHaveLength(3);
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[2].role).toBe('user');
+    expect(messages[2].content).toBe('Second user message');
+
+    // Terminal should clear the queue
+    const queued = useAppStore.getState().queuedMessages[conversationId] ?? [];
+    expect(queued).toHaveLength(0);
+  });
+
+  it('appends queued message correctly when no streaming text exists', () => {
+    // This covers the !streaming?.text branch (e.g. turn_complete after result already finalized)
+    useAppStore.setState({
+      messagesByConversation: {
+        [conversationId]: [
+          {
+            id: 'msg-user1',
+            conversationId,
+            role: 'user',
+            content: 'First user message',
+            timestamp: '2025-07-01T12:00:00Z',
+          },
+          {
+            id: 'msg-assistant1',
+            conversationId,
+            role: 'assistant',
+            content: 'Assistant response.',
+            timestamp: '2025-07-01T12:00:03Z',
+          },
+        ],
+      },
+      streamingState: {
+        [conversationId]: {
+          text: '', // No streaming text (already finalized by result event)
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {
+        [conversationId]: [
+          {
+            id: 'msg-user2',
+            content: 'Second user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:05Z',
+          },
+        ],
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      commitQueued: true,
+    });
+
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe('user');
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[2].role).toBe('user');
+    expect(messages[2].content).toBe('Second user message');
+  });
+
+  it('does not add queued message when none exists', () => {
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: 'Simple response.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {},
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 1000,
+      commitQueued: true,
+    });
+
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('assistant');
+    expect(messages[0].content).toBe('Simple response.');
+  });
+});

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -446,7 +446,7 @@ interface AppState {
       durationMs?: number;
       toolUsage?: ToolUsage[];
       runSummary?: RunSummary;
-      commitQueuedFirst?: boolean;
+      commitQueued?: boolean;
       /** When true, force isStreaming=false and clear all remaining queued messages.
        *  Use for terminal events (complete, error, interrupted, stop). */
       terminal?: boolean;
@@ -1840,7 +1840,7 @@ updateFileTabContent: (id, content) => set((state) => ({
 
       // If no streaming text, just clear the state (but still commit first queued message if requested)
       if (!streaming?.text) {
-        const queued = metadata.commitQueuedFirst && queuedQueue.length > 0 ? queuedQueue[0] : null;
+        const queued = metadata.commitQueued && queuedQueue.length > 0 ? queuedQueue[0] : null;
         // Terminal: clear entire queue after committing first; otherwise preserve remaining
         const remaining = metadata.terminal ? [] : (queued ? queuedQueue.slice(1) : queuedQueue);
         const convPagination = state.messagePagination[conversationId];
@@ -1953,13 +1953,13 @@ updateFileTabContent: (id, content) => set((state) => ({
       };
 
       // Atomically: add message AND clear streaming state
-      // When commitQueuedFirst is set, place the first queued user message BEFORE the assistant message
-      const queued = metadata.commitQueuedFirst && queuedQueue.length > 0 ? queuedQueue[0] : null;
+      // When commitQueued is set, commit the first queued user message AFTER the assistant message
+      const queued = metadata.commitQueued && queuedQueue.length > 0 ? queuedQueue[0] : null;
       // Terminal: clear entire queue after committing first; otherwise preserve remaining
       const remaining = metadata.terminal ? [] : (queued ? queuedQueue.slice(1) : queuedQueue);
       const existing = state.messagesByConversation[conversationId] ?? [];
       const updatedMessages = queued
-        ? [...existing, queuedToMessage(queued, conversationId), newMessage]
+        ? [...existing, newMessage, queuedToMessage(queued, conversationId)]
         : [...existing, newMessage];
 
       const convPagination = state.messagePagination[conversationId];


### PR DESCRIPTION
## Summary

- Queued user messages were rendered **before** the assistant response they were queued during, causing out-of-order conversation bubbles
- Swapped the message ordering in `finalizeStreamingMessage` so the assistant message appears first, followed by the queued user message
- Renamed misleading `commitQueuedFirst` flag to `commitQueued` since the queued message is now appended after (not before) the assistant message

## Changes Made

- **appStore.ts** — Swapped `[queued, assistant]` → `[assistant, queued]` in `finalizeStreamingMessage`; renamed `commitQueuedFirst` → `commitQueued` in type definition and both code paths
- **useWebSocket.ts** — Updated all 6 call sites from `commitQueuedFirst` → `commitQueued`; corrected comments
- **ChatInput.tsx** — Updated call site and comment
- **appStore.queuedMessages.test.ts** — New test file covering 4 scenarios: turn_complete, terminal event, empty streaming text, and no queued messages

## Test plan

- [ ] Run `npx vitest run src/stores/__tests__/appStore.queuedMessages.test.ts` — all 4 tests pass
- [ ] Run `npm run build` — build succeeds with no type errors
- [ ] Manual: send a message while assistant is streaming → user bubble appears after the assistant response, not before

🤖 Generated with [Claude Code](https://claude.com/claude-code)