### PR TITLE
fix: auto-scroll to bottom after sending a message

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -576,6 +576,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   // We track the first visible data index per conversation via Virtuoso's rangeChanged.
   // On remount (key change), Virtuoso uses initialTopMostItemIndex — no animation, no flash.
   const isAtBottomRef = useRef(true);
+  const forceFollowRef = useRef(false);
 
   // Continuously track the visible range — called by Virtuoso on every scroll
   const handleRangeChanged = useCallback((range: { startIndex: number; endIndex: number }) => {
@@ -589,6 +590,11 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   // Compute initialTopMostItemIndex for the current conversation.
   // Read from the module-level map — this is computed fresh each render when
   // selectedConversationId changes (which triggers Virtuoso remount via key).
+  // Clear forceFollow on conversation switch to avoid stale state
+  useEffect(() => {
+    forceFollowRef.current = false;
+  }, [selectedConversationId]);
+
   const initialTopMostItemIndex = useMemo(() => {
     if (!selectedConversationId) return { index: 'LAST' as const, align: 'end' as const };
     const saved = scrollPositions.get(selectedConversationId);
@@ -603,12 +609,15 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   const handleAtBottomStateChange = useCallback((atBottom: boolean) => {
     setShowScrollButton(!atBottom);
     isAtBottomRef.current = atBottom;
+    if (atBottom) {
+      forceFollowRef.current = false;
+    }
   }, []);
 
   // Force scroll to bottom (for manual button click or message submit)
   const forceScrollToBottom = useCallback(() => {
     setShowScrollButton(false);
-    messageListRef.current?.scrollToBottom('smooth');
+    messageListRef.current?.scrollToBottom('auto');
   }, []);
 
   // Stable footer for VirtualizedMessageList (avoids remounting on every render)
@@ -639,6 +648,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   // Listen for message submit events to force scroll to bottom
   useEffect(() => {
     const handleMessageSubmit = () => {
+      forceFollowRef.current = true;
       forceScrollToBottom();
     };
 
@@ -1195,6 +1205,7 @@ export function ConversationArea({ children }: ConversationAreaProps) {
             footer={messageListFooter}
             isStreaming={selectedStreaming?.isStreaming ?? false}
             pendingPlanApproval={!!selectedStreaming?.pendingPlanApproval}
+            forceFollowRef={forceFollowRef}
           />
           {/* Fade overlay at bottom of messages */}
           <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-chat-background to-transparent pointer-events-none z-10" />

--- a/src/components/conversation/VirtualizedMessageList.tsx
+++ b/src/components/conversation/VirtualizedMessageList.tsx
@@ -37,6 +37,8 @@ interface VirtualizedMessageListProps {
   onRangeChanged?: (range: ListRange) => void;
   /** When true, suppress followOutput to prevent auto-scroll-to-bottom from fighting plan scroll */
   pendingPlanApproval?: boolean;
+  /** Mutable ref — when true, followOutput always returns auto-scroll regardless of isAtBottom */
+  forceFollowRef?: React.RefObject<boolean>;
 }
 
 export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, VirtualizedMessageListProps>(
@@ -58,6 +60,7 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
       initialTopMostItemIndex,
       onRangeChanged,
       pendingPlanApproval,
+      forceFollowRef,
     },
     ref
   ) {
@@ -118,10 +121,12 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
     const followOutput = useCallback(
       (isAtBottom: boolean) => {
         if (pendingPlanApproval) return false as const;
-        if (isAtBottom) return isStreaming ? true as const : 'smooth' as const;
+        if (isAtBottom || forceFollowRef?.current) {
+          return isStreaming ? true as const : 'smooth' as const;
+        }
         return false as const;
       },
-      [isStreaming, pendingPlanApproval]
+      [isStreaming, pendingPlanApproval, forceFollowRef]
     );
 
     // Footer component: streaming message + padding


### PR DESCRIPTION
## Summary

- **Fix auto-scroll after message submit**: When the user scrolled up in a conversation and then sent a message, the chat would not auto-scroll to follow the new assistant response. Adds a `forceFollowRef` that forces Virtuoso's `followOutput` to track new content after submit, cleared once the user reaches the bottom or switches conversations.
- **Instant scroll on submit**: Changes `forceScrollToBottom` from `'smooth'` to `'auto'` for immediate positioning when sending a message.

## Test plan

- [ ] Scroll up in a conversation, send a message — chat should auto-scroll to the bottom and follow the streaming response
- [ ] Scroll up, send a message, then manually scroll up again during streaming — auto-follow should stop
- [ ] Switch conversations after sending a message — no stale scroll behavior
- [ ] Click the "scroll to bottom" button — should still work as before
- [ ] Verify plan approval scroll suppression still works (pendingPlanApproval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)