### PR TITLE
perf: add max node count limit to buildFileTree

### DIFF
--- a/backend/server/file_handlers.go
+++ b/backend/server/file_handlers.go
@@ -17,11 +17,15 @@ import (
 
 // FileNode represents a file or directory in the tree
 type FileNode struct {
-	Name     string      `json:"name"`
-	Path     string      `json:"path"`
-	IsDir    bool        `json:"isDir"`
-	Children []*FileNode `json:"children,omitempty"`
+	Name      string      `json:"name"`
+	Path      string      `json:"path"`
+	IsDir     bool        `json:"isDir"`
+	Children  []*FileNode `json:"children,omitempty"`
+	Truncated bool        `json:"truncated,omitempty"`
 }
+
+// maxNodeCount is the maximum number of nodes returned in a file tree response.
+const maxNodeCount = 10000
 
 // ListRepoFiles returns the file tree for a repository
 func (h *Handlers) ListRepoFiles(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +55,8 @@ func (h *Handlers) ListRepoFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tree, err := buildFileTree(repo.Path, "", maxDepth, 0)
+	nodeCount := 0
+	tree, err := buildFileTree(repo.Path, "", maxDepth, 0, &nodeCount)
 	if err != nil {
 		writeInternalError(w, "failed to list files", err)
 		return
@@ -62,8 +67,10 @@ func (h *Handlers) ListRepoFiles(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, tree)
 }
 
-// buildFileTree recursively builds the file tree
-func buildFileTree(basePath, relativePath string, maxDepth, currentDepth int) ([]*FileNode, error) {
+// buildFileTree recursively builds the file tree.
+// nodeCount tracks the total nodes added across all recursive calls;
+// when *nodeCount reaches maxNodeCount the current level is marked truncated.
+func buildFileTree(basePath, relativePath string, maxDepth, currentDepth int, nodeCount *int) ([]*FileNode, error) {
 	fullPath := filepath.Join(basePath, relativePath)
 	entries, err := os.ReadDir(fullPath)
 	if err != nil {
@@ -112,8 +119,15 @@ func buildFileTree(basePath, relativePath string, maxDepth, currentDepth int) ([
 	sortEntries(dirs)
 	sortEntries(files)
 
+	truncated := false
+
 	// Add directories first
 	for _, entry := range dirs {
+		if *nodeCount >= maxNodeCount {
+			truncated = true
+			break
+		}
+
 		name := entry.Name()
 		nodePath := filepath.Join(relativePath, name)
 		node := &FileNode{
@@ -121,13 +135,16 @@ func buildFileTree(basePath, relativePath string, maxDepth, currentDepth int) ([
 			Path:  nodePath,
 			IsDir: true,
 		}
+		*nodeCount++
 
-		// Recursively build children if within depth limit
-		if maxDepth == -1 || currentDepth < maxDepth {
-			children, err := buildFileTree(basePath, nodePath, maxDepth, currentDepth+1)
+		// Recursively build children if within depth limit and under node cap
+		if *nodeCount < maxNodeCount && (maxDepth == -1 || currentDepth < maxDepth) {
+			children, err := buildFileTree(basePath, nodePath, maxDepth, currentDepth+1, nodeCount)
 			if err == nil {
 				node.Children = children
 			}
+		} else if *nodeCount >= maxNodeCount {
+			node.Truncated = true
 		}
 
 		nodes = append(nodes, node)
@@ -135,12 +152,28 @@ func buildFileTree(basePath, relativePath string, maxDepth, currentDepth int) ([
 
 	// Add files
 	for _, entry := range files {
+		if *nodeCount >= maxNodeCount {
+			truncated = true
+			break
+		}
+
 		name := entry.Name()
 		nodePath := filepath.Join(relativePath, name)
 		nodes = append(nodes, &FileNode{
 			Name:  name,
 			Path:  nodePath,
 			IsDir: false,
+		})
+		*nodeCount++
+	}
+
+	// If we hit the limit, attach a sentinel node so the client knows
+	if truncated {
+		nodes = append(nodes, &FileNode{
+			Name:      "...",
+			Path:      filepath.Join(relativePath, "..."),
+			IsDir:     false,
+			Truncated: true,
 		})
 	}
 
@@ -457,7 +490,8 @@ func (h *Handlers) ListSessionFiles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build file tree from worktree path
-	tree, err := buildFileTree(session.WorktreePath, "", maxDepth, 0)
+	nodeCount := 0
+	tree, err := buildFileTree(session.WorktreePath, "", maxDepth, 0, &nodeCount)
 	if err != nil {
 		writeInternalError(w, "failed to list files", err)
 		return

--- a/src/components/files/FileTree.tsx
+++ b/src/components/files/FileTree.tsx
@@ -22,6 +22,7 @@ export interface FileNode {
   path: string;
   isDir: boolean;
   children?: FileNode[];
+  truncated?: boolean;
 }
 
 interface FileTreeProps {
@@ -132,6 +133,18 @@ function FileTreeNode({ node, depth, onFileSelect, expandedPaths, onToggle }: Fi
 
   const isHidden = node.name.startsWith('.');
 
+  if (node.truncated && !node.isDir) {
+    return (
+      <div
+        className="flex items-center gap-1.5 py-0.5 px-1 text-xs text-muted-foreground italic"
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
+      >
+        <span className="w-3" />
+        <span className="truncate">... truncated (too many files)</span>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div
@@ -162,6 +175,15 @@ function FileTreeNode({ node, depth, onFileSelect, expandedPaths, onToggle }: Fi
         )}
         <span className="truncate">{node.name}</span>
       </div>
+      {node.isDir && isExpanded && node.truncated && (!node.children || node.children.length === 0) && (
+        <div
+          className="flex items-center gap-1.5 py-0.5 px-1 text-xs text-muted-foreground italic"
+          style={{ paddingLeft: `${(depth + 1) * 12 + 4}px` }}
+        >
+          <span className="w-3" />
+          <span className="truncate">... truncated (too many files)</span>
+        </div>
+      )}
       {node.isDir && isExpanded && node.children && (
         <div>
           {node.children.map((child) => (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -126,6 +126,7 @@ export interface FileNodeDTO {
   path: string;
   isDir: boolean;
   children?: FileNodeDTO[];
+  truncated?: boolean;
 }
 
 export async function listRepos(): Promise<RepoDTO[]> {


### PR DESCRIPTION
## Summary
- Cap `buildFileTree` at 10,000 total nodes to prevent memory spikes and massive JSON responses on large repos
- Directories that hit the limit get a `truncated: true` flag; a sentinel `"..."` node is appended so the client knows the listing is incomplete
- Frontend renders a subtle "... truncated (too many files)" indicator for both sentinel nodes and truncated directories

Closes #919

## Test plan
- [ ] `cd backend && go test ./server/...` passes
- [ ] Open a large repo (50k+ files) and verify the file tree loads quickly and shows truncation
- [ ] `curl` the `/api/repos/{id}/files?depth=all` endpoint and confirm `"truncated": true` appears when the limit is hit
- [ ] Verify normal-sized repos are unaffected (no truncation indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)