### PR TITLE
fix: prevent conversation markers minimap from interfering with scrollbar

### DIFF
--- a/src/components/conversation/ConversationMarkers.tsx
+++ b/src/components/conversation/ConversationMarkers.tsx
@@ -132,11 +132,11 @@ export const ConversationMarkers = memo(function ConversationMarkers({
   if (markers.length === 0) return null;
 
   return (
-    <div className="absolute top-3 right-3 z-[15]">
+    <div className="absolute top-3 right-5 z-[15] pointer-events-none">
       {/* Marker track — compact minimap in top-right corner */}
       <div
         ref={trackRef}
-        className="relative w-4 rounded-sm bg-muted/30 border border-border/30 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="relative w-4 rounded-sm bg-muted/30 border border-border/30 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-ring pointer-events-auto"
         style={{ height: trackHeight }}
         tabIndex={0}
         role="navigation"
@@ -174,7 +174,7 @@ export const ConversationMarkers = memo(function ConversationMarkers({
         className={cn(
           'absolute top-0 right-full mr-2 transition-all duration-150 ease-out motion-reduce:transition-none',
           isOpen
-            ? 'opacity-100 translate-x-0'
+            ? 'opacity-100 translate-x-0 pointer-events-auto'
             : 'opacity-0 translate-x-2 pointer-events-none'
         )}
         onMouseEnter={handlePopoverEnter}


### PR DESCRIPTION
## Summary
- The conversation markers minimap track was positioned at `right-3` (12px from right edge), overlapping the native macOS overlay scrollbar zone and intercepting mouse events
- This caused the scrollbar handle to visually "grow" when hovering near it
- Moved track to `right-5` (20px) and added `pointer-events-none` on the wrapper with `pointer-events-auto` only on interactive children (track + popover)

## Test plan
- [ ] Hover near the conversation scrollbar — it should behave normally without visual growth
- [ ] Hover over the markers minimap track — popover should still open after 150ms
- [ ] Move mouse from track to popover — should stay open (200ms close timer)
- [ ] Keyboard navigation on the markers track still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)