### PR TITLE
fix: prevent double character input in terminal on release builds

### DIFF
--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -272,6 +272,7 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
               // Merged with inherited process env by portable-pty —
               // PATH, HOME, etc. are preserved.
               env: {
+                TERM: 'xterm-256color',
                 COLORTERM: 'truecolor',
                 TERM_PROGRAM: 'ChatML',
                 LANG: 'en_US.UTF-8',
@@ -301,8 +302,21 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
             });
 
             // Terminal input -> PTY
+            // Dedup guard: WKWebView on custom protocols (release builds) may fire
+            // onData twice per keystroke via both keydown and input events.
+            // Real key repeat is ~30-50ms; duplicate events arrive within <2ms.
+            let lastData = '';
+            let lastDataTime = 0;
+            const DEDUP_WINDOW_MS = 10;
+
             terminal.onData((data: string) => {
               if (!cleanupCalled && ptyRef.current) {
+                const now = performance.now();
+                if (data.length === 1 && data === lastData && (now - lastDataTime) < DEDUP_WINDOW_MS) {
+                  return; // Skip WKWebView duplicate
+                }
+                lastData = data;
+                lastDataTime = now;
                 pty.write(data).catch((e) => {
                   console.warn('PTY write error:', e);
                 });


### PR DESCRIPTION
## Summary

- Fix double character input in the integrated terminal on release builds caused by WKWebView firing `onData` twice per keystroke (via both `keydown` and `input` events on custom protocols)
- Add `TERM=xterm-256color` env var for proper terminal capability detection

## Changes Made

- **`src/hooks/useTerminal.ts`** — Added a time-window dedup guard that suppresses duplicate single-character input arriving within 10ms. Scoped to `data.length === 1` so paste and multi-char input are unaffected. Also added `TERM: 'xterm-256color'` to the PTY environment.

## Test Plan

- [ ] `npm run lint` — no new warnings
- [ ] `npm run build` — build succeeds
- [ ] Manual test (release build): open terminal, type normally — no doubled characters
- [ ] Manual test (release build): hold a key down — key repeat works correctly (repeat rate ~30-50ms, well above 10ms window)
- [ ] Manual test: paste text — paste works correctly, no characters dropped
- [ ] Manual test: verify terminal colors render correctly with `TERM=xterm-256color`

🤖 Generated with [Claude Code](https://claude.com/claude-code)