### PR TITLE
perf: stabilize VirtualizedMessageList itemContent callback

### DIFF
--- a/src/components/conversation/VirtualizedMessageList.tsx
+++ b/src/components/conversation/VirtualizedMessageList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useCallback, useMemo, useRef, useImperativeHandle } from 'react';
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useImperativeHandle } from 'react';
 import { Virtuoso, type VirtuosoHandle, type ListRange } from 'react-virtuoso';
 import { MessageBlock } from '@/components/conversation/MessageBlock';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -67,6 +67,13 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
     const virtuosoRef = useRef<VirtuosoHandle>(null);
     const scrollerElRef = useRef<HTMLElement | null>(null);
 
+    const messageOffsetsRef = useRef(searchMatches.messageOffsets);
+    const messageHasMatchesRef = useRef(messageHasMatches);
+    useEffect(() => {
+      messageOffsetsRef.current = searchMatches.messageOffsets;
+      messageHasMatchesRef.current = messageHasMatches;
+    });
+
     const scrollerRefCallback = useCallback((el: HTMLElement | Window | null) => {
       scrollerElRef.current = el instanceof HTMLElement ? el : null;
     }, []);
@@ -104,13 +111,13 @@ export const VirtualizedMessageList = forwardRef<VirtualizedMessageListHandle, V
               worktreePath={worktreePath}
               searchQuery={searchQuery}
               currentMatchIndex={currentMatchIndex}
-              matchOffset={searchMatches.messageOffsets[index] ?? 0}
-              hasMatches={messageHasMatches[index] ?? false}
+              matchOffset={messageOffsetsRef.current[index] ?? 0}
+              hasMatches={messageHasMatchesRef.current[index] ?? false}
             />
           </ErrorBoundary>
         </div>
       ),
-      [worktreePath, searchQuery, currentMatchIndex, searchMatches.messageOffsets, messageHasMatches]
+      [worktreePath, searchQuery, currentMatchIndex, searchMatches.total]
     );
 
     // Determine follow output behavior: auto-scroll when at bottom.


### PR DESCRIPTION
## Summary
- Move `searchMatches.messageOffsets` and `messageHasMatches` into refs so the `itemContent` callback identity stays stable across search recomputations
- Prevents react-virtuoso from re-rendering all visible items when only the search arrays change

Closes #918

## Test plan
- [ ] Open a conversation and use search — matches should still highlight correctly
- [ ] Verify via React DevTools/profiler that `itemContent` callback identity is stable when search arrays update

🤖 Generated with [Claude Code](https://claude.com/claude-code)