### PR TITLE
perf: optimize useSidebarSessions workspace grouping from O(w×n) to O(w+n)

### DIFF
--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -155,10 +155,18 @@ export function useSidebarSessions({
       };
     }
 
+    // Pre-group sessions by workspace for O(w+n) instead of O(w×n)
+    const byWorkspace = new Map<string, WorktreeSession[]>();
+    for (const s of filtered) {
+      const list = byWorkspace.get(s.workspaceId);
+      if (list) list.push(s);
+      else byWorkspace.set(s.workspaceId, [s]);
+    }
+
     if (groupBy === 'project') {
       const groups: SidebarGroup[] = [];
       for (const ws of workspaces) {
-        const wsSessions = filtered.filter((s) => s.workspaceId === ws.id);
+        const wsSessions = byWorkspace.get(ws.id) ?? [];
         if (wsSessions.length === 0 && filters.searchTerm) continue;
         const color = workspaceColors[ws.id] || getDefaultColor(ws.id);
         groups.push({
@@ -179,7 +187,7 @@ export function useSidebarSessions({
     if (groupBy === 'project-status') {
       const groups: SidebarGroup[] = [];
       for (const ws of workspaces) {
-        const wsSessions = filtered.filter((s) => s.workspaceId === ws.id);
+        const wsSessions = byWorkspace.get(ws.id) ?? [];
         if (wsSessions.length === 0 && filters.searchTerm) continue;
         const color = workspaceColors[ws.id] || getDefaultColor(ws.id);
         const subGroups = buildStatusGroups(wsSessions, sortBy, `project:${ws.id}`);


### PR DESCRIPTION
## Summary
- Pre-group filtered sessions by `workspaceId` into a `Map` before iterating workspaces
- Replace nested `filtered.filter()` calls in both `project` and `project-status` groupBy modes with O(1) Map lookups
- Reduces complexity from O(w×n) to O(w+n)

Closes #926

## Test plan
- [ ] Verify sidebar grouping in `project` mode shows correct sessions per workspace
- [ ] Verify sidebar grouping in `project-status` mode shows correct sessions with status sub-groups
- [ ] Verify search filtering still hides empty workspace groups
- [ ] Verify `none` and `status` groupBy modes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)