### PR TITLE
release: v0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatml",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@10.30.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "chatml"
-version = "0.1.9"
+version = "0.1.15"
 dependencies = [
  "argon2",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chatml"
-version = "0.1.14"
+version = "0.1.15"
 description = "ChatML"
 authors = ["you"]
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "chatml",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "identifier": "com.chatml.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## What's Changed

### Fixes
- register missing language aliases in Pierre preload to prevent crashes (#874)
- restore brand color from blue to purple (#873)
- include Cargo.lock in release version bump commit (#872)
- use hex purple for merged PR status color in light mode (#871)