### PR TITLE
fix: update release target to use pnpm instead of npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ release:
 	@sed -i '' 's/"version": "[^"]*"/"version": "$(VERSION)"/' package.json
 	@sed -i '' '/"version":/{s/"version": "[^"]*"/"version": "$(VERSION)"/;};' src-tauri/tauri.conf.json
 	@sed -i '' '/^\[package\]/,/^\[/{s/^version = "[^"]*"/version = "$(VERSION)"/;}' src-tauri/Cargo.toml
-	npm install --package-lock-only
-	git add package.json package-lock.json src-tauri/tauri.conf.json src-tauri/Cargo.toml
+	pnpm install --lockfile-only
+	git add package.json pnpm-lock.yaml src-tauri/tauri.conf.json src-tauri/Cargo.toml
 	git diff --cached --quiet && echo "Version already at $(VERSION)" || true
 	git commit --allow-empty -m "release: v$(VERSION)"
 	git push -u origin release/v$(VERSION)


### PR DESCRIPTION
## Summary
- Updated the `release` Makefile target to use `pnpm install --lockfile-only` instead of `npm install --package-lock-only`
- Changed lockfile staging from `package-lock.json` to `pnpm-lock.yaml`

## Test plan
- [ ] Run `make release VERSION=x.y.z` (dry run) and verify it uses pnpm commands
- [ ] Confirm `pnpm-lock.yaml` is staged correctly during release flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)