### PR TITLE
fix: fetch tags during release to fix changelog range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install-debug: build-debug
 # Usage: make release VERSION=0.2.0
 release:
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=x.y.z"; exit 1; fi
-	git checkout main && git pull origin main
+	git checkout main && git pull origin main --tags
 	@git branch -D release/v$(VERSION) 2>/dev/null || true
 	@git push origin --delete release/v$(VERSION) 2>/dev/null || true
 	git checkout -b release/v$(VERSION)


### PR DESCRIPTION
## Summary
- Add `--tags` to `git pull origin main` in the release target so CI-created release tags are fetched locally
- Without this, `git describe --tags` falls back to an older tag and the changelog includes commits from multiple releases

## Test plan
- [ ] Run `make release VERSION=x.y.z` and verify the changelog only includes commits since the last release

🤖 Generated with [Claude Code](https://claude.com/claude-code)