### PR TITLE
fix: reset CodeViewer to diff mode when diff data arrives after initial render

### DIFF
--- a/src/components/files/CodeViewer.tsx
+++ b/src/components/files/CodeViewer.tsx
@@ -68,8 +68,18 @@ export const CodeViewer = memo(function CodeViewer({
     setViewMode(getDefaultViewMode(filename, typeof oldContent === 'string'));
   }
 
-  const isMarkdown = isMarkdownFile(filename);
+  // Reset view mode when diff data appears/disappears (loading → loaded transition).
+  // Skip when the filename also changed — the block above already handles that case.
   const hasDiff = typeof oldContent === 'string';
+  const [prevHasDiff, setPrevHasDiff] = useState(hasDiff);
+  if (prevHasDiff !== hasDiff) {
+    setPrevHasDiff(hasDiff);
+    if (prevFilename === filename) {
+      setViewMode(getDefaultViewMode(filename, hasDiff));
+    }
+  }
+
+  const isMarkdown = isMarkdownFile(filename);
   const canEdit = !!onChange;
   const getContent = useCallback(() => content, [content]);
 


### PR DESCRIPTION
## Summary
- When opening a file from the Changes panel, `oldContent` may not be available on the first render, causing the view mode to default to `code` instead of `diff`
- Adds a `prevHasDiff` state check that resets view mode to diff when `oldContent` becomes available after the initial render
- Skips the reset when the filename also changed simultaneously (already handled by the existing `prevFilename` block)

## Test plan
- [ ] Open a file from the Changes panel — should auto-select diff mode even if diff data loads after the component mounts
- [ ] Switch between files in the Changes panel — view mode should reset correctly for each file
- [ ] Open a file without diff data — should default to code mode as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)