### PR TITLE
fix: remove opaque CSS background on xterm canvases that hid terminal content

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -746,10 +746,6 @@ code.hljs { padding: 3px 5px; }
   background-color: #0f1111 !important;
 }
 
-.dark .xterm canvas {
-  background-color: #0f1111 !important;
-}
-
 html:not(.dark) .xterm,
 html:not(.dark) .xterm-viewport,
 html:not(.dark) .xterm-screen,
@@ -757,10 +753,6 @@ html:not(.dark) .xterm-rows,
 html:not(.dark) .xterm-helper-textarea,
 html:not(.dark) .xterm-cursor-layer,
 html:not(.dark) .xterm-text-layer {
-  background-color: #ffffff !important;
-}
-
-html:not(.dark) .xterm canvas {
   background-color: #ffffff !important;
 }
 


### PR DESCRIPTION
## Summary
- The terminal panel showed tabs but content was completely blank (no prompt, cursor, or text) in both themes
- **Root cause**: CSS rules `.dark .xterm canvas` and `html:not(.dark) .xterm canvas` applied opaque `background-color` to ALL canvases inside xterm, including the `xterm-link-layer` canvas which has `z-index: 2` and sits above the WebGL rendering canvas
- The opaque link-layer overlay covered all terminal content rendered by the WebGL canvas beneath it
- Fix: remove the two `.xterm canvas` rules — parent element selectors (`.xterm`, `.xterm-viewport`, `.xterm-screen`) already handle background colors

## Test plan
- [ ] Open a session and toggle the terminal panel open
- [ ] Verify shell prompt and blinking cursor are visible
- [ ] Switch between dark and light themes — terminal renders correctly in both
- [ ] Verify text input, scrolling, and command execution work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)