### PR TITLE
feat: add LRU eviction to PRCache to bound memory usage

### DIFF
--- a/backend/branch/pr_watcher_test.go
+++ b/backend/branch/pr_watcher_test.go
@@ -249,7 +249,7 @@ func TestPRWatcher_UpdateSessionBranch_UpdatesEntry(t *testing.T) {
 
 func TestPRWatcher_UpdateSessionBranch_InvalidatesPRCache(t *testing.T) {
 	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
-	prCache := github.NewPRCache(5*time.Minute, 30*time.Minute)
+	prCache := github.NewPRCache(5*time.Minute, 30*time.Minute, 100)
 	w := newTestPRWatcher(newMockStore(), repoMgr, prCache)
 	defer w.Close()
 
@@ -913,7 +913,7 @@ func TestPRWatcher_CheckSessionsWithoutPR_SkipsCache(t *testing.T) {
 	// skip the cache and fetch from GitHub, where the new PR now exists.
 	store := newMockStore()
 	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
-	prCache := github.NewPRCache(5*time.Minute, 30*time.Minute)
+	prCache := github.NewPRCache(5*time.Minute, 30*time.Minute, 100)
 	defer prCache.Close()
 
 	// Pre-populate the cache with NO open PRs (simulates cache set before PR creation).
@@ -1020,7 +1020,7 @@ func TestPRWatcher_CheckSessionsWithPR_UsesCache(t *testing.T) {
 	// cache for the PR list, unlike checkSessionsWithoutPR which skips it.
 	store := newMockStore()
 	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
-	prCache := github.NewPRCache(5*time.Minute, 30*time.Minute)
+	prCache := github.NewPRCache(5*time.Minute, 30*time.Minute, 100)
 	defer prCache.Close()
 
 	// Pre-populate cache with an open PR on "feature/bar" including details,

--- a/backend/github/pr_cache.go
+++ b/backend/github/pr_cache.go
@@ -1,11 +1,17 @@
 package github
 
 import (
+	"container/list"
 	"sync"
 	"time"
 
 	"github.com/chatml/chatml-backend/logger"
 )
+
+// lruItem is stored in the LRU list to track access order
+type lruItem struct {
+	key string
+}
 
 // CacheFreshness indicates how fresh a cache entry is
 type CacheFreshness int
@@ -31,10 +37,15 @@ type PRCacheEntry struct {
 
 // PRCache provides time-based caching for PR lists and details with stale-while-revalidate
 type PRCache struct {
-	mu       sync.RWMutex
-	entries  map[string]*PRCacheEntry
-	freshTTL time.Duration
-	staleTTL time.Duration
+	mu         sync.Mutex
+	entries    map[string]*PRCacheEntry
+	freshTTL   time.Duration
+	staleTTL   time.Duration
+	maxEntries int
+
+	// LRU eviction order (front = most recent, back = least recent)
+	order *list.List
+	items map[string]*list.Element
 
 	// Background refresh deduplication
 	refreshMu  sync.Mutex
@@ -46,11 +57,16 @@ type PRCache struct {
 
 // NewPRCache creates a new PR cache with the given fresh and stale TTLs.
 // Fresh TTL: serve directly from cache. Stale TTL: serve stale + trigger background refresh.
-func NewPRCache(freshTTL, staleTTL time.Duration) *PRCache {
+// maxEntries limits the cache size; when exceeded, the least-recently-accessed entry is evicted.
+// A maxEntries <= 0 means unlimited.
+func NewPRCache(freshTTL, staleTTL time.Duration, maxEntries int) *PRCache {
 	cache := &PRCache{
 		entries:    make(map[string]*PRCacheEntry),
 		freshTTL:   freshTTL,
 		staleTTL:   staleTTL,
+		maxEntries: maxEntries,
+		order:      list.New(),
+		items:      make(map[string]*list.Element),
 		refreshing: make(map[string]bool),
 		done:       make(chan struct{}),
 	}
@@ -69,8 +85,8 @@ func cacheKey(owner, repo string) string {
 // GetWithStale retrieves cached PRs with freshness status.
 // Returns the entry, its freshness, and whether data was found.
 func (c *PRCache) GetWithStale(owner, repo string) (*PRCacheEntry, CacheFreshness) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	key := cacheKey(owner, repo)
 	entry, ok := c.entries[key]
@@ -81,10 +97,12 @@ func (c *PRCache) GetWithStale(owner, repo string) (*PRCacheEntry, CacheFreshnes
 	now := time.Now()
 
 	if now.Before(entry.ExpiresAt) {
+		c.touchLRU(key)
 		return entry, CacheFresh
 	}
 
 	if now.Before(entry.StaleUntil) {
+		c.touchLRU(key)
 		return entry, CacheStale
 	}
 
@@ -106,8 +124,8 @@ func (c *PRCache) Get(owner, repo string) ([]PRListItem, bool) {
 
 // GetDetails retrieves cached details for a single PR
 func (c *PRCache) GetDetails(owner, repo string, prNumber int) (*PRDetails, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	key := cacheKey(owner, repo)
 	entry, ok := c.entries[key]
@@ -122,6 +140,9 @@ func (c *PRCache) GetDetails(owner, repo string, prNumber int) (*PRDetails, bool
 	}
 
 	details, ok := entry.Details[prNumber]
+	if ok {
+		c.touchLRU(key)
+	}
 	return details, ok
 }
 
@@ -156,6 +177,9 @@ func (c *PRCache) SetFull(owner, repo string, prs []PRListItem, details map[int]
 		StaleUntil: now.Add(c.staleTTL),
 	}
 
+	c.touchLRU(key)
+	c.evictIfNeeded()
+
 	logger.GitHub.Debugf("PR cache SET %s: %d PRs, %d details, etag=%q", key, len(prs), len(details), etag)
 }
 
@@ -187,6 +211,8 @@ func (c *PRCache) SetDetails(owner, repo string, details map[int]*PRDetails) {
 		}
 		entry.Details[k] = &copied
 	}
+
+	c.touchLRU(key)
 }
 
 // BumpTTL atomically extends the fresh and stale deadlines for an existing entry.
@@ -205,13 +231,14 @@ func (c *PRCache) BumpTTL(owner, repo string) bool {
 	entry.ExpiresAt = now.Add(c.freshTTL)
 	entry.StaleUntil = now.Add(c.staleTTL)
 	entry.CachedAt = now
+	c.touchLRU(key)
 	return true
 }
 
 // GetETag returns the stored ETag for a repo's PR list
 func (c *PRCache) GetETag(owner, repo string) string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	key := cacheKey(owner, repo)
 	entry, ok := c.entries[key]
@@ -251,6 +278,7 @@ func (c *PRCache) Invalidate(owner, repo string) {
 
 	key := cacheKey(owner, repo)
 	delete(c.entries, key)
+	c.removeLRU(key)
 	logger.GitHub.Debugf("PR cache INVALIDATE %s", key)
 }
 
@@ -259,6 +287,8 @@ func (c *PRCache) Clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries = make(map[string]*PRCacheEntry)
+	c.order = list.New()
+	c.items = make(map[string]*list.Element)
 }
 
 // Done returns a channel that is closed when the cache is shut down.
@@ -301,14 +331,63 @@ func (c *PRCache) cleanup() {
 	for key, entry := range c.entries {
 		if now.After(entry.StaleUntil) {
 			delete(c.entries, key)
+			c.removeLRU(key)
 		}
 	}
+
+	logger.GitHub.Debugf("PR cache cleanup: %d entries remaining (max %d)", len(c.entries), c.maxEntries)
+}
+
+// touchLRU moves the key to the front of the LRU list (most recently used).
+// Must be called while holding c.mu.
+func (c *PRCache) touchLRU(key string) {
+	if elem, ok := c.items[key]; ok {
+		c.order.MoveToFront(elem)
+	} else {
+		elem := c.order.PushFront(&lruItem{key: key})
+		c.items[key] = elem
+	}
+}
+
+// evictIfNeeded removes the least-recently-used entries until within maxEntries.
+// Must be called while holding c.mu.
+func (c *PRCache) evictIfNeeded() {
+	if c.maxEntries <= 0 {
+		return
+	}
+	for len(c.entries) > c.maxEntries {
+		back := c.order.Back()
+		if back == nil {
+			break
+		}
+		item := back.Value.(*lruItem)
+		delete(c.entries, item.key)
+		c.order.Remove(back)
+		delete(c.items, item.key)
+		logger.GitHub.Debugf("PR cache LRU evict %s", item.key)
+	}
+}
+
+// removeLRU removes a key from the LRU tracking structures.
+// Must be called while holding c.mu.
+func (c *PRCache) removeLRU(key string) {
+	if elem, ok := c.items[key]; ok {
+		c.order.Remove(elem)
+		delete(c.items, key)
+	}
+}
+
+// Size returns the number of entries in the cache
+func (c *PRCache) Size() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
 }
 
 // Stats returns cache statistics
 func (c *PRCache) Stats() (total int, fresh int, stale int, expired int) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	now := time.Now()
 	total = len(c.entries)

--- a/backend/github/pr_cache_test.go
+++ b/backend/github/pr_cache_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -9,7 +10,7 @@ import (
 )
 
 func TestPRCache_SetAndGet(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	prs := []PRListItem{
 		{Number: 1, Title: "First PR", Branch: "feature-1"},
@@ -27,7 +28,7 @@ func TestPRCache_SetAndGet(t *testing.T) {
 }
 
 func TestPRCache_GetNotFound(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	result, ok := cache.Get("owner", "nonexistent")
 	require.False(t, ok)
@@ -35,7 +36,7 @@ func TestPRCache_GetNotFound(t *testing.T) {
 }
 
 func TestPRCache_Expiration(t *testing.T) {
-	cache := NewPRCache(50*time.Millisecond, 150*time.Millisecond)
+	cache := NewPRCache(50*time.Millisecond, 150*time.Millisecond, 100)
 
 	prs := []PRListItem{{Number: 1, Title: "Test PR"}}
 	cache.Set("owner", "repo", prs)
@@ -63,7 +64,7 @@ func TestPRCache_Expiration(t *testing.T) {
 }
 
 func TestPRCache_Invalidate(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	prs := []PRListItem{{Number: 1, Title: "Test PR"}}
 	cache.Set("owner", "repo", prs)
@@ -81,7 +82,7 @@ func TestPRCache_Invalidate(t *testing.T) {
 }
 
 func TestPRCache_Clear(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	cache.Set("owner1", "repo1", []PRListItem{{Number: 1}})
 	cache.Set("owner2", "repo2", []PRListItem{{Number: 2}})
@@ -96,7 +97,7 @@ func TestPRCache_Clear(t *testing.T) {
 }
 
 func TestPRCache_ImmutableCopy(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	prs := []PRListItem{{Number: 1, Title: "Original"}}
 	cache.Set("owner", "repo", prs)
@@ -119,7 +120,7 @@ func TestPRCache_ImmutableCopy(t *testing.T) {
 }
 
 func TestPRCache_ConcurrentAccess(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	var wg sync.WaitGroup
 	const numGoroutines = 100
@@ -156,7 +157,7 @@ func TestPRCache_ConcurrentAccess(t *testing.T) {
 }
 
 func TestPRCache_Stats(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	cache.Set("owner1", "repo1", []PRListItem{{Number: 1}})
 	cache.Set("owner2", "repo2", []PRListItem{{Number: 2}})
@@ -169,7 +170,7 @@ func TestPRCache_Stats(t *testing.T) {
 }
 
 func TestPRCache_StaleWhileRevalidate(t *testing.T) {
-	cache := NewPRCache(50*time.Millisecond, 200*time.Millisecond)
+	cache := NewPRCache(50*time.Millisecond, 200*time.Millisecond, 100)
 
 	prs := []PRListItem{{Number: 1, Title: "Test PR"}}
 	details := map[int]*PRDetails{
@@ -203,7 +204,7 @@ func TestPRCache_StaleWhileRevalidate(t *testing.T) {
 }
 
 func TestPRCache_RefreshDeduplication(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	// First call should succeed
 	ok := cache.TryStartRefresh("owner", "repo")
@@ -221,7 +222,7 @@ func TestPRCache_RefreshDeduplication(t *testing.T) {
 }
 
 func TestPRCache_GetDetails(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	details := map[int]*PRDetails{
 		1: {Number: 1, Title: "PR 1", CheckStatus: CheckStatusSuccess},
@@ -244,7 +245,7 @@ func TestPRCache_GetDetails(t *testing.T) {
 }
 
 func TestPRCache_SetDetails(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	// Set initial data
 	cache.SetFull("owner", "repo", []PRListItem{{Number: 1}}, nil, "")
@@ -260,7 +261,7 @@ func TestPRCache_SetDetails(t *testing.T) {
 }
 
 func TestPRCache_BumpTTL(t *testing.T) {
-	cache := NewPRCache(50*time.Millisecond, 200*time.Millisecond)
+	cache := NewPRCache(50*time.Millisecond, 200*time.Millisecond, 100)
 	defer cache.Close()
 
 	prs := []PRListItem{{Number: 1, Title: "Test PR"}}
@@ -286,7 +287,7 @@ func TestPRCache_BumpTTL(t *testing.T) {
 }
 
 func TestPRCache_BumpTTL_PreservesData(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 	defer cache.Close()
 
 	details := map[int]*PRDetails{
@@ -307,7 +308,7 @@ func TestPRCache_BumpTTL_PreservesData(t *testing.T) {
 }
 
 func TestPRCache_Close(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	// Close should not panic
 	cache.Close()
@@ -323,7 +324,7 @@ func TestPRCache_Close(t *testing.T) {
 }
 
 func TestPRCache_GetETag(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 	defer cache.Close()
 
 	// No entry returns empty string
@@ -343,7 +344,7 @@ func TestPRCache_GetETag(t *testing.T) {
 }
 
 func TestPRCache_SetFull_WithETagAndDetails(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 	defer cache.Close()
 
 	prs := []PRListItem{
@@ -374,7 +375,7 @@ func TestPRCache_SetFull_WithETagAndDetails(t *testing.T) {
 }
 
 func TestPRCache_SetFull_ImmutableDetails(t *testing.T) {
-	cache := NewPRCache(5*time.Minute, 10*time.Minute)
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 100)
 	defer cache.Close()
 
 	details := map[int]*PRDetails{
@@ -404,4 +405,127 @@ func TestPRCache_SetFull_ImmutableDetails(t *testing.T) {
 func TestCacheKey(t *testing.T) {
 	require.Equal(t, "owner/repo", cacheKey("owner", "repo"))
 	require.Equal(t, "my-org/my-repo", cacheKey("my-org", "my-repo"))
+}
+
+func TestPRCache_LRU_EvictsLeastRecent(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 3)
+	defer cache.Close()
+
+	cache.Set("owner", "repo1", []PRListItem{{Number: 1}})
+	cache.Set("owner", "repo2", []PRListItem{{Number: 2}})
+	cache.Set("owner", "repo3", []PRListItem{{Number: 3}})
+
+	require.Equal(t, 3, cache.Size())
+
+	// Adding a 4th entry should evict repo1 (least recently used)
+	cache.Set("owner", "repo4", []PRListItem{{Number: 4}})
+
+	require.Equal(t, 3, cache.Size())
+
+	_, ok := cache.Get("owner", "repo1")
+	require.False(t, ok, "repo1 should have been evicted")
+
+	_, ok = cache.Get("owner", "repo4")
+	require.True(t, ok, "repo4 should exist")
+}
+
+func TestPRCache_LRU_AccessRefreshesOrder(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 3)
+	defer cache.Close()
+
+	cache.Set("owner", "repo1", []PRListItem{{Number: 1}})
+	cache.Set("owner", "repo2", []PRListItem{{Number: 2}})
+	cache.Set("owner", "repo3", []PRListItem{{Number: 3}})
+
+	// Access repo1 to move it to front
+	cache.Get("owner", "repo1")
+
+	// Adding repo4 should evict repo2 (now least recently used)
+	cache.Set("owner", "repo4", []PRListItem{{Number: 4}})
+
+	_, ok := cache.Get("owner", "repo1")
+	require.True(t, ok, "repo1 should still exist after access")
+
+	_, ok = cache.Get("owner", "repo2")
+	require.False(t, ok, "repo2 should have been evicted")
+}
+
+func TestPRCache_LRU_WriteRefreshesOrder(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 3)
+	defer cache.Close()
+
+	cache.Set("owner", "repo1", []PRListItem{{Number: 1}})
+	cache.Set("owner", "repo2", []PRListItem{{Number: 2}})
+	cache.Set("owner", "repo3", []PRListItem{{Number: 3}})
+
+	// BumpTTL on repo1 should refresh its LRU position
+	cache.BumpTTL("owner", "repo1")
+
+	// Adding repo4 should evict repo2
+	cache.Set("owner", "repo4", []PRListItem{{Number: 4}})
+
+	_, ok := cache.Get("owner", "repo1")
+	require.True(t, ok, "repo1 should still exist after BumpTTL")
+
+	_, ok = cache.Get("owner", "repo2")
+	require.False(t, ok, "repo2 should have been evicted")
+}
+
+func TestPRCache_Size(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 5)
+	defer cache.Close()
+
+	require.Equal(t, 0, cache.Size())
+
+	cache.Set("owner", "repo1", []PRListItem{{Number: 1}})
+	require.Equal(t, 1, cache.Size())
+
+	cache.Set("owner", "repo2", []PRListItem{{Number: 2}})
+	require.Equal(t, 2, cache.Size())
+
+	cache.Invalidate("owner", "repo1")
+	require.Equal(t, 1, cache.Size())
+}
+
+func TestPRCache_LRU_InvalidateRemovesFromOrder(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 3)
+	defer cache.Close()
+
+	cache.Set("owner", "repo1", []PRListItem{{Number: 1}})
+	cache.Set("owner", "repo2", []PRListItem{{Number: 2}})
+	cache.Set("owner", "repo3", []PRListItem{{Number: 3}})
+
+	// Invalidate repo2
+	cache.Invalidate("owner", "repo2")
+	require.Equal(t, 2, cache.Size())
+
+	// Adding two more entries should work without evicting repo1 or repo3
+	cache.Set("owner", "repo4", []PRListItem{{Number: 4}})
+	require.Equal(t, 3, cache.Size())
+
+	cache.Set("owner", "repo5", []PRListItem{{Number: 5}})
+	require.Equal(t, 3, cache.Size())
+
+	// repo1 should have been evicted (oldest)
+	_, ok := cache.Get("owner", "repo1")
+	require.False(t, ok, "repo1 should have been evicted")
+
+	// repo3, repo4, repo5 should exist
+	_, ok = cache.Get("owner", "repo3")
+	require.True(t, ok)
+	_, ok = cache.Get("owner", "repo4")
+	require.True(t, ok)
+	_, ok = cache.Get("owner", "repo5")
+	require.True(t, ok)
+}
+
+func TestPRCache_LRU_UnlimitedWhenZero(t *testing.T) {
+	cache := NewPRCache(5*time.Minute, 10*time.Minute, 0)
+	defer cache.Close()
+
+	// Should accept any number of entries without eviction
+	for i := 0; i < 200; i++ {
+		cache.Set("owner", fmt.Sprintf("repo%d", i), []PRListItem{{Number: i}})
+	}
+	require.Equal(t, 200, cache.Size())
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -345,7 +345,7 @@ func main() {
 	go hub.Run()
 
 	// Shared PR cache used by both PRWatcher and HTTP handlers
-	prCache := github.NewPRCache(2*time.Minute, 10*time.Minute)
+	prCache := github.NewPRCache(2*time.Minute, 10*time.Minute, 100)
 	defer prCache.Close()
 
 	// PR watcher for background GitHub PR status monitoring

--- a/backend/server/router_test.go
+++ b/backend/server/router_test.go
@@ -33,7 +33,7 @@ func setupTestRouter(t *testing.T) (http.Handler, *store.SQLiteStore) {
 	wm := gitpkg.NewWorktreeManager()
 	agentMgr := agent.NewManager(context.Background(), s, wm, 9876)
 	ghClient := github.NewClient("", "")
-	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute, 100)
 	t.Cleanup(func() { prCache.Close() })
 
 	linearClient := linear.NewClient("")

--- a/backend/server/testhelpers_test.go
+++ b/backend/server/testhelpers_test.go
@@ -48,7 +48,7 @@ func setupTestHandlers(t *testing.T) (*Handlers, *store.SQLiteStore) {
 	err = sqliteStore.SetSetting(context.Background(), "workspaces-base-dir", tmpWorkspaces)
 	require.NoError(t, err)
 
-	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	t.Cleanup(func() {
 		sqliteStore.Close()
@@ -74,7 +74,7 @@ func setupTestHandlersWithAgentManager(t *testing.T) (*Handlers, *store.SQLiteSt
 
 	worktreeManager := git.NewWorktreeManager()
 	agentManager := agent.NewManager(context.Background(), sqliteStore, worktreeManager, 9876)
-	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	t.Cleanup(func() {
 		sqliteStore.Close()
@@ -227,7 +227,7 @@ func setupTestHandlersWithAIClient(t *testing.T, aiServerURL string) (*Handlers,
 	err = sqliteStore.SetSetting(context.Background(), "workspaces-base-dir", tmpWorkspaces)
 	require.NoError(t, err)
 
-	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute, 100)
 	aiClient := ai.NewTestClient("sk-test-key", aiServerURL)
 
 	t.Cleanup(func() {
@@ -247,7 +247,7 @@ func setupTestHandlersWithGitHub(t *testing.T, ghServer *httptest.Server) (*Hand
 	sqliteStore, err := store.NewSQLiteStoreInMemory()
 	require.NoError(t, err)
 
-	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute)
+	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
 	ghClient := github.NewClient("", "")
 	ghClient.SetAPIURL(ghServer.URL)


### PR DESCRIPTION
## Summary

- Adds LRU eviction to `PRCache` using `container/list` with a configurable `maxEntries` limit (default 100)
- When the cache exceeds `maxEntries`, the least-recently-accessed entry is evicted
- Reads (`Get`, `GetWithStale`, `GetDetails`) and writes (`Set`, `SetFull`, `SetDetails`, `BumpTTL`) promote entries in the LRU
- `GetETag` does **not** promote entries since it's internal plumbing for conditional HTTP requests
- `GetDetails` only promotes on a successful detail lookup, not on miss
- `maxEntries <= 0` means unlimited (no eviction)
- `sync.RWMutex` replaced with `sync.Mutex` since read paths now modify LRU state

## Test plan

- [x] All existing `PRCache` tests pass
- [x] New tests cover: LRU eviction order, access-refresh ordering, write-refresh ordering, invalidation cleanup, size tracking, unlimited mode
- [ ] Run `cd backend && go test ./...` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)