### PR TITLE
feat: attach GitHub/Linear issue content to sessions

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -48,7 +48,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
                 .build(app)?,
         )
         .item(
-            &MenuItemBuilder::with_id("create_from_pr", "Create Session from...")
+            &MenuItemBuilder::with_id("create_session", "Create Session from...")
                 .accelerator("CmdOrCtrl+Shift+O")
                 .enabled(false)
                 .build(app)?,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -483,7 +483,7 @@ export default function Home() {
     onOpenSettings: (category?: string) => dialogRef.current?.openSettings(category),
     onCloseSettings: () => dialogRef.current?.closeSettings(),
     onShowAddWorkspace: () => dialogRef.current?.showAddWorkspace(),
-    onShowCreateFromPR: () => dialogRef.current?.showCreateFromPR(),
+    onShowCreateSession: () => dialogRef.current?.showCreateSession(),
     onShowShortcuts: () => dialogRef.current?.showShortcuts(),
     onShowBottomTerminal: () => {
       if (layout.selectedSessionId) {
@@ -620,7 +620,7 @@ export default function Home() {
                     onOpenShortcuts={() => dialogRef.current?.showShortcuts()}
                     onOpenWorkspaceSettings={(workspaceId) => dialogRef.current?.openWorkspaceSettings(workspaceId)}
                     onNewSession={handleNewSession}
-                    onCreateFromPR={() => dialogRef.current?.showCreateFromPR()}
+                    onCreateSession={() => dialogRef.current?.showCreateSession()}
                   />
                 ) : (
                   // INNER GROUP: Conversation + Terminal | Right Sidebar

--- a/src/components/conversation/AttachmentCard.tsx
+++ b/src/components/conversation/AttachmentCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { X, File, FileText, FileCode, Image, FileJson, Terminal, FileType, ScrollText, type LucideIcon } from 'lucide-react';
+import { X, File, FileText, FileCode, Image, FileJson, Terminal, FileType, ScrollText, CircleDot, type LucideIcon } from 'lucide-react';
 import type { Attachment } from '@/lib/types';
 import { getFileCategory, getAttachmentSubtitle } from '@/lib/attachments';
 import { cn } from '@/lib/utils';
@@ -36,19 +36,51 @@ export function AttachmentCard({ attachment, onRemove, onClick, readOnly = false
   const filePath = attachment.path || attachment.name;
   const category = useMemo(() => getFileCategory(filePath), [filePath]);
   const isInstruction = attachment.isInstruction;
-  const Icon = isInstruction ? ScrollText : (CATEGORY_ICONS[category] || FileType);
-  const subtitle = isInstruction ? 'Instructions' : getAttachmentSubtitle(attachment);
+  const isContext = !!attachment.contextType;
+  const isGitHub = attachment.contextType === 'github-issue';
+  const isLinear = attachment.contextType === 'linear-issue';
+
+  // Resolve icon
+  const Icon = isContext
+    ? CircleDot
+    : isInstruction
+      ? ScrollText
+      : (CATEGORY_ICONS[category] || FileType);
+
+  // Resolve subtitle
+  const subtitle = isContext
+    ? (isGitHub ? 'GitHub Issue' : 'Linear Issue')
+    : isInstruction
+      ? 'Instructions'
+      : getAttachmentSubtitle(attachment);
 
   // CSS truncate on the span handles ellipsis; full name shown via title tooltip
   const displayName = attachment.name;
+
+  // Context color: green for open GitHub issues, purple for closed, blue for Linear
+  const contextColorClass = isGitHub
+    ? (attachment.contextMeta?.state === 'open'
+      ? 'border-green-500/30 bg-green-500/10 hover:bg-green-500/15'
+      : 'border-purple-500/30 bg-purple-500/10 hover:bg-purple-500/15')
+    : isLinear
+      ? 'border-blue-500/30 bg-blue-500/10 hover:bg-blue-500/15'
+      : '';
+
+  const contextIconClass = isGitHub
+    ? (attachment.contextMeta?.state === 'open' ? 'text-green-500' : 'text-purple-500')
+    : isLinear
+      ? 'text-blue-500'
+      : '';
 
   return (
     <div
       className={cn(
         'group relative flex items-center gap-2 rounded-md border px-2.5 py-1.5',
-        isInstruction
-          ? 'border-purple-500/30 bg-purple-500/10 hover:bg-purple-500/15'
-          : 'border-border bg-muted/50 hover:bg-muted/80',
+        isContext
+          ? contextColorClass
+          : isInstruction
+            ? 'border-purple-500/30 bg-purple-500/10 hover:bg-purple-500/15'
+            : 'border-border bg-muted/50 hover:bg-muted/80',
         'transition-colors',
         'min-w-0 max-w-[220px]',
         onClick && 'cursor-pointer'
@@ -58,7 +90,14 @@ export function AttachmentCard({ attachment, onRemove, onClick, readOnly = false
       onMouseLeave={() => setIsHovered(false)}
     >
       {/* Icon */}
-      <div className={cn('flex-shrink-0', isInstruction ? 'text-purple-500' : 'text-muted-foreground')}>
+      <div className={cn(
+        'flex-shrink-0',
+        isContext
+          ? contextIconClass
+          : isInstruction
+            ? 'text-purple-500'
+            : 'text-muted-foreground'
+      )}>
         <Icon className="h-4 w-4" />
       </div>
 

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -184,13 +184,13 @@ const COMMANDS: Command[] = [
     action: () => window.dispatchEvent(new CustomEvent('new-conversation')),
   },
   {
-    id: 'create-from-pr',
+    id: 'create-session',
     category: 'Actions',
     label: 'Create Session from...',
     icon: Link,
-    shortcutId: 'createFromPR',
+    shortcutId: 'createSession',
     keywords: ['pull request', 'pr', 'branch', 'issue', 'linear', 'github', 'checkout', 'review'],
-    action: () => window.dispatchEvent(new CustomEvent('create-from-pr')),
+    action: () => window.dispatchEvent(new CustomEvent('create-session')),
   },
   {
     id: 'add-repository',

--- a/src/components/dialogs/CreateSessionModal.tsx
+++ b/src/components/dialogs/CreateSessionModal.tsx
@@ -51,12 +51,13 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getWorkspaceColor } from '@/lib/workspace-colors';
+import { buildContextAttachment } from '@/lib/attachments';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-interface CreateFromPRModalProps {
+interface CreateSessionModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
@@ -182,7 +183,7 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
 // Main Component
 // ============================================================================
 
-export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
+export function CreateSessionModal({ isOpen, onClose }: CreateSessionModalProps) {
   const [tab, setTab] = useState<TabId>('pr');
   const [search, setSearch] = useState('');
   const [creating, setCreating] = useState(false);
@@ -305,7 +306,9 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
     return () => { cancelled = true; clearTimeout(timer); };
   }, [isOpen, tab, selectedWorkspaceId, search]);
 
-  // Fetch issues when workspace changes or issues tab is active
+  // Fetch issues when workspace changes or issues tab is active.
+  // No guard on selectedWorkspaceId: Linear issues are workspace-independent,
+  // and GitHub issues gracefully fall back to [] when no workspace is selected.
   useEffect(() => {
     if (!isOpen || tab !== 'issues') {
       return;
@@ -371,6 +374,7 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
   const createSessionAndNavigate = useCallback(async (
     workspaceId: string,
     params: { branch: string; checkoutExisting: boolean; task?: string; systemMessage?: string },
+    draft?: { text: string; attachments: import('@/lib/types').Attachment[] },
   ) => {
     const session = await createSessionApi(workspaceId, params);
 
@@ -397,6 +401,11 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
         updatedAt: conv.updatedAt,
       });
     });
+
+    // Set draft BEFORE navigation so ChatInput picks it up on mount
+    if (draft) {
+      useAppStore.getState().setDraftInput(session.id, draft);
+    }
 
     expandWorkspace(workspaceId);
     navigate({
@@ -459,12 +468,28 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
     try {
       // Fetch full issue body
       const details = await getGitHubIssueDetails(selectedWorkspaceId, issue.number);
+      const systemMessage = buildGitHubIssueSystemMessage(issue, details.body);
+
+      // Build context attachment so the issue appears in the composer
+      const issueAttachment = buildContextAttachment({
+        contextType: 'github-issue',
+        title: `#${issue.number} ${issue.title}`,
+        markdownBody: systemMessage,
+        meta: {
+          number: issue.number,
+          title: issue.title,
+          url: issue.htmlUrl,
+          state: issue.state,
+        },
+      });
+
+      // Empty branch tells the backend to auto-create a new session branch
       await createSessionAndNavigate(selectedWorkspaceId, {
         branch: '',
         checkoutExisting: false,
         task: issue.title,
-        systemMessage: buildGitHubIssueSystemMessage(issue, details.body),
-      });
+        systemMessage,
+      }, { text: '', attachments: [issueAttachment] });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create session');
     } finally {
@@ -480,12 +505,27 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
     setCreating(true);
     setError('');
     try {
+      const systemMessage = buildLinearIssueSystemMessage(issue);
+
+      // Build context attachment so the issue appears in the composer
+      const linearAttachment = buildContextAttachment({
+        contextType: 'linear-issue',
+        title: `${issue.identifier} ${issue.title}`,
+        markdownBody: systemMessage,
+        meta: {
+          identifier: issue.identifier,
+          title: issue.title,
+          state: issue.stateName,
+        },
+      });
+
+      // Empty branch tells the backend to auto-create a new session branch
       await createSessionAndNavigate(selectedWorkspaceId, {
         branch: '',
         checkoutExisting: false,
         task: issue.title,
-        systemMessage: buildLinearIssueSystemMessage(issue),
-      });
+        systemMessage,
+      }, { text: '', attachments: [linearAttachment] });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create session');
     } finally {
@@ -524,13 +564,13 @@ export function CreateFromPRModal({ isOpen, onClose }: CreateFromPRModalProps) {
       {/* Tab bar + workspace selector */}
       <div className="flex items-center justify-between border-b px-3 py-1.5">
         <div className="flex gap-1">
-          <TabButton active={tab === 'pr'} onClick={() => { setTab('pr'); setSearch(''); }}>
+          <TabButton active={tab === 'pr'} onClick={() => { setTab('pr'); setSearch(''); setError(''); }}>
             Pull requests
           </TabButton>
-          <TabButton active={tab === 'branch'} onClick={() => { setTab('branch'); setSearch(''); }}>
+          <TabButton active={tab === 'branch'} onClick={() => { setTab('branch'); setSearch(''); setError(''); }}>
             Branches
           </TabButton>
-          <TabButton active={tab === 'issues'} onClick={() => { setTab('issues'); setSearch(''); }}>
+          <TabButton active={tab === 'issues'} onClick={() => { setTab('issues'); setSearch(''); setError(''); }}>
             Issues
           </TabButton>
         </div>

--- a/src/components/dialogs/__tests__/CreateSessionModal.test.tsx
+++ b/src/components/dialogs/__tests__/CreateSessionModal.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../../__mocks__/server';
-import { CreateFromPRModal } from '../CreateFromPRModal';
+import { CreateSessionModal } from '../CreateSessionModal';
 import { useAppStore } from '@/stores/appStore';
 
 const API_BASE = 'http://localhost:9876';
@@ -86,7 +86,7 @@ vi.mock('@/lib/navigation', () => ({
   navigate: vi.fn(),
 }));
 
-describe('CreateFromPRModal', () => {
+describe('CreateSessionModal', () => {
   const defaultProps = {
     isOpen: true,
     onClose: vi.fn(),
@@ -144,7 +144,7 @@ describe('CreateFromPRModal', () => {
   });
 
   it('renders with three tabs: Pull requests, Branches, Issues', () => {
-    render(<CreateFromPRModal {...defaultProps} />);
+    render(<CreateSessionModal {...defaultProps} />);
 
     expect(screen.getByText('Pull requests')).toBeInTheDocument();
     expect(screen.getByText('Branches')).toBeInTheDocument();
@@ -152,7 +152,7 @@ describe('CreateFromPRModal', () => {
   });
 
   it('renders the search input', () => {
-    render(<CreateFromPRModal {...defaultProps} />);
+    render(<CreateSessionModal {...defaultProps} />);
 
     expect(
       screen.getByPlaceholderText('Search by title, number, or author...')
@@ -160,7 +160,7 @@ describe('CreateFromPRModal', () => {
   });
 
   it('shows PR list on the Pull requests tab', async () => {
-    render(<CreateFromPRModal {...defaultProps} />);
+    render(<CreateSessionModal {...defaultProps} />);
 
     await waitFor(
       () => {
@@ -172,7 +172,7 @@ describe('CreateFromPRModal', () => {
   });
 
   it('shows draft PR with draft icon styling', async () => {
-    render(<CreateFromPRModal {...defaultProps} />);
+    render(<CreateSessionModal {...defaultProps} />);
 
     await waitFor(
       () => {
@@ -186,7 +186,7 @@ describe('CreateFromPRModal', () => {
   it('shows the Branches tab content when clicked', async () => {
     const user = userEvent.setup();
 
-    render(<CreateFromPRModal {...defaultProps} />);
+    render(<CreateSessionModal {...defaultProps} />);
 
     await user.click(screen.getByText('Branches'));
 
@@ -199,7 +199,7 @@ describe('CreateFromPRModal', () => {
   it('shows the Issues tab with GitHub and Linear issues', async () => {
     const user = userEvent.setup();
 
-    render(<CreateFromPRModal {...defaultProps} />);
+    render(<CreateSessionModal {...defaultProps} />);
 
     await user.click(screen.getByText('Issues'));
 
@@ -220,7 +220,7 @@ describe('CreateFromPRModal', () => {
   });
 
   it('does not render when isOpen is false', () => {
-    render(<CreateFromPRModal isOpen={false} onClose={vi.fn()} />);
+    render(<CreateSessionModal isOpen={false} onClose={vi.fn()} />);
 
     expect(
       screen.queryByText('Pull requests')
@@ -228,14 +228,14 @@ describe('CreateFromPRModal', () => {
   });
 
   it('shows workspace selector', () => {
-    render(<CreateFromPRModal {...defaultProps} />);
+    render(<CreateSessionModal {...defaultProps} />);
 
     expect(screen.getByText('test-repo')).toBeInTheDocument();
   });
 
   it('filters PRs by search term', async () => {
     const user = userEvent.setup();
-    render(<CreateFromPRModal {...defaultProps} />);
+    render(<CreateSessionModal {...defaultProps} />);
 
     // Wait for PRs to load
     await waitFor(() => {

--- a/src/components/layout/ContentRouter.tsx
+++ b/src/components/layout/ContentRouter.tsx
@@ -19,7 +19,7 @@ interface ContentRouterProps {
   onOpenShortcuts: () => void;
   onOpenWorkspaceSettings: (workspaceId: string) => void;
   onNewSession: () => void;
-  onCreateFromPR: () => void;
+  onCreateSession: () => void;
 }
 
 /**
@@ -37,7 +37,7 @@ export function ContentRouter({
   onOpenShortcuts,
   onOpenWorkspaceSettings,
   onNewSession,
-  onCreateFromPR,
+  onCreateSession,
 }: ContentRouterProps) {
   const contentView = useSettingsStore((s) => s.contentView);
 
@@ -75,7 +75,7 @@ export function ContentRouter({
           onOpenProject={onOpenProject}
           onCloneFromUrl={onCloneFromUrl}
           onNewSession={onNewSession}
-          onCreateFromPR={onCreateFromPR}
+          onCreateSession={onCreateSession}
           onOpenSettings={onOpenSettings}
           onOpenShortcuts={onOpenShortcuts}
           showLeftSidebar={showLeftSidebar}

--- a/src/components/layout/DialogManager.tsx
+++ b/src/components/layout/DialogManager.tsx
@@ -7,7 +7,7 @@ import { useShortcut } from '@/hooks/useShortcut';
 import { SettingsPage } from '@/components/settings/SettingsPage';
 import type { WorkspaceSettingsSection } from '@/components/settings/settingsRegistry';
 import { AddWorkspaceModal } from '@/components/dialogs/AddWorkspaceModal';
-import { CreateFromPRModal } from '@/components/dialogs/CreateFromPRModal';
+import { CreateSessionModal } from '@/components/dialogs/CreateSessionModal';
 import { CloneFromUrlDialog } from '@/components/dialogs/CloneFromUrlDialog';
 import { GitHubReposDialog } from '@/components/dialogs/GitHubReposDialog';
 import { CloseTabConfirmDialog } from '@/components/dialogs/CloseTabConfirmDialog';
@@ -59,7 +59,7 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
   expandWorkspace,
 }, ref) {
   const [showAddWorkspace, setShowAddWorkspace] = useState(false);
-  const [showCreateFromPR, setShowCreateFromPR] = useState(false);
+  const [showCreateSession, setShowCreateSession] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [settingsInitialCategory, setSettingsInitialCategory] = useState<string | undefined>(undefined);
   const [settingsInitialWorkspaceId, setSettingsInitialWorkspaceId] = useState<string | undefined>(undefined);
@@ -93,8 +93,8 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
     return () => window.removeEventListener('show-shortcuts', handleShowShortcuts);
   }, []);
 
-  useShortcut('createFromPR', useCallback(() => {
-    setShowCreateFromPR(true);
+  useShortcut('createSession', useCallback(() => {
+    setShowCreateSession(true);
   }, []));
 
   // Expose dialog openers for use by parent via the returned object
@@ -148,7 +148,7 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
     openSettings,
     closeSettings,
     showAddWorkspace: () => setShowAddWorkspace(true),
-    showCreateFromPR: () => setShowCreateFromPR(true),
+    showCreateSession: () => setShowCreateSession(true),
     showCloneFromUrl: () => setShowCloneFromUrl(true),
     showGitHubRepos: () => setShowGitHubRepos(true),
     showShortcuts: () => setShowShortcuts(true),
@@ -177,9 +177,9 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
       />
 
       {/* Create Session from PR/Branch Modal */}
-      <CreateFromPRModal
-        isOpen={showCreateFromPR}
-        onClose={() => setShowCreateFromPR(false)}
+      <CreateSessionModal
+        isOpen={showCreateSession}
+        onClose={() => setShowCreateSession(false)}
       />
 
       {/* Clone from URL Dialog */}
@@ -250,7 +250,7 @@ export type DialogManagerHandles = {
   openSettings: (category?: string) => void;
   closeSettings: () => void;
   showAddWorkspace: () => void;
-  showCreateFromPR: () => void;
+  showCreateSession: () => void;
   showCloneFromUrl: () => void;
   showGitHubRepos: () => void;
   showShortcuts: () => void;

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -987,7 +987,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
                   )}
-                  <DropdownMenuItem onClick={() => window.dispatchEvent(new CustomEvent('create-from-pr'))}>
+                  <DropdownMenuItem onClick={() => window.dispatchEvent(new CustomEvent('create-session'))}>
                     <Link className="h-4 w-4" />
                     Create Session from...
                     <DropdownMenuShortcut>⌘⇧O</DropdownMenuShortcut>

--- a/src/components/shared/EmptyView.tsx
+++ b/src/components/shared/EmptyView.tsx
@@ -14,7 +14,7 @@ interface EmptyViewProps {
   onOpenProject: () => void;
   onCloneFromUrl: () => void;
   onNewSession: () => void;
-  onCreateFromPR: () => void;
+  onCreateSession: () => void;
   onOpenSettings?: () => void;
   onOpenShortcuts?: () => void;
   showLeftSidebar?: boolean;
@@ -24,7 +24,7 @@ export function EmptyView({
   onOpenProject,
   onCloneFromUrl,
   onNewSession,
-  onCreateFromPR,
+  onCreateSession,
   onOpenSettings,
   onOpenShortcuts,
   showLeftSidebar = true,
@@ -92,7 +92,7 @@ export function EmptyView({
               onOpenProject={onOpenProject}
               onCloneFromUrl={onCloneFromUrl}
               onNewSession={onNewSession}
-              onCreateFromPR={onCreateFromPR}
+              onCreateSession={onCreateSession}
               hasWorkspace={hasWorkspace}
             />
           </div>

--- a/src/components/shared/smart-launcher/QuickActions.tsx
+++ b/src/components/shared/smart-launcher/QuickActions.tsx
@@ -7,7 +7,7 @@ interface QuickActionsProps {
   onOpenProject: () => void;
   onCloneFromUrl: () => void;
   onNewSession: () => void;
-  onCreateFromPR: () => void;
+  onCreateSession: () => void;
   hasWorkspace: boolean;
 }
 
@@ -47,7 +47,7 @@ export function QuickActions({
   onOpenProject,
   onCloneFromUrl,
   onNewSession,
-  onCreateFromPR,
+  onCreateSession,
   hasWorkspace,
 }: QuickActionsProps) {
   const handleCardClick = (key: string) => {
@@ -62,7 +62,7 @@ export function QuickActions({
         onNewSession();
         break;
       case 'from-pr':
-        onCreateFromPR();
+        onCreateSession();
         break;
     }
   };

--- a/src/hooks/__tests__/useDotMcpTrustCheck.test.ts
+++ b/src/hooks/__tests__/useDotMcpTrustCheck.test.ts
@@ -34,7 +34,7 @@ const mockDialogRef = {
     openSettings: vi.fn(),
     closeSettings: vi.fn(),
     showAddWorkspace: vi.fn(),
-    showCreateFromPR: vi.fn(),
+    showCreateSession: vi.fn(),
     showCloneFromUrl: vi.fn(),
     showGitHubRepos: vi.fn(),
     showShortcuts: vi.fn(),

--- a/src/hooks/__tests__/useMenuHandlers.paste.test.ts
+++ b/src/hooks/__tests__/useMenuHandlers.paste.test.ts
@@ -96,7 +96,7 @@ function makeOptions() {
     onOpenSettings: vi.fn(),
     onCloseSettings: vi.fn(),
     onShowAddWorkspace: vi.fn(),
-    onShowCreateFromPR: vi.fn(),
+    onShowCreateSession: vi.fn(),
     onShowShortcuts: vi.fn(),
     onShowBottomTerminal: vi.fn(),
   };

--- a/src/hooks/useMenuHandlers.ts
+++ b/src/hooks/useMenuHandlers.ts
@@ -31,7 +31,7 @@ interface MenuHandlersOptions {
   onOpenSettings: (category?: string) => void;
   onCloseSettings: () => void;
   onShowAddWorkspace: () => void;
-  onShowCreateFromPR: () => void;
+  onShowCreateSession: () => void;
   onShowShortcuts: () => void;
   onShowBottomTerminal: () => void;
 }
@@ -100,8 +100,8 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
         case 'new_conversation':
           handleNewConversationRef.current();
           break;
-        case 'create_from_pr':
-          window.dispatchEvent(new CustomEvent('create-from-pr'));
+        case 'create_session':
+          window.dispatchEvent(new CustomEvent('create-session'));
           break;
         case 'add_workspace':
           options.onShowAddWorkspace();
@@ -379,7 +379,7 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
     const handleSpawnAgent = () => handleNewSessionRef.current();
     const handleNewConv = () => handleNewConversationRef.current();
     const handleAddWorkspace = () => options.onShowAddWorkspace();
-    const handleCreateFromPR = () => options.onShowCreateFromPR();
+    const handleCreateSession = () => options.onShowCreateSession();
     const handleToggleTheme = () => {
       setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
     };
@@ -400,7 +400,7 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
     window.addEventListener('spawn-agent', handleSpawnAgent);
     window.addEventListener('new-conversation', handleNewConv);
     window.addEventListener('add-workspace', handleAddWorkspace);
-    window.addEventListener('create-from-pr', handleCreateFromPR);
+    window.addEventListener('create-session', handleCreateSession);
     window.addEventListener('toggle-theme', handleToggleTheme);
     window.addEventListener('toggle-left-panel', handleToggleLeftPanel);
     window.addEventListener('toggle-right-panel', handleToggleRightPanel);
@@ -414,7 +414,7 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
       window.removeEventListener('spawn-agent', handleSpawnAgent);
       window.removeEventListener('new-conversation', handleNewConv);
       window.removeEventListener('add-workspace', handleAddWorkspace);
-      window.removeEventListener('create-from-pr', handleCreateFromPR);
+      window.removeEventListener('create-session', handleCreateSession);
       window.removeEventListener('toggle-theme', handleToggleTheme);
       window.removeEventListener('toggle-left-panel', handleToggleLeftPanel);
       window.removeEventListener('toggle-right-panel', handleToggleRightPanel);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 import { HEALTH_CHECK_REQUEST_TIMEOUT_MS } from '@/lib/constants';
 import { getAuthToken } from '@/lib/auth-token';
 import { getBackendPortSync, getBackendPort, initBackendPort } from '@/lib/backend-port';
-import type { McpServerConfig } from '@/lib/types';
+import type { McpServerConfig, AttachmentContextType, AttachmentContextMeta } from '@/lib/types';
 
 // Re-export for convenience
 export { initBackendPort };
@@ -961,6 +961,8 @@ export interface AttachmentDTO {
   base64Data?: string;
   preview?: string;
   isInstruction?: boolean; // Frontend-only: not persisted by the backend
+  contextType?: AttachmentContextType;
+  contextMeta?: AttachmentContextMeta;
 }
 
 export interface ToolUsageDTO {

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -346,6 +346,33 @@ export async function loadAllAttachmentContents(attachments: Attachment[]): Prom
 }
 
 // ============================================================================
+// Context Attachment Builder
+// ============================================================================
+
+/**
+ * Build an in-memory context attachment for an issue (GitHub or Linear).
+ * The attachment has base64Data pre-populated so no file path is needed.
+ */
+export function buildContextAttachment(opts: {
+  contextType: 'github-issue' | 'linear-issue';
+  title: string;
+  markdownBody: string;
+  meta: Attachment['contextMeta'];
+}): Attachment {
+  const encoded = btoa(String.fromCharCode(...new TextEncoder().encode(opts.markdownBody)));
+  return {
+    id: generateAttachmentId(),
+    type: 'file',
+    name: opts.title,
+    mimeType: 'text/markdown',
+    size: new Blob([opts.markdownBody]).size,
+    base64Data: encoded,
+    contextType: opts.contextType,
+    contextMeta: opts.meta,
+  };
+}
+
+// ============================================================================
 // Display Helpers
 // ============================================================================
 

--- a/src/lib/menuContext.ts
+++ b/src/lib/menuContext.ts
@@ -44,7 +44,7 @@ export function computeMenuState(inputs: MenuContextInputs): Record<string, bool
     // File menu
     new_session: hasWorkspace,
     new_conversation: hasSession,
-    create_from_pr: hasWorkspace,
+    create_session: hasWorkspace,
     add_workspace: true,
     save_file: hasDirtyFileTabs,
     close_tab: hasSession || hasBrowserTabs,

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -61,7 +61,7 @@ export const SHORTCUTS: Shortcut[] = [
     category: 'General',
   },
   {
-    id: 'createFromPR',
+    id: 'createSession',
     key: 'o',
     modifiers: ['meta', 'shift'],
     label: 'Create Session from...',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -224,6 +224,18 @@ export interface Attachment {
   base64Data?: string;       // Loaded on demand before send
   preview?: string;          // Text preview (first N chars)
   isInstruction?: boolean;   // Frontend-only: visual distinction for template/instruction attachments (not persisted by backend)
+  contextType?: AttachmentContextType;
+  contextMeta?: AttachmentContextMeta;
+}
+
+export type AttachmentContextType = 'github-issue' | 'linear-issue';
+
+export interface AttachmentContextMeta {
+  number?: number;
+  identifier?: string;
+  title?: string;
+  url?: string;
+  state?: string;
 }
 
 // SuggestionPill = A clickable suggestion option


### PR DESCRIPTION
## Summary
- **Rename `CreateFromPRModal` → `CreateSessionModal`** with consistent event/shortcut/menu ID naming (`create-from-pr` → `create-session` across frontend, Tauri menu, and command palette)
- **Add issue context attachments**: When creating a session from a GitHub or Linear issue, the issue content is attached as a markdown context attachment that appears in the composer
- **New `AttachmentContextMeta` type**: Extracted shared type for `contextType`/`contextMeta` fields on `Attachment` and `AttachmentDTO`
- **AttachmentCard styling**: Context-aware colors — green/purple for GitHub open/closed issues, blue for Linear
- **Code quality**: Replaced deprecated `unescape()` with `TextEncoder`, clear error state on tab switch, added clarifying comments

## Test plan
- [ ] Open "Create Session from..." modal (Cmd+Shift+O) and verify all three tabs work
- [ ] Select a GitHub issue → verify session is created with issue content as a context attachment in the composer
- [ ] Select a Linear issue → verify same behavior with blue-styled attachment card
- [ ] Trigger an error on one tab (e.g., disconnect network), switch tabs, verify error clears
- [ ] Verify command palette "Create Session from..." action works
- [ ] Verify native macOS menu "Create Session from..." item works
- [ ] Run `npm run lint` and `npm run build` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)