### PR TITLE
fix: add retry/backoff for GitHub API rate limits

### DIFF
--- a/backend/github/client.go
+++ b/backend/github/client.go
@@ -51,12 +51,24 @@ type Client struct {
 
 // NewClient creates a new GitHub client
 func NewClient(clientID, clientSecret string) *Client {
+	rt := &retryTransport{
+		base:       http.DefaultTransport,
+		maxRetries: 3,
+		baseDelay:  1 * time.Second,
+	}
+	// Fewer retries for the no-redirect client used in interactive log fetching.
+	noRedirectRT := &retryTransport{
+		base:       http.DefaultTransport,
+		maxRetries: 1,
+		baseDelay:  500 * time.Millisecond,
+	}
 	return &Client{
 		clientID:     clientID,
 		clientSecret: clientSecret,
-		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		httpClient:   &http.Client{Timeout: 30 * time.Second, Transport: rt},
 		noRedirectClient: &http.Client{
 			Timeout: 30 * time.Second,
+			Transport: noRedirectRT,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
@@ -457,11 +469,6 @@ func (c *Client) GetAvatarByEmail(ctx context.Context, email string) (string, er
 		return "", fmt.Errorf("searching users: %w", err)
 	}
 	defer resp.Body.Close()
-
-	// Handle rate limiting
-	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
-		return "", fmt.Errorf("rate limited by GitHub API")
-	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, readErr := io.ReadAll(resp.Body)

--- a/backend/github/retry_transport.go
+++ b/backend/github/retry_transport.go
@@ -1,0 +1,182 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/chatml/chatml-backend/logger"
+)
+
+// retryTransport wraps an http.RoundTripper with automatic retry and
+// exponential backoff for GitHub API rate-limit responses (429 and 403).
+type retryTransport struct {
+	base       http.RoundTripper
+	maxRetries int
+	baseDelay  time.Duration
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Buffer the request body so it can be replayed on retry.
+	if req.Body != nil && req.GetBody == nil {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading request body for retry: %w", err)
+		}
+		req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+	}
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt <= t.maxRetries; attempt++ {
+		// Reset body for retries.
+		if attempt > 0 && req.GetBody != nil {
+			req.Body, err = req.GetBody()
+			if err != nil {
+				return nil, fmt.Errorf("resetting request body for retry: %w", err)
+			}
+		}
+
+		resp, err = t.base.RoundTrip(req)
+		if err != nil {
+			// Don't retry context cancellation or deadline exceeded.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+			// Last attempt — return the network error as-is.
+			if attempt == t.maxRetries {
+				return nil, err
+			}
+			wait := t.backoffDelay(attempt)
+			logger.GitHub.Warnf("GitHub request failed (%v), retry %d/%d in %v",
+				err, attempt+1, t.maxRetries, wait)
+
+			select {
+			case <-time.After(wait):
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			}
+			continue
+		}
+
+		if !isRateLimited(resp) {
+			return resp, nil
+		}
+
+		// Last attempt — return the rate-limited response as-is.
+		if attempt == t.maxRetries {
+			return resp, nil
+		}
+
+		wait := t.retryDelay(resp, attempt)
+		logger.GitHub.Warnf("GitHub rate limited (HTTP %d), retry %d/%d in %v",
+			resp.StatusCode, attempt+1, t.maxRetries, wait)
+
+		// Drain and close body to free the connection.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		// Sleep with context cancellation support.
+		select {
+		case <-time.After(wait):
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}
+
+	return resp, nil
+}
+
+// backoffDelay returns an exponential backoff duration for network errors
+// (no response headers available).
+func (t *retryTransport) backoffDelay(attempt int) time.Duration {
+	backoff := t.baseDelay * (1 << uint(attempt))
+	return clampAndJitter(backoff)
+}
+
+// retryDelay computes how long to wait before the next retry attempt.
+// It checks Retry-After and X-RateLimit-Reset headers first, falling back
+// to exponential backoff. Jitter of ±50% is added and the result is capped
+// at 10 seconds.
+func (t *retryTransport) retryDelay(resp *http.Response, attempt int) time.Duration {
+	if d := parseRetryAfter(resp); d > 0 {
+		return clampAndJitter(d)
+	}
+	if d := parseRateLimitReset(resp); d > 0 {
+		return clampAndJitter(d)
+	}
+	// Exponential backoff: baseDelay * 2^attempt
+	backoff := t.baseDelay * (1 << uint(attempt))
+	return clampAndJitter(backoff)
+}
+
+// isRateLimited returns true if the response is a GitHub rate-limit error.
+// 429 is always a rate limit. 403 is only a rate limit when
+// X-RateLimit-Remaining is "0".
+func isRateLimited(resp *http.Response) bool {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return resp.Header.Get("X-RateLimit-Remaining") == "0"
+	}
+	return false
+}
+
+// parseRetryAfter parses the Retry-After header as integer seconds.
+func parseRetryAfter(resp *http.Response) time.Duration {
+	v := resp.Header.Get("Retry-After")
+	if v == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs < 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// parseRateLimitReset parses the X-RateLimit-Reset header (Unix epoch
+// timestamp) and returns the duration until that time.
+func parseRateLimitReset(resp *http.Response) time.Duration {
+	v := resp.Header.Get("X-RateLimit-Reset")
+	if v == "" {
+		return 0
+	}
+	epoch, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0
+	}
+	d := time.Until(time.Unix(epoch, 0))
+	if d <= 0 {
+		return 0
+	}
+	return d
+}
+
+const maxRetryWait = 10 * time.Second
+
+// clampAndJitter adds ±50% jitter and caps the duration at maxRetryWait.
+func clampAndJitter(d time.Duration) time.Duration {
+	// Jitter: multiply by random factor in [0.5, 1.5)
+	jitter := 0.5 + rand.Float64()
+	d = time.Duration(float64(d) * jitter)
+	if d > maxRetryWait {
+		d = maxRetryWait
+	}
+	if d < 0 {
+		d = 0
+	}
+	return d
+}

--- a/backend/github/retry_transport_test.go
+++ b/backend/github/retry_transport_test.go
@@ -1,0 +1,330 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestTransport(handler http.Handler) (*retryTransport, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+	return &retryTransport{
+		base:       &http.Transport{},
+		maxRetries: 3,
+		baseDelay:  1 * time.Millisecond, // fast for tests
+	}, srv
+}
+
+func TestRetryOn429(t *testing.T) {
+	var attempts int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("rate limited"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	})
+
+	rt, srv := newTestTransport(handler)
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/test", nil)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "success", string(body))
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestRetryOn403WithRateLimit(t *testing.T) {
+	var attempts int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("rate limited"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	})
+
+	rt, srv := newTestTransport(handler)
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/test", nil)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+}
+
+func TestNoRetryOn403PermissionDenied(t *testing.T) {
+	var attempts int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("permission denied"))
+	})
+
+	rt, srv := newTestTransport(handler)
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/test", nil)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "should not retry 403 without rate-limit header")
+}
+
+func TestMaxRetriesExhausted(t *testing.T) {
+	var attempts int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte("rate limited"))
+	})
+
+	rt, srv := newTestTransport(handler)
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/test", nil)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, int32(4), atomic.LoadInt32(&attempts), "1 initial + 3 retries")
+}
+
+func TestContextCancellation(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte("rate limited"))
+	})
+
+	rt, srv := newTestTransport(handler)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay so the backoff sleep is interrupted.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL+"/test", nil)
+	_, err := rt.RoundTrip(req)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBodyPreservedOnRetry(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(b))
+		n := len(bodies)
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rt, srv := newTestTransport(handler)
+	defer srv.Close()
+
+	body := `{"key":"value"}`
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/test", bytes.NewReader([]byte(body)))
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 2)
+	assert.Equal(t, body, bodies[0])
+	assert.Equal(t, body, bodies[1])
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected time.Duration
+	}{
+		{"valid seconds", "5", 5 * time.Second},
+		{"zero", "0", 0},
+		{"negative", "-1", 0},
+		{"empty", "", 0},
+		{"non-numeric", "abc", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{}}
+			if tt.value != "" {
+				resp.Header.Set("Retry-After", tt.value)
+			}
+			assert.Equal(t, tt.expected, parseRetryAfter(resp))
+		})
+	}
+}
+
+func TestParseRateLimitReset(t *testing.T) {
+	// Set reset to 5 seconds from now.
+	future := time.Now().Add(5 * time.Second).Unix()
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("X-RateLimit-Reset", strconv.FormatInt(future, 10))
+
+	d := parseRateLimitReset(resp)
+	// Should be roughly 5 seconds (allow tolerance for test execution).
+	assert.InDelta(t, 5*time.Second, d, float64(2*time.Second))
+
+	// Past timestamp returns 0.
+	past := time.Now().Add(-10 * time.Second).Unix()
+	resp.Header.Set("X-RateLimit-Reset", strconv.FormatInt(past, 10))
+	assert.Equal(t, time.Duration(0), parseRateLimitReset(resp))
+
+	// Missing header returns 0.
+	resp.Header.Del("X-RateLimit-Reset")
+	assert.Equal(t, time.Duration(0), parseRateLimitReset(resp))
+}
+
+func TestIsRateLimited(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		headers  map[string]string
+		expected bool
+	}{
+		{"429 always rate limited", 429, nil, true},
+		{"403 with remaining 0", 403, map[string]string{"X-RateLimit-Remaining": "0"}, true},
+		{"403 without header", 403, nil, false},
+		{"403 with remaining > 0", 403, map[string]string{"X-RateLimit-Remaining": "100"}, false},
+		{"200 not rate limited", 200, nil, false},
+		{"500 not rate limited", 500, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: tt.status,
+				Header:     http.Header{},
+			}
+			for k, v := range tt.headers {
+				resp.Header.Set(k, v)
+			}
+			assert.Equal(t, tt.expected, isRateLimited(resp))
+		})
+	}
+}
+
+func TestRetryOnNetworkError(t *testing.T) {
+	var attempts int32
+	transientErr := errors.New("connection reset by peer")
+
+	rt := &retryTransport{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			n := atomic.AddInt32(&attempts, 1)
+			if n <= 2 {
+				return nil, transientErr
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte("success"))),
+				Header:     http.Header{},
+			}, nil
+		}),
+		maxRetries: 3,
+		baseDelay:  1 * time.Millisecond,
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com/test", nil)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestNoRetryOnContextCanceledError(t *testing.T) {
+	var attempts int32
+
+	rt := &retryTransport{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return nil, context.Canceled
+		}),
+		maxRetries: 3,
+		baseDelay:  1 * time.Millisecond,
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com/test", nil)
+	_, err := rt.RoundTrip(req)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "should not retry context.Canceled")
+}
+
+func TestRetryAfterHeaderRespected(t *testing.T) {
+	var attempts int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("rate limited"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	})
+
+	rt, srv := newTestTransport(handler)
+	defer srv.Close()
+
+	start := time.Now()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/test", nil)
+	resp, err := rt.RoundTrip(req)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+	// Retry-After: 1 with jitter [0.5, 1.5) should wait at least ~500ms.
+	assert.Greater(t, elapsed, 400*time.Millisecond, "should respect Retry-After header delay")
+}
+
+// roundTripFunc adapts a function to the http.RoundTripper interface.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
## Summary
- Add a custom `http.RoundTripper` (`retryTransport`) that transparently retries rate-limited GitHub API responses with exponential backoff and jitter
- Retries HTTP 429 (always) and HTTP 403 only when `X-RateLimit-Remaining: 0` (distinguishes rate limits from permission errors)
- Parses `Retry-After` and `X-RateLimit-Reset` headers for optimal wait times, falling back to exponential backoff (1s, 2s, 4s)
- Also retries transient network errors (but not context cancellation)
- Applied at the transport layer — all ~30 GitHub API call sites benefit with zero code changes

## Test plan
- [x] Unit tests for retry on 429, 403 rate limit, no retry on 403 permission denied
- [x] Tests for max retries exhausted, context cancellation, body preservation across retries
- [x] Tests for Retry-After header parsing, X-RateLimit-Reset parsing, `isRateLimited` logic
- [x] Tests for network error retry and no-retry on context.Canceled
- [x] Full `go test ./github/...` passes
- [x] `go build ./github/...` passes

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)