### PR TITLE
feat: auto-generate changelog in release PR body

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ release:
 	git diff --cached --quiet && echo "Version already at $(VERSION)" || true
 	git commit --allow-empty -m "release: v$(VERSION)"
 	git push -u origin release/v$(VERSION)
-	gh pr create --title "release: v$(VERSION)" --body "Bump version to $(VERSION)."
+	gh pr create --title "release: v$(VERSION)" --body "$$(./scripts/changelog.sh)"
 	@echo "PR created. Merge it to trigger the release build."
 
 # Initialize fresh worktree - explicit setup command

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Generate a categorized changelog from conventional commits since the last tag.
+# Usage: ./scripts/changelog.sh [FROM_TAG]
+
+set -euo pipefail
+
+FROM_TAG="${1:-$(git describe --tags --abbrev=0 2>/dev/null || echo "")}"
+
+if [ -z "$FROM_TAG" ]; then
+  echo "No tags found. Cannot generate changelog."
+  exit 1
+fi
+
+features=""
+fixes=""
+other=""
+
+while IFS= read -r line; do
+  # Skip release commits
+  [[ "$line" =~ ^release: ]] && continue
+
+  # Categorize and strip prefix
+  if [[ "$line" =~ ^feat(\(.+\))?:\ (.+) ]]; then
+    features+="- ${BASH_REMATCH[2]}"$'\n'
+  elif [[ "$line" =~ ^fix(\(.+\))?:\ (.+) ]]; then
+    fixes+="- ${BASH_REMATCH[2]}"$'\n'
+  else
+    # Strip any conventional commit prefix (word + optional scope + colon)
+    stripped=$(echo "$line" | sed 's/^[a-z]*\([^)]*\): //')
+    other+="- ${stripped}"$'\n'
+  fi
+done < <(git log "${FROM_TAG}..HEAD" --pretty=format:"%s")
+
+# Build output
+output="## What's Changed"$'\n'
+
+if [ -n "$features" ]; then
+  output+=$'\n'"### Features"$'\n'
+  output+="${features}"
+fi
+
+if [ -n "$fixes" ]; then
+  output+=$'\n'"### Fixes"$'\n'
+  output+="${fixes}"
+fi
+
+if [ -n "$other" ]; then
+  output+=$'\n'"### Other"$'\n'
+  output+="${other}"
+fi
+
+echo "$output"


### PR DESCRIPTION
## Summary
- Add `scripts/changelog.sh` that generates a categorized markdown changelog from conventional commits since the last git tag
- Groups commits into **Features** (`feat:`), **Fixes** (`fix:`), and **Other** sections, skipping `release:` commits
- Update Makefile `release` target to use the script output as the PR body instead of static "Bump version" text

## Test plan
- [ ] Run `./scripts/changelog.sh` and verify output is correctly categorized
- [ ] Run `make release VERSION=x.y.z` and verify the PR body contains the changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)