### PR TITLE
fix: add tiered git command timeouts and clone retry with backoff

### DIFF
--- a/backend/git/cleanup.go
+++ b/backend/git/cleanup.go
@@ -310,7 +310,7 @@ func (rm *RepoManager) getMergedBranches(ctx context.Context, repoPath string, r
 			args = append(args, "-r")
 		}
 
-		cmd, cancel := gitCmdWithContext(ctx, repoPath, args...)
+		cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, args...)
 		out, err := cmd.Output()
 		cancel()
 		if err != nil {
@@ -341,7 +341,7 @@ func (rm *RepoManager) getOrphanedBranches(ctx context.Context, repoPath string)
 	orphaned := make(map[string]bool)
 
 	// Get all local branches with their upstream
-	cmd, cancel := gitCmdWithContext(ctx, repoPath,
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath,
 		"for-each-ref", "--format=%(refname:short) %(upstream)", "refs/heads/")
 	out, err := cmd.Output()
 	cancel()
@@ -468,7 +468,7 @@ func (rm *RepoManager) deleteLocalBranch(ctx context.Context, repoPath string, n
 		flag = "-D"
 	}
 
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "branch", flag, name)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "branch", flag, name)
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -479,7 +479,7 @@ func (rm *RepoManager) deleteLocalBranch(ctx context.Context, repoPath string, n
 
 // deleteRemoteBranch deletes a remote branch
 func (rm *RepoManager) deleteRemoteBranch(ctx context.Context, repoPath string, name string) error {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "push", "origin", "--delete", name)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "push", "origin", "--delete", name)
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/backend/git/clone.go
+++ b/backend/git/clone.go
@@ -10,11 +10,16 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/chatml/chatml-backend/logger"
 )
 
-// cloneCommandTimeout is the timeout for git clone operations.
-// Clone can take much longer than regular git commands for large repos.
-const cloneCommandTimeout = 5 * time.Minute
+// Clone retry configuration
+const (
+	cloneMaxRetries = 2
+	cloneBaseDelay  = 2 * time.Second
+	cloneMaxDelay   = 30 * time.Second
+)
 
 // validGitURLPattern validates common git URL formats.
 // Also allows file:// for local repos (used in testing and local clones).
@@ -28,6 +33,7 @@ func IsValidGitURL(url string) bool {
 }
 
 // CloneRepo clones a git repository from url into parentDir/dirName.
+// Retries transient failures (timeouts, network errors) with exponential backoff.
 // Returns the full path of the cloned repository.
 func (rm *RepoManager) CloneRepo(ctx context.Context, url, parentDir, dirName string) (string, error) {
 	if !IsValidGitURL(url) {
@@ -59,8 +65,41 @@ func (rm *RepoManager) CloneRepo(ctx context.Context, url, parentDir, dirName st
 		return "", fmt.Errorf("directory already exists: %s", targetPath)
 	}
 
-	// Run git clone with a dedicated timeout
-	cloneCtx, cancel := context.WithTimeout(ctx, cloneCommandTimeout)
+	var lastErr error
+	for attempt := 0; attempt <= cloneMaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := cloneBaseDelay * time.Duration(1<<uint(attempt-1)) // 2s, 4s, 8s
+			if delay > cloneMaxDelay {
+				delay = cloneMaxDelay
+			}
+			logger.Main.Infof("Clone attempt %d/%d failed, retrying in %s: %v", attempt+1, cloneMaxRetries+1, delay, lastErr)
+
+			select {
+			case <-ctx.Done():
+				return "", fmt.Errorf("git clone cancelled: %w", ctx.Err())
+			case <-time.After(delay):
+			}
+
+		}
+
+		path, err := rm.doClone(ctx, url, targetPath)
+		if err == nil {
+			return path, nil
+		}
+		lastErr = err
+
+		// Don't retry non-transient errors
+		if isNonRetryableCloneError(err) {
+			return "", err
+		}
+	}
+
+	return "", fmt.Errorf("clone failed after %d attempts: %w", cloneMaxRetries+1, lastErr)
+}
+
+// doClone executes a single clone attempt.
+func (rm *RepoManager) doClone(ctx context.Context, url, targetPath string) (string, error) {
+	cloneCtx, cancel := context.WithTimeout(ctx, TimeoutClone)
 	defer cancel()
 
 	cmd := exec.CommandContext(cloneCtx, "git", "clone", url, targetPath)
@@ -78,7 +117,7 @@ func (rm *RepoManager) CloneRepo(ctx context.Context, url, parentDir, dirName st
 		os.RemoveAll(targetPath)
 
 		if cloneCtx.Err() == context.DeadlineExceeded {
-			return "", fmt.Errorf("git clone timed out after %s", cloneCommandTimeout)
+			return "", fmt.Errorf("git clone timed out after %s", TimeoutClone)
 		}
 		if ctx.Err() != nil {
 			return "", fmt.Errorf("git clone cancelled: %w", ctx.Err())
@@ -89,6 +128,20 @@ func (rm *RepoManager) CloneRepo(ctx context.Context, url, parentDir, dirName st
 	}
 
 	return targetPath, nil
+}
+
+// isNonRetryableCloneError returns true for errors that should not be retried
+// (authentication failures, repository not found, etc.)
+func isNonRetryableCloneError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "authentication failed") ||
+		strings.Contains(msg, "ssh authentication failed") ||
+		strings.Contains(msg, "repository not found") ||
+		strings.Contains(msg, "invalid git url") ||
+		strings.Contains(msg, "directory already exists") ||
+		strings.Contains(msg, "parent directory does not exist") ||
+		strings.Contains(msg, "invalid directory name") ||
+		strings.Contains(msg, "cancelled")
 }
 
 // classifyCloneError maps common git stderr messages to user-friendly error messages.

--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -16,15 +16,36 @@ import (
 	"github.com/chatml/chatml-backend/logger"
 )
 
-// Default timeout for git commands
-const gitCommandTimeout = 30 * time.Second
+// Git command timeout tiers — choose the appropriate tier at each call site.
+const (
+	// TimeoutFast is for simple queries that read small amounts of data.
+	// Examples: rev-parse, branch -m, remote, remote get-url
+	TimeoutFast = 10 * time.Second
+
+	// TimeoutMedium is for local operations that scan moderate data.
+	// Examples: status --porcelain, check-ignore, stash list, merge-base, rev-list --count,
+	// worktree list/add/remove/prune, branch -d/-D
+	TimeoutMedium = 30 * time.Second
+
+	// TimeoutSlow is for operations that may produce large output or scan history.
+	// Examples: diff --stat, diff --name-only, log, show ref:path,
+	// branch --merged, branch -a (with format), for-each-ref
+	TimeoutSlow = 60 * time.Second
+
+	// TimeoutHeavy is for network or compute-intensive operations.
+	// Examples: diff (full unified), fetch, rebase, merge, stash push/pop, push, status -uall
+	TimeoutHeavy = 120 * time.Second
+
+	// TimeoutClone is for clone operations (per attempt, with retry).
+	TimeoutClone = 5 * time.Minute
+)
 
 // gitCmdWithContext creates a git command with the given context and an additional timeout.
 // The timeout is layered on top of the parent context, so the command will be cancelled
 // if either the parent context is cancelled or the timeout expires.
 // Returns the command and a cancel function that MUST be called when done.
-func gitCmdWithContext(ctx context.Context, repoPath string, args ...string) (*exec.Cmd, context.CancelFunc) {
-	ctx, cancel := context.WithTimeout(ctx, gitCommandTimeout)
+func gitCmdWithContext(ctx context.Context, timeout time.Duration, repoPath string, args ...string) (*exec.Cmd, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = repoPath
 	return cmd, cancel
@@ -34,7 +55,7 @@ func gitCmdWithContext(ctx context.Context, repoPath string, args ...string) (*e
 // Returns the command and a cancel function that MUST be called when done.
 // Deprecated: Use gitCmdWithContext for better context propagation.
 func gitCmd(repoPath string, args ...string) (*exec.Cmd, context.CancelFunc) {
-	return gitCmdWithContext(context.Background(), repoPath, args...)
+	return gitCmdWithContext(context.Background(), TimeoutMedium, repoPath, args...)
 }
 
 type RepoManager struct{}
@@ -75,7 +96,7 @@ func (rm *RepoManager) ValidateRepo(path string) error {
 }
 
 func (rm *RepoManager) GetCurrentBranch(ctx context.Context, repoPath string) (string, error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-parse", "--abbrev-ref", "HEAD")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--abbrev-ref", "HEAD")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -90,7 +111,7 @@ func (rm *RepoManager) GetRepoName(path string) string {
 
 // ListRemotes returns the names of all git remotes in the repository.
 func (rm *RepoManager) ListRemotes(ctx context.Context, repoPath string) ([]string, error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "remote")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "remote")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -107,7 +128,7 @@ func (rm *RepoManager) ListRemotes(ctx context.Context, repoPath string) ([]stri
 
 // ListRemoteBranches returns remote branch refs for a given remote (e.g., ["origin/main", "origin/develop"]).
 func (rm *RepoManager) ListRemoteBranches(ctx context.Context, repoPath string, remote string) ([]string, error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "branch", "-r", "--list", remote+"/*")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "branch", "-r", "--list", remote+"/*")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -130,7 +151,7 @@ func (rm *RepoManager) ListRemoteBranches(ctx context.Context, repoPath string, 
 
 // RefExists checks whether a git ref (branch, tag, or commit) exists in the repository.
 func (rm *RepoManager) RefExists(ctx context.Context, repoPath, ref string) bool {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-parse", "--verify", "--quiet", ref)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--verify", "--quiet", ref)
 	defer cancel()
 	return cmd.Run() == nil
 }
@@ -140,7 +161,7 @@ func (rm *RepoManager) GetFileAtRef(ctx context.Context, repoPath, ref, filePath
 	if err := ValidateGitRef(ref); err != nil {
 		return "", fmt.Errorf("invalid ref: %w", err)
 	}
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "show", fmt.Sprintf("%s:%s", ref, filePath))
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, "show", fmt.Sprintf("%s:%s", ref, filePath))
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -154,7 +175,7 @@ func (rm *RepoManager) GetChangedFiles(ctx context.Context, repoPath, baseRef st
 	if err := ValidateGitRef(baseRef); err != nil {
 		return nil, fmt.Errorf("invalid base ref: %w", err)
 	}
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "diff", "--name-only", baseRef)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, "diff", "--name-only", baseRef)
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -186,7 +207,7 @@ func (rm *RepoManager) GetChangedFilesWithStats(ctx context.Context, repoPath, b
 	}
 
 	// Get file statuses (A/M/D/R) in a single git command instead of per-file ls-tree
-	statusCmd, statusCancel := gitCmdWithContext(ctx, repoPath, "diff", "--name-status", baseRef)
+	statusCmd, statusCancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, "diff", "--name-status", baseRef)
 	statusOut, err := statusCmd.Output()
 	statusCancel()
 	if err != nil {
@@ -223,7 +244,7 @@ func (rm *RepoManager) GetChangedFilesWithStats(ctx context.Context, repoPath, b
 	}
 
 	// Get diff stats (additions/deletions per file)
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "diff", "--numstat", baseRef)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, "diff", "--numstat", baseRef)
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -280,7 +301,7 @@ func (rm *RepoManager) GetMergeBase(ctx context.Context, repoPath, ref1, ref2 st
 	if err := ValidateGitRef(ref2); err != nil {
 		return "", fmt.Errorf("invalid ref2: %w", err)
 	}
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "merge-base", ref1, ref2)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "merge-base", ref1, ref2)
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -304,7 +325,7 @@ func (rm *RepoManager) FilterGitIgnored(ctx context.Context, repoPath string, ch
 	}
 
 	// Use git check-ignore --stdin to batch-check all paths in a single call
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "check-ignore", "--stdin")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "check-ignore", "--stdin")
 	defer cancel()
 	cmd.Stdin = strings.NewReader(strings.Join(paths, "\n"))
 	out, _ := cmd.Output() // exit code 1 means "none ignored", not an error
@@ -336,7 +357,7 @@ func (rm *RepoManager) FilterGitIgnored(ctx context.Context, repoPath string, ch
 // GetUntrackedFiles returns files that are not tracked by git
 func (rm *RepoManager) GetUntrackedFiles(ctx context.Context, repoPath string) ([]FileChange, error) {
 	// Use -uall to show individual files inside untracked directories
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "status", "--porcelain", "-uall")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "status", "--porcelain", "-uall")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -394,7 +415,7 @@ func (rm *RepoManager) GetFileCommitHistory(ctx context.Context, repoPath, fileP
 		filePath,
 	}
 
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, args...)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, args...)
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -488,7 +509,7 @@ func (rm *RepoManager) GetCommitsAheadOfBase(ctx context.Context, repoPath, base
 		baseRef + "..HEAD",
 	}
 
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, args...)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, args...)
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -571,7 +592,7 @@ func (rm *RepoManager) GetCommitsAheadOfBase(ctx context.Context, repoPath, base
 
 // HasMergeConflicts checks if there are any merge conflicts in the repo
 func (rm *RepoManager) HasMergeConflicts(ctx context.Context, repoPath string) (bool, error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "diff", "--check")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, "diff", "--check")
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	// git diff --check returns exit code 2 if there are conflict markers
@@ -694,7 +715,7 @@ func (rm *RepoManager) GetStatus(ctx context.Context, worktreePath, baseBranch s
 // is the sum of all counts, representing the total number of status entries,
 // not unique files.
 func (rm *RepoManager) getWorkingDirectoryStatus(ctx context.Context, repoPath string) (*WorkingDirectoryStatus, error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "status", "--porcelain")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "status", "--porcelain")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -745,7 +766,7 @@ func (rm *RepoManager) getSyncStatus(ctx context.Context, repoPath, baseBranch s
 	}
 
 	// Check if remote tracking branch exists
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
 	remoteOut, _ := cmd.Output()
 	cancel()
 	remoteBranch := strings.TrimSpace(string(remoteOut))
@@ -756,12 +777,12 @@ func (rm *RepoManager) getSyncStatus(ctx context.Context, repoPath, baseBranch s
 
 	// Get ahead/behind compared to base branch (origin/main or similar)
 	remoteBase := "origin/" + baseBranch
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "rev-list", "--left-right", "--count", remoteBase+"...HEAD")
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "rev-list", "--left-right", "--count", remoteBase+"...HEAD")
 	countOut, err := cmd.Output()
 	cancel()
 	if err != nil {
 		// Try without origin prefix
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "rev-list", "--left-right", "--count", baseBranch+"...HEAD")
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "rev-list", "--left-right", "--count", baseBranch+"...HEAD")
 		countOut, err = cmd.Output()
 		cancel()
 		if err != nil {
@@ -779,7 +800,7 @@ func (rm *RepoManager) getSyncStatus(ctx context.Context, repoPath, baseBranch s
 
 	// Get unpushed commits (if we have a remote tracking branch)
 	if status.HasRemote {
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "rev-list", "@{u}..HEAD", "--count")
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "rev-list", "@{u}..HEAD", "--count")
 		unpushedOut, err := cmd.Output()
 		cancel()
 		if err == nil {
@@ -798,7 +819,7 @@ func (rm *RepoManager) getInProgressStatus(ctx context.Context, repoPath string)
 	status := &InProgressStatus{Type: "none"}
 
 	// Get the git directory for this worktree
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-parse", "--git-dir")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--git-dir")
 	defer cancel()
 	gitDirOut, err := cmd.Output()
 	if err != nil {
@@ -860,7 +881,7 @@ func (rm *RepoManager) getInProgressStatus(ctx context.Context, repoPath string)
 func (rm *RepoManager) getConflictStatus(ctx context.Context, repoPath string) (*ConflictStatus, error) {
 	status := &ConflictStatus{Files: []string{}}
 
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "diff", "--name-only", "--diff-filter=U")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, "diff", "--name-only", "--diff-filter=U")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -882,7 +903,7 @@ func (rm *RepoManager) getConflictStatus(ctx context.Context, repoPath string) (
 
 // getStashCount returns the number of stashed changes
 func (rm *RepoManager) getStashCount(ctx context.Context, repoPath string) (int, error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "stash", "list")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "stash", "list")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -946,7 +967,7 @@ func (rm *RepoManager) ListBranches(ctx context.Context, repoPath string, opts B
 		args = append(args, "-a")
 	}
 
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, args...)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, args...)
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -1060,7 +1081,7 @@ func (rm *RepoManager) ListBranches(ctx context.Context, repoPath string, opts B
 // PruneRemoteRefs removes stale remote-tracking references that no longer exist on the remote.
 // Uses "git remote prune origin" which is lightweight (only removes stale refs, no data fetch).
 func (rm *RepoManager) PruneRemoteRefs(ctx context.Context, repoPath string) error {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "remote", "prune", "origin")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "remote", "prune", "origin")
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1071,7 +1092,7 @@ func (rm *RepoManager) PruneRemoteRefs(ctx context.Context, repoPath string) err
 
 // FetchAndPrune runs "git fetch --prune origin" to both update refs and remove stale ones.
 func (rm *RepoManager) FetchAndPrune(ctx context.Context, repoPath string) error {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "fetch", "--prune", "origin")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "fetch", "--prune", "origin")
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1116,7 +1137,7 @@ func (rm *RepoManager) CleanMergedLocalBranches(ctx context.Context, repoPath st
 		}
 
 		// Safe delete — only works if fully merged
-		cmd, cancel := gitCmdWithContext(ctx, repoPath, "branch", "-d", name)
+		cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "branch", "-d", name)
 		out, err := cmd.CombinedOutput()
 		cancel()
 		if err != nil {
@@ -1132,7 +1153,7 @@ func (rm *RepoManager) CleanMergedLocalBranches(ctx context.Context, repoPath st
 // getWorktreeBranches returns a set of branch names currently checked out in any worktree.
 func (rm *RepoManager) getWorktreeBranches(ctx context.Context, repoPath string) map[string]bool {
 	branches := make(map[string]bool)
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "worktree", "list", "--porcelain")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "list", "--porcelain")
 	out, err := cmd.Output()
 	cancel()
 	if err != nil {
@@ -1169,7 +1190,7 @@ func (rm *RepoManager) getAheadBehind(ctx context.Context, repoPath, branchName 
 	// Try origin/main first, then main
 	bases := []string{"origin/main", "main", "origin/master", "master"}
 	for _, base := range bases {
-		cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-list", "--left-right", "--count", base+"..."+branchName)
+		cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "rev-list", "--left-right", "--count", base+"..."+branchName)
 		out, err := cmd.Output()
 		cancel()
 		if err != nil {
@@ -1188,7 +1209,7 @@ func (rm *RepoManager) getAheadBehind(ctx context.Context, repoPath, branchName 
 
 // GetHeadSHA returns the SHA of the current HEAD commit
 func (rm *RepoManager) GetHeadSHA(ctx context.Context, repoPath string) (string, error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-parse", "HEAD")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "HEAD")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -1199,7 +1220,7 @@ func (rm *RepoManager) GetHeadSHA(ctx context.Context, repoPath string) (string,
 
 // GetGitHubRemote extracts the GitHub owner and repo name from the origin remote URL
 func (rm *RepoManager) GetGitHubRemote(ctx context.Context, repoPath string) (owner, repo string, err error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "remote", "get-url", "origin")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "remote", "get-url", "origin")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -1273,7 +1294,7 @@ func (rm *RepoManager) GetBranchSyncStatus(ctx context.Context, worktreePath, ba
 	branchName := strings.TrimPrefix(targetBranch, "origin/")
 
 	// Fetch the target branch to get latest commits
-	cmd, cancel := gitCmdWithContext(ctx, worktreePath, "fetch", "origin", branchName)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "fetch", "origin", branchName)
 	_, err := cmd.CombinedOutput()
 	cancel()
 	if err != nil {
@@ -1289,7 +1310,7 @@ func (rm *RepoManager) GetBranchSyncStatus(ctx context.Context, worktreePath, ba
 	}
 
 	// Get count of commits between baseCommitSHA and origin/main
-	cmd, cancel = gitCmdWithContext(ctx, worktreePath, "rev-list", "--count", baseCommitSHA+".."+status.BaseBranch)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, worktreePath, "rev-list", "--count", baseCommitSHA+".."+status.BaseBranch)
 	out, err := cmd.Output()
 	cancel()
 	if err != nil {
@@ -1300,7 +1321,7 @@ func (rm *RepoManager) GetBranchSyncStatus(ctx context.Context, worktreePath, ba
 	// If behind, get commit SHA and subjects
 	if status.BehindBy > 0 {
 		// Get commits with short SHA and subject, one per line
-		cmd, cancel = gitCmdWithContext(ctx, worktreePath, "log", "--pretty=format:%h|||%s", baseCommitSHA+".."+status.BaseBranch)
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutSlow, worktreePath, "log", "--pretty=format:%h|||%s", baseCommitSHA+".."+status.BaseBranch)
 		out, err := cmd.Output()
 		cancel()
 		if err == nil && len(out) > 0 {
@@ -1334,7 +1355,7 @@ func (rm *RepoManager) RebaseOntoTarget(ctx context.Context, worktreePath, targe
 	baseBranch := targetBranch
 
 	// Fetch the target branch to ensure we have the latest
-	cmd, cancel := gitCmdWithContext(ctx, worktreePath, "fetch", "origin", branchName)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "fetch", "origin", branchName)
 	_, err := cmd.CombinedOutput()
 	cancel()
 	if err != nil {
@@ -1352,7 +1373,7 @@ func (rm *RepoManager) RebaseOntoTarget(ctx context.Context, worktreePath, targe
 	// Stash if there are changes
 	stashed := false
 	if wdStatus.HasChanges {
-		cmd, cancel := gitCmdWithContext(ctx, worktreePath, "stash", "push", "-m", "auto-stash before rebase")
+		cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "stash", "push", "-m", "auto-stash before rebase")
 		_, err := cmd.CombinedOutput()
 		cancel()
 		if err == nil {
@@ -1361,7 +1382,7 @@ func (rm *RepoManager) RebaseOntoTarget(ctx context.Context, worktreePath, targe
 	}
 
 	// Run rebase
-	cmd, cancel = gitCmdWithContext(ctx, worktreePath, "rebase", baseBranch)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "rebase", baseBranch)
 	out, err := cmd.CombinedOutput()
 	cancel()
 
@@ -1377,7 +1398,7 @@ func (rm *RepoManager) RebaseOntoTarget(ctx context.Context, worktreePath, targe
 
 		// Try to pop stash even on failure (best effort)
 		if stashed {
-			cmd, cancel = gitCmdWithContext(ctx, worktreePath, "stash", "pop")
+			cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "stash", "pop")
 			cmd.CombinedOutput()
 			cancel()
 		}
@@ -1385,7 +1406,7 @@ func (rm *RepoManager) RebaseOntoTarget(ctx context.Context, worktreePath, targe
 	}
 
 	// Get new base SHA
-	cmd, cancel = gitCmdWithContext(ctx, worktreePath, "rev-parse", baseBranch)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutFast, worktreePath, "rev-parse", baseBranch)
 	out, err = cmd.Output()
 	cancel()
 	if err == nil {
@@ -1394,7 +1415,7 @@ func (rm *RepoManager) RebaseOntoTarget(ctx context.Context, worktreePath, targe
 
 	// Pop stash if we stashed
 	if stashed {
-		cmd, cancel = gitCmdWithContext(ctx, worktreePath, "stash", "pop")
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "stash", "pop")
 		out, err := cmd.CombinedOutput()
 		cancel()
 		if err != nil {
@@ -1419,7 +1440,7 @@ func (rm *RepoManager) MergeFromTarget(ctx context.Context, worktreePath, target
 	baseBranch := targetBranch
 
 	// Fetch the target branch to ensure we have the latest
-	cmd, cancel := gitCmdWithContext(ctx, worktreePath, "fetch", "origin", branchName)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "fetch", "origin", branchName)
 	_, err := cmd.CombinedOutput()
 	cancel()
 	if err != nil {
@@ -1437,7 +1458,7 @@ func (rm *RepoManager) MergeFromTarget(ctx context.Context, worktreePath, target
 	// Stash if there are changes
 	stashed := false
 	if wdStatus.HasChanges {
-		cmd, cancel := gitCmdWithContext(ctx, worktreePath, "stash", "push", "-m", "auto-stash before merge")
+		cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "stash", "push", "-m", "auto-stash before merge")
 		_, err := cmd.CombinedOutput()
 		cancel()
 		if err == nil {
@@ -1446,7 +1467,7 @@ func (rm *RepoManager) MergeFromTarget(ctx context.Context, worktreePath, target
 	}
 
 	// Run merge
-	cmd, cancel = gitCmdWithContext(ctx, worktreePath, "merge", baseBranch, "-m", "Merge "+baseBranch+" into branch")
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "merge", baseBranch, "-m", "Merge "+baseBranch+" into branch")
 	out, err := cmd.CombinedOutput()
 	cancel()
 
@@ -1462,7 +1483,7 @@ func (rm *RepoManager) MergeFromTarget(ctx context.Context, worktreePath, target
 
 		// Try to pop stash even on failure (best effort)
 		if stashed {
-			cmd, cancel = gitCmdWithContext(ctx, worktreePath, "stash", "pop")
+			cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "stash", "pop")
 			cmd.CombinedOutput()
 			cancel()
 		}
@@ -1470,7 +1491,7 @@ func (rm *RepoManager) MergeFromTarget(ctx context.Context, worktreePath, target
 	}
 
 	// Get new base SHA
-	cmd, cancel = gitCmdWithContext(ctx, worktreePath, "rev-parse", baseBranch)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutFast, worktreePath, "rev-parse", baseBranch)
 	out, err = cmd.Output()
 	cancel()
 	if err == nil {
@@ -1479,7 +1500,7 @@ func (rm *RepoManager) MergeFromTarget(ctx context.Context, worktreePath, target
 
 	// Pop stash if we stashed
 	if stashed {
-		cmd, cancel = gitCmdWithContext(ctx, worktreePath, "stash", "pop")
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "stash", "pop")
 		out, err := cmd.CombinedOutput()
 		cancel()
 		if err != nil {
@@ -1495,7 +1516,7 @@ func (rm *RepoManager) MergeFromTarget(ctx context.Context, worktreePath, target
 
 // AbortRebase aborts an in-progress rebase
 func (rm *RepoManager) AbortRebase(ctx context.Context, worktreePath string) error {
-	cmd, cancel := gitCmdWithContext(ctx, worktreePath, "rebase", "--abort")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "rebase", "--abort")
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1506,7 +1527,7 @@ func (rm *RepoManager) AbortRebase(ctx context.Context, worktreePath string) err
 
 // AbortMerge aborts an in-progress merge
 func (rm *RepoManager) AbortMerge(ctx context.Context, worktreePath string) error {
-	cmd, cancel := gitCmdWithContext(ctx, worktreePath, "merge", "--abort")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "merge", "--abort")
 	defer cancel()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1516,15 +1537,12 @@ func (rm *RepoManager) AbortMerge(ctx context.Context, worktreePath string) erro
 }
 
 // PushBranch pushes the current branch to origin, setting upstream tracking.
-// Uses a 60-second timeout since pushes can take longer than normal git operations.
 func (rm *RepoManager) PushBranch(ctx context.Context, worktreePath, branch string) error {
 	if err := ValidateGitRef(branch); err != nil {
 		return fmt.Errorf("invalid branch name: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, worktreePath, "push", "-u", "origin", branch)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "push", "-u", "origin", branch)
-	cmd.Dir = worktreePath
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("push failed: %s", strings.TrimSpace(string(out)))
@@ -1540,7 +1558,7 @@ func (rm *RepoManager) GetDiffSummary(ctx context.Context, repoPath, baseRef str
 	}
 
 	// Get diff stat first
-	statCmd, statCancel := gitCmdWithContext(ctx, repoPath, "diff", "--stat", baseRef)
+	statCmd, statCancel := gitCmdWithContext(ctx, TimeoutSlow, repoPath, "diff", "--stat", baseRef)
 	defer statCancel()
 	statOut, err := statCmd.Output()
 	if err != nil {
@@ -1548,7 +1566,7 @@ func (rm *RepoManager) GetDiffSummary(ctx context.Context, repoPath, baseRef str
 	}
 
 	// Get unified diff
-	diffCmd, diffCancel := gitCmdWithContext(ctx, repoPath, "diff", baseRef)
+	diffCmd, diffCancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "diff", baseRef)
 	defer diffCancel()
 	diffOut, err := diffCmd.Output()
 	if err != nil {
@@ -1577,7 +1595,7 @@ func (rm *RepoManager) GetFileDiffUnified(ctx context.Context, repoPath, baseRef
 		return "", fmt.Errorf("invalid base ref: %w", err)
 	}
 
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "diff", baseRef, "--", filePath)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "diff", baseRef, "--", filePath)
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {

--- a/backend/git/worktree.go
+++ b/backend/git/worktree.go
@@ -76,7 +76,7 @@ func (wm *WorktreeManager) CreateWithBranch(ctx context.Context, repoPath, workt
 // The worktree branch is based on the specified targetBranch (e.g. "origin/main", "origin/develop").
 func (wm *WorktreeManager) CreateAtPath(ctx context.Context, repoPath, worktreePath, branchName, targetBranch string) (string, string, string, error) {
 	// Capture target branch commit - this is the base commit for the new worktree
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-parse", targetBranch)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", targetBranch)
 	out, err := cmd.Output()
 	cancel()
 	if err != nil {
@@ -90,7 +90,7 @@ func (wm *WorktreeManager) CreateAtPath(ctx context.Context, repoPath, worktreeP
 		return "", "", "", fmt.Errorf("failed to create parent dir %s: %w", parentDir, err)
 	}
 
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "add", "-b", branchName, worktreePath, targetBranch)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "add", "-b", branchName, worktreePath, targetBranch)
 	defer cancel()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", "", "", fmt.Errorf("failed to create worktree: %s: %w", string(out), err)
@@ -105,7 +105,7 @@ func (wm *WorktreeManager) CreateAtPath(ctx context.Context, repoPath, worktreeP
 // The worktree branch is based on the specified targetBranch (e.g. "origin/main", "origin/develop").
 func (wm *WorktreeManager) CreateInExistingDir(ctx context.Context, repoPath, worktreePath, branchName, targetBranch string) (string, string, string, error) {
 	// Capture target branch commit - this is the base commit for the new worktree
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-parse", targetBranch)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", targetBranch)
 	out, err := cmd.Output()
 	cancel()
 	if err != nil {
@@ -115,7 +115,7 @@ func (wm *WorktreeManager) CreateInExistingDir(ctx context.Context, repoPath, wo
 
 	// Create worktree in the existing directory
 	// git worktree add will work with an existing empty directory
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "add", "-b", branchName, worktreePath, targetBranch)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "add", "-b", branchName, worktreePath, targetBranch)
 	defer cancel()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		errMsg := string(out)
@@ -144,7 +144,7 @@ func (wm *WorktreeManager) CheckoutExistingBranchInDir(ctx context.Context, repo
 	}
 
 	// Fetch the specific branch from origin (targeted fetch is faster than fetching all refs)
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "fetch", "origin", remoteBranch)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "fetch", "origin", remoteBranch)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		cancel()
 		return "", "", "", fmt.Errorf("failed to fetch origin: %s: %w", string(out), err)
@@ -153,7 +153,7 @@ func (wm *WorktreeManager) CheckoutExistingBranchInDir(ctx context.Context, repo
 
 	// Resolve the remote branch ref to get the base commit SHA
 	remoteRef := fmt.Sprintf("origin/%s", remoteBranch)
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "rev-parse", remoteRef)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", remoteRef)
 	out, err := cmd.Output()
 	cancel()
 	if err != nil {
@@ -166,7 +166,7 @@ func (wm *WorktreeManager) CheckoutExistingBranchInDir(ctx context.Context, repo
 	// tracking the remote. Possible errors:
 	// - "already checked out" / "is already used by worktree" → branch is in use by another worktree
 	// - "already exists" → local branch exists but is not checked out in a worktree
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "add", "-b", remoteBranch, "--track", worktreePath, remoteRef)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "add", "-b", remoteBranch, "--track", worktreePath, remoteRef)
 	defer cancel()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		errMsg := string(out)
@@ -198,7 +198,7 @@ func (wm *WorktreeManager) RestoreSessionWorktree(ctx context.Context, repoPath,
 	// Step 1: Check if worktree already exists and is valid
 	if _, err := os.Stat(worktreePath); err == nil {
 		// Directory exists — check if it's a valid worktree
-		cmd, cancel := gitCmdWithContext(ctx, repoPath, "worktree", "list", "--porcelain")
+		cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "list", "--porcelain")
 		out, listErr := cmd.Output()
 		cancel()
 		if listErr == nil {
@@ -216,7 +216,7 @@ func (wm *WorktreeManager) RestoreSessionWorktree(ctx context.Context, repoPath,
 	}
 
 	// Prune stale worktree entries before trying to create a new one
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "worktree", "prune")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "prune")
 	if pruneOut, pruneErr := cmd.CombinedOutput(); pruneErr != nil {
 		logger.Cleanup.Warnf("git worktree prune failed: %s", strings.TrimSpace(string(pruneOut)))
 	}
@@ -229,14 +229,14 @@ func (wm *WorktreeManager) RestoreSessionWorktree(ctx context.Context, repoPath,
 	}
 
 	// Step 2: Check if local branch still exists
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "rev-parse", "--verify", "refs/heads/"+branchName)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--verify", "refs/heads/"+branchName)
 	_, localErr := cmd.Output()
 	cancel()
 
 	if localErr == nil {
 		// Local branch exists — just create a worktree from it
 		logger.Cleanup.Infof("Restoring worktree from existing local branch %s", branchName)
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "add", worktreePath, branchName)
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "add", worktreePath, branchName)
 		out, err := cmd.CombinedOutput()
 		cancel()
 		if err != nil {
@@ -247,18 +247,18 @@ func (wm *WorktreeManager) RestoreSessionWorktree(ctx context.Context, repoPath,
 
 	// Step 3: Check if remote branch exists
 	remoteRef := "refs/remotes/origin/" + branchName
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "rev-parse", "--verify", remoteRef)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--verify", remoteRef)
 	_, remoteErr := cmd.Output()
 	cancel()
 
 	if remoteErr == nil {
 		// Remote branch exists — fetch and create tracking worktree
 		logger.Cleanup.Infof("Restoring worktree from remote branch origin/%s", branchName)
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "fetch", "origin", branchName)
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "fetch", "origin", branchName)
 		cmd.CombinedOutput()
 		cancel()
 
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "add", "-b", branchName, "--track", worktreePath, "origin/"+branchName)
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "add", "-b", branchName, "--track", worktreePath, "origin/"+branchName)
 		out, err := cmd.CombinedOutput()
 		cancel()
 		if err != nil {
@@ -270,7 +270,7 @@ func (wm *WorktreeManager) RestoreSessionWorktree(ctx context.Context, repoPath,
 	// Step 4: Fall back to BaseCommitSHA
 	if baseCommitSHA != "" {
 		logger.Cleanup.Infof("Restoring worktree from base commit %s for branch %s", baseCommitSHA, branchName)
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "add", "-b", branchName, worktreePath, baseCommitSHA)
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "add", "-b", branchName, worktreePath, baseCommitSHA)
 		out, err := cmd.CombinedOutput()
 		cancel()
 		if err != nil {
@@ -282,7 +282,7 @@ func (wm *WorktreeManager) RestoreSessionWorktree(ctx context.Context, repoPath,
 	// Step 5: Fall back to targetBranch (e.g. origin/main) as last resort
 	if targetBranch != "" {
 		logger.Cleanup.Infof("Restoring worktree from target branch %s for branch %s", targetBranch, branchName)
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "add", "-b", branchName, worktreePath, targetBranch)
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "add", "-b", branchName, worktreePath, targetBranch)
 		out, err := cmd.CombinedOutput()
 		cancel()
 		if err != nil {
@@ -312,7 +312,7 @@ func (wm *WorktreeManager) RemoveAtPath(ctx context.Context, repoPath, worktreeP
 	logger.Cleanup.Infof("Removing worktree: path=%s branch=%s repo=%s", worktreePath, branchName, repoPath)
 
 	// Remove the worktree
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "worktree", "remove", worktreePath, "--force")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "remove", worktreePath, "--force")
 	out, err := cmd.CombinedOutput()
 	cancel()
 	if err != nil {
@@ -320,7 +320,7 @@ func (wm *WorktreeManager) RemoveAtPath(ctx context.Context, repoPath, worktreeP
 	}
 
 	// Prune stale worktree entries from git's internal tracking (.git/worktrees/)
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "worktree", "prune")
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "prune")
 	pruneOut, pruneErr := cmd.CombinedOutput()
 	cancel()
 	if pruneErr != nil {
@@ -329,7 +329,7 @@ func (wm *WorktreeManager) RemoveAtPath(ctx context.Context, repoPath, worktreeP
 
 	// Delete the branch if specified
 	if branchName != "" {
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "branch", "-D", branchName)
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "branch", "-D", branchName)
 		if branchOut, branchErr := cmd.CombinedOutput(); branchErr != nil {
 			logger.Cleanup.Warnf("Failed to delete branch %q in %s: %s: %v", branchName, repoPath, string(branchOut), branchErr)
 		}
@@ -340,7 +340,7 @@ func (wm *WorktreeManager) RemoveAtPath(ctx context.Context, repoPath, worktreeP
 }
 
 func (wm *WorktreeManager) List(ctx context.Context, repoPath string) ([]string, error) {
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "worktree", "list", "--porcelain")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "worktree", "list", "--porcelain")
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {
@@ -367,7 +367,7 @@ func (wm *WorktreeManager) GetDiff(ctx context.Context, repoPath, agentID string
 	branchName := fmt.Sprintf("agent/%s", agentID)
 
 	// Get the base branch
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "rev-parse", "--abbrev-ref", "HEAD")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--abbrev-ref", "HEAD")
 	baseOut, err := cmd.Output()
 	cancel()
 	if err != nil {
@@ -376,12 +376,12 @@ func (wm *WorktreeManager) GetDiff(ctx context.Context, repoPath, agentID string
 	baseBranch := strings.TrimSpace(string(baseOut))
 
 	// Get diff
-	cmd, cancel = gitCmdWithContext(ctx, repoPath, "diff", baseBranch+"..."+branchName)
+	cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "diff", baseBranch+"..."+branchName)
 	out, err := cmd.Output()
 	cancel()
 	if err != nil {
 		// If diff fails, try without the three-dot syntax
-		cmd, cancel = gitCmdWithContext(ctx, repoPath, "diff", baseBranch, branchName)
+		cmd, cancel = gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "diff", baseBranch, branchName)
 		out, err = cmd.Output()
 		cancel()
 		if err != nil {
@@ -395,7 +395,7 @@ func (wm *WorktreeManager) GetDiff(ctx context.Context, repoPath, agentID string
 func (wm *WorktreeManager) Merge(ctx context.Context, repoPath, agentID string) error {
 	branchName := fmt.Sprintf("agent/%s", agentID)
 
-	cmd, cancel := gitCmdWithContext(ctx, repoPath, "merge", branchName, "--no-edit")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "merge", branchName, "--no-edit")
 	defer cancel()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("merge failed: %s: %w", string(out), err)
@@ -407,7 +407,7 @@ func (wm *WorktreeManager) Merge(ctx context.Context, repoPath, agentID string) 
 // RenameBranch renames a git branch. The command must be run from within the worktree
 // that has the branch checked out, as you cannot rename a branch from outside.
 func (wm *WorktreeManager) RenameBranch(ctx context.Context, worktreePath, oldBranchName, newBranchName string) error {
-	cmd, cancel := gitCmdWithContext(ctx, worktreePath, "branch", "-m", oldBranchName, newBranchName)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, worktreePath, "branch", "-m", oldBranchName, newBranchName)
 	defer cancel()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to rename branch: %s: %w", string(out), err)


### PR DESCRIPTION
## Summary

Fixes #894

- **Tiered timeouts**: Replace the single 30s `gitCommandTimeout` with 5 tiers (`TimeoutFast` 10s, `TimeoutMedium` 30s, `TimeoutSlow` 60s, `TimeoutHeavy` 120s, `TimeoutClone` 5min) assigned per call site based on expected cost
- **Clone retry**: Add exponential-backoff retry (up to 2 retries, 2s/4s delays) for transient clone failures, with non-retryable error detection for auth/not-found/invalid-input errors
- **Timeout fixes from review**: `merge-base` bumped to Medium (was Fast, can be slow on large repos), `status -uall` bumped to Heavy (enumerates all files in untracked dirs)
- **Consolidation**: `PushBranch` now uses `gitCmdWithContext` instead of raw `exec.CommandContext`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./git/...` passes
- [ ] Manual: clone a large repo — verify timeout doesn't fire prematurely
- [ ] Manual: clone with bad credentials — verify no retry (non-retryable error)
- [ ] Manual: simulate network flake — verify retry with backoff in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)