### PR TITLE
feat: add GitHub personal access token settings

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -2937,6 +2937,26 @@ func (m *Manager) loadEnvVars(ctx context.Context, claudeSettings *ai.ClaudeCode
 		envMap["ANTHROPIC_API_KEY"] = decrypted
 	}
 
+	// Load encrypted GitHub personal access token if configured.
+	// Only set GITHUB_TOKEN if not already present (e.g. from custom env vars or gh auth).
+	if _, hasGHToken := envMap["GITHUB_TOKEN"]; !hasGHToken {
+		encrypted, found, err = m.store.GetSetting(ctx, "github-personal-token")
+		if err != nil {
+			return envMap, nil // non-fatal: proceed without the token
+		}
+		if found && encrypted != "" {
+			decrypted, err := crypto.Decrypt(encrypted)
+			if err != nil {
+				logger.Manager.Errorf("failed to decrypt GitHub personal token: %v", err)
+				return envMap, nil
+			}
+			if envMap == nil {
+				envMap = make(map[string]string)
+			}
+			envMap["GITHUB_TOKEN"] = decrypted
+		}
+	}
+
 	return envMap, nil
 }
 

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -603,6 +603,15 @@ const settingKeyEnvVars = "env-vars"
 // settingKeyAnthropicAPIKey is the settings key for the encrypted Anthropic API key
 const settingKeyAnthropicAPIKey = "anthropic-api-key"
 
+// settingKeyGitHubPersonalToken is the settings key for the encrypted GitHub personal access token
+const settingKeyGitHubPersonalToken = "github-personal-token"
+
+// settingKeyGitHubPersonalTokenUser is the settings key for the GitHub username associated with the PAT
+const settingKeyGitHubPersonalTokenUser = "github-personal-token-user"
+
+// settingKeyGitHubPersonalTokenMasked is the settings key for the pre-computed masked token display string
+const settingKeyGitHubPersonalTokenMasked = "github-personal-token-masked"
+
 // getWorkspacesBaseDir returns the configured workspaces base directory,
 // falling back to the default (~/Library/Application Support/ChatML/workspaces) if not configured.
 func (h *Handlers) getWorkspacesBaseDir(ctx context.Context) (string, error) {

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -238,6 +238,8 @@ func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient
 	r.Put("/api/settings/pr-template", h.SetGlobalPRTemplate)
 	r.Get("/api/settings/anthropic-api-key", h.GetAnthropicApiKey)
 	r.Put("/api/settings/anthropic-api-key", h.SetAnthropicApiKey)
+	r.Get("/api/settings/github-personal-token", h.GetGitHubPersonalToken)
+	r.Put("/api/settings/github-personal-token", h.SetGitHubPersonalToken)
 	r.Get("/api/settings/action-templates", h.GetActionTemplates)
 	r.Put("/api/settings/action-templates", h.SetActionTemplates)
 	r.Get("/api/settings/claude-auth-status", h.GetClaudeAuthStatus)

--- a/backend/server/settings_handlers.go
+++ b/backend/server/settings_handlers.go
@@ -404,6 +404,115 @@ func maskAPIKey(key string) string {
 	return key[:prefixEnd] + "..." + suffix
 }
 
+// GetGitHubPersonalToken returns whether a GitHub PAT is configured, its masked form, and the associated username.
+// The masked token is read from a pre-computed setting to avoid decrypting the real token on every GET.
+func (h *Handlers) GetGitHubPersonalToken(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, found, err := h.store.GetSetting(ctx, settingKeyGitHubPersonalToken)
+	if err != nil {
+		writeInternalError(w, "failed to get GitHub personal token setting", err)
+		return
+	}
+	if !found {
+		writeJSON(w, map[string]interface{}{"configured": false, "maskedToken": "", "username": ""})
+		return
+	}
+
+	// Read pre-computed masked token and username (best-effort)
+	maskedToken, _, _ := h.store.GetSetting(ctx, settingKeyGitHubPersonalTokenMasked)
+	username, _, _ := h.store.GetSetting(ctx, settingKeyGitHubPersonalTokenUser)
+
+	writeJSON(w, map[string]interface{}{
+		"configured":  true,
+		"maskedToken": maskedToken,
+		"username":    username,
+	})
+}
+
+// SetGitHubPersonalToken validates, encrypts, and stores (or removes) a GitHub personal access token.
+func (h *Handlers) SetGitHubPersonalToken(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	// Empty token = remove
+	if req.Token == "" {
+		if err := h.store.DeleteSetting(ctx, settingKeyGitHubPersonalToken); err != nil {
+			writeInternalError(w, "failed to remove GitHub personal token", err)
+			return
+		}
+		if err := h.store.DeleteSetting(ctx, settingKeyGitHubPersonalTokenUser); err != nil {
+			writeInternalError(w, "failed to remove GitHub personal token user", err)
+			return
+		}
+		_ = h.store.DeleteSetting(ctx, settingKeyGitHubPersonalTokenMasked)
+		writeJSON(w, map[string]interface{}{"configured": false, "maskedToken": "", "username": ""})
+		return
+	}
+
+	// Validate the token by calling the GitHub API
+	user, err := h.ghClient.GetUser(ctx, req.Token)
+	if err != nil {
+		writeValidationError(w, "Invalid GitHub token. Please check the token and try again.")
+		return
+	}
+
+	encrypted, err := crypto.Encrypt(req.Token)
+	if err != nil {
+		writeInternalError(w, "failed to encrypt GitHub personal token", err)
+		return
+	}
+
+	if err := h.store.SetSetting(ctx, settingKeyGitHubPersonalToken, encrypted); err != nil {
+		writeInternalError(w, "failed to save GitHub personal token", err)
+		return
+	}
+
+	// Store the username and masked token for display (no need to encrypt — they're non-sensitive)
+	username := user.Login
+	masked := maskGitHubToken(req.Token)
+	_ = h.store.SetSetting(ctx, settingKeyGitHubPersonalTokenUser, username)
+	_ = h.store.SetSetting(ctx, settingKeyGitHubPersonalTokenMasked, masked)
+
+	writeJSON(w, map[string]interface{}{
+		"configured":  true,
+		"maskedToken": masked,
+		"username":    username,
+	})
+}
+
+// maskGitHubToken returns a masked version of a GitHub token.
+// Shows the known prefix + "..." + last 4 chars, ensuring at least 4 chars are masked.
+func maskGitHubToken(token string) string {
+	// Known GitHub token prefixes (longest first for correct matching)
+	knownPrefixes := []string{"github_pat_", "ghp_", "gho_", "ghu_", "ghs_", "ghr_"}
+
+	prefixEnd := 0
+	for _, p := range knownPrefixes {
+		if len(token) > len(p) && token[:len(p)] == p {
+			prefixEnd = len(p)
+			break
+		}
+	}
+
+	// Need at least prefix + 4 masked chars + 4 suffix = prefix + 8
+	if prefixEnd == 0 || len(token) < prefixEnd+8 {
+		// Unknown format or too short: show nothing recognizable
+		if len(token) <= 8 {
+			return "****"
+		}
+		return token[:4] + "..." + token[len(token)-4:]
+	}
+
+	return token[:prefixEnd] + "..." + token[len(token)-4:]
+}
+
 // GetClaudeAuthStatus checks all possible sources of Claude/Anthropic credentials
 // and returns which ones are available. Sources checked:
 //   - Settings-stored encrypted API key

--- a/src/components/settings/sections/AccountSettings.tsx
+++ b/src/components/settings/sections/AccountSettings.tsx
@@ -3,13 +3,15 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import { CheckCircle2, LogOut, Loader2 } from 'lucide-react';
+import { CheckCircle2, LogOut, Loader2, Eye, EyeOff } from 'lucide-react';
 import { useSettingsStore, SETTINGS_DEFAULTS } from '@/stores/settingsStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useLinearAuthStore } from '@/stores/linearAuthStore';
 import { logout } from '@/lib/auth';
 import { startLinearOAuthFlow, linearLogout, cancelLinearOAuthFlow } from '@/lib/linearAuth';
 import { checkGhAuthStatus, openUrlInBrowser, type GhCliStatus } from '@/lib/tauri';
+import { getGitHubPersonalToken, setGitHubPersonalToken } from '@/lib/api';
+import { useToast } from '@/components/ui/toast';
 import { SettingsRow } from '../shared/SettingsRow';
 import { SettingsGroup } from '../shared/SettingsGroup';
 
@@ -177,6 +179,9 @@ export function AccountSettings() {
           )}
         </SettingsRow>
 
+        {/* GitHub Personal Access Token */}
+        <GitHubPatSection />
+
         {/* Linear Integration */}
         <SettingsRow
           settingId="linearIntegration"
@@ -249,5 +254,126 @@ export function AccountSettings() {
         </SettingsRow>
       </SettingsGroup>
     </div>
+  );
+}
+
+function GitHubPatSection() {
+  const [tokenInput, setTokenInput] = useState('');
+  const [configured, setConfigured] = useState(false);
+  const [maskedToken, setMaskedToken] = useState('');
+  const [username, setUsername] = useState('');
+  const [showToken, setShowToken] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const toasts = useToast();
+
+  useEffect(() => {
+    let cancelled = false;
+    getGitHubPersonalToken().then((data) => {
+      if (cancelled) return;
+      setConfigured(data.configured);
+      setMaskedToken(data.maskedToken);
+      setUsername(data.username);
+    }).catch(() => {
+      // ignore -- settings page should still render
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const result = await setGitHubPersonalToken(tokenInput);
+      setConfigured(result.configured);
+      setMaskedToken(result.maskedToken);
+      setUsername(result.username);
+      setTokenInput('');
+      toasts.success('New sessions will use this token.', 'GitHub token saved');
+    } catch (err) {
+      // ApiError already extracts JSON error messages into err.message
+      const msg = err instanceof Error ? err.message : 'Failed to save token';
+      setError(msg);
+      toasts.error(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      await setGitHubPersonalToken('');
+      setConfigured(false);
+      setMaskedToken('');
+      setUsername('');
+      toasts.success('GitHub token removed');
+    } catch {
+      toasts.error('Failed to remove token');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const description = configured && username
+    ? `Authenticated as @${username}`
+    : 'Optional. Used as GITHUB_TOKEN for agent operations.';
+
+  return (
+    <SettingsRow
+      settingId="githubPersonalToken"
+      variant="stacked"
+      title="Personal access token"
+      description={description}
+      badge={configured ? <CheckCircle2 className="w-4 h-4 text-text-success" /> : undefined}
+    >
+      {configured && (
+        <p className="text-xs text-muted-foreground mb-2">
+          Current token: <code className="text-xs bg-muted px-1 py-0.5 rounded">{maskedToken}</code>
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1 max-w-xs">
+          <input
+            type={showToken ? 'text' : 'password'}
+            value={tokenInput}
+            onChange={(e) => { setTokenInput(e.target.value); setError(''); }}
+            placeholder={configured ? 'Enter new token to replace' : 'ghp_xxxxxxxxxxxx'}
+            aria-label="GitHub Personal Access Token"
+            className="w-full px-3 py-1.5 pr-8 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+          <button
+            type="button"
+            onClick={() => setShowToken(!showToken)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            aria-label={showToken ? 'Hide token' : 'Show token'}
+          >
+            {showToken ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+          </button>
+        </div>
+        <Button
+          size="sm"
+          disabled={!tokenInput.trim() || saving}
+          onClick={handleSave}
+        >
+          {saving ? 'Validating...' : 'Save'}
+        </Button>
+        {configured && (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={saving}
+            onClick={handleRemove}
+          >
+            Remove
+          </Button>
+        )}
+      </div>
+      {error && (
+        <p className="text-xs text-destructive mt-1">{error}</p>
+      )}
+    </SettingsRow>
   );
 }

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -309,6 +309,14 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
     category: 'account',
     categoryLabel: 'Account',
   },
+  {
+    id: 'githubPersonalToken',
+    title: 'Personal access token',
+    description: 'GitHub personal access token for agent operations',
+    keywords: ['github', 'token', 'pat', 'personal', 'access', 'ghp', 'authentication'],
+    category: 'account',
+    categoryLabel: 'Account',
+  },
 
   // ── Account: Privacy ──
   {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1624,6 +1624,27 @@ export async function setAnthropicApiKey(apiKey: string): Promise<{ configured: 
 }
 
 // =============================================================================
+// GitHub Personal Access Token
+// =============================================================================
+
+export async function getGitHubPersonalToken(): Promise<{ configured: boolean; maskedToken: string; username: string }> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/settings/github-personal-token`);
+  return handleResponse<{ configured: boolean; maskedToken: string; username: string }>(res);
+}
+
+export async function setGitHubPersonalToken(token: string): Promise<{ configured: boolean; maskedToken: string; username: string }> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/settings/github-personal-token`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    }
+  );
+  return handleResponse<{ configured: boolean; maskedToken: string; username: string }>(res);
+}
+
+// =============================================================================
 // CI / GitHub Actions Types and Functions
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- Adds encrypted GitHub PAT storage with GET/PUT API endpoints at `/api/settings/github-personal-token`
- Validates tokens against GitHub API (fetches authenticated user) before saving
- Injects `GITHUB_TOKEN` into agent sessions, respecting existing tokens (won't override `gh auth` or custom env vars)
- New "Personal access token" section in Account settings with save, remove, and show/hide toggle
- Stores pre-computed masked token to avoid decrypting on every settings page load

## Test plan

- [ ] Add a valid GitHub PAT in Settings → Account → Personal access token
- [ ] Verify token is validated (shows username on success, error on invalid token)
- [ ] Verify masked token display (e.g. `ghp_...xxxx`)
- [ ] Remove token and verify it's cleared
- [ ] Start a new session and verify `GITHUB_TOKEN` is available in agent environment
- [ ] Verify existing `GITHUB_TOKEN` from env/gh auth is not overridden when PAT is also configured
- [ ] Backend: `cd backend && go test ./server/... -run "GitHub|Token" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)