### PR TITLE
feat: auto-merge fallback for branch protection

### DIFF
--- a/src/lib/action-templates.ts
+++ b/src/lib/action-templates.ts
@@ -97,7 +97,8 @@ export const ACTION_TEMPLATES: Record<ActionTemplateKey, string> = {
 2. Verify the branch is up to date with the base branch
 3. If the branch is behind, rebase onto the base branch and push first
 4. Merge using \`gh pr merge\` with the appropriate flag (--squash, --merge, or --rebase)
-5. Confirm the merge was successful and report the result` + SAFETY_FOOTER,
+5. If the merge is blocked by branch protection rules (required reviews, status checks, etc.), automatically enable auto-merge using \`gh pr merge --auto\` with the same merge strategy so the PR merges once requirements are satisfied
+6. Confirm the merge was successful, or confirm that auto-merge has been enabled` + SAFETY_FOOTER,
 };
 
 /**


### PR DESCRIPTION
## Summary

- Updates the `merge-pr` action template to automatically enable auto-merge (`gh pr merge --auto`) when a merge is blocked by branch protection rules (required reviews, status checks, etc.)
- The auto-merge uses the same merge strategy the user originally requested (squash, merge commit, or rebase)

## Changes Made

- **`src/lib/action-templates.ts`** — Added step 5 to the merge-pr template instructing the agent to fall back to `gh pr merge --auto` when blocked, and updated step 6 to confirm either a successful merge or that auto-merge was enabled

## Test Plan

- [ ] Run `npm run lint` — no new warnings
- [ ] Trigger a merge action on a PR with branch protection enabled — agent should enable auto-merge instead of failing
- [ ] Trigger a merge action on a PR without branch protection — agent should merge immediately as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)