### PR TITLE
feat: Create Session from PR, branch, or issue dialog

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -48,7 +48,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
                 .build(app)?,
         )
         .item(
-            &MenuItemBuilder::with_id("create_from_pr", "Create from...")
+            &MenuItemBuilder::with_id("create_from_pr", "Create Session from...")
                 .accelerator("CmdOrCtrl+Shift+O")
                 .enabled(false)
                 .build(app)?,

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -186,7 +186,7 @@ const COMMANDS: Command[] = [
   {
     id: 'create-from-pr',
     category: 'Actions',
-    label: 'Create from...',
+    label: 'Create Session from...',
     icon: Link,
     shortcutId: 'createFromPR',
     keywords: ['pull request', 'pr', 'branch', 'issue', 'linear', 'github', 'checkout', 'review'],

--- a/src/components/dialogs/CreateFromPRModal.tsx
+++ b/src/components/dialogs/CreateFromPRModal.tsx
@@ -508,7 +508,7 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
     <CommandDialog
       open={isOpen}
       onOpenChange={(open) => { if (!open) onClose(); }}
-      title="Create from..."
+      title="Create Session from..."
       description="Create a session from a pull request, branch, or issue"
       shouldFilter={false}
       variant="centered"
@@ -538,13 +538,7 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
         {workspaces.length > 0 && (
           <Select value={selectedWorkspaceId} onValueChange={setSelectedWorkspaceId}>
             <SelectTrigger className="h-7 w-auto max-w-[160px] text-xs gap-1.5 border-none shadow-none px-2">
-              <div className="flex items-center gap-1.5 min-w-0">
-                <div
-                  className="w-2 h-2 rounded-full shrink-0"
-                  style={{ backgroundColor: workspaceColors[selectedWorkspaceId] || getWorkspaceColor(selectedWorkspaceId) }}
-                />
-                <SelectValue />
-              </div>
+              <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {workspaces.map((ws) => (
@@ -563,7 +557,7 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
         )}
       </div>
 
-      <CommandList className="max-h-[320px]">
+      <CommandList className="h-[320px]">
         {/* Error display */}
         {error && (
           <div className="px-3 py-2 text-xs text-destructive bg-destructive/10 mx-2 mt-2 rounded">

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -989,7 +989,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                   )}
                   <DropdownMenuItem onClick={() => window.dispatchEvent(new CustomEvent('create-from-pr'))}>
                     <Link className="h-4 w-4" />
-                    Create from...
+                    Create Session from...
                     <DropdownMenuShortcut>⌘⇧O</DropdownMenuShortcut>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -64,7 +64,7 @@ export const SHORTCUTS: Shortcut[] = [
     id: 'createFromPR',
     key: 'o',
     modifiers: ['meta', 'shift'],
-    label: 'Create from...',
+    label: 'Create Session from...',
     category: 'General',
   },
   {


### PR DESCRIPTION
## Summary
- Rewrite the "Create from..." dialog using `CommandDialog` (cmdk) for keyboard-first UX with tabs for Pull Requests, Branches, and Issues (GitHub + Linear)
- Add "Create Session from..." menu item to the sessions sidebar "+" dropdown with ⌘⇧O shortcut
- Rename label to "Create Session from..." across all entry points (menu bar, command palette, shortcuts, sidebar, dialog)
- Fix workspace selector showing duplicate colored dots by removing redundant dot in SelectTrigger
- Use fixed height for CommandList to prevent dialog position shift when switching tabs
- Add GitHub Issues API wrappers (`listGitHubIssues`, `searchGitHubIssues`, `getGitHubIssueDetails`)

## Test plan
- [ ] Open ⌘⇧O — dialog title says "Create Session from..."
- [ ] "+" dropdown in sessions sidebar → menu item says "Create Session from..."
- [ ] Command palette → action says "Create Session from..."
- [ ] File menu → says "Create Session from..."
- [ ] Keyboard shortcuts dialog → says "Create Session from..."
- [ ] Switch between PR/Branches/Issues tabs — dialog stays in same position
- [ ] Workspace selector shows a single colored dot (not two)
- [ ] Select a PR → creates session with checkout and system message
- [ ] Select a GitHub issue → creates session with issue context
- [ ] Select a Linear issue → creates session with issue context
- [ ] Search filtering works on each tab
- [ ] Run `pnpm test:run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)