### PR TITLE
perf: replace global scriptOutputVersion with per-run version map

### DIFF
--- a/src/components/panels/ScriptsPanel.tsx
+++ b/src/components/panels/ScriptsPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAppStore, getScriptOutputLines } from '@/stores/appStore';
-import { useSelectedIds } from '@/stores/selectors';
+import { useSelectedIds, useScriptOutputVersion } from '@/stores/selectors';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ScriptLogViewer } from './ScriptLogViewer';
@@ -318,8 +318,8 @@ function ScriptRunItem({
   onStop?: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  // Subscribe to output version counter to re-render when new lines arrive
-  const outputVersion = useAppStore((s) => s.scriptOutputVersion);
+  // Subscribe to per-run output version counter to re-render when new lines arrive
+  const outputVersion = useScriptOutputVersion(run?.sessionId, run?.id);
   const outputLines = useMemo(
     () => run ? getScriptOutputLines(run.sessionId, run.id) : [],
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -308,8 +308,8 @@ interface AppState {
   // Script runs state (keyed by sessionId)
   scriptRuns: Record<string, ScriptRun[]>;
   setupProgress: Record<string, SetupProgress>;
-  // Monotonic counter bumped on each output line to trigger re-renders
-  scriptOutputVersion: number;
+  // Per-run version counters bumped on each output line to trigger re-renders
+  scriptOutputVersions: Record<string, number>;  // keyed by "sessionId:runId"
 
   // Draft input actions
   setDraftInput: (sessionId: string, draft: { text: string; attachments: Attachment[] }) => void;
@@ -610,7 +610,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   // Script state
   scriptRuns: {},
   setupProgress: {},
-  scriptOutputVersion: 0,
+  scriptOutputVersions: {},
 
   // Draft input actions
   setDraftInput: (sessionId, draft) => set((state) => ({
@@ -655,8 +655,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       scriptOutputBuffers.set(key, buf);
     }
     buf.push(line);
-    // Bump version counter to trigger re-renders
-    set((state) => ({ scriptOutputVersion: state.scriptOutputVersion + 1 }));
+    // Bump per-run version counter to trigger re-renders.
+    // Use get() + shallow clone to avoid the set(fn) callback spreading on every line.
+    const prev = get().scriptOutputVersions;
+    set({ scriptOutputVersions: { ...prev, [key]: (prev[key] ?? 0) + 1 } });
   },
 
   setSetupProgress: (sessionId, progress) => set((state) => ({
@@ -829,6 +831,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       const { [id]: _panelVisible, ...remainingTerminalPanelVisible } = state.terminalPanelVisible;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [id]: _convsBySession, ...remainingConversationsBySession } = state.conversationsBySession;
+      const cleanedScriptOutputVersions = Object.fromEntries(
+        Object.entries(state.scriptOutputVersions).filter(([k]) => !k.startsWith(`${id}:`))
+      );
 
       return {
         sessions: state.sessions.filter((s) => s.id !== id),
@@ -855,6 +860,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         terminalInstances: remainingTerminalInstances,
         activeTerminalId: remainingActiveTerminalId,
         terminalPanelVisible: remainingTerminalPanelVisible,
+        scriptOutputVersions: cleanedScriptOutputVersions,
         selectedFileTabId: null,
         fileTabs: [],
       };

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -459,6 +459,17 @@ export const useTerminalPanelVisible = (sessionId: string | null) =>
   useAppStore((s) => (sessionId ? s.terminalPanelVisible[sessionId] ?? false : false));
 
 // ============================================================================
+// Script Output State
+// ============================================================================
+
+/**
+ * Per-run script output version counter.
+ * Use in: ScriptsPanel (ScriptRunCard)
+ */
+export const useScriptOutputVersion = (sessionId: string | undefined, runId: string | undefined) =>
+  useAppStore((s) => (sessionId && runId) ? s.scriptOutputVersions[`${sessionId}:${runId}`] ?? 0 : 0);
+
+// ============================================================================
 // Todo State
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Replaces the single global `scriptOutputVersion` counter with a per-key `scriptOutputVersions` map keyed by `sessionId:runId`
- Adds scoped `useScriptOutputVersion(sessionId, runId)` selector so only the relevant `ScriptRunCard` re-renders when output arrives
- Cleans up version entries in `removeSession` to prevent memory leaks

Closes #923

## Test plan
- [ ] Open two script runs side-by-side; output from one should not cause the other's component to re-render (verify via React DevTools highlight)
- [ ] Verify script output still streams correctly in ScriptsPanel
- [ ] Remove a session and confirm no stale entries remain in `scriptOutputVersions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)