### PR TITLE
ci: add missing dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: agent-runner/package-lock.json
 
       - name: Install dependencies
         working-directory: agent-runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,12 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          cache-on-failure: true
+
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
         run: |


### PR DESCRIPTION
## Summary
- Add npm dependency caching to the **agent-runner** CI job (`ci.yml`) via `actions/setup-node` with `cache: 'npm'`
- Add Rust dependency caching to the **build-tauri** release job (`release.yml`) via `Swatinem/rust-cache@v2`, matching what CI already uses

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm cache restore/save logs appear in agent-runner and release workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)