### PR TITLE
fix: use correct purple color for merged session label

### DIFF
--- a/src/components/session-manager/SessionRow.tsx
+++ b/src/components/session-manager/SessionRow.tsx
@@ -38,7 +38,7 @@ export function SessionRow({ session, workspace, onSelect, onUnarchive, onPrevie
       return { text: 'Working...', color: 'text-text-warning' };
     }
     if (session.prStatus === 'merged') {
-      return { text: 'Merged', color: 'text-brand' };
+      return { text: 'Merged', color: 'text-nav-icon-prs' };
     }
     if (session.hasMergeConflict) {
       return { text: 'Merge conflict', color: 'text-text-error' };

--- a/src/components/session-manager/WorkspaceTreeItem.tsx
+++ b/src/components/session-manager/WorkspaceTreeItem.tsx
@@ -45,7 +45,7 @@ export function WorkspaceTreeItem({
       return { text: 'Checks failing', color: 'text-text-error', icon: XCircle };
     }
     if (session.prStatus === 'merged') {
-      return { text: 'Merged', color: 'text-brand', icon: CheckCircle2 };
+      return { text: 'Merged', color: 'text-nav-icon-prs', icon: CheckCircle2 };
     }
     if (session.prStatus === 'open') {
       if (session.checkStatus === 'pending') {


### PR DESCRIPTION
## Summary
- The "Merged" text label in the sidebar used `text-brand` (indigo) instead of `text-nav-icon-prs` (purple), causing a color mismatch with the PR badge
- Updated both `SessionRow.tsx` and `WorkspaceTreeItem.tsx` to use `text-nav-icon-prs`

## Test plan
- [ ] Open sidebar with a workspace that has a merged PR session
- [ ] Confirm the "Merged" text color now matches the purple PR badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)