### PR TITLE
fix: make AskUserQuestion footer button advance on multi-select questions

### DIFF
--- a/src/components/conversation/UserQuestionPrompt.tsx
+++ b/src/components/conversation/UserQuestionPrompt.tsx
@@ -186,6 +186,16 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
     });
   }, [pending]);
 
+  // Check if the current question has an answer (for advancing in multi-question flows)
+  const currentQuestionAnswered = useMemo(() => {
+    if (!pending || !currentQuestion) return false;
+    const answer = pending.answers[currentQuestion.header];
+    return !!answer && answer.length > 0;
+  }, [pending, currentQuestion]);
+
+  const isLastQuestion = currentIndex === totalQuestions - 1;
+  const shouldAdvance = !isLastQuestion && currentQuestionAnswered && !canSubmit;
+
   // Sync free-text state when the current question changes
   const currentHeader = currentQuestion?.header;
   const hasFreeText = currentQuestion && currentQuestion.options.length === 0;
@@ -507,8 +517,8 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
                   ? 'bg-brand hover:bg-brand/90 text-primary-foreground border-brand'
                   : 'bg-foreground hover:bg-foreground/90 text-background border-foreground'
               )}
-              disabled={!canSubmit || isSubmitting}
-              onClick={handleSubmit}
+              disabled={!(shouldAdvance || canSubmit) || isSubmitting}
+              onClick={shouldAdvance ? handleNext : handleSubmit}
               data-testid="submit-question"
             >
               {isSubmitting ? (

--- a/src/components/conversation/__tests__/UserQuestionPrompt.test.tsx
+++ b/src/components/conversation/__tests__/UserQuestionPrompt.test.tsx
@@ -426,9 +426,24 @@ describe('UserQuestionPrompt', () => {
       expect(pending?.answers['Database']).toBe('PostgreSQL');
     });
 
-    it('submit is disabled until all questions are answered', () => {
+    it('footer button acts as next when current question answered but not all', () => {
       setPending(makeMultiPending());
       useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Framework', 'React');
+
+      render(<UserQuestionPrompt conversationId={CONV_ID} />);
+
+      // Button should be enabled (acts as "Next", not "Submit")
+      const button = screen.getByTestId('submit-question');
+      expect(button).not.toBeDisabled();
+
+      // Clicking it should advance to next question
+      fireEvent.click(button);
+      const pending = useAppStore.getState().pendingUserQuestion[CONV_ID];
+      expect(pending?.currentIndex).toBe(1);
+    });
+
+    it('footer button is disabled when current question has no answer', () => {
+      setPending(makeMultiPending());
 
       render(<UserQuestionPrompt conversationId={CONV_ID} />);
 


### PR DESCRIPTION
## Summary
- The footer ArrowRight button was disabled on multi-select questions because `canSubmit` required ALL questions to have answers
- Now the button acts as "Next" when the current question is answered but it's not the last question, advancing the user through the wizard
- On the last question (or when all questions are answered), it still acts as "Submit"

## Test plan
- [x] Updated existing test to verify new "advance" behavior
- [x] Added test for disabled state when current question has no answer
- [x] All 49 tests pass
- [ ] Manual test: trigger AskUserQuestion with 4 questions (mix of single/multi-select), verify advancing works on multi-select questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)