### PR TITLE
feat: add defaultWordWrap prop to CodeViewer

### DIFF
--- a/src/components/conversation/AttachmentPreviewModal.tsx
+++ b/src/components/conversation/AttachmentPreviewModal.tsx
@@ -317,7 +317,7 @@ export function AttachmentPreviewModal({
       case 'markup':
       case 'data':
       default:
-        return <CodeViewer content={content} filename={attachment.name} />;
+        return <CodeViewer content={content} filename={attachment.name} defaultWordWrap />;
     }
   }
 

--- a/src/components/files/CodeViewer.tsx
+++ b/src/components/files/CodeViewer.tsx
@@ -32,6 +32,8 @@ interface CodeViewerProps {
   scrollToLine?: number;
   /** Callback when file content is edited. Enables the Edit toggle button. */
   onChange?: (content: string) => void;
+  /** Initial word-wrap state for the code viewer (default: false) */
+  defaultWordWrap?: boolean;
 }
 
 function isMarkdownFile(filename: string): boolean {
@@ -55,6 +57,7 @@ export const CodeViewer = memo(function CodeViewer({
   onCreateComment,
   scrollToLine,
   onChange,
+  defaultWordWrap,
 }: CodeViewerProps) {
   const [viewMode, setViewMode] = useState<ViewMode>(getDefaultViewMode(filename, typeof oldContent === 'string'));
 
@@ -228,6 +231,7 @@ export const CodeViewer = memo(function CodeViewer({
         filename={filename}
         onToggleMarkdownView={isMarkdown ? () => setViewMode(v => v === 'code' ? 'rendered' : 'code') : undefined}
         headerMetadata={toggleButtons}
+        defaultWordWrap={defaultWordWrap}
       />
     </div>
   );

--- a/src/components/files/PierreEditor.tsx
+++ b/src/components/files/PierreEditor.tsx
@@ -32,6 +32,8 @@ interface PierreEditorProps {
   onToggleMarkdownView?: () => void;
   /** Extra elements to render in the header bar (e.g. Diff/Edit toggle buttons) */
   headerMetadata?: React.ReactNode;
+  /** Initial word-wrap state (default: false) */
+  defaultWordWrap?: boolean;
 }
 
 function truncateContent(content: string): { text: string; truncated: boolean; totalLines: number } {
@@ -47,10 +49,11 @@ export const PierreEditor = memo(function PierreEditor({
   filename,
   onToggleMarkdownView,
   headerMetadata,
+  defaultWordWrap = false,
 }: PierreEditorProps) {
   const themeType = useResolvedThemeType();
   const [showAll, setShowAll] = useState(false);
-  const [wordWrap, setWordWrap] = useState(false);
+  const [wordWrap, setWordWrap] = useState(defaultWordWrap);
 
   const getContent = useCallback(() => content, [content]);
 


### PR DESCRIPTION
## Summary
- Adds a `defaultWordWrap` prop to `PierreEditor` and `CodeViewer` components
- Enables word-wrap by default in `AttachmentPreviewModal` for better readability of attachment content
- Backward compatible — defaults to `false` when not specified

## Test plan
- [ ] Open an attachment preview modal and verify text wraps instead of scrolling horizontally
- [ ] Open a file in the code viewer (not from attachments) and verify word-wrap is still off by default
- [ ] Toggle word-wrap on/off in both contexts and verify it works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)