### PR TITLE
fix: add double-unlock guard to SessionLockManager

### DIFF
--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -66,6 +66,12 @@ func (m *SessionLockManager) Unlock(path string) {
 		logger.Handlers.Warnf("SessionLockManager: attempted to unlock non-existent path: %s", path)
 		return
 	}
+	if entry.refCount <= 0 {
+		delete(m.locks, path)
+		m.mu.Unlock()
+		logger.Handlers.Warnf("SessionLockManager: double unlock for path: %s", path)
+		return
+	}
 	entry.refCount--
 	if entry.refCount == 0 {
 		delete(m.locks, path)


### PR DESCRIPTION
## Summary
- Add a guard in `SessionLockManager.Unlock` to prevent `refCount` from going negative on spurious double-unlock calls
- When detected, the leaked lock entry is cleaned up from the map and a warning is logged
- Prevents a potential permanent memory leak if a future bug triggers double-unlock

Closes #917

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./server/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)