### PR TITLE
fix: register missing Pierre language aliases to prevent diff crashes

### DIFF
--- a/src/lib/pierrePreload.ts
+++ b/src/lib/pierrePreload.ts
@@ -118,6 +118,7 @@ const LANGS: Array<[string, unknown]> = [
   ['kotlin', kotlinGrammar],
   ['scss', scssGrammar],
   ['shellscript', shellGrammar],
+  ['zsh', shellGrammar],        // Pierre's getFiletypeFromFileName maps .sh/.bash → "zsh"
   ['diff', diffGrammar],
   ['dockerfile', dockerfileGrammar],
   ['graphql', graphqlGrammar],
@@ -140,6 +141,8 @@ const LANGS: Array<[string, unknown]> = [
   ['ini', iniGrammar],
   ['hcl', hclGrammar],
   ['proto', protobufGrammar],
+  ['protobuf', protobufGrammar], // Pierre's getFiletypeFromFileName maps .proto → "protobuf"
+  ['tex', latexGrammar],         // Pierre's getFiletypeFromFileName maps .tex → "tex"
 ];
 
 interface ResolvedLang {
@@ -166,5 +169,23 @@ for (const [langName, grammar] of LANGS) {
       name: langName,
       data: extractGrammar(langName, grammar),
     });
+  }
+}
+
+// Also register aliases declared in each grammar's metadata.
+// Pierre's internal getFiletypeFromFileName may return non-canonical IDs
+// (e.g. "yml" instead of "yaml") that differ from Shiki's canonical names.
+// parseDiffFromFile() does NOT copy the `lang` field from FileContents to
+// FileDiffMetadata, so the diff view always falls back to
+// getFiletypeFromFileName(filename) — making alias coverage critical.
+for (const [langName] of LANGS) {
+  const resolved = langMap.get(langName);
+  if (!resolved || resolved.data.length === 0) continue;
+  const aliases = (resolved.data[0] as { aliases?: string[] }).aliases;
+  if (!aliases) continue;
+  for (const alias of aliases) {
+    if (!langMap.has(alias)) {
+      langMap.set(alias, { name: langName, data: resolved.data });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- **Added explicit language entries** for `zsh`, `protobuf`, and `tex` which Pierre's `getFiletypeFromFileName` returns but weren't registered in the preloaded Shiki grammar map
- **Added generic alias registration loop** that extracts aliases from each grammar's metadata (e.g. `yml` from `yaml`) to automatically cover non-canonical IDs Pierre may return
- Scoped the alias loop to only iterate our own `LANGS` entries (not pre-existing `ResolvedLanguages` entries) and uses canonical names for alias registrations

## Test plan
- [ ] Open a diff view for `.sh`, `.bash`, `.zsh` files — should syntax-highlight as shell
- [ ] Open a diff view for `.proto` files — should highlight as protobuf
- [ ] Open a diff view for `.tex` files — should highlight as LaTeX
- [ ] Open a diff view for `.yml` files — should highlight as YAML (alias coverage)
- [ ] Verify no console errors or crashes in the diff view for any supported language

🤖 Generated with [Claude Code](https://claude.com/claude-code)