### PR TITLE
release: v0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatml",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@10.30.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "chatml"
-version = "0.1.9"
+version = "0.1.15"
 dependencies = [
  "argon2",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chatml"
-version = "0.1.14"
+version = "0.1.15"
 description = "ChatML"
 authors = ["you"]
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "chatml",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "identifier": "com.chatml.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## What's Changed

### Features
- auto-generate changelog in release PR body (#868)
- add conversation markers minimap with hover previews (#854)
- add GitHub personal access token settings (#852)
- add resolve_review_comment tool and improve add-to-chat UX (#849)

### Fixes
- register missing language aliases in Pierre preload to prevent crashes (#874)
- restore brand color from blue to purple (#873)
- include Cargo.lock in release version bump commit (#872)
- use hex purple for merged PR status color in light mode (#871)
- show Archive Session button after PR merge instead of New Pull Request (#870)
- update release target to use pnpm instead of npm (#865)
- use correct purple color for merged session label (#864)
- reset CodeViewer to diff mode when diff data arrives after initial render (#863)
- prevent conversation markers minimap from interfering with scrollbar (#861)
- Enter key not submitting in composer due to markers minimap listbox (#860)
- make AskUserQuestion footer button advance on multi-select questions (#859)
- always open files from Changes panel in diff mode (#858)
- redesign conversation markers minimap as dedicated top-right region (#857)
- polish AskUserQuestion tool UI with accessibility and HTML fixes (#856)
- polish review comment card title wrapping and icon placement (#853)
- bypass shiki bundle-full.mjs to fix syntax highlighting in release builds (#851)
- auto-import ANTHROPIC_API_KEY to resolve credentials banner (#847)
- restrict session title generation to task conversations and fix credential polling (#848)
- prevent double character input in terminal on release builds (#845)

### Other
- add missing dependency caching to agent-runner and release builds (#867)
- upgrade safe dependencies (#855)
- separate --brand from --primary to match shadcn/ui neutral defaults (#850)