### PR TITLE
fix: expose comment id and title in MCP review comment tools

### DIFF
--- a/agent-runner/src/mcp/tools/comments.ts
+++ b/agent-runner/src/mcp/tools/comments.ts
@@ -58,11 +58,11 @@ export function createCommentTools(context: WorkspaceContext) {
             };
           }
 
-          await response.json();
+          const comment = await response.json();
           return {
             content: [{
               type: "text",
-              text: `Added ${severity || "review"} comment to ${filePath}:${lineNumber}`,
+              text: `Added ${severity || "review"} comment to ${filePath}:${lineNumber} (id: ${comment.id})`,
             }],
           };
         } catch (error) {
@@ -116,8 +116,10 @@ export function createCommentTools(context: WorkspaceContext) {
 
           // Format comments for display
           interface CommentResponse {
+            id: string;
             filePath: string;
             lineNumber: number;
+            title?: string;
             content: string;
             severity?: string;
             resolved?: boolean;
@@ -125,7 +127,8 @@ export function createCommentTools(context: WorkspaceContext) {
           const formatted = comments.map((c: CommentResponse) => {
             const severityTag = c.severity ? `[${c.severity.toUpperCase()}] ` : "";
             const resolved = c.resolved ? " (resolved)" : "";
-            return `${c.filePath}:${c.lineNumber} - ${severityTag}${c.content}${resolved}`;
+            const titlePart = c.title ? `${c.title} - ` : "";
+            return `[${c.id}] ${c.filePath}:${c.lineNumber} - ${titlePart}${severityTag}${c.content}${resolved}`;
           }).join("\n\n");
 
           return {


### PR DESCRIPTION
## Summary
- **add_review_comment** now returns the created comment's `id` in its response text, enabling agents to immediately reference or resolve the comment
- **list_review_comments** now includes `id` and `title` in formatted output, so agents can identify and resolve specific comments
- Improved formatting template readability for the title/dash pattern

## Context
Without the comment ID in tool responses, agents had no way to call `resolve_review_comment` after creating or listing comments. This was a gap in the review comment workflow.

## Test plan
- [ ] Create a review comment via `add_review_comment` and verify the response includes `(id: <uuid>)`
- [ ] List comments via `list_review_comments` and verify each entry shows `[<id>] file:line - Title - [SEV] content`
- [ ] Use the returned ID with `resolve_review_comment` to mark a comment as fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)