### PR TITLE
fix: show Archive Session button after PR merge

### DIFF
--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -60,8 +60,7 @@ export function useActionState(
     // Helper: does the working tree have new work beyond the merged PR?
     const hasNewWork = gitStatus && (
       gitStatus.workingDirectory.hasChanges ||
-      gitStatus.sync.unpushedCommits > 0 ||
-      gitStatus.sync.aheadBy > 0
+      gitStatus.sync.unpushedCommits > 0
     );
 
     // Priority 7: PR is merged


### PR DESCRIPTION
## Summary
- After a squash merge, the primary action button incorrectly showed "New Pull Request" instead of "Archive Session" for completed sessions
- Root cause: `hasNewWork` included `aheadBy > 0`, which is a false positive after squash merge (branch commits have different SHAs from the squash commit on main)
- Fix: remove `aheadBy` from the merged-PR new-work check — genuine new work shows up as uncommitted changes or unpushed commits

## Test plan
- [ ] Open a session with a merged PR and clean working tree → button shows "Archive Session"
- [ ] Make a local change in a merged-PR session → button switches to "New Pull Request"
- [ ] Commit but don't push in a merged-PR session → button shows "New Pull Request"
- [ ] Non-merged session with commits ahead → "New Pull Request" still works (Priority 5 has its own `hasAhead` check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)