### PR TITLE
fix: improve merge PR dropdown with icons and group separators

### DIFF
--- a/src/components/shared/PrimaryActionButton/ActionButton.tsx
+++ b/src/components/shared/PrimaryActionButton/ActionButton.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, Fragment } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Loader2, ChevronDown } from 'lucide-react';
@@ -159,24 +160,28 @@ export function ActionButton({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {action.dropdownActions?.map((dropdownAction) => {
+            {action.dropdownActions?.map((dropdownAction, index) => {
               const DropdownIcon = dropdownAction.icon;
+              const prevAction = action.dropdownActions?.[index - 1];
+              const showSeparator = index > 0 && !!dropdownAction.description !== !!prevAction?.description;
               return (
-                <DropdownMenuItem
-                  key={dropdownAction.label}
-                  onClick={() => handleDropdownClick(dropdownAction.message)}
-                  className={dropdownAction.description ? 'flex-col items-start py-2' : ''}
-                >
-                  <div className="flex items-center gap-2">
-                    {DropdownIcon && <DropdownIcon className="size-4" />}
-                    <span className="font-medium">{dropdownAction.label}</span>
-                  </div>
-                  {dropdownAction.description && (
-                    <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                      {dropdownAction.description}
-                    </p>
-                  )}
-                </DropdownMenuItem>
+                <Fragment key={dropdownAction.label}>
+                  {showSeparator && <DropdownMenuSeparator />}
+                  <DropdownMenuItem
+                    onClick={() => handleDropdownClick(dropdownAction.message)}
+                    className={dropdownAction.description ? 'flex-col items-start py-2' : ''}
+                  >
+                    <div className="flex items-center gap-2">
+                      {DropdownIcon && <DropdownIcon className="size-4" />}
+                      <span className="font-medium">{dropdownAction.label}</span>
+                    </div>
+                    {dropdownAction.description && (
+                      <p className="text-xs text-muted-foreground mt-1 pl-6 leading-relaxed">
+                        {dropdownAction.description}
+                      </p>
+                    )}
+                  </DropdownMenuItem>
+                </Fragment>
               );
             })}
             {action.secondaryAction && (

--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -9,6 +9,7 @@ import {
   Archive,
   FileEdit,
   GitMerge,
+  Combine,
   Rocket,
   Download,
 } from 'lucide-react';
@@ -240,16 +241,19 @@ export function useActionState(
           label: 'Create a merge commit',
           message: 'Merge the pull request with a merge commit',
           description: 'All commits from this branch will be added to the base branch via a merge commit.',
+          icon: GitMerge,
         },
         {
           label: 'Squash and merge',
           message: 'Squash and merge the pull request',
           description: 'The commits from this branch will be combined into one commit in the base branch.',
+          icon: Combine,
         },
         {
           label: 'Rebase and merge',
           message: 'Rebase and merge the pull request',
           description: 'The commits from this branch will be rebased and added to the base branch.',
+          icon: GitBranch,
         },
       );
 


### PR DESCRIPTION
## Summary

- Add distinct icons (GitMerge, Combine, GitBranch) to each merge strategy dropdown option for better visual clarity
- Fix separator logic to only appear at group boundaries (e.g., between "Push Latest Changes" and merge options) instead of between every item
- Indent description text (`pl-6`) to align with label text after icons

## Changes Made

- **ActionButton.tsx** — Added `DropdownMenuSeparator` between action groups using boundary detection (`!!current.description !== !!prev.description`). Wrapped items in `Fragment` for separator support. Added `pl-6` to description paragraphs.
- **useActionState.ts** — Added `GitMerge`, `Combine`, and `GitBranch` icons to the three merge strategy dropdown actions.

## Test plan

- [ ] Open a session with an active PR
- [ ] Click the merge dropdown chevron
- [ ] Verify each merge option shows its distinct icon
- [ ] Verify a separator appears between "Push Latest Changes" and the merge options (when unpushed commits exist)
- [ ] Verify no separators appear between the three merge strategy options
- [ ] Verify description text is indented and aligned with labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)