### PR TITLE
fix: use absolute path for Turbopack shiki alias to fix release builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,11 +15,11 @@ const nextConfig: NextConfig = {
   // @shikijs/core + @shikijs/engine-javascript, bypassing bundle-full.mjs
   // which pulls in Oniguruma WASM and hundreds of dynamic import() calls
   // that fail in Tauri release builds.
-  // Turbopack resolveAlias requires a relative path (prefixed with ./) —
-  // absolute paths get treated as relative to the server root and fail in CI.
+  // Uses absolute path so the alias applies to transpiled packages
+  // (e.g. @pierre/diffs) in production builds, not just first-party code.
   turbopack: {
     resolveAlias: {
-      shiki: './src/lib/shiki-shim.ts',
+      shiki: shikiShim,
     },
   },
   webpack: (config) => {


### PR DESCRIPTION
## Summary
- Switches the Turbopack `resolveAlias` for `shiki` from a relative path (`'./src/lib/shiki-shim.ts'`) to an absolute path via `path.resolve()`
- The relative path only matched imports from first-party source code; transpiled packages like `@pierre/diffs` (resolved from `node_modules`) weren't hitting the alias, causing syntax highlighting to break in Tauri release builds
- Removed temporary diagnostic code (`console.log`, `__SHIKI_SHIM__` marker, duplicate preload import) that was added during debugging

## Test plan
- [ ] Run `npm run build` — verify no build errors
- [ ] Run `make dev` — verify syntax highlighting works in dev mode
- [ ] Build a Tauri release (`make build`) and verify syntax highlighting works in the release build
- [ ] Confirm no `[pierrePreload]` diagnostic logs appear in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)