### PR TITLE
fix: use openUrlInBrowser for Checks panel external links

### DIFF
--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -19,6 +19,7 @@ import {
   type WorkflowJobDTO,
 } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { openUrlInBrowser } from '@/lib/tauri';
 import {
   X,
   AlertTriangle,
@@ -453,7 +454,7 @@ function PRHeaderSection({
         variant="ghost"
         size="icon"
         className="h-5 w-5 shrink-0 text-muted-foreground/50 hover:text-muted-foreground"
-        onClick={() => window.open(pr.htmlUrl, '_blank')}
+        onClick={() => openUrlInBrowser(pr.htmlUrl)}
         title="View on GitHub"
       >
         <ExternalLink className="h-3 w-3" />
@@ -655,7 +656,7 @@ function CIChecksSection({
               variant="ghost"
               size="icon"
               className="h-4 w-4 text-muted-foreground/50 hover:text-muted-foreground"
-              onClick={() => window.open(latestRun.htmlUrl, '_blank')}
+              onClick={() => openUrlInBrowser(latestRun.htmlUrl)}
               title="View on GitHub"
             >
               <ExternalLink className="h-2 w-2" />
@@ -714,7 +715,7 @@ function CIChecksSection({
                         variant="ghost"
                         size="icon"
                         className="h-4 w-4 shrink-0 text-muted-foreground/50 hover:text-muted-foreground"
-                        onClick={() => window.open(job.htmlUrl, '_blank')}
+                        onClick={() => openUrlInBrowser(job.htmlUrl)}
                       >
                         <ExternalLink className="h-2 w-2" />
                       </Button>


### PR DESCRIPTION
## Summary
- External link icons in the Checks panel (PR header, CI checks header, individual job items) were using `window.open()` which doesn't work in Tauri's webview
- Replaced all 3 occurrences with the existing `openUrlInBrowser()` utility from `@/lib/tauri` that properly handles both Tauri (via `@tauri-apps/plugin-shell`) and browser environments

## Test plan
- [ ] Click the external link icon next to the PR number in the Checks panel — should open the PR on GitHub
- [ ] Click the external link icon next to the CI Checks header — should open the workflow run on GitHub
- [ ] Click the external link icon next to individual job items — should open the job on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)