### PR TITLE
perf: batch-fetch repos by ID in ListAllSessions (#905)

### DIFF
--- a/backend/server/session_handlers.go
+++ b/backend/server/session_handlers.go
@@ -40,32 +40,48 @@ func (h *Handlers) ListAllSessions(w http.ResponseWriter, r *http.Request) {
 
 	// Serve cached stats immediately; compute uncached ones in background via WebSocket.
 	if h.statsCache != nil {
-		// Build workspace map for branch lookup
-		repos, repoErr := h.store.ListRepos(ctx)
-		if repoErr != nil {
-			logger.Handlers.Warnf("ListSessions: failed to list repos for stats: %v", repoErr)
+		// First pass: apply cached stats and collect workspace IDs for uncached sessions
+		type pendingSession struct {
+			session     *models.Session
+			workspaceID string
 		}
-		workspaceByID := make(map[string]*models.Repo)
-		for _, repo := range repos {
-			workspaceByID[repo.ID] = repo
-		}
-
-		var uncached []uncachedSession
+		var pending []pendingSession
+		needWorkspaceIDs := make(map[string]bool)
 		for _, session := range sessions {
 			if session.Archived {
 				continue
 			}
 			if cached, ok := h.statsCache.Get(session.ID); ok {
 				session.Stats = cached
-			} else if ws := workspaceByID[session.WorkspaceID]; ws != nil {
-				uncached = append(uncached, uncachedSession{
-					session:   session,
-					workspace: ws,
-				})
+			} else {
+				pending = append(pending, pendingSession{session: session, workspaceID: session.WorkspaceID})
+				needWorkspaceIDs[session.WorkspaceID] = true
 			}
 		}
-		if len(uncached) > 0 && h.hub != nil {
-			go h.computeAndBroadcastStats(uncached)
+
+		// Batch-fetch only the workspaces needed for uncached sessions
+		if len(pending) > 0 {
+			ids := make([]string, 0, len(needWorkspaceIDs))
+			for id := range needWorkspaceIDs {
+				ids = append(ids, id)
+			}
+			workspaceByID, repoErr := h.store.GetReposByIDs(ctx, ids)
+			if repoErr != nil {
+				logger.Handlers.Warnf("ListAllSessions: failed to get repos for stats: %v", repoErr)
+			}
+
+			var uncached []uncachedSession
+			for _, p := range pending {
+				if ws := workspaceByID[p.workspaceID]; ws != nil {
+					uncached = append(uncached, uncachedSession{
+						session:   p.session,
+						workspace: ws,
+					})
+				}
+			}
+			if len(uncached) > 0 && h.hub != nil {
+				go h.computeAndBroadcastStats(uncached)
+			}
 		}
 	}
 

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -404,6 +404,54 @@ func (s *SQLiteStore) ListRepos(ctx context.Context) ([]*models.Repo, error) {
 	return repos, nil
 }
 
+// GetReposByIDs returns repos for the given IDs as a map keyed by repo ID.
+// Returns an empty map when ids is empty (no query executed).
+// IDs are queried in batches to stay within SQLite's parameter limit.
+func (s *SQLiteStore) GetReposByIDs(ctx context.Context, ids []string) (map[string]*models.Repo, error) {
+	result := make(map[string]*models.Repo, len(ids))
+	if len(ids) == 0 {
+		return result, nil
+	}
+
+	const batchSize = 500 // well under SQLite's default 999 parameter limit
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[i:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]interface{}, len(batch))
+		for j, id := range batch {
+			placeholders[j] = "?"
+			args[j] = id
+		}
+
+		query := `SELECT id, name, path, branch, remote, branch_prefix, custom_prefix, created_at
+			FROM repos WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+		rows, err := s.db.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("GetReposByIDs: %w", err)
+		}
+
+		for rows.Next() {
+			var repo models.Repo
+			if err := rows.Scan(&repo.ID, &repo.Name, &repo.Path, &repo.Branch, &repo.Remote, &repo.BranchPrefix, &repo.CustomPrefix, &repo.CreatedAt); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("GetReposByIDs scan: %w", err)
+			}
+			result[repo.ID] = &repo
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("GetReposByIDs rows: %w", err)
+		}
+		rows.Close()
+	}
+	return result, nil
+}
+
 func (s *SQLiteStore) GetRepoByPath(ctx context.Context, path string) (*models.Repo, error) {
 	var repo models.Repo
 	err := s.db.QueryRowContext(ctx, `

--- a/backend/store/sqlite_test.go
+++ b/backend/store/sqlite_test.go
@@ -451,6 +451,44 @@ func TestListAllSessions_ReadsArchivedField(t *testing.T) {
 	assert.True(t, sessions[0].Archived, "Archived field should be read from DB")
 }
 
+func TestGetReposByIDs(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	createTestRepo(t, s, "ws-1")
+	createTestRepo(t, s, "ws-2")
+	createTestRepo(t, s, "ws-3")
+
+	// Empty IDs returns empty map
+	result, err := s.GetReposByIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+
+	// Subset of IDs
+	result, err = s.GetReposByIDs(ctx, []string{"ws-1", "ws-3"})
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "ws-1", result["ws-1"].ID)
+	assert.Equal(t, "ws-3", result["ws-3"].ID)
+
+	// Non-existent ID is silently skipped
+	result, err = s.GetReposByIDs(ctx, []string{"ws-1", "nonexistent"})
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "ws-1", result["ws-1"].ID)
+
+	// Batching: create enough repos to span multiple batches (batch size is 500)
+	const total = 502
+	allIDs := make([]string, total)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("batch-%d", i)
+		allIDs[i] = id
+		createTestRepo(t, s, id)
+	}
+	result, err = s.GetReposByIDs(ctx, allIDs)
+	require.NoError(t, err)
+	assert.Len(t, result, total, "all repos across multiple batches should be returned")
+}
+
 func TestUpdateSession_SetArchived(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)


### PR DESCRIPTION
## Summary
- **`ListAllSessions`** was calling `ListRepos()` to load every repo into memory just to build a workspace lookup map for stats computation
- Now collects only the workspace IDs actually needed (non-archived sessions without cached stats) and batch-fetches them via a new `GetReposByIDs` store method
- New method uses `WHERE id IN (...)` with batching (500 per batch) to stay within SQLite's parameter limit

## Changes
- `backend/store/sqlite.go` — added `GetReposByIDs(ctx, ids)` batch method
- `backend/server/session_handlers.go` — rewrote `ListAllSessions` stats section to collect needed IDs first, then batch-fetch
- `backend/store/sqlite_test.go` — added tests for `GetReposByIDs` including empty input, partial matches, and multi-batch scenarios

Closes #905

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./store/... -run TestGetReposByIDs` passes (new test)
- [x] `go test ./store/... -run TestListAllSessions` passes (existing tests)
- [x] `go test ./...` full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)