### PR TITLE
fix: use server-scoped context for background goroutines (#908)

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -476,7 +476,7 @@ func main() {
 	// AI client: nil at init — handlers.getAIClient() resolves dynamically via
 	// agentMgr.CreateAIClient() on each call, picking up credentials as they
 	// become available (env var, keychain, credentials file, cached SDK token).
-	router, routerCleanup := server.NewRouter(s, hub, agentMgr, ghClient, linearClient, branchWatcher, prWatcher, prCache, issueCache, statsCache, diffCache, nil, scriptRunner)
+	router, routerCleanup := server.NewRouter(ctx, s, hub, agentMgr, ghClient, linearClient, branchWatcher, prWatcher, prCache, issueCache, statsCache, diffCache, nil, scriptRunner)
 	defer routerCleanup()
 
 	// Pre-warm session stats cache in background so the first getDashboardData

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -545,13 +545,42 @@ type Handlers struct {
 	diffCache        *DiffCache
 	aiClient         ai.Provider
 	scriptRunner     *scripts.Runner
+	serverCtx        context.Context
+	serverCancel     context.CancelFunc
+	bgWg             sync.WaitGroup
 }
 
-// Close releases resources owned by Handlers (caches with background goroutines).
+// Close cancels background goroutines, waits for them to drain, then releases
+// resources owned by Handlers (caches with background goroutines).
 func (h *Handlers) Close() {
+	h.serverCancel()
+
+	done := make(chan struct{})
+	go func() { h.bgWg.Wait(); close(done) }()
+	select {
+	case <-done:
+		logger.Handlers.Info("All background goroutines completed")
+	case <-time.After(5 * time.Second):
+		logger.Handlers.Warn("Timed out waiting for background goroutines")
+	}
+
 	h.dirCache.Close()
 	h.branchCache.Close()
 	h.avatarCache.Close()
+}
+
+// goBackground launches fn as a tracked background goroutine.
+// The goroutine is counted in bgWg so Close() can wait for completion.
+// It is a no-op if the server context is already cancelled (shutting down).
+func (h *Handlers) goBackground(fn func()) {
+	if h.serverCtx.Err() != nil {
+		return
+	}
+	h.bgWg.Add(1)
+	go func() {
+		defer h.bgWg.Done()
+		fn()
+	}()
 }
 
 // getAIClient returns an AI provider using the agent manager's multi-source
@@ -622,7 +651,9 @@ func (h *Handlers) getWorkspacesBaseDir(ctx context.Context) (string, error) {
 	return git.WorkspacesBaseDirWithOverride(configured)
 }
 
-func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, diffCache *DiffCache, aiClient ai.Provider, scriptRunner *scripts.Runner) *Handlers {
+func NewHandlers(ctx context.Context, s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirListingCacheConfig, bw *branch.Watcher, prw *branch.PRWatcher, hub *Hub, ghClient *github.Client, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, diffCache *DiffCache, aiClient ai.Provider, scriptRunner *scripts.Runner) *Handlers {
+	serverCtx, serverCancel := context.WithCancel(ctx)
+
 	// Initialize session name cache with workspaces directory
 	// Cache initializes lazily on first use
 	workspacesDir, err := git.WorkspacesBaseDir()
@@ -650,6 +681,8 @@ func NewHandlers(s *store.SQLiteStore, am *agent.Manager, dirCacheConfig DirList
 		diffCache:        diffCache,
 		aiClient:         aiClient,
 		scriptRunner:     scriptRunner,
+		serverCtx:        serverCtx,
+		serverCancel:     serverCancel,
 	}
 }
 
@@ -770,7 +803,7 @@ type uncachedSession struct {
 func (h *Handlers) computeAndBroadcastStats(sessions []uncachedSession) {
 	sem := make(chan struct{}, 10)
 	var wg sync.WaitGroup
-	ctx := context.Background()
+	ctx := h.serverCtx
 
 	for _, us := range sessions {
 		wg.Add(1)

--- a/backend/server/pr_handlers.go
+++ b/backend/server/pr_handlers.go
@@ -446,7 +446,7 @@ func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
 			// If details are missing (previous fetch failed), trigger background refresh
 			if len(prDetailsMap) == 0 && len(ghPRs) > 0 {
 				if h.prCache.TryStartRefresh(owner, repoName) {
-					go h.refreshPRCache(owner, repoName)
+					h.goBackground(func() { h.refreshPRCache(owner, repoName) })
 				}
 			}
 
@@ -456,7 +456,7 @@ func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
 			prDetailsMap = cacheEntry.Details
 
 			if h.prCache.TryStartRefresh(owner, repoName) {
-				go h.refreshPRCache(owner, repoName)
+				h.goBackground(func() { h.refreshPRCache(owner, repoName) })
 			}
 
 		default:
@@ -574,16 +574,8 @@ func (h *Handlers) refreshPRCache(owner, repoName string) {
 		}
 	}()
 
-	// Derive a context that cancels on timeout OR server shutdown (whichever comes first)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(h.serverCtx, 30*time.Second)
 	defer cancel()
-	go func() {
-		select {
-		case <-ctx.Done():
-		case <-h.prCache.Done():
-			cancel()
-		}
-	}()
 
 	// Use cached ETag for conditional request
 	etag := h.prCache.GetETag(owner, repoName)

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -18,10 +19,10 @@ import (
 	"github.com/rs/cors"
 )
 
-func NewRouter(s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, linearClient *linear.Client, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, diffCache *DiffCache, aiClient ai.Provider, scriptRunner *scripts.Runner) (http.Handler, func()) {
+func NewRouter(ctx context.Context, s *store.SQLiteStore, hub *Hub, agentMgr *agent.Manager, ghClient *github.Client, linearClient *linear.Client, bw *branch.Watcher, prw *branch.PRWatcher, prCache *github.PRCache, issueCache *github.IssueCache, statsCache *SessionStatsCache, diffCache *DiffCache, aiClient ai.Provider, scriptRunner *scripts.Runner) (http.Handler, func()) {
 	r := chi.NewRouter()
 	dirCacheConfig := LoadDirListingCacheConfig()
-	h := NewHandlers(s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, issueCache, statsCache, diffCache, aiClient, scriptRunner)
+	h := NewHandlers(ctx, s, agentMgr, dirCacheConfig, bw, prw, hub, ghClient, prCache, issueCache, statsCache, diffCache, aiClient, scriptRunner)
 	auth := NewAuthHandlers(ghClient, s)
 	linearAuth := NewLinearAuthHandlers(linearClient, s)
 

--- a/backend/server/router_test.go
+++ b/backend/server/router_test.go
@@ -39,7 +39,7 @@ func setupTestRouter(t *testing.T) (http.Handler, *store.SQLiteStore) {
 	linearClient := linear.NewClient("")
 
 	// Create router without branch watcher, pr watcher, stats cache, or diff cache
-	router, cleanup := NewRouter(s, hub, agentMgr, ghClient, linearClient, nil, nil, prCache, nil, nil, nil, nil, nil)
+	router, cleanup := NewRouter(context.Background(), s, hub, agentMgr, ghClient, linearClient, nil, nil, prCache, nil, nil, nil, nil, nil)
 	t.Cleanup(cleanup)
 
 	return router, s

--- a/backend/server/session_handlers.go
+++ b/backend/server/session_handlers.go
@@ -80,7 +80,7 @@ func (h *Handlers) ListAllSessions(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			if len(uncached) > 0 && h.hub != nil {
-				go h.computeAndBroadcastStats(uncached)
+				h.goBackground(func() { h.computeAndBroadcastStats(uncached) })
 			}
 		}
 	}
@@ -124,7 +124,7 @@ func (h *Handlers) ListSessions(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if len(uncached) > 0 && h.hub != nil {
-			go h.computeAndBroadcastStats(uncached)
+			h.goBackground(func() { h.computeAndBroadcastStats(uncached) })
 		}
 	}
 
@@ -676,7 +676,7 @@ func (h *Handlers) UpdateSession(w http.ResponseWriter, r *http.Request) {
 				logger.Error.Errorf("Failed to set generating status for session %s: %v", id, err)
 			} else {
 				session.ArchiveSummaryStatus = models.SummaryStatusGenerating
-				go h.generateArchiveSummary(id, aiClient)
+				h.goBackground(func() { h.generateArchiveSummary(id, aiClient) })
 			}
 		}
 	}
@@ -729,7 +729,7 @@ func (h *Handlers) UpdateSession(w http.ResponseWriter, r *http.Request) {
 
 // generateArchiveSummary fetches all conversations for a session and generates a combined summary.
 func (h *Handlers) generateArchiveSummary(sessionID string, aiClient ai.Provider) {
-	bgCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	bgCtx, cancel := context.WithTimeout(h.serverCtx, 90*time.Second)
 	defer cancel()
 
 	// Fetch all conversations for this session

--- a/backend/server/testhelpers_test.go
+++ b/backend/server/testhelpers_test.go
@@ -50,12 +50,13 @@ func setupTestHandlers(t *testing.T) (*Handlers, *store.SQLiteStore) {
 
 	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
+	handlers := NewHandlers(context.Background(), sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, nil, nil)
+
 	t.Cleanup(func() {
+		handlers.Close()
 		sqliteStore.Close()
 		prCache.Close()
 	})
-
-	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, nil, nil)
 
 	return handlers, sqliteStore
 }
@@ -76,12 +77,13 @@ func setupTestHandlersWithAgentManager(t *testing.T) (*Handlers, *store.SQLiteSt
 	agentManager := agent.NewManager(context.Background(), sqliteStore, worktreeManager, 9876)
 	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute, 100)
 
+	handlers := NewHandlers(context.Background(), sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, nil, nil)
+
 	t.Cleanup(func() {
+		handlers.Close()
 		sqliteStore.Close()
 		prCache.Close()
 	})
-
-	handlers := NewHandlers(sqliteStore, agentManager, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, nil, nil)
 
 	return handlers, sqliteStore, agentManager
 }
@@ -230,12 +232,13 @@ func setupTestHandlersWithAIClient(t *testing.T, aiServerURL string) (*Handlers,
 	prCache := github.NewPRCache(5*time.Minute, 10*time.Minute, 100)
 	aiClient := ai.NewTestClient("sk-test-key", aiServerURL)
 
+	handlers := NewHandlers(context.Background(), sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, aiClient, nil)
+
 	t.Cleanup(func() {
+		handlers.Close()
 		sqliteStore.Close()
 		prCache.Close()
 	})
-
-	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, nil, prCache, nil, nil, nil, aiClient, nil)
 
 	return handlers, sqliteStore
 }
@@ -253,12 +256,13 @@ func setupTestHandlersWithGitHub(t *testing.T, ghServer *httptest.Server) (*Hand
 	ghClient.SetAPIURL(ghServer.URL)
 	ghClient.SetToken("test_token")
 
+	handlers := NewHandlers(context.Background(), sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, ghClient, prCache, nil, nil, nil, nil, nil)
+
 	t.Cleanup(func() {
+		handlers.Close()
 		sqliteStore.Close()
 		prCache.Close()
 	})
-
-	handlers := NewHandlers(sqliteStore, nil, DirListingCacheConfig{TTL: 30 * time.Second}, nil, nil, nil, ghClient, prCache, nil, nil, nil, nil, nil)
 
 	return handlers, sqliteStore
 }


### PR DESCRIPTION
## Summary
- Adds `serverCtx`/`serverCancel` and `sync.WaitGroup` to `Handlers` struct, derived from the signal context in `main.go`
- Replaces `context.Background()` with `h.serverCtx` in `computeAndBroadcastStats`, `refreshPRCache`, and `generateArchiveSummary`
- Wraps all fire-and-forget `go` calls with `h.goBackground()` so outstanding goroutines are tracked
- Extends `Close()` to cancel the server context and wait up to 5s for goroutines to drain before releasing cache resources
- Removes redundant `prCache.Done()` select goroutine in `refreshPRCache` (now covered by server context cancellation)

Closes #908

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./server/...` passes
- [ ] Manual: start server, trigger background work (list sessions, archive a session), send SIGINT, verify "All background goroutines completed" in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)