### PR TITLE
feat: add conversation markers minimap with hover previews

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -14,6 +14,7 @@ import {
   useReviewCommentActions,
   useStreamingState,
 } from '@/stores/selectors';
+import { ConversationMarkers } from '@/components/conversation/ConversationMarkers';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -395,6 +396,11 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     }
     messageListRef.current?.scrollToIndex(targetIndex, { align: 'center', behavior: 'smooth' });
   }, [clampedMatchIndex, searchQuery, searchMatches]);
+
+  // Scroll handler for conversation markers minimap
+  const handleMarkerScrollToIndex = useCallback((index: number) => {
+    messageListRef.current?.scrollToIndex(index, { align: 'start', behavior: 'smooth' });
+  }, []);
 
   // Register keyboard shortcuts for search
   useShortcut('searchChat', useCallback(() => {
@@ -1207,6 +1213,13 @@ export function ConversationArea({ children }: ConversationAreaProps) {
             pendingPlanApproval={!!selectedStreaming?.pendingPlanApproval}
             forceFollowRef={forceFollowRef}
           />
+          {/* Conversation markers minimap */}
+          {conversationMessages.length > 3 && (
+            <ConversationMarkers
+              messages={conversationMessages}
+              onScrollToIndex={handleMarkerScrollToIndex}
+            />
+          )}
           {/* Fade overlay at bottom of messages */}
           <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-chat-background to-transparent pointer-events-none z-10" />
         </div>

--- a/src/components/conversation/ConversationMarkers.tsx
+++ b/src/components/conversation/ConversationMarkers.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ClipboardCheck, User } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { extractMarkers, type ConversationMarker } from '@/lib/conversationMarkers';
+import type { Message } from '@/lib/types';
+
+interface ConversationMarkersProps {
+  messages: readonly Message[];
+  onScrollToIndex: (index: number) => void;
+}
+
+export const ConversationMarkers = memo(function ConversationMarkers({
+  messages,
+  onScrollToIndex,
+}: ConversationMarkersProps) {
+  const markers = useMemo(() => extractMarkers(messages), [messages]);
+  const totalMessages = messages.length;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [hoveredMarkerId, setHoveredMarkerId] = useState<string | null>(null);
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimers = useCallback(() => {
+    if (openTimerRef.current) clearTimeout(openTimerRef.current);
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+  }, []);
+
+  // Clean up timers on unmount
+  useEffect(() => clearTimers, [clearTimers]);
+
+  const handleTrackEnter = useCallback(() => {
+    clearTimers();
+    openTimerRef.current = setTimeout(() => setIsOpen(true), 150);
+  }, [clearTimers]);
+
+  const handleTrackLeave = useCallback(() => {
+    clearTimers();
+    closeTimerRef.current = setTimeout(() => {
+      setIsOpen(false);
+      setHoveredMarkerId(null);
+    }, 200);
+  }, [clearTimers]);
+
+  const handlePopoverEnter = useCallback(() => {
+    clearTimers();
+    setIsOpen(true);
+  }, [clearTimers]);
+
+  const handlePopoverLeave = useCallback(() => {
+    clearTimers();
+    closeTimerRef.current = setTimeout(() => {
+      setIsOpen(false);
+      setHoveredMarkerId(null);
+    }, 200);
+  }, [clearTimers]);
+
+  const handleMarkerClick = useCallback(
+    (marker: ConversationMarker) => {
+      onScrollToIndex(marker.index);
+      setIsOpen(false);
+    },
+    [onScrollToIndex]
+  );
+
+  const hoveredMarker = useMemo(
+    () => (hoveredMarkerId ? markers.find((m) => m.id === hoveredMarkerId) ?? null : null),
+    [hoveredMarkerId, markers]
+  );
+
+  if (markers.length === 0) return null;
+
+  return (
+    <>
+      {/* Marker track — narrow strip on right edge */}
+      <div
+        className="absolute top-0 right-0 bottom-0 w-3 z-[15] cursor-pointer"
+        onMouseEnter={handleTrackEnter}
+        onMouseLeave={handleTrackLeave}
+      >
+        {markers.map((marker) => {
+          const topPercent =
+            totalMessages <= 1
+              ? 50
+              : (marker.index / (totalMessages - 1)) * 100;
+
+          return (
+            <div
+              key={marker.id}
+              className={cn(
+                'absolute right-0.5 h-[3px] w-[8px] rounded-full transition-opacity',
+                marker.type === 'plan'
+                  ? 'bg-brand/70'
+                  : 'bg-muted-foreground/40'
+              )}
+              style={{ top: `${topPercent}%` }}
+              onClick={() => handleMarkerClick(marker)}
+            />
+          );
+        })}
+      </div>
+
+      {/* Hover popover — positioned to the left of the track */}
+      {isOpen && (
+        <div
+          className="absolute top-0 right-3 bottom-0 z-[16] flex items-start pointer-events-none"
+        >
+          <div
+            className={cn(
+              'pointer-events-auto mt-8 flex max-h-[calc(100%-4rem)]',
+              'rounded-md border bg-popover text-popover-foreground shadow-lg',
+              'animate-in fade-in-0 zoom-in-95 duration-150'
+            )}
+            onMouseEnter={handlePopoverEnter}
+            onMouseLeave={handlePopoverLeave}
+          >
+            {/* Left panel: preview of hovered item */}
+            {hoveredMarker && (
+              <div className="w-48 border-r p-3 text-xs text-muted-foreground overflow-hidden">
+                <div className="flex items-center gap-1.5 mb-2 text-[10px] uppercase tracking-wider font-medium">
+                  {hoveredMarker.type === 'plan' ? (
+                    <>
+                      <ClipboardCheck className="w-3 h-3" />
+                      Plan
+                    </>
+                  ) : (
+                    <>
+                      <User className="w-3 h-3" />
+                      User
+                    </>
+                  )}
+                </div>
+                <p className="leading-relaxed line-clamp-[12]">
+                  {hoveredMarker.title}
+                </p>
+              </div>
+            )}
+
+            {/* Right panel: marker list */}
+            <div className="w-56 overflow-y-auto py-1">
+              {markers.map((marker) => (
+                <button
+                  key={marker.id}
+                  className={cn(
+                    'flex items-center gap-2 w-full px-3 py-1.5 text-left text-xs',
+                    'hover:bg-accent transition-colors cursor-pointer',
+                    hoveredMarkerId === marker.id && 'bg-accent'
+                  )}
+                  onClick={() => handleMarkerClick(marker)}
+                  onMouseEnter={() => setHoveredMarkerId(marker.id)}
+                >
+                  {marker.type === 'plan' ? (
+                    <ClipboardCheck className="w-3 h-3 shrink-0 text-brand" />
+                  ) : (
+                    <User className="w-3 h-3 shrink-0 text-muted-foreground" />
+                  )}
+                  <span className="truncate">{marker.title}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+});

--- a/src/lib/conversationMarkers.ts
+++ b/src/lib/conversationMarkers.ts
@@ -1,0 +1,51 @@
+import type { Message } from '@/lib/types';
+
+export interface ConversationMarker {
+  id: string;
+  index: number;
+  type: 'user' | 'plan';
+  title: string;
+}
+
+/**
+ * Extract navigation markers from a conversation's messages.
+ * Returns markers for user turns and plan proposals.
+ */
+export function extractMarkers(messages: readonly Message[]): ConversationMarker[] {
+  const markers: ConversationMarker[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (msg.role === 'user' && msg.content.trim()) {
+      markers.push({
+        id: msg.id,
+        index: i,
+        type: 'user',
+        title: truncate(msg.content, 60),
+      });
+    }
+
+    // Plan proposals — from planContent or timeline plan entries
+    const planEntry = msg.timeline?.find((e): e is Extract<typeof e, { type: 'plan' }> => e.type === 'plan');
+    const planText = msg.planContent || planEntry?.content;
+
+    if (planText) {
+      markers.push({
+        id: `${msg.id}-plan`,
+        index: i,
+        type: 'plan',
+        title: truncate(planText, 60),
+      });
+    }
+  }
+
+  return markers;
+}
+
+function truncate(text: string, max: number): string {
+  // Strip markdown heading prefixes and trim
+  const cleaned = text.replace(/^#+\s+/, '').trim();
+  if (cleaned.length <= max) return cleaned;
+  return cleaned.slice(0, max).trimEnd() + '…';
+}


### PR DESCRIPTION
## Summary

- Adds a minimap strip on the right edge of the conversation area showing markers for user turns and plan proposals
- Hovering the strip reveals a popover with a scrollable marker list and a preview panel for the hovered item
- Clicking a marker smoothly scrolls to that message in the conversation

### New files
- `src/components/conversation/ConversationMarkers.tsx` — memoized marker track + hover popover component
- `src/lib/conversationMarkers.ts` — pure extraction logic for user and plan markers from messages

### Changes
- `src/components/conversation/ConversationArea.tsx` — integrates `ConversationMarkers` with stable `useCallback` scroll handler; only shown when conversation has >3 messages

## Test plan
- [ ] Open a conversation with multiple user turns — verify marker dots appear on the right edge
- [ ] Hover over the marker strip — popover should appear after 150ms delay
- [ ] Move mouse from strip to popover — popover should stay open
- [ ] Hover over individual markers in the list — preview panel should show on the left
- [ ] Click a marker — conversation should scroll to that message and popover should close
- [ ] Verify plan markers (with clipboard icon) appear for messages containing plans
- [ ] Conversations with ≤3 messages should not show the markers strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)