### PR TITLE
fix: add size guard to GetFileDiff for large files (#893)

### DIFF
--- a/backend/server/file_handlers.go
+++ b/backend/server/file_handlers.go
@@ -1,14 +1,17 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/chatml/chatml-backend/git"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -152,6 +155,12 @@ type FileContentResponse struct {
 	Size    int64  `json:"size"`
 }
 
+// maxDiffContentBytes is the maximum size (per file side) before falling back to unified diff.
+const maxDiffContentBytes = 1 * 1024 * 1024 // 1MB
+
+// maxUnifiedDiffBytes caps the unified diff fallback payload.
+const maxUnifiedDiffBytes = 256 * 1024 // 256KB
+
 // FileDiffResponse represents a diff between two versions of a file
 type FileDiffResponse struct {
 	Path        string `json:"path"`
@@ -161,6 +170,65 @@ type FileDiffResponse struct {
 	NewFilename string `json:"newFilename"`
 	HasConflict bool   `json:"hasConflict"`
 	IsDeleted   bool   `json:"isDeleted"`
+	Truncated   bool   `json:"truncated,omitempty"`
+	UnifiedDiff string `json:"unifiedDiff,omitempty"`
+}
+
+// diffInput groups the parameters needed to build a FileDiffResponse.
+type diffInput struct {
+	repoPath   string
+	baseRef    string
+	path       string
+	oldContent string
+	newContent []byte
+	isDeleted  bool
+}
+
+// conflictMarkersPresent checks for git conflict markers in the first limit bytes of data.
+func conflictMarkersPresent(data []byte, limit int) bool {
+	if limit > 0 && len(data) > limit {
+		data = data[:limit]
+	}
+	s := string(data)
+	return strings.Contains(s, "<<<<<<<") &&
+		strings.Contains(s, "=======") &&
+		strings.Contains(s, ">>>>>>>")
+}
+
+// buildDiffResponse constructs a FileDiffResponse, falling back to a unified diff
+// when either file side exceeds maxDiffContentBytes.
+func buildDiffResponse(ctx context.Context, rm *git.RepoManager, in diffInput) FileDiffResponse {
+	truncated := len(in.oldContent) > maxDiffContentBytes || len(in.newContent) > maxDiffContentBytes
+
+	// Check conflict markers — scan only the first 64KB for truncated files.
+	scanLimit := 0 // 0 = no limit
+	if truncated {
+		scanLimit = 64 * 1024
+	}
+	hasConflict := conflictMarkersPresent(in.newContent, scanLimit)
+
+	resp := FileDiffResponse{
+		Path:        in.path,
+		OldFilename: in.path + " (base)",
+		NewFilename: in.path,
+		HasConflict: hasConflict,
+		IsDeleted:   in.isDeleted,
+		Truncated:   truncated,
+	}
+
+	if truncated {
+		diff, err := rm.GetFileDiffUnified(ctx, in.repoPath, in.baseRef, in.path, maxUnifiedDiffBytes)
+		if err != nil {
+			slog.Warn("unified diff fallback failed", "path", in.path, "err", err)
+		} else {
+			resp.UnifiedDiff = diff
+		}
+	} else {
+		resp.OldContent = in.oldContent
+		resp.NewContent = string(in.newContent)
+	}
+
+	return resp
 }
 
 // GetFileDiff returns the diff between the base branch and current state for a file
@@ -217,21 +285,14 @@ func (h *Handlers) GetFileDiff(w http.ResponseWriter, r *http.Request) {
 		oldContent = ""
 	}
 
-	// Check for conflict markers
-	hasConflict := strings.Contains(string(newContent), "<<<<<<<") &&
-		strings.Contains(string(newContent), "=======") &&
-		strings.Contains(string(newContent), ">>>>>>>")
-
-	response := FileDiffResponse{
-		Path:        cleanPath,
-		OldContent:  oldContent,
-		NewContent:  string(newContent),
-		OldFilename: cleanPath + " (base)",
-		NewFilename: cleanPath,
-		HasConflict: hasConflict,
-		IsDeleted:   isDeleted,
-	}
-
+	response := buildDiffResponse(ctx, h.repoManager, diffInput{
+		repoPath:   repo.Path,
+		baseRef:    baseBranch,
+		path:       cleanPath,
+		oldContent: oldContent,
+		newContent: newContent,
+		isDeleted:  isDeleted,
+	})
 	writeJSON(w, response)
 }
 

--- a/backend/server/session_git_handlers.go
+++ b/backend/server/session_git_handlers.go
@@ -226,20 +226,14 @@ func (h *Handlers) GetSessionFileDiff(w http.ResponseWriter, r *http.Request) {
 		oldContent = ""
 	}
 
-	// Check for conflict markers
-	hasConflict := strings.Contains(string(newContent), "<<<<<<<") &&
-		strings.Contains(string(newContent), "=======") &&
-		strings.Contains(string(newContent), ">>>>>>>")
-
-	response := FileDiffResponse{
-		Path:        cleanPath,
-		OldContent:  oldContent,
-		NewContent:  string(newContent),
-		OldFilename: cleanPath + " (base)",
-		NewFilename: cleanPath,
-		HasConflict: hasConflict,
-		IsDeleted:   isDeleted,
-	}
+	response := buildDiffResponse(ctx, h.repoManager, diffInput{
+		repoPath:   workingPath,
+		baseRef:    baseRef,
+		path:       cleanPath,
+		oldContent: oldContent,
+		newContent: newContent,
+		isDeleted:  isDeleted,
+	})
 
 	// Cache the result
 	if h.diffCache != nil {

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -41,6 +41,7 @@ import {
   Eye,
   RefreshCw,
   FileText,
+  AlertTriangle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { FileTab, Conversation } from '@/lib/types';
@@ -713,26 +714,34 @@ export function ConversationArea({ children }: ConversationAreaProps) {
         // Check frontend diff cache first
         const cachedDiff = getDiffFromCache(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path);
         if (cachedDiff) {
-          updateFileTab(currentFileTab.id, {
-            diff: {
-              oldContent: cachedDiff.oldContent ?? '',
-              newContent: cachedDiff.newContent ?? '',
-            },
-            isLoading: false,
-          });
+          if (cachedDiff.truncated) {
+            updateFileTab(currentFileTab.id, { isLoading: false, isTooLarge: true, unifiedDiff: cachedDiff.unifiedDiff });
+          } else {
+            updateFileTab(currentFileTab.id, {
+              diff: {
+                oldContent: cachedDiff.oldContent ?? '',
+                newContent: cachedDiff.newContent ?? '',
+              },
+              isLoading: false,
+            });
+          }
           return;
         }
         updateFileTab(currentFileTab.id, { isLoading: true });
         try {
           const diffData = await getSessionFileDiff(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path);
           setDiffInCache(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path, diffData);
-          updateFileTab(currentFileTab.id, {
-            diff: {
-              oldContent: diffData.oldContent ?? '',
-              newContent: diffData.newContent ?? '',
-            },
-            isLoading: false,
-          });
+          if (diffData.truncated) {
+            updateFileTab(currentFileTab.id, { isLoading: false, isTooLarge: true, unifiedDiff: diffData.unifiedDiff });
+          } else {
+            updateFileTab(currentFileTab.id, {
+              diff: {
+                oldContent: diffData.oldContent ?? '',
+                newContent: diffData.newContent ?? '',
+              },
+              isLoading: false,
+            });
+          }
         } catch (error) {
           console.error('Failed to load diff:', error);
           updateFileTab(currentFileTab.id, {
@@ -1104,13 +1113,25 @@ export function ConversationArea({ children }: ConversationAreaProps) {
                     </div>
                   </div>
                 ) : tab.isTooLarge ? (
-                  <div className="h-full flex items-center justify-center">
-                    <div className="text-center">
-                      <FileQuestion className="w-12 h-12 mx-auto mb-3 text-muted-foreground/50" />
-                      <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
-                      <p className="text-xs text-muted-foreground">File is too large to display</p>
+                  tab.unifiedDiff ? (
+                    <div className="h-full flex flex-col">
+                      <div className="flex items-center gap-1.5 px-3 py-2 text-xs text-amber-500 border-b border-border/50">
+                        <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+                        <span>File too large for inline diff — showing unified diff</span>
+                      </div>
+                      <pre className="flex-1 overflow-auto text-xs bg-muted/30 p-3 whitespace-pre font-mono">
+                        {tab.unifiedDiff}
+                      </pre>
                     </div>
-                  </div>
+                  ) : (
+                    <div className="h-full flex items-center justify-center">
+                      <div className="text-center">
+                        <FileQuestion className="w-12 h-12 mx-auto mb-3 text-muted-foreground/50" />
+                        <p className="text-sm font-medium text-foreground mb-1">{tab.name}</p>
+                        <p className="text-xs text-muted-foreground">File is too large to display</p>
+                      </div>
+                    </div>
+                  )
                 ) : tab.isEmpty ? (
                   <div className="h-full flex items-center justify-center">
                     <div className="text-center">

--- a/src/components/conversation/tool-details/WorkspaceDiffDetail.tsx
+++ b/src/components/conversation/tool-details/WorkspaceDiffDetail.tsx
@@ -385,7 +385,26 @@ const FileDiffViewer = memo(function FileDiffViewer({
     );
   }
 
-  if (!diffData || !fileDiff) return null;
+  if (!diffData) return null;
+
+  // Server indicated file exceeded size limit — show unified diff fallback
+  if (diffData.truncated) {
+    return (
+      <div className="px-3 py-2 space-y-1.5">
+        <div className="flex items-center gap-1.5 text-2xs text-amber-500">
+          <AlertTriangle className="w-3 h-3 shrink-0" />
+          <span>File too large for inline diff</span>
+        </div>
+        {diffData.unifiedDiff && (
+          <pre className="max-h-[350px] overflow-auto text-2xs bg-muted/50 rounded p-2 whitespace-pre font-mono">
+            {diffData.unifiedDiff}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  if (!fileDiff) return null;
 
   // Guard against very large files
   const totalSize = (diffData.oldContent?.length ?? 0) + (diffData.newContent?.length ?? 0);

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -323,6 +323,10 @@ export function ChangesPanel() {
     // Check frontend diff cache first — avoids HTTP round-trip on re-open
     const cachedDiff = getDiffFromCache(workspaceId, sessionId, path);
     if (cachedDiff) {
+      if (cachedDiff.truncated) {
+        updateFileTab(tabId, { isLoading: false, isTooLarge: true, unifiedDiff: cachedDiff.unifiedDiff });
+        return;
+      }
       const totalSize = (cachedDiff.oldContent?.length || 0) + (cachedDiff.newContent?.length || 0);
       if (totalSize > MAX_DIFF_SIZE) {
         updateFileTab(tabId, { isLoading: false, isTooLarge: true });
@@ -345,6 +349,11 @@ export function ChangesPanel() {
 
       // Cache the result for fast re-opens
       setDiffInCache(workspaceId, sessionId, path, diffData);
+
+      if (diffData.truncated) {
+        updateFileTab(tabId, { isLoading: false, isTooLarge: true, unifiedDiff: diffData.unifiedDiff });
+        return;
+      }
 
       const totalSize = (diffData.oldContent?.length || 0) + (diffData.newContent?.length || 0);
       if (totalSize > MAX_DIFF_SIZE) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -215,6 +215,8 @@ export interface FileDiffDTO {
   newFilename: string;
   hasConflict: boolean;
   isDeleted: boolean;
+  truncated?: boolean;
+  unifiedDiff?: string;
 }
 
 export async function getFileDiff(repoId: string, filePath: string, baseBranch?: string): Promise<FileDiffDTO> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -696,6 +696,7 @@ export interface FileTab {
   };
   isBinary?: boolean;
   isTooLarge?: boolean;
+  unifiedDiff?: string;       // Unified diff fallback for files too large for inline diff
   isEmpty?: boolean;          // File has no content (0 bytes)
   loadError?: string;         // Error message if loading failed
   saveError?: string;         // Error message if saving failed


### PR DESCRIPTION
## Summary
- Adds a 1MB per-side size limit to `GetFileDiff` and `GetSessionFileDiff` handlers
- Files exceeding the limit return `truncated: true` with a 256KB unified diff fallback (via existing `GetFileDiffUnified`) instead of full file contents
- Extracts shared `buildDiffResponse` helper to eliminate duplication between the two handlers
- Frontend handles truncated responses gracefully — shows unified diff text in ConversationArea, WorkspaceDiffDetail, and ChangesPanel

## Test plan
- [ ] Create a file >1MB in a session worktree, open the diff — should show "File too large for inline diff" with unified diff text
- [ ] Verify small files (<1MB) still render full inline diffs as before
- [ ] Run `cd backend && go test ./server/...` — all tests pass

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)