### PR TITLE
fix: include Cargo.lock in release version bump commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ release:
 	@sed -i '' '/"version":/{s/"version": "[^"]*"/"version": "$(VERSION)"/;};' src-tauri/tauri.conf.json
 	@sed -i '' '/^\[package\]/,/^\[/{s/^version = "[^"]*"/version = "$(VERSION)"/;}' src-tauri/Cargo.toml
 	pnpm install --lockfile-only
-	git add package.json pnpm-lock.yaml src-tauri/tauri.conf.json src-tauri/Cargo.toml
+	cd src-tauri && cargo update --workspace
+	git add package.json pnpm-lock.yaml src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
 	git diff --cached --quiet && echo "Version already at $(VERSION)" || true
 	git commit --allow-empty -m "release: v$(VERSION)"
 	git push -u origin release/v$(VERSION)


### PR DESCRIPTION
## Summary
- Add `cargo update --workspace` to the release target so `Cargo.lock` reflects the version bump in `Cargo.toml`
- Include `src-tauri/Cargo.lock` in the `git add` so it's committed with the release PR

Previously every `make release` left `Cargo.lock` dirty, requiring a manual follow-up commit.

## Test plan
- [ ] Run `make release VERSION=x.y.z` and verify `Cargo.lock` is included in the release commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)