### PR TITLE
fix: restore brand color from blue to purple

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,7 +231,7 @@ code.hljs { padding: 3px 5px; }
   --nav-icon-branches: oklch(0.55 0.15 155);
   --nav-icon-prs: #7c3aed;
   --nav-icon-skills: oklch(0.65 0.18 85);
-  --brand: oklch(0.623 0.214 259.815);
+  --brand: oklch(0.623 0.214 292);
 }
 
 .dark {
@@ -310,7 +310,7 @@ code.hljs { padding: 3px 5px; }
   --nav-icon-branches: #4ade80;
   --nav-icon-prs: #a78bfa;
   --nav-icon-skills: #fbbf24;
-  --brand: oklch(0.707 0.165 254.624);
+  --brand: oklch(0.707 0.165 292);
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary
- The `--brand` CSS variable OKLCH hue was ~260 (blue) instead of ~292 (purple), causing the logo "ml" text and all brand-colored elements to render blue instead of purple
- Shifted hue to 292 for both light and dark mode to restore the correct purple brand color

## Test plan
- [ ] Verify the "chatml" logo "ml" text appears purple (not blue) in both light and dark mode
- [ ] Check gradient elements (ChatInput glow, primary button, ActivityBar indicator) look cohesive

🤖 Generated with [Claude Code](https://claude.com/claude-code)