### PR TITLE
fix: close useMessagePrefetch subscription leak on abort

### DIFF
--- a/src/hooks/useMessagePrefetch.ts
+++ b/src/hooks/useMessagePrefetch.ts
@@ -31,14 +31,20 @@ export function useMessagePrefetch(enabled: boolean) {
       // On first run, wait until the initial conversation's messages are loaded.
       // On subsequent runs (triggered by conversationsVersion), skip the wait.
       if (!hasRunInitialRef.current && initialConvId && !state.messagePagination[initialConvId]) {
+        if (isAborted()) return;
         await new Promise<void>((resolve) => {
-          if (isAborted()) { resolve(); return; }
           const unsub = useAppStore.subscribe((s) => {
             if (s.messagePagination[initialConvId!] || isAborted()) {
               unsub();
               resolve();
             }
           });
+          // Immediate post-subscribe check closes the race window where state
+          // changed or abort fired between getState() above and subscribe()
+          if (useAppStore.getState().messagePagination[initialConvId] || isAborted()) {
+            unsub();
+            resolve();
+          }
         });
       }
 


### PR DESCRIPTION
## Summary
- Fixes a race condition in `useMessagePrefetch` where a Zustand subscription leaks if abort fires between `subscribe()` and the next subscriber callback
- Adds an early abort guard before creating the subscription and an immediate post-subscribe state check to close the race window

Closes #924

## Test plan
- [ ] Verify prefetch still works: switch between conversations and confirm messages are preloaded
- [ ] Rapidly switch conversations during initial load to exercise the abort path
- [ ] Confirm no subscription leaks via React DevTools or store subscriber count

🤖 Generated with [Claude Code](https://claude.com/claude-code)