### PR TITLE
fix: resolve plan mode stuck state caused by SDK Zod validation errors

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1504,7 +1504,6 @@ const exitPlanModeHook: HookCallback = async (_input) => {
         permissionDecision: "deny" as const,
         permissionDecisionReason: "Plan mode already exited successfully. Your plan was approved by the user. Do not call ExitPlanMode again. Proceed with implementation immediately.",
       },
-      systemMessage: "The user has already approved your plan. Plan mode has been exited. Proceed with implementing the plan now.",
     };
   }
 
@@ -1616,8 +1615,8 @@ const canUseTool: CanUseTool = async (toolName, toolInput, _options) => {
   if (currentPermissionMode === "plan" && PLAN_MODE_DENIED_TOOLS.has(toolName)) {
     return { behavior: "deny", message: "This tool is not available in plan mode. Present your plan using ExitPlanMode first." };
   }
-  // SDK 0.2.72: updatedInput is now optional in PermissionResult (Zod bug fixed)
-  return { behavior: "allow" };
+  // SDK 0.2.72: updatedInput is still required in PermissionResult — pass through toolInput
+  return { behavior: "allow", updatedInput: toolInput };
 };
 
 // Hooks configuration - all always enabled


### PR DESCRIPTION
## Summary
- **Primary fix**: `canUseTool` callback returned `{ behavior: "allow" }` without `updatedInput`, which fails the SDK's Zod schema validation in plan mode. Now passes `toolInput` through as `updatedInput`.
- **Secondary fix**: Removed unsupported `systemMessage` field from the ExitPlanMode hook retry response (SDK bug #15755 cooldown path) — this field is not part of the SDK's hook response Zod schema.

## Root Cause
In `bypassPermissions` mode (default), the SDK auto-allows tools before reaching `canUseTool`, so the missing `updatedInput` was invisible. In **plan mode**, `canUseTool` IS called for ExitPlanMode, and the Zod validation fails. This caused the agent to get stuck in a retry loop after plan approval.

## Test plan
- [ ] Build agent-runner: `cd agent-runner && npm run build`
- [ ] Start a session with plan mode, let the agent create a plan, approve it
- [ ] Verify the agent exits plan mode and proceeds with implementation (no "stuck" message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)