### PR TITLE
fix: use content-based key in FileTree to prevent unnecessary state resets

### DIFF
--- a/src/components/files/FileTree.tsx
+++ b/src/components/files/FileTree.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useImperativeHandle, forwardRef } from 'react';
+import { useState, useMemo, useEffect, useCallback, useImperativeHandle, forwardRef } from 'react';
 import { Icon } from '@iconify/react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
@@ -52,16 +52,27 @@ function collectAllDirPaths(nodes: FileNode[]): string[] {
 
 export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileTree({ files, onFileSelect }, ref) {
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
-  const [prevFiles, setPrevFiles] = useState(files);
+  const filesKey = useMemo(() => {
+    const paths: string[] = [];
+    function walk(nodes: FileNode[]) {
+      for (const n of nodes) {
+        paths.push(n.path);
+        if (n.children) walk(n.children);
+      }
+    }
+    walk(files);
+    return paths.join('\0');
+  }, [files]);
+  const [prevKey, setPrevKey] = useState(filesKey);
 
   // Preload folder icons on first render
   useEffect(() => {
     ensureIconsPreloaded();
   }, []);
 
-  // Reset expanded state when files change (e.g., switching sessions)
-  if (prevFiles !== files) {
-    setPrevFiles(files);
+  // Reset expanded state when file list content changes (e.g., switching sessions)
+  if (prevKey !== filesKey) {
+    setPrevKey(filesKey);
     setExpandedPaths(new Set());
   }
 


### PR DESCRIPTION
## Summary
- Replace reference comparison (`prevFiles !== files`) with a content-based key derived from file paths in `FileTree.tsx`
- The parent (`ChangesPanel`) passes new array references on cache restore and API revalidation even when content is identical, causing expanded folder state to reset unnecessarily
- Uses `useMemo` to compute a stable key from all file paths (including nested children), only resetting expanded state when actual file content changes

Fixes #920

## Test plan
- [ ] Expand folders in file tree, trigger a session data refresh (e.g., make a file change in the workspace) — expanded state should be preserved
- [ ] Switch to a different session with different files — expanded state should reset
- [ ] Verify no regressions in file tree rendering or interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)