### PR TITLE
perf: replace bulk useConversationsWithUserMessages with scoped selectors

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -9,7 +9,8 @@ import {
   useFileTabState,
   useMessages,
   useMessagePagination,
-  useConversationsWithUserMessages,
+  useHasUserMessages,
+  useConversationFreshness,
   useReviewComments,
   useReviewCommentActions,
   useStreamingConversationArea,
@@ -148,15 +149,15 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   const setMessagePage = useAppStore((s) => s.setMessagePage);
   const prependMessages = useAppStore((s) => s.prependMessages);
   const setLoadingMoreMessages = useAppStore((s) => s.setLoadingMoreMessages);
-  // Get Set of conversation IDs that have user messages (avoids subscribing to all messages)
-  const conversationsWithUserMessages = useConversationsWithUserMessages();
+  // Check if the selected conversation has any user messages (O(1) lookup + O(m) scan)
+  const hasUserMessages = useHasUserMessages(selectedConversationId);
 
   // Hide the setupInfo system card once the user has sent their first message
   const conversationMessages = useMemo(() => {
     if (!selectedConversationId) return allConversationMessages;
-    if (!conversationsWithUserMessages.includes(selectedConversationId)) return allConversationMessages;
+    if (!hasUserMessages) return allConversationMessages;
     return allConversationMessages.filter(m => !(m.role === 'system' && m.setupInfo));
-  }, [allConversationMessages, selectedConversationId, conversationsWithUserMessages]);
+  }, [allConversationMessages, selectedConversationId, hasUserMessages]);
 
   // Review comments for current session
   const reviewComments = useReviewComments(selectedSessionId);
@@ -462,12 +463,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     selectConversation(sessionConversations[0].id);
   }, [selectedSessionId, selectedConversationId, sessionConversations, selectConversation]);
 
-  // Check if a conversation is fresh (no user messages yet)
-  const isFreshConversation = useCallback(
-    (convId: string) => !conversationsWithUserMessages.includes(convId),
-    [conversationsWithUserMessages]
-  );
-
   // Session-scoped streaming states for conversation tab indicators.
   // Only subscribes to isStreaming/error for this session's conversations,
   // preventing cross-session re-renders. Flattened to primitives so
@@ -475,6 +470,15 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   const sessionConvIds = useMemo(
     () => sessionConversations.map((c) => c.id),
     [sessionConversations]
+  );
+
+  // Reactive freshness map — only subscribes to this session's conversations
+  const conversationFreshness = useConversationFreshness(sessionConvIds);
+
+  // Check if a conversation is fresh (no user messages yet)
+  const isFreshConversation = useCallback(
+    (convId: string) => !conversationFreshness[convId],
+    [conversationFreshness]
   );
   const sessionStreamingFlat = useAppStore(
     useShallow(

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -95,28 +95,21 @@ export const useHasUserMessages = (conversationId: string | null) =>
       : false
   );
 
-// Stable empty array for conversations with user messages
-const EMPTY_CONVERSATION_IDS: readonly string[] = [];
-
 /**
- * Get an array of conversation IDs that have user messages.
- * Use in: ConversationArea for checking "fresh" status across multiple conversations
+ * Track which conversation IDs (from a given set) have user messages.
+ * Use in: ConversationArea tab indicators for "fresh" status.
  *
- * This avoids subscribing to the entire messages array when you need to check
- * freshness for multiple conversations (e.g., in tab rendering).
- *
- * Returns a stable reference when empty to avoid infinite re-render loops.
+ * Scoped to the provided IDs so it only reacts to relevant conversations,
+ * unlike the old useConversationsWithUserMessages which iterated ALL conversations.
  */
-export const useConversationsWithUserMessages = () =>
+export const useConversationFreshness = (conversationIds: string[]) =>
   useAppStore(
     useShallow((s) => {
-      const ids: string[] = [];
-      for (const [convId, msgs] of Object.entries(s.messagesByConversation)) {
-        if (msgs.some((m) => m.role === 'user')) {
-          ids.push(convId);
-        }
+      const map: Record<string, boolean> = {};
+      for (const id of conversationIds) {
+        map[id] = (s.messagesByConversation[id] ?? []).some((m) => m.role === 'user');
       }
-      return ids.length > 0 ? ids : EMPTY_CONVERSATION_IDS;
+      return map;
     })
   );
 


### PR DESCRIPTION
## Summary
- Replace `useConversationsWithUserMessages()` (iterates ALL conversations on every store update) with two scoped selectors:
  - `useHasUserMessages(selectedConversationId)` — single-conversation check for setup card filtering
  - `useConversationFreshness(sessionConvIds)` — session-scoped map for tab "fresh" indicators
- Delete `EMPTY_CONVERSATION_IDS` constant and old bulk selector

## Test plan
- [ ] Open a fresh conversation — setup card (system message with `setupInfo`) is visible
- [ ] Send a user message — setup card hides
- [ ] Conversation tab shows sparkle icon for fresh conversations, disappears after first user message
- [ ] Multiple sessions: tab indicators only react to their own conversations

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)