### PR TITLE
fix: Enter key not submitting in composer

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -1103,7 +1103,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     // Check both: focused combobox input OR visible combobox popover (listbox)
     const activeElement = document.activeElement as HTMLElement | null;
     const isInCombobox = activeElement?.closest('[role="combobox"]');
-    const hasOpenPopover = document.querySelector('[role="listbox"]');
+    const hasOpenPopover = document.querySelector('[role="combobox"][aria-expanded="true"]');
     if ((isInCombobox || hasOpenPopover) && (e.key === 'Enter' || e.key === 'Tab')) {
       // Let the combobox handle item selection
       return;


### PR DESCRIPTION
## Summary
- The conversation markers minimap (`role="listbox"`, added in #854/#857) is always visible in the DOM
- `ChatInput.handleKeyDown` used `document.querySelector('[role="listbox"]')` to detect open combobox popovers, but this matched the minimap
- This caused Enter/Tab to always early-return before reaching `handleSubmit()`, making Enter act like Shift+Enter (inserting newlines instead of submitting)
- Fixed by scoping the check to `[role="combobox"][aria-expanded="true"]`, which only matches when an actual inline combobox (@mention or /slash command) has its popover open

## Test plan
- [ ] Type text in composer → press Enter → should submit
- [ ] Type `@` to trigger mention combobox → press Enter → should select mention item (not submit)
- [ ] Type `/` to trigger slash command → press Enter → should select command (not submit)
- [ ] Dismiss combobox (Escape) → press Enter → should submit
- [ ] Verify conversation markers minimap still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)