### PR TITLE
chore: upgrade claude-agent-sdk from 0.2.72 to 0.2.75

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.72",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.75",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.72",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.72.tgz",
-      "integrity": "sha512-GR3QaLRCoWO5DkRknaaCH6zzmUNZ3E6VckEKNE7EO5R7qDBexQe9tDKag257pji2NenTrnBDMxznoZrhNCRTzA==",
+      "version": "0.2.75",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.75.tgz",
+      "integrity": "sha512-BSF5m0z7mwP5zB0G9JOEhCBovPpRBTe69oMSdUOYvEX6rLcHM0lp38MC2mr81vqSFo91a21/hVxOeifZyn/qkw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.72",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.75",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -2551,6 +2551,7 @@ function handleMessage(message: SDKMessage): void {
           description: taskMsg.description,
           usage: taskMsg.usage,
           lastToolName: taskMsg.last_tool_name,
+          status: (taskMsg as any).status, // SDK 0.2.75: includes "queued_to_running"
           sessionId: taskMsg.session_id,
         });
       } else if (sysMsg.subtype === "files_persisted") {


### PR DESCRIPTION
## Summary
- Bumps `@anthropic-ai/claude-agent-sdk` from 0.2.72 to 0.2.75
- Forwards the new `status` field on `task_progress` events to support the `queued_to_running` sub-agent status (SDK 0.2.75)
- Picks up free bug fixes: env override fix (0.2.73), module resolution + skills fix (0.2.74), better subprocess error reporting (0.2.75)

## Test plan
- [ ] `cd agent-runner && npm run build` compiles cleanly
- [ ] Start the app, create a session, send a message — agent works end-to-end
- [ ] Trigger a sub-agent task — verify `task_progress` events flow correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)