### PR TITLE
fix: redesign conversation markers minimap as dedicated top-right region

### DIFF
--- a/src/components/conversation/ConversationMarkers.tsx
+++ b/src/components/conversation/ConversationMarkers.tsx
@@ -20,16 +20,26 @@ export const ConversationMarkers = memo(function ConversationMarkers({
 
   const [isOpen, setIsOpen] = useState(false);
   const [hoveredMarkerId, setHoveredMarkerId] = useState<string | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
 
   const clearTimers = useCallback(() => {
     if (openTimerRef.current) clearTimeout(openTimerRef.current);
     if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
   }, []);
 
-  // Clean up timers on unmount
   useEffect(() => clearTimers, [clearTimers]);
+
+  // Scroll focused item into view
+  useEffect(() => {
+    if (focusedIndex >= 0 && listRef.current) {
+      const items = listRef.current.querySelectorAll('[role="option"]');
+      items[focusedIndex]?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [focusedIndex]);
 
   const handleTrackEnter = useCallback(() => {
     clearTimers();
@@ -41,6 +51,7 @@ export const ConversationMarkers = memo(function ConversationMarkers({
     closeTimerRef.current = setTimeout(() => {
       setIsOpen(false);
       setHoveredMarkerId(null);
+      setFocusedIndex(-1);
     }, 200);
   }, [clearTimers]);
 
@@ -54,6 +65,7 @@ export const ConversationMarkers = memo(function ConversationMarkers({
     closeTimerRef.current = setTimeout(() => {
       setIsOpen(false);
       setHoveredMarkerId(null);
+      setFocusedIndex(-1);
     }, 200);
   }, [clearTimers]);
 
@@ -61,8 +73,50 @@ export const ConversationMarkers = memo(function ConversationMarkers({
     (marker: ConversationMarker) => {
       onScrollToIndex(marker.index);
       setIsOpen(false);
+      setFocusedIndex(-1);
     },
     [onScrollToIndex]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (markers.length === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault();
+          const next = focusedIndex < markers.length - 1 ? focusedIndex + 1 : 0;
+          setFocusedIndex(next);
+          setHoveredMarkerId(markers[next].id);
+          if (!isOpen) setIsOpen(true);
+          break;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          const prev = focusedIndex > 0 ? focusedIndex - 1 : markers.length - 1;
+          setFocusedIndex(prev);
+          setHoveredMarkerId(markers[prev].id);
+          if (!isOpen) setIsOpen(true);
+          break;
+        }
+        case 'Enter': {
+          e.preventDefault();
+          if (focusedIndex >= 0 && focusedIndex < markers.length) {
+            handleMarkerClick(markers[focusedIndex]);
+          }
+          break;
+        }
+        case 'Escape': {
+          e.preventDefault();
+          setIsOpen(false);
+          setHoveredMarkerId(null);
+          setFocusedIndex(-1);
+          trackRef.current?.blur();
+          break;
+        }
+      }
+    },
+    [markers, focusedIndex, isOpen, handleMarkerClick]
   );
 
   const hoveredMarker = useMemo(
@@ -70,99 +124,126 @@ export const ConversationMarkers = memo(function ConversationMarkers({
     [hoveredMarkerId, markers]
   );
 
+  const trackHeight = useMemo(
+    () => Math.max(32, Math.min(markers.length * 8 + 16, 200)),
+    [markers.length]
+  );
+
   if (markers.length === 0) return null;
 
   return (
-    <>
-      {/* Marker track — narrow strip on right edge */}
+    <div className="absolute top-3 right-3 z-[15]">
+      {/* Marker track — compact minimap in top-right corner */}
       <div
-        className="absolute top-0 right-0 bottom-0 w-3 z-[15] cursor-pointer"
+        ref={trackRef}
+        className="relative w-4 rounded-sm bg-muted/30 border border-border/30 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        style={{ height: trackHeight }}
+        tabIndex={0}
+        role="navigation"
+        aria-label="Conversation markers"
         onMouseEnter={handleTrackEnter}
         onMouseLeave={handleTrackLeave}
+        onKeyDown={handleKeyDown}
       >
-        {markers.map((marker) => {
-          const topPercent =
-            totalMessages <= 1
-              ? 50
-              : (marker.index / (totalMessages - 1)) * 100;
+        <div className="absolute inset-x-0 top-2 bottom-2">
+          {markers.map((marker) => {
+            const topPercent =
+              totalMessages <= 1
+                ? 50
+                : (marker.index / (totalMessages - 1)) * 100;
 
-          return (
-            <div
-              key={marker.id}
-              className={cn(
-                'absolute right-0.5 h-[3px] w-[8px] rounded-full transition-opacity',
-                marker.type === 'plan'
-                  ? 'bg-brand/70'
-                  : 'bg-muted-foreground/40'
-              )}
-              style={{ top: `${topPercent}%` }}
-              onClick={() => handleMarkerClick(marker)}
-            />
-          );
-        })}
+            return (
+              <div
+                key={marker.id}
+                className={cn(
+                  'absolute left-1/2 -translate-x-1/2 h-[3px] w-[10px] rounded-full transition-opacity',
+                  marker.type === 'plan'
+                    ? 'bg-brand/70'
+                    : 'bg-muted-foreground/40'
+                )}
+                style={{ top: `${topPercent}%` }}
+                onClick={() => handleMarkerClick(marker)}
+              />
+            );
+          })}
+        </div>
       </div>
 
-      {/* Hover popover — positioned to the left of the track */}
-      {isOpen && (
+      {/* Popover — always mounted, visibility toggled */}
+      <div
+        className={cn(
+          'absolute top-0 right-full mr-2 transition-all duration-150 ease-out motion-reduce:transition-none',
+          isOpen
+            ? 'opacity-100 translate-x-0'
+            : 'opacity-0 translate-x-2 pointer-events-none'
+        )}
+        onMouseEnter={handlePopoverEnter}
+        onMouseLeave={handlePopoverLeave}
+      >
         <div
-          className="absolute top-0 right-3 bottom-0 z-[16] flex items-start pointer-events-none"
+          className={cn(
+            'flex max-h-[60vh]',
+            'rounded-lg border bg-popover/95 backdrop-blur-md text-popover-foreground shadow-lg'
+          )}
         >
-          <div
-            className={cn(
-              'pointer-events-auto mt-8 flex max-h-[calc(100%-4rem)]',
-              'rounded-md border bg-popover text-popover-foreground shadow-lg',
-              'animate-in fade-in-0 zoom-in-95 duration-150'
-            )}
-            onMouseEnter={handlePopoverEnter}
-            onMouseLeave={handlePopoverLeave}
-          >
-            {/* Left panel: preview of hovered item */}
-            {hoveredMarker && (
-              <div className="w-48 border-r p-3 text-xs text-muted-foreground overflow-hidden">
-                <div className="flex items-center gap-1.5 mb-2 text-[10px] uppercase tracking-wider font-medium">
-                  {hoveredMarker.type === 'plan' ? (
-                    <>
-                      <ClipboardCheck className="w-3 h-3" />
-                      Plan
-                    </>
-                  ) : (
-                    <>
-                      <User className="w-3 h-3" />
-                      User
-                    </>
-                  )}
-                </div>
-                <p className="leading-relaxed line-clamp-[12]">
-                  {hoveredMarker.title}
-                </p>
+          {/* Left panel: preview of hovered item */}
+          {hoveredMarker && (
+            <div className="w-48 border-r p-3 text-xs text-muted-foreground overflow-hidden">
+              <div className="flex items-center gap-1.5 mb-2 text-[10px] uppercase tracking-wider font-medium">
+                {hoveredMarker.type === 'plan' ? (
+                  <>
+                    <ClipboardCheck className="w-3 h-3" />
+                    Plan
+                  </>
+                ) : (
+                  <>
+                    <User className="w-3 h-3" />
+                    User
+                  </>
+                )}
               </div>
-            )}
-
-            {/* Right panel: marker list */}
-            <div className="w-56 overflow-y-auto py-1">
-              {markers.map((marker) => (
-                <button
-                  key={marker.id}
-                  className={cn(
-                    'flex items-center gap-2 w-full px-3 py-1.5 text-left text-xs',
-                    'hover:bg-accent transition-colors cursor-pointer',
-                    hoveredMarkerId === marker.id && 'bg-accent'
-                  )}
-                  onClick={() => handleMarkerClick(marker)}
-                  onMouseEnter={() => setHoveredMarkerId(marker.id)}
-                >
-                  {marker.type === 'plan' ? (
-                    <ClipboardCheck className="w-3 h-3 shrink-0 text-brand" />
-                  ) : (
-                    <User className="w-3 h-3 shrink-0 text-muted-foreground" />
-                  )}
-                  <span className="truncate">{marker.title}</span>
-                </button>
-              ))}
+              <p className="leading-relaxed line-clamp-[12]">
+                {hoveredMarker.title}
+              </p>
             </div>
+          )}
+
+          {/* Right panel: marker list */}
+          <div
+            ref={listRef}
+            className="w-56 overflow-y-auto py-1 scrollbar-thin"
+            role="listbox"
+            aria-label="Conversation markers"
+            aria-activedescendant={focusedIndex >= 0 ? markers[focusedIndex]?.id : undefined}
+          >
+            {markers.map((marker, i) => (
+              <button
+                key={marker.id}
+                id={marker.id}
+                role="option"
+                aria-selected={focusedIndex === i}
+                className={cn(
+                  'flex items-center gap-2 w-full px-3 py-1.5 text-left text-xs',
+                  'hover:bg-accent transition-colors cursor-pointer',
+                  (hoveredMarkerId === marker.id || focusedIndex === i) && 'bg-accent'
+                )}
+                onClick={() => handleMarkerClick(marker)}
+                onMouseEnter={() => {
+                  setHoveredMarkerId(marker.id);
+                  setFocusedIndex(i);
+                }}
+              >
+                {marker.type === 'plan' ? (
+                  <ClipboardCheck className="w-3 h-3 shrink-0 text-brand" />
+                ) : (
+                  <User className="w-3 h-3 shrink-0 text-muted-foreground" />
+                )}
+                <span className="truncate">{marker.title}</span>
+              </button>
+            ))}
           </div>
         </div>
-      )}
-    </>
+      </div>
+    </div>
   );
 });


### PR DESCRIPTION
## Summary
- Moves the conversation markers minimap from a full-height scrollbar overlay to a compact, fixed region in the top-right corner of the scroll area — matching the reference design
- Polishes the popover with smooth CSS transitions (always mounted, class-toggled), backdrop blur, and rounded corners
- Adds keyboard navigation: Arrow Up/Down to browse markers, Enter to scroll to selection, Escape to close

## Test plan
- [ ] Open a conversation with 4+ messages and verify the minimap appears as a compact strip in the top-right corner (not overlaying the scrollbar)
- [ ] Hover over the minimap track and verify the popover slides in from the right with a smooth transition
- [ ] Click a marker in the popover list and verify smooth scroll to the correct message
- [ ] Tab to focus the minimap, use Arrow keys to navigate, Enter to select, Escape to close
- [ ] Verify the minimap is hidden for conversations with fewer than 4 messages
- [ ] Verify reduced motion preference is respected (no transitions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)