### PR TITLE
perf: use Set for O(1) active session lookups (#912)

### DIFF
--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -194,9 +194,10 @@ export const useActiveSessions = <T extends { id: string }>(sessions: T[]): T[] 
     )
   );
 
+  const activeIdSet = useMemo(() => new Set(activeIds), [activeIds]);
   return useMemo(
-    () => sessions.filter((s) => activeIds.includes(s.id)),
-    [sessions, activeIds]
+    () => sessions.filter((s) => activeIdSet.has(s.id)),
+    [sessions, activeIdSet]
   );
 };
 


### PR DESCRIPTION
## Summary
- Replace `activeIds.includes(s.id)` with `Set.has()` in `useActiveSessions` to eliminate O(n) linear scan per session in the final filter
- Adds a memoized `Set` from the active IDs array, making each lookup O(1)

Closes #912

## Test plan
- [ ] Verify active session indicators still appear correctly in the sidebar
- [ ] Confirm LiveActivityStrip highlights active sessions as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)