### PR TITLE
feat: unify Create from... modal with PR, branch, and issue tabs

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -48,7 +48,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
                 .build(app)?,
         )
         .item(
-            &MenuItemBuilder::with_id("create_from_pr", "New Session from PR/Branch...")
+            &MenuItemBuilder::with_id("create_from_pr", "Create from...")
                 .accelerator("CmdOrCtrl+Shift+O")
                 .enabled(false)
                 .build(app)?,

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -27,6 +27,7 @@ import {
   Settings,
   Layers,
   GitPullRequest,
+  Link,
   Archive,
   // Actions
   Plus,
@@ -185,10 +186,10 @@ const COMMANDS: Command[] = [
   {
     id: 'create-from-pr',
     category: 'Actions',
-    label: 'New Session from PR/Branch',
-    icon: GitPullRequest,
+    label: 'Create from...',
+    icon: Link,
     shortcutId: 'createFromPR',
-    keywords: ['pull request', 'pr', 'branch', 'checkout', 'review'],
+    keywords: ['pull request', 'pr', 'branch', 'issue', 'linear', 'github', 'checkout', 'review'],
     action: () => window.dispatchEvent(new CustomEvent('create-from-pr')),
   },
   {

--- a/src/components/dialogs/CreateFromPRModal.tsx
+++ b/src/components/dialogs/CreateFromPRModal.tsx
@@ -1,33 +1,39 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useAppStore } from '@/stores/appStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { navigate } from '@/lib/navigation';
 import {
   resolvePR,
+  getPRs,
   createSession as createSessionApi,
   listConversations as listConversationsApi,
   listBranches,
+  listGitHubIssues,
+  searchGitHubIssues,
+  getGitHubIssueDetails,
+  listMyLinearIssues,
+  searchLinearIssues,
   mapSessionDTO,
 } from '@/lib/api';
-import { useBranchCacheStore } from '@/stores/branchCacheStore';
-import type { ResolvePRResponse } from '@/lib/api';
+import type {
+  PRDashboardItem,
+  ResolvePRResponse,
+  GitHubIssueListItem,
+  LinearIssueDTO,
+} from '@/lib/api';
 import type { SetupInfo } from '@/lib/types';
+import { useBranchCacheStore } from '@/stores/branchCacheStore';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { ScrollArea } from '@/components/ui/scroll-area';
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
 import {
   Select,
   SelectContent,
@@ -38,20 +44,37 @@ import {
 import {
   GitPullRequest,
   GitBranch,
-  AlertCircle,
+  CircleDot,
   Loader2,
-  Plus,
-  Minus,
-  FileCode,
-  Users,
+  GitMerge,
+  CircleDashed,
 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getWorkspaceColor } from '@/lib/workspace-colors';
+
+// ============================================================================
+// Types
+// ============================================================================
 
 interface CreateFromPRModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-const PR_URL_PATTERN = /github\.com\/[^/]+\/[^/]+\/pull\/\d+/;
+type TabId = 'pr' | 'branch' | 'issues';
+
+interface BranchInfo {
+  name: string;
+  lastCommitDate: string;
+  lastAuthor: string;
+  lastCommitSubject: string;
+  aheadMain: number;
+  behindMain: number;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
 
 function buildPRSystemMessage(pr: ResolvePRResponse): string {
   const lines = [
@@ -70,32 +93,117 @@ function buildPRSystemMessage(pr: ResolvePRResponse): string {
   return lines.join('\n');
 }
 
-interface BranchInfo {
-  name: string;
-  lastCommitDate: string;
-  lastAuthor: string;
-  lastCommitSubject: string;
-  aheadMain: number;
-  behindMain: number;
+function buildGitHubIssueSystemMessage(issue: GitHubIssueListItem, body: string): string {
+  const lines = [
+    `## GitHub Issue #${issue.number}: ${issue.title}`,
+    `**State:** ${issue.state}`,
+    `**Author:** ${issue.user.login}`,
+  ];
+  if (issue.labels.length > 0) {
+    lines.push(`**Labels:** ${issue.labels.map((l) => l.name).join(', ')}`);
+  }
+  if (issue.assignees.length > 0) {
+    lines.push(`**Assignees:** ${issue.assignees.map((a) => a.login).join(', ')}`);
+  }
+  lines.push('', '### Description', body || 'No description provided.');
+  return lines.join('\n');
 }
 
+function buildLinearIssueSystemMessage(issue: LinearIssueDTO): string {
+  const lines = [
+    `## ${issue.identifier}: ${issue.title}`,
+    `**Status:** ${issue.stateName}`,
+  ];
+  if (issue.assignee) {
+    lines.push(`**Assignee:** ${issue.assignee}`);
+  }
+  if (issue.labels.length > 0) {
+    lines.push(`**Labels:** ${issue.labels.join(', ')}`);
+  }
+  if (issue.project) {
+    lines.push(`**Project:** ${issue.project}`);
+  }
+  lines.push('', '### Description', issue.description || 'No description provided.');
+  return lines.join('\n');
+}
+
+// Protected branch names to filter out from branch list
+const PROTECTED_BRANCHES = ['main', 'master', 'develop'];
+
+function filterBranches(
+  rawBranches: { name: string; isRemote: boolean; lastCommitDate: string; lastAuthor: string; lastCommitSubject: string; aheadMain: number; behindMain: number }[]
+): BranchInfo[] {
+  return rawBranches
+    .filter((b) => {
+      if (!b.isRemote) return false;
+      if (b.name.startsWith('session/')) return false;
+      const branchName = b.name.replace(/^origin\//, '');
+      return !PROTECTED_BRANCHES.includes(branchName);
+    })
+    .map((b) => ({
+      name: b.name,
+      lastCommitDate: b.lastCommitDate,
+      lastAuthor: b.lastAuthor,
+      lastCommitSubject: b.lastCommitSubject,
+      aheadMain: b.aheadMain,
+      behindMain: b.behindMain,
+    }));
+}
+
+function PRStatusIcon({ state, isDraft }: { state: string; isDraft: boolean }) {
+  if (isDraft) return <CircleDashed className="w-3.5 h-3.5 text-muted-foreground shrink-0" />;
+  if (state === 'merged') return <GitMerge className="w-3.5 h-3.5 text-purple-500 shrink-0" />;
+  if (state === 'closed') return <CircleDot className="w-3.5 h-3.5 text-red-500 shrink-0" />;
+  return <GitPullRequest className="w-3.5 h-3.5 text-green-500 shrink-0" />;
+}
+
+// ============================================================================
+// Tab Button
+// ============================================================================
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'px-3 py-1 text-xs font-medium rounded-md transition-colors',
+        active
+          ? 'bg-accent text-accent-foreground'
+          : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
 export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
-  const [tab, setTab] = useState<string>('pr');
+  const [tab, setTab] = useState<TabId>('pr');
+  const [search, setSearch] = useState('');
+  const [creating, setCreating] = useState(false);
+  const creatingRef = useRef(false);
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
+
+  // Workspace state
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>('');
 
   // PR tab state
-  const [prUrl, setPrUrl] = useState('');
-  const [prDetails, setPrDetails] = useState<ResolvePRResponse | null>(null);
+  const [prs, setPrs] = useState<PRDashboardItem[]>([]);
   const [prLoading, setPrLoading] = useState(false);
-  const [prError, setPrError] = useState('');
 
   // Branch tab state
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>('');
   const [branches, setBranches] = useState<BranchInfo[]>([]);
-  const [branchSearch, setBranchSearch] = useState('');
   const [branchLoading, setBranchLoading] = useState(false);
-  const [selectedBranch, setSelectedBranch] = useState<string>('');
+
+  // Issues tab state
+  const [githubIssues, setGithubIssues] = useState<GitHubIssueListItem[]>([]);
+  const [linearIssues, setLinearIssues] = useState<LinearIssueDTO[]>([]);
+  const [issuesLoading, setIssuesLoading] = useState(false);
 
   const { workspaces, addSession, addConversation } = useAppStore(
     useShallow((s) => ({
@@ -106,408 +214,471 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
   );
   const currentWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const { expandWorkspace } = useSettingsStore();
+  const workspaceColors = useSettingsStore((s) => s.workspaceColors);
 
   // Reset state when modal opens
   useEffect(() => {
     if (isOpen) {
-      setPrUrl('');
-      setPrDetails(null);
-      setPrError('');
-      setPrLoading(false);
+      setSearch('');
       setError('');
-      setLoading(false);
+      setCreating(false);
+      creatingRef.current = false;
+      setTab('pr');
+      setPrs([]);
       setBranches([]);
-      setBranchSearch('');
-      setSelectedBranch('');
-      setSelectedWorkspaceId(currentWorkspaceId || '');
+      setGithubIssues([]);
+      setLinearIssues([]);
     }
-  }, [isOpen, currentWorkspaceId]);
+  }, [isOpen]);
 
-  // Resolve PR when URL changes (debounced with abort on cleanup)
+  // Sync selected workspace when modal opens or current workspace changes
   useEffect(() => {
-    if (!prUrl || !PR_URL_PATTERN.test(prUrl)) {
-      setPrDetails(null);
-      setPrError('');
+    if (isOpen) {
+      setSelectedWorkspaceId(currentWorkspaceId || workspaces[0]?.id || '');
+    }
+  }, [isOpen, currentWorkspaceId, workspaces]);
+
+  // ============================================================================
+  // Data Fetching
+  // ============================================================================
+
+  // Fetch PRs when workspace changes or PR tab is active
+  useEffect(() => {
+    if (!isOpen || tab !== 'pr' || !selectedWorkspaceId) {
+      return;
+    }
+
+    let cancelled = false;
+    const fetchPRs = async () => {
+      setPrLoading(true);
+      try {
+        const result = await getPRs(selectedWorkspaceId);
+        if (!cancelled) setPrs(result);
+      } catch (err) {
+        if (!cancelled) {
+          setPrs([]);
+          setError(err instanceof Error ? err.message : 'Failed to load pull requests');
+        }
+      } finally {
+        if (!cancelled) setPrLoading(false);
+      }
+    };
+
+    fetchPRs();
+    return () => { cancelled = true; };
+  }, [isOpen, tab, selectedWorkspaceId]);
+
+  // Fetch branches when workspace changes or branch tab is active
+  useEffect(() => {
+    if (!isOpen || tab !== 'branch' || !selectedWorkspaceId) {
+      setBranches([]);
       return;
     }
 
     let cancelled = false;
     const timer = setTimeout(async () => {
-      setPrLoading(true);
-      setPrError('');
-      setPrDetails(null);
-      try {
-        const details = await resolvePR(prUrl);
-        if (cancelled) return;
-        setPrDetails(details);
-        // Auto-select matched workspace
-        if (details.matchedWorkspaceId) {
-          setSelectedWorkspaceId(details.matchedWorkspaceId);
-        }
-      } catch (err) {
-        if (cancelled) return;
-        setPrError(err instanceof Error ? err.message : 'Failed to resolve PR');
-      } finally {
-        if (!cancelled) setPrLoading(false);
-      }
-    }, 500);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [prUrl]);
-
-  // Fetch branches when workspace changes (branch tab)
-  // Uses the branch cache for initial display (no search), falls back to API for search
-  useEffect(() => {
-    if (tab !== 'branch' || !selectedWorkspaceId) {
-      setBranches([]);
-      return;
-    }
-
-    // Note: Keep this list in sync with backend/git/protected.go
-    const PROTECTED_BRANCHES = ['main', 'master', 'develop'];
-
-    const filterBranches = (rawBranches: { name: string; isRemote: boolean; lastCommitDate: string; lastAuthor: string; lastCommitSubject: string; aheadMain: number; behindMain: number }[]) =>
-      rawBranches
-        .filter((b) => {
-          if (!b.isRemote) return false;
-          if (b.name.startsWith('session/')) return false;
-          const branchName = b.name.replace(/^origin\//, '');
-          return !PROTECTED_BRANCHES.includes(branchName);
-        })
-        .map((b) => ({
-          name: b.name,
-          lastCommitDate: b.lastCommitDate,
-          lastAuthor: b.lastAuthor,
-          lastCommitSubject: b.lastCommitSubject,
-          aheadMain: b.aheadMain,
-          behindMain: b.behindMain,
-        }));
-
-    const fetchBranches = async () => {
       setBranchLoading(true);
       try {
-        if (!branchSearch) {
-          // Use cache for initial display
+        if (!search) {
           const cached = await useBranchCacheStore.getState().fetchBranches(selectedWorkspaceId);
-          setBranches(filterBranches(cached).slice(0, 50));
+          if (!cancelled) setBranches(filterBranches(cached).slice(0, 50));
         } else {
-          // Use API for server-side search
           const result = await listBranches(selectedWorkspaceId, {
             includeRemote: true,
-            search: branchSearch,
+            search,
             sortBy: 'date',
             limit: 50,
           });
           const allBranches = [...result.sessionBranches, ...result.otherBranches];
-          setBranches(filterBranches(allBranches));
+          if (!cancelled) setBranches(filterBranches(allBranches));
         }
-      } catch {
-        setBranches([]);
+      } catch (err) {
+        if (!cancelled) {
+          setBranches([]);
+          setError(err instanceof Error ? err.message : 'Failed to load branches');
+        }
       } finally {
-        setBranchLoading(false);
+        if (!cancelled) setBranchLoading(false);
       }
-    };
+    }, 300);
 
-    const timer = setTimeout(fetchBranches, 300);
-    return () => clearTimeout(timer);
-  }, [tab, selectedWorkspaceId, branchSearch]);
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, [isOpen, tab, selectedWorkspaceId, search]);
+
+  // Fetch issues when workspace changes or issues tab is active
+  useEffect(() => {
+    if (!isOpen || tab !== 'issues') {
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setIssuesLoading(true);
+      try {
+        if (!search) {
+          // Fetch both GitHub and Linear issues in parallel
+          const [ghResult, linearResult] = await Promise.allSettled([
+            selectedWorkspaceId ? listGitHubIssues(selectedWorkspaceId) : Promise.resolve([]),
+            listMyLinearIssues(),
+          ]);
+          if (!cancelled) {
+            setGithubIssues(ghResult.status === 'fulfilled' ? ghResult.value : []);
+            setLinearIssues(linearResult.status === 'fulfilled' ? linearResult.value : []);
+          }
+        } else {
+          // Search both in parallel
+          const [ghResult, linearResult] = await Promise.allSettled([
+            selectedWorkspaceId ? searchGitHubIssues(selectedWorkspaceId, search) : Promise.resolve({ totalCount: 0, issues: [] }),
+            searchLinearIssues(search),
+          ]);
+          if (!cancelled) {
+            setGithubIssues(ghResult.status === 'fulfilled' ? ghResult.value.issues : []);
+            setLinearIssues(linearResult.status === 'fulfilled' ? linearResult.value : []);
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setGithubIssues([]);
+          setLinearIssues([]);
+          setError(err instanceof Error ? err.message : 'Failed to load issues');
+        }
+      } finally {
+        if (!cancelled) setIssuesLoading(false);
+      }
+    }, 300);
+
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, [isOpen, tab, selectedWorkspaceId, search]);
+
+  // ============================================================================
+  // Filtered items (client-side for PRs)
+  // ============================================================================
+
+  const filteredPRs = useMemo(() => {
+    if (!search) return prs;
+    const q = search.toLowerCase();
+    return prs.filter((pr) =>
+      pr.title.toLowerCase().includes(q) ||
+      String(pr.number).includes(q) ||
+      pr.branch.toLowerCase().includes(q)
+    );
+  }, [prs, search]);
+
+  // ============================================================================
+  // Session Creation
+  // ============================================================================
 
   const createSessionAndNavigate = useCallback(async (
     workspaceId: string,
     params: { branch: string; checkoutExisting: boolean; task?: string; systemMessage?: string },
   ) => {
-    setLoading(true);
+    const session = await createSessionApi(workspaceId, params);
+
+    addSession(mapSessionDTO(session));
+
+    const conversations = await listConversationsApi(workspaceId, session.id);
+    conversations.forEach((conv) => {
+      addConversation({
+        id: conv.id,
+        sessionId: conv.sessionId,
+        type: conv.type,
+        name: conv.name,
+        status: conv.status,
+        messages: conv.messages.map((m) => ({
+          id: m.id,
+          conversationId: conv.id,
+          role: m.role as 'user' | 'assistant' | 'system',
+          content: m.content,
+          setupInfo: (m as { setupInfo?: SetupInfo }).setupInfo,
+          timestamp: m.timestamp,
+        })),
+        toolSummary: conv.toolSummary,
+        createdAt: conv.createdAt,
+        updatedAt: conv.updatedAt,
+      });
+    });
+
+    expandWorkspace(workspaceId);
+    navigate({
+      workspaceId,
+      sessionId: session.id,
+      contentView: { type: 'conversation' },
+    });
+
+    onClose();
+  }, [addSession, addConversation, expandWorkspace, onClose]);
+
+  // Handle PR selection
+  const handleSelectPR = useCallback(async (pr: PRDashboardItem) => {
+    if (creatingRef.current || !selectedWorkspaceId) return;
+    creatingRef.current = true;
+    setCreating(true);
     setError('');
     try {
-      const session = await createSessionApi(workspaceId, params);
-
-      addSession(mapSessionDTO(session));
-
-      const conversations = await listConversationsApi(workspaceId, session.id);
-      conversations.forEach((conv) => {
-        addConversation({
-          id: conv.id,
-          sessionId: conv.sessionId,
-          type: conv.type,
-          name: conv.name,
-          status: conv.status,
-          messages: conv.messages.map((m) => ({
-            id: m.id,
-            conversationId: conv.id,
-            role: m.role as 'user' | 'assistant' | 'system',
-            content: m.content,
-            setupInfo: (m as { setupInfo?: SetupInfo }).setupInfo,
-            timestamp: m.timestamp,
-          })),
-          toolSummary: conv.toolSummary,
-          createdAt: conv.createdAt,
-          updatedAt: conv.updatedAt,
-        });
+      // Resolve full PR details for the system message
+      const details = await resolvePR(pr.htmlUrl);
+      await createSessionAndNavigate(selectedWorkspaceId, {
+        branch: details.branch,
+        checkoutExisting: true,
+        task: `${details.title}\n\n${details.body || ''}`.trim(),
+        systemMessage: buildPRSystemMessage(details),
       });
-
-      expandWorkspace(workspaceId);
-      navigate({
-        workspaceId,
-        sessionId: session.id,
-        contentView: { type: 'conversation' },
-      });
-
-      onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create session');
     } finally {
-      setLoading(false);
+      creatingRef.current = false;
+      setCreating(false);
     }
-  }, [addSession, addConversation, expandWorkspace, onClose]);
+  }, [selectedWorkspaceId, createSessionAndNavigate]);
 
-  const createSessionFromPR = useCallback(async () => {
-    if (!prDetails || !selectedWorkspaceId) return;
-    await createSessionAndNavigate(selectedWorkspaceId, {
-      branch: prDetails.branch,
-      checkoutExisting: true,
-      task: `${prDetails.title}\n\n${prDetails.body || ''}`.trim(),
-      systemMessage: buildPRSystemMessage(prDetails),
-    });
-  }, [prDetails, selectedWorkspaceId, createSessionAndNavigate]);
+  // Handle branch selection
+  const handleSelectBranch = useCallback(async (branchName: string) => {
+    if (creatingRef.current || !selectedWorkspaceId) return;
+    creatingRef.current = true;
+    setCreating(true);
+    setError('');
+    try {
+      await createSessionAndNavigate(selectedWorkspaceId, {
+        branch: branchName,
+        checkoutExisting: true,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create session');
+    } finally {
+      creatingRef.current = false;
+      setCreating(false);
+    }
+  }, [selectedWorkspaceId, createSessionAndNavigate]);
 
-  const createSessionFromBranch = useCallback(async () => {
-    if (!selectedBranch || !selectedWorkspaceId) return;
-    await createSessionAndNavigate(selectedWorkspaceId, {
-      branch: selectedBranch,
-      checkoutExisting: true,
-    });
-  }, [selectedBranch, selectedWorkspaceId, createSessionAndNavigate]);
+  // Handle GitHub issue selection
+  const handleSelectGitHubIssue = useCallback(async (issue: GitHubIssueListItem) => {
+    if (creatingRef.current || !selectedWorkspaceId) return;
+    creatingRef.current = true;
+    setCreating(true);
+    setError('');
+    try {
+      // Fetch full issue body
+      const details = await getGitHubIssueDetails(selectedWorkspaceId, issue.number);
+      await createSessionAndNavigate(selectedWorkspaceId, {
+        branch: '',
+        checkoutExisting: false,
+        task: issue.title,
+        systemMessage: buildGitHubIssueSystemMessage(issue, details.body),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create session');
+    } finally {
+      creatingRef.current = false;
+      setCreating(false);
+    }
+  }, [selectedWorkspaceId, createSessionAndNavigate]);
 
-  const canSubmitPR = prDetails && selectedWorkspaceId && !loading;
-  const canSubmitBranch = selectedBranch && selectedWorkspaceId && !loading;
+  // Handle Linear issue selection
+  const handleSelectLinearIssue = useCallback(async (issue: LinearIssueDTO) => {
+    if (creatingRef.current || !selectedWorkspaceId) return;
+    creatingRef.current = true;
+    setCreating(true);
+    setError('');
+    try {
+      await createSessionAndNavigate(selectedWorkspaceId, {
+        branch: '',
+        checkoutExisting: false,
+        task: issue.title,
+        systemMessage: buildLinearIssueSystemMessage(issue),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create session');
+    } finally {
+      creatingRef.current = false;
+      setCreating(false);
+    }
+  }, [selectedWorkspaceId, createSessionAndNavigate]);
+
+  // ============================================================================
+  // Loading state
+  // ============================================================================
+
+  const isLoading = tab === 'pr' ? prLoading : tab === 'branch' ? branchLoading : issuesLoading;
+
+  // ============================================================================
+  // Render
+  // ============================================================================
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <GitPullRequest className="w-5 h-5" />
-            New Session from PR / Branch
-          </DialogTitle>
-          <DialogDescription>
-            Create a session that checks out an existing branch.
-          </DialogDescription>
-        </DialogHeader>
+    <CommandDialog
+      open={isOpen}
+      onOpenChange={(open) => { if (!open) onClose(); }}
+      title="Create from..."
+      description="Create a session from a pull request, branch, or issue"
+      shouldFilter={false}
+      variant="centered"
+      className="sm:max-w-xl"
+      showCloseButton={false}
+    >
+      <CommandInput
+        placeholder="Search by title, number, or author..."
+        value={search}
+        onValueChange={setSearch}
+      />
 
-        <Tabs value={tab} onValueChange={setTab}>
-          <TabsList>
-            <TabsTrigger value="pr" className="gap-1.5">
-              <GitPullRequest className="w-3.5 h-3.5" />
-              From PR
-            </TabsTrigger>
-            <TabsTrigger value="branch" className="gap-1.5">
-              <GitBranch className="w-3.5 h-3.5" />
-              From Branch
-            </TabsTrigger>
-          </TabsList>
+      {/* Tab bar + workspace selector */}
+      <div className="flex items-center justify-between border-b px-3 py-1.5">
+        <div className="flex gap-1">
+          <TabButton active={tab === 'pr'} onClick={() => { setTab('pr'); setSearch(''); }}>
+            Pull requests
+          </TabButton>
+          <TabButton active={tab === 'branch'} onClick={() => { setTab('branch'); setSearch(''); }}>
+            Branches
+          </TabButton>
+          <TabButton active={tab === 'issues'} onClick={() => { setTab('issues'); setSearch(''); }}>
+            Issues
+          </TabButton>
+        </div>
 
-          <TabsContent value="pr">
-            <div className="space-y-3 py-2">
-              <Input
-                value={prUrl}
-                onChange={(e) => setPrUrl(e.target.value)}
-                placeholder="https://github.com/owner/repo/pull/123"
-                className="font-mono text-sm"
-                autoFocus
-              />
-
-              {prLoading && (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  Loading PR details...
-                </div>
-              )}
-
-              {prError && (
-                <div className="flex items-center gap-2 text-sm text-destructive bg-destructive/10 p-3 rounded-lg">
-                  <AlertCircle className="w-4 h-4 shrink-0" />
-                  {prError}
-                </div>
-              )}
-
-              {prDetails && (
-                <div className="space-y-2 rounded-lg border p-3">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="font-medium text-sm leading-snug">
-                      #{prDetails.prNumber} {prDetails.title}
-                    </div>
-                    <div className="flex items-center gap-1.5 shrink-0">
-                      {prDetails.isDraft && (
-                        <Badge variant="outline" className="text-2xs">Draft</Badge>
-                      )}
-                      <Badge
-                        variant={prDetails.state === 'open' ? 'default' : 'secondary'}
-                        className="text-2xs"
-                      >
-                        {prDetails.state}
-                      </Badge>
-                    </div>
+        {workspaces.length > 0 && (
+          <Select value={selectedWorkspaceId} onValueChange={setSelectedWorkspaceId}>
+            <SelectTrigger className="h-7 w-auto max-w-[160px] text-xs gap-1.5 border-none shadow-none px-2">
+              <div className="flex items-center gap-1.5 min-w-0">
+                <div
+                  className="w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: workspaceColors[selectedWorkspaceId] || getWorkspaceColor(selectedWorkspaceId) }}
+                />
+                <SelectValue />
+              </div>
+            </SelectTrigger>
+            <SelectContent>
+              {workspaces.map((ws) => (
+                <SelectItem key={ws.id} value={ws.id} className="text-xs">
+                  <div className="flex items-center gap-1.5">
+                    <div
+                      className="w-2 h-2 rounded-full shrink-0"
+                      style={{ backgroundColor: workspaceColors[ws.id] || getWorkspaceColor(ws.id) }}
+                    />
+                    {ws.name}
                   </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
 
-                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                    <span className="flex items-center gap-1 font-mono">
-                      <GitBranch className="w-3 h-3" />
-                      {prDetails.branch}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Plus className="w-3 h-3 text-green-500" />
-                      {prDetails.additions}
-                      <Minus className="w-3 h-3 text-red-500" />
-                      {prDetails.deletions}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <FileCode className="w-3 h-3" />
-                      {prDetails.changedFiles} files
-                    </span>
-                    {prDetails.reviewers.length > 0 && (
-                      <span className="flex items-center gap-1">
-                        <Users className="w-3 h-3" />
-                        {prDetails.reviewers.join(', ')}
-                      </span>
-                    )}
-                  </div>
-
-                  {prDetails.labels.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
-                      {prDetails.labels.map((label) => (
-                        <Badge key={label} variant="outline" className="text-2xs">
-                          {label}
-                        </Badge>
-                      ))}
-                    </div>
-                  )}
-
-                  {!prDetails.matchedWorkspaceId && workspaces.length > 0 && (
-                    <div className="space-y-1.5 pt-1">
-                      <p className="text-xs text-amber-500">
-                        No matching workspace found. Select one:
-                      </p>
-                      <Select value={selectedWorkspaceId} onValueChange={setSelectedWorkspaceId}>
-                        <SelectTrigger className="h-8 text-xs">
-                          <SelectValue placeholder="Select workspace" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {workspaces.map((ws) => (
-                            <SelectItem key={ws.id} value={ws.id} className="text-xs">
-                              {ws.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  )}
-
-                  {prDetails.matchedWorkspaceId && (
-                    <p className="text-xs text-muted-foreground">
-                      Workspace: {workspaces.find((w) => w.id === prDetails.matchedWorkspaceId)?.name}
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
-          </TabsContent>
-
-          <TabsContent value="branch">
-            <div className="space-y-3 py-2">
-              <Select value={selectedWorkspaceId} onValueChange={(v) => { setSelectedWorkspaceId(v); setSelectedBranch(''); }}>
-                <SelectTrigger className="h-8 text-xs">
-                  <SelectValue placeholder="Select workspace" />
-                </SelectTrigger>
-                <SelectContent>
-                  {workspaces.map((ws) => (
-                    <SelectItem key={ws.id} value={ws.id} className="text-xs">
-                      {ws.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-
-              {selectedWorkspaceId && (
-                <>
-                  <Input
-                    value={branchSearch}
-                    onChange={(e) => setBranchSearch(e.target.value)}
-                    placeholder="Search branches..."
-                    className="text-sm h-8"
-                  />
-
-                  <ScrollArea className="h-48 rounded-lg border">
-                    {branchLoading ? (
-                      <div className="flex items-center justify-center h-full py-8">
-                        <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
-                      </div>
-                    ) : branches.length === 0 ? (
-                      <div className="flex items-center justify-center h-full py-8 text-xs text-muted-foreground">
-                        No remote branches found
-                      </div>
-                    ) : (
-                      <div className="p-1">
-                        {branches.map((branch) => (
-                          <button
-                            key={branch.name}
-                            className={`w-full text-left px-2 py-1.5 rounded text-xs transition-colors ${
-                              selectedBranch === branch.name
-                                ? 'bg-accent text-accent-foreground'
-                                : 'hover:bg-accent/50'
-                            }`}
-                            onClick={() => setSelectedBranch(branch.name)}
-                          >
-                            <div className="flex items-center justify-between">
-                              <span className="font-mono truncate">{branch.name}</span>
-                              <span className="text-2xs text-muted-foreground shrink-0 ml-2">
-                                {branch.lastAuthor}
-                              </span>
-                            </div>
-                            <div className="text-2xs text-muted-foreground truncate mt-0.5">
-                              {branch.lastCommitSubject}
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </ScrollArea>
-                </>
-              )}
-            </div>
-          </TabsContent>
-        </Tabs>
-
+      <CommandList className="max-h-[320px]">
+        {/* Error display */}
         {error && (
-          <div className="flex items-center gap-2 text-sm text-destructive bg-destructive/10 p-3 rounded-lg">
-            <AlertCircle className="w-4 h-4 shrink-0" />
+          <div className="px-3 py-2 text-xs text-destructive bg-destructive/10 mx-2 mt-2 rounded">
             {error}
           </div>
         )}
 
-        <DialogFooter>
-          <Button type="button" variant="outline" onClick={onClose}>
-            Cancel
-          </Button>
-          {tab === 'pr' ? (
-            <Button
-              onClick={createSessionFromPR}
-              disabled={!canSubmitPR}
-            >
-              {loading ? 'Creating...' : 'Create Session'}
-            </Button>
-          ) : (
-            <Button
-              onClick={createSessionFromBranch}
-              disabled={!canSubmitBranch}
-            >
-              {loading ? 'Creating...' : 'Create Session'}
-            </Button>
-          )}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        {/* Creating indicator */}
+        {creating && (
+          <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground justify-center">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Creating session...
+          </div>
+        )}
+
+        {/* Loading indicator */}
+        {isLoading && !creating && (
+          <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground justify-center">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Loading...
+          </div>
+        )}
+
+        {/* PR Tab */}
+        {tab === 'pr' && !isLoading && !creating && (
+          <>
+            <CommandEmpty>No pull requests found</CommandEmpty>
+            <CommandGroup>
+              {filteredPRs.map((pr) => (
+                <CommandItem
+                  key={pr.number}
+                  value={`pr-${pr.number}-${pr.title}`}
+                  onSelect={() => handleSelectPR(pr)}
+                >
+                  <PRStatusIcon state={pr.state} isDraft={pr.isDraft} />
+                  <span className="text-muted-foreground font-mono text-xs shrink-0">#{pr.number}</span>
+                  <span className="truncate flex-1">{pr.title}</span>
+                  <span className="text-2xs text-muted-foreground shrink-0">
+                    {pr.state === 'open' ? 'Open' : pr.state === 'merged' ? 'Merged' : 'Closed'}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+        {/* Branch Tab */}
+        {tab === 'branch' && !isLoading && !creating && (
+          <>
+            <CommandEmpty>No branches found</CommandEmpty>
+            <CommandGroup>
+              {branches.map((branch) => (
+                <CommandItem
+                  key={branch.name}
+                  value={`branch-${branch.name}`}
+                  onSelect={() => handleSelectBranch(branch.name)}
+                >
+                  <GitBranch className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                  <div className="flex flex-col gap-0 min-w-0 flex-1">
+                    <span className="font-mono text-xs truncate">{branch.name}</span>
+                    <span className="text-2xs text-muted-foreground truncate">{branch.lastCommitSubject}</span>
+                  </div>
+                  <span className="text-2xs text-muted-foreground shrink-0">{branch.lastAuthor}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+        {/* Issues Tab */}
+        {tab === 'issues' && !isLoading && !creating && (
+          <>
+            {githubIssues.length === 0 && linearIssues.length === 0 && (
+              <CommandEmpty>No issues found</CommandEmpty>
+            )}
+
+            {githubIssues.length > 0 && (
+              <CommandGroup heading="GitHub Issues">
+                {githubIssues.map((issue) => (
+                  <CommandItem
+                    key={`gh-${issue.number}`}
+                    value={`gh-issue-${issue.number}-${issue.title}`}
+                    onSelect={() => handleSelectGitHubIssue(issue)}
+                  >
+                    <CircleDot className={cn(
+                      'w-3.5 h-3.5 shrink-0',
+                      issue.state === 'open' ? 'text-green-500' : 'text-purple-500'
+                    )} />
+                    <span className="text-muted-foreground font-mono text-xs shrink-0">#{issue.number}</span>
+                    <span className="truncate flex-1">{issue.title}</span>
+                    <span className="text-2xs text-muted-foreground shrink-0">{issue.user.login}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {linearIssues.length > 0 && (
+              <CommandGroup heading="Linear Issues">
+                {linearIssues.map((issue) => (
+                  <CommandItem
+                    key={`linear-${issue.id}`}
+                    value={`linear-issue-${issue.identifier}-${issue.title}`}
+                    onSelect={() => handleSelectLinearIssue(issue)}
+                  >
+                    <CircleDot className="w-3.5 h-3.5 text-blue-500 shrink-0" />
+                    <span className="text-muted-foreground font-mono text-xs shrink-0">{issue.identifier}</span>
+                    <span className="truncate flex-1">{issue.title}</span>
+                    <span className="text-2xs text-muted-foreground shrink-0">{issue.stateName}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
   );
 }

--- a/src/components/dialogs/__tests__/CreateFromPRModal.test.tsx
+++ b/src/components/dialogs/__tests__/CreateFromPRModal.test.tsx
@@ -8,24 +8,78 @@ import { useAppStore } from '@/stores/appStore';
 
 const API_BASE = 'http://localhost:9876';
 
-const mockPRResponse = {
-  owner: 'testorg',
-  repo: 'testrepo',
-  prNumber: 42,
-  title: 'Add authentication',
-  body: 'Adds OAuth2 flow for login',
-  branch: 'feature/auth',
-  baseBranch: 'main',
-  state: 'open',
-  isDraft: false,
-  labels: ['enhancement'],
-  reviewers: ['alice'],
-  additions: 200,
-  deletions: 50,
-  changedFiles: 8,
-  matchedWorkspaceId: 'workspace-1',
-  htmlUrl: 'https://github.com/testorg/testrepo/pull/42',
-};
+const mockPRs = [
+  {
+    number: 885,
+    title: 'feat: add image paste support via Cmd+V in chat input',
+    state: 'open',
+    htmlUrl: 'https://github.com/testorg/testrepo/pull/885',
+    isDraft: false,
+    mergeable: true,
+    mergeableState: 'clean',
+    checkStatus: 'success',
+    checkDetails: [],
+    labels: [],
+    branch: 'feature/image-paste',
+    baseBranch: 'main',
+    workspaceId: 'workspace-1',
+    workspaceName: 'test-repo',
+    repoOwner: 'testorg',
+    repoName: 'testrepo',
+    checksTotal: 3,
+    checksPassed: 3,
+    checksFailed: 0,
+  },
+  {
+    number: 539,
+    title: 'feat: Add Agent Teams support for parallel sub-agents',
+    state: 'open',
+    htmlUrl: 'https://github.com/testorg/testrepo/pull/539',
+    isDraft: true,
+    mergeable: null,
+    mergeableState: 'unknown',
+    checkStatus: 'pending',
+    checkDetails: [],
+    labels: [],
+    branch: 'feature/agent-teams',
+    baseBranch: 'main',
+    workspaceId: 'workspace-1',
+    workspaceName: 'test-repo',
+    repoOwner: 'testorg',
+    repoName: 'testrepo',
+    checksTotal: 0,
+    checksPassed: 0,
+    checksFailed: 0,
+  },
+];
+
+const mockGitHubIssues = [
+  {
+    number: 42,
+    title: 'Bug: Login fails on Safari',
+    state: 'open',
+    htmlUrl: 'https://github.com/testorg/testrepo/issues/42',
+    labels: [{ name: 'bug', color: 'fc2929' }],
+    user: { login: 'alice', avatarUrl: '' },
+    assignees: [],
+    comments: 3,
+    createdAt: '2026-03-10T00:00:00Z',
+    updatedAt: '2026-03-12T00:00:00Z',
+  },
+];
+
+const mockLinearIssues = [
+  {
+    id: 'lin-1',
+    identifier: 'ENG-123',
+    title: 'Implement dark mode toggle',
+    description: 'Users want a dark mode option',
+    stateName: 'In Progress',
+    labels: ['feature'],
+    assignee: 'bob',
+    project: 'UI Improvements',
+  },
+];
 
 // Mock navigation
 vi.mock('@/lib/navigation', () => ({
@@ -55,77 +109,111 @@ describe('CreateFromPRModal', () => {
       selectedWorkspaceId: 'workspace-1',
     });
 
-    // Default handler for resolve-pr (never called unless URL is valid)
+    // Default handlers
     server.use(
+      http.get(`${API_BASE}/api/prs`, () => {
+        return HttpResponse.json(mockPRs);
+      }),
+      http.get(`${API_BASE}/api/repos/:workspaceId/issues`, () => {
+        return HttpResponse.json(mockGitHubIssues);
+      }),
+      http.get(`${API_BASE}/api/auth/linear/issues`, () => {
+        return HttpResponse.json(mockLinearIssues);
+      }),
       http.post(`${API_BASE}/api/resolve-pr`, () => {
-        return HttpResponse.json(mockPRResponse);
-      })
+        return HttpResponse.json({
+          owner: 'testorg',
+          repo: 'testrepo',
+          prNumber: 885,
+          title: 'feat: add image paste support via Cmd+V in chat input',
+          body: 'Adds image paste functionality',
+          branch: 'feature/image-paste',
+          baseBranch: 'main',
+          state: 'open',
+          isDraft: false,
+          labels: [],
+          reviewers: [],
+          additions: 100,
+          deletions: 20,
+          changedFiles: 5,
+          matchedWorkspaceId: 'workspace-1',
+          htmlUrl: 'https://github.com/testorg/testrepo/pull/885',
+        });
+      }),
     );
   });
 
-  it('renders with two tabs: From PR and From Branch', () => {
+  it('renders with three tabs: Pull requests, Branches, Issues', () => {
     render(<CreateFromPRModal {...defaultProps} />);
 
-    expect(screen.getByText('From PR')).toBeInTheDocument();
-    expect(screen.getByText('From Branch')).toBeInTheDocument();
+    expect(screen.getByText('Pull requests')).toBeInTheDocument();
+    expect(screen.getByText('Branches')).toBeInTheDocument();
+    expect(screen.getByText('Issues')).toBeInTheDocument();
   });
 
-  it('renders the dialog title', () => {
-    render(<CreateFromPRModal {...defaultProps} />);
-
-    expect(screen.getByText(/New Session from PR/)).toBeInTheDocument();
-  });
-
-  it('shows PR URL input on the PR tab', () => {
+  it('renders the search input', () => {
     render(<CreateFromPRModal {...defaultProps} />);
 
     expect(
-      screen.getByPlaceholderText('https://github.com/owner/repo/pull/123')
+      screen.getByPlaceholderText('Search by title, number, or author...')
     ).toBeInTheDocument();
   });
 
-  it('shows PR details after entering a valid PR URL', async () => {
-    const user = userEvent.setup();
+  it('shows PR list on the Pull requests tab', async () => {
     render(<CreateFromPRModal {...defaultProps} />);
 
-    const input = screen.getByPlaceholderText(
-      'https://github.com/owner/repo/pull/123'
-    );
-    await user.type(input, 'https://github.com/testorg/testrepo/pull/42');
-
-    // Wait for debounced API call and rendering
     await waitFor(
       () => {
-        expect(screen.getByText(/Add authentication/)).toBeInTheDocument();
+        expect(screen.getByText(/add image paste support/)).toBeInTheDocument();
+        expect(screen.getByText('#885')).toBeInTheDocument();
       },
       { timeout: 2000 }
     );
-
-    // Check branch name is displayed in the PR details
-    expect(screen.getByText('feature/auth')).toBeInTheDocument();
   });
 
-  it('shows error when PR resolution fails', async () => {
-    server.use(
-      http.post(`${API_BASE}/api/resolve-pr`, () => {
-        return HttpResponse.json(
-          { error: 'PR not found' },
-          { status: 404 }
-        );
-      })
-    );
-
-    const user = userEvent.setup();
+  it('shows draft PR with draft icon styling', async () => {
     render(<CreateFromPRModal {...defaultProps} />);
-
-    const input = screen.getByPlaceholderText(
-      'https://github.com/owner/repo/pull/123'
-    );
-    await user.type(input, 'https://github.com/testorg/testrepo/pull/999');
 
     await waitFor(
       () => {
-        expect(screen.getByText(/Failed to resolve PR|PR not found/)).toBeInTheDocument();
+        expect(screen.getByText(/Agent Teams/)).toBeInTheDocument();
+        expect(screen.getByText('#539')).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  it('shows the Branches tab content when clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    await user.click(screen.getByText('Branches'));
+
+    // Should switch to branches tab (content change, empty state)
+    await waitFor(() => {
+      expect(screen.getByText('No branches found')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the Issues tab with GitHub and Linear issues', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateFromPRModal {...defaultProps} />);
+
+    await user.click(screen.getByText('Issues'));
+
+    await waitFor(
+      () => {
+        // GitHub issues group
+        expect(screen.getByText('GitHub Issues')).toBeInTheDocument();
+        expect(screen.getByText(/Login fails on Safari/)).toBeInTheDocument();
+        expect(screen.getByText('#42')).toBeInTheDocument();
+
+        // Linear issues group
+        expect(screen.getByText('Linear Issues')).toBeInTheDocument();
+        expect(screen.getByText(/dark mode toggle/)).toBeInTheDocument();
+        expect(screen.getByText('ENG-123')).toBeInTheDocument();
       },
       { timeout: 2000 }
     );
@@ -135,76 +223,33 @@ describe('CreateFromPRModal', () => {
     render(<CreateFromPRModal isOpen={false} onClose={vi.fn()} />);
 
     expect(
-      screen.queryByText(/New Session from PR/)
+      screen.queryByText('Pull requests')
     ).not.toBeInTheDocument();
   });
 
-  it('disables Create Session button when no PR is resolved', () => {
+  it('shows workspace selector', () => {
     render(<CreateFromPRModal {...defaultProps} />);
 
-    const createButton = screen.getByRole('button', {
-      name: /Create Session/i,
-    });
-    expect(createButton).toBeDisabled();
+    expect(screen.getByText('test-repo')).toBeInTheDocument();
   });
 
-  it('shows the Branch tab content when clicked', async () => {
+  it('filters PRs by search term', async () => {
     const user = userEvent.setup();
-
-    // Mock branches endpoint
-    server.use(
-      http.get(`${API_BASE}/api/repos/:workspaceId/branches`, () => {
-        return HttpResponse.json({
-          branches: [
-            {
-              name: 'feature/cool-thing',
-              lastCommitDate: new Date().toISOString(),
-              lastAuthor: 'dev',
-              lastCommitSubject: 'Add cool thing',
-              aheadMain: 3,
-              behindMain: 0,
-            },
-          ],
-        });
-      })
-    );
-
     render(<CreateFromPRModal {...defaultProps} />);
 
-    // Click on the Branch tab
-    await user.click(screen.getByText('From Branch'));
-
-    // Should show workspace selector and branch search
+    // Wait for PRs to load
     await waitFor(() => {
-      expect(
-        screen.getByPlaceholderText('Search branches...')
-      ).toBeInTheDocument();
+      expect(screen.getByText('#885')).toBeInTheDocument();
+    }, { timeout: 2000 });
+
+    // Type search
+    const input = screen.getByPlaceholderText('Search by title, number, or author...');
+    await user.type(input, 'Agent');
+
+    // Should only show matching PR
+    await waitFor(() => {
+      expect(screen.queryByText('#885')).not.toBeInTheDocument();
+      expect(screen.getByText('#539')).toBeInTheDocument();
     });
-  });
-
-  it('shows draft badge for draft PRs', async () => {
-    server.use(
-      http.post(`${API_BASE}/api/resolve-pr`, () => {
-        return HttpResponse.json({
-          ...mockPRResponse,
-          isDraft: true,
-        });
-      })
-    );
-
-    const user = userEvent.setup();
-    render(<CreateFromPRModal {...defaultProps} />);
-
-    const input = screen.getByPlaceholderText(
-      'https://github.com/owner/repo/pull/123'
-    );
-    await user.type(input, 'https://github.com/testorg/testrepo/pull/42');
-
-    await waitFor(
-      () => {
-        expect(screen.getByText('Draft')).toBeInTheDocument();
-      },
-      { timeout: 2000 }
-    );
   });
 });

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -82,6 +82,7 @@ import {
   Check,
   MessageCircleQuestion,
   ClipboardCheck,
+  Link,
 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
@@ -986,6 +987,11 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
                   )}
+                  <DropdownMenuItem onClick={() => window.dispatchEvent(new CustomEvent('create-from-pr'))}>
+                    <Link className="h-4 w-4" />
+                    Create from...
+                    <DropdownMenuShortcut>⌘⇧O</DropdownMenuShortcut>
+                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                 </>
               )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1304,6 +1304,61 @@ export async function listSessionSummaries(
   return handleResponse<SummaryDTO[]>(res);
 }
 
+// GitHub Issue DTOs and functions
+
+export interface GitHubIssueLabel {
+  name: string;
+  color: string;
+}
+
+export interface GitHubIssueUser {
+  login: string;
+  avatarUrl: string;
+}
+
+export interface GitHubIssueListItem {
+  number: number;
+  title: string;
+  state: string;
+  htmlUrl: string;
+  labels: GitHubIssueLabel[];
+  user: GitHubIssueUser;
+  assignees: GitHubIssueUser[];
+  comments: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GitHubIssueDetails extends GitHubIssueListItem {
+  body: string;
+  milestone?: {
+    title: string;
+    number: number;
+  };
+}
+
+export interface SearchGitHubIssuesResult {
+  totalCount: number;
+  issues: GitHubIssueListItem[];
+}
+
+export async function listGitHubIssues(workspaceId: string): Promise<GitHubIssueListItem[]> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/issues`);
+  return handleResponse<GitHubIssueListItem[]>(res);
+}
+
+export async function searchGitHubIssues(workspaceId: string, query: string): Promise<SearchGitHubIssuesResult> {
+  const res = await fetchWithAuth(
+    `${getApiBase()}/api/repos/${workspaceId}/issues/search?q=${encodeURIComponent(query)}`
+  );
+  return handleResponse<SearchGitHubIssuesResult>(res);
+}
+
+export async function getGitHubIssueDetails(workspaceId: string, issueNumber: number): Promise<GitHubIssueDetails> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/issues/${issueNumber}`);
+  return handleResponse<GitHubIssueDetails>(res);
+}
+
 // Linear Issue DTOs and functions
 
 export interface LinearIssueDTO {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -64,7 +64,7 @@ export const SHORTCUTS: Shortcut[] = [
     id: 'createFromPR',
     key: 'o',
     modifiers: ['meta', 'shift'],
-    label: 'New session from PR/Branch',
+    label: 'Create from...',
     category: 'General',
   },
   {


### PR DESCRIPTION
## Summary

- Refactors the "Create from PR" modal into a unified tabbed "Create from..." dialog with three tabs: **Pull Requests**, **Branches**, and **Issues** (GitHub + Linear)
- Adds GitHub issue API functions (`listGitHubIssues`, `searchGitHubIssues`, `getGitHubIssueDetails`) and integrates Linear issue listing/search
- Adds workspace selector so users can create sessions in any workspace from the modal
- Adds "Create from..." menu item to the workspace sidebar dropdown with keyboard shortcut

### Code quality fixes (from review)
- Fixes double-click race condition on session creation handlers using `useRef` guard
- Adds error feedback in data fetch effects (previously errors were silently swallowed)
- Splits reset effect to avoid clearing search/results when workspace list changes while modal is open
- Removes unnecessary `Array.isArray` defensive check in search branch
- Uses consistent `Link` icon across command palette and sidebar

## Test plan

- [x] Lint passes (0 errors)
- [x] All 9 `CreateFromPRModal` tests pass
- [ ] Manual: Open modal via `⌘⇧O`, verify three tabs render
- [ ] Manual: Switch between tabs, verify data loads per tab
- [ ] Manual: Search filters PRs client-side, branches/issues server-side
- [ ] Manual: Select a PR → session created with PR context
- [ ] Manual: Select a GitHub issue → session created with issue context
- [ ] Manual: Select a Linear issue → session created with issue context
- [ ] Manual: Workspace selector switches data source
- [ ] Manual: Sidebar "Create from..." menu item opens the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)