### PR TITLE
fix: correct merged PR status color in light mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -229,7 +229,7 @@ code.hljs { padding: 3px 5px; }
   --nav-icon-dashboard: oklch(0.55 0.15 250);
   --nav-icon-sessions: oklch(0.60 0.15 55);
   --nav-icon-branches: oklch(0.55 0.15 155);
-  --nav-icon-prs: oklch(0.55 0.15 300);
+  --nav-icon-prs: #7c3aed;
   --nav-icon-skills: oklch(0.65 0.18 85);
   --brand: oklch(0.623 0.214 259.815);
 }


### PR DESCRIPTION
## Summary
- The "Merged" status text in session cells appeared **blue** instead of **purple** in light mode
- The `oklch(0.55 0.15 300)` CSS value was being gamut-mapped to blue by browsers
- Switched to `#7c3aed` (Tailwind purple-600) for correct purple rendering

## Test plan
- [ ] Verify "Merged" text shows purple in light mode (session cells, PR badges, hover cards)
- [ ] Verify dark mode "Merged" text is still purple (unchanged `#a78bfa`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)