### PR TITLE
fix: defer editor focus in clear() to prevent undefined node error

### DIFF
--- a/src/components/conversation/PlateInput.tsx
+++ b/src/components/conversation/PlateInput.tsx
@@ -146,7 +146,10 @@ export const PlateInput = forwardRef<PlateInputHandle, PlateInputProps>(
       },
       clear: () => {
         editor.tf.reset();
-        editor.tf.focus();
+        // Defer until React reconciles the DOM after reset
+        setTimeout(() => {
+          editor.tf.focus();
+        }, 0);
       },
       getText: () => {
         return extractText(editor.children);


### PR DESCRIPTION
## Summary
- Fixed `TypeError: undefined is not an object (evaluating 'Editor.node(editor, path)')` crash when executing slash commands
- The `clear()` method in `PlateInput` called `editor.tf.focus()` synchronously after `editor.tf.reset()`, but the editor's internal path references were stale before React reconciled the DOM
- Deferred `editor.tf.focus()` with `setTimeout(..., 0)`, matching the existing pattern used by `setText()` in the same `useImperativeHandle` block

## Test plan
- [ ] Open a chat input, type `/` to trigger slash commands
- [ ] Click on an action-type slash command — confirm no console error and editor clears + focuses correctly
- [ ] Test `setText()` still works (e.g., editing a previous message)
- [ ] Test session switching (another `clear()` caller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)