### PR TITLE
perf: add composite indexes for hot query paths

### DIFF
--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -218,6 +218,7 @@ func (s *SQLiteStore) initSchema() error {
 		FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
 	);
 	CREATE INDEX IF NOT EXISTS idx_file_tabs_workspace ON file_tabs(workspace_id);
+	CREATE INDEX IF NOT EXISTS idx_file_tabs_workspace_position ON file_tabs(workspace_id, position);
 
 	-- Review Comments
 	CREATE TABLE IF NOT EXISTS review_comments (
@@ -273,6 +274,7 @@ func (s *SQLiteStore) initSchema() error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_summaries_conversation ON summaries(conversation_id);
 	CREATE INDEX IF NOT EXISTS idx_summaries_session ON summaries(session_id);
+	CREATE INDEX IF NOT EXISTS idx_summaries_session_status ON summaries(session_id, status);
 
 	-- Checkpoints (file state snapshots from Agent SDK)
 	CREATE TABLE IF NOT EXISTS checkpoints (


### PR DESCRIPTION
## Summary
- Add composite index `file_tabs(workspace_id, position)` to eliminate filesort in `ListFileTabs` (called every tab bar render)
- Add composite index `summaries(session_id, status)` to eliminate post-index filter scan in `ListSummariesBySession`
- Skipped the checkpoint index proposed in #902 — no query currently filters by both `conversation_id` and `uuid`

Closes #902

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./store/...` passes
- [ ] Verify with `EXPLAIN QUERY PLAN` that new indexes are used

🤖 Generated with [Claude Code](https://claude.com/claude-code)