### PR TITLE
perf: eliminate redundant string clones in file watcher event loop

### DIFF
--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -227,7 +227,9 @@ pub fn start_global_watcher(
                     if let Some(window) = app_handle.get_webview_window("main") {
                         for (workspace_id, files) in &workspace_changes {
                             let count = files.len();
-                            let Some((last_path, last_full)) = files.last() else { continue };
+                            let Some((last_path, last_full)) = files.last() else {
+                                continue;
+                            };
                             let file_list: Vec<serde_json::Value> = files
                                 .iter()
                                 .map(|(path, full)| {


### PR DESCRIPTION
## Summary
- Simplify `WorkspaceChanges` type from a 4-field tuple to `Vec<(String, String)>`, removing redundant `last_path`, `last_full`, and `count` fields that are derivable from the vec
- Move `workspace_id`, `relative_path`, and `event_path_str` by ownership instead of cloning in the event loop — reduces per-event allocations from 3 clones to zero
- Derive `count`, `last_path`, `last_full` from the vec at emit time

Closes #916

## Test plan
- [ ] `cargo check` compiles without errors (watcher.rs changes only)
- [ ] `cargo test` — existing watcher unit tests pass
- [ ] Manual: trigger file changes in a workspace and verify `file-changed` events still emit correctly with all fields (`workspaceId`, `path`, `fullPath`, `files`, `fileCount`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)