### PR TITLE
feat: show per-message token count and cost below AI responses

### DIFF
--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -33,6 +33,7 @@ import { AttachmentPreviewModal } from '@/components/conversation/AttachmentPrev
 import { MentionText } from '@/components/conversation/MentionText';
 import { ApprovedPlanBlock } from '@/components/conversation/ApprovedPlanBlock';
 import { TurnStatusIndicator } from '@/components/conversation/TurnStatusIndicator';
+import { MessageTokenFooter } from '@/components/conversation/MessageTokenFooter';
 
 // Collapsed tool summary with individual ToolUsageBlock instances when expanded
 const ToolUsageSummary = memo(function ToolUsageSummary({ tools, worktreePath, conversationId, messageId, compacted }: { tools: ToolUsage[]; worktreePath?: string; conversationId?: string; messageId?: string; compacted?: boolean }) {
@@ -342,6 +343,11 @@ export const MessageBlock = memo(function MessageBlock({
         {/* File Changes */}
         {message.fileChanges && message.fileChanges.length > 0 && (
           <FileChangesBlock changes={message.fileChanges} worktreePath={worktreePath} />
+        )}
+
+        {/* Per-message token/cost footer */}
+        {message.runSummary && (
+          <MessageTokenFooter summary={message.runSummary} />
         )}
 
         {/* Run Summary */}

--- a/src/components/conversation/MessageTokenFooter.tsx
+++ b/src/components/conversation/MessageTokenFooter.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { memo } from 'react';
+import { formatTokens, formatCost } from '@/lib/format';
+import { useSettingsStore } from '@/stores/settingsStore';
+import type { RunSummary } from '@/lib/types';
+
+interface MessageTokenFooterProps {
+  summary: RunSummary;
+}
+
+export const MessageTokenFooter = memo(function MessageTokenFooter({ summary }: MessageTokenFooterProps) {
+  const show = useSettingsStore((s) => s.showMessageTokenCost);
+  if (!show) return null;
+
+  const input = summary.usage?.inputTokens ?? 0;
+  const output = summary.usage?.outputTokens ?? 0;
+  const cacheRead = summary.usage?.cacheReadInputTokens ?? 0;
+  const cacheWrite = summary.usage?.cacheCreationInputTokens ?? 0;
+  const cost = summary.cost;
+
+  if (input === 0 && output === 0) return null;
+
+  const parts: string[] = [];
+  parts.push(`${formatTokens(input)} in`);
+  parts.push(`${formatTokens(output)} out`);
+  if (cacheRead > 0) parts.push(`${formatTokens(cacheRead)} cached`);
+  if (cacheWrite > 0) parts.push(`${formatTokens(cacheWrite)} cache write`);
+
+  return (
+    <div className="flex items-center gap-1.5 text-2xs text-muted-foreground/60 select-none">
+      <span>{parts.join(' \u00b7 ')}</span>
+      {cost != null && cost > 0 && (
+        <>
+          <span className="text-muted-foreground/30">&mdash;</span>
+          <span>{formatCost(cost)}</span>
+        </>
+      )}
+    </div>
+  );
+});

--- a/src/components/conversation/RunSummaryBlock.tsx
+++ b/src/components/conversation/RunSummaryBlock.tsx
@@ -86,6 +86,7 @@ export const RunSummaryBlock = memo(function RunSummaryBlock({ summary, checkpoi
   const [confirmOpen, setConfirmOpen] = useState(false);
   const showTokenUsage = useSettingsStore((s) => s.showTokenUsage);
   const showChatCost = useSettingsStore((s) => s.showChatCost);
+  const showMessageTokenCost = useSettingsStore((s) => s.showMessageTokenCost);
 
   const handleRewind = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -221,16 +222,16 @@ export const RunSummaryBlock = memo(function RunSummaryBlock({ summary, checkpoi
           </span>
         )}
 
-        {/* Cost */}
-        {showChatCost && cost && (
+        {/* Cost (hidden when per-message footer already shows it) */}
+        {showChatCost && !showMessageTokenCost && cost && (
           <>
             <DotSeparator />
             <span className="font-medium">{cost}</span>
           </>
         )}
 
-        {/* Token counts — grouped pair */}
-        {showTokenUsage && (totalInputTokens > 0 || totalOutputTokens > 0) && (
+        {/* Token counts — grouped pair (hidden when per-message footer already shows them) */}
+        {showTokenUsage && !showMessageTokenCost && (totalInputTokens > 0 || totalOutputTokens > 0) && (
           <>
             <DotSeparator />
             <span className="flex items-center gap-2">

--- a/src/components/settings/sections/AppearanceSettings.tsx
+++ b/src/components/settings/sections/AppearanceSettings.tsx
@@ -109,6 +109,8 @@ export function AppearanceSettings() {
   const setShowTokenUsage = useSettingsStore((s) => s.setShowTokenUsage);
   const showChatCost = useSettingsStore((s) => s.showChatCost);
   const setShowChatCost = useSettingsStore((s) => s.setShowChatCost);
+  const showMessageTokenCost = useSettingsStore((s) => s.showMessageTokenCost);
+  const setShowMessageTokenCost = useSettingsStore((s) => s.setShowMessageTokenCost);
   const { theme, setTheme } = useTheme();
 
   return (
@@ -189,6 +191,16 @@ export function AppearanceSettings() {
           onReset={() => setShowChatCost(SETTINGS_DEFAULTS.showChatCost)}
         >
           <Switch checked={showChatCost} onCheckedChange={setShowChatCost} aria-label="Show cost" />
+        </SettingsRow>
+
+        <SettingsRow
+          settingId="showMessageTokenCost"
+          title="Show per-message tokens & cost"
+          description="Display a compact token count and cost line below each assistant message"
+          isModified={showMessageTokenCost !== SETTINGS_DEFAULTS.showMessageTokenCost}
+          onReset={() => setShowMessageTokenCost(SETTINGS_DEFAULTS.showMessageTokenCost)}
+        >
+          <Switch checked={showMessageTokenCost} onCheckedChange={setShowMessageTokenCost} aria-label="Show per-message tokens and cost" />
         </SettingsRow>
       </SettingsGroup>
     </div>

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -153,6 +153,14 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
     category: 'appearance',
     categoryLabel: 'Appearance',
   },
+  {
+    id: 'showMessageTokenCost',
+    title: 'Show per-message tokens & cost',
+    description: 'Display a compact token count and cost line below each assistant message',
+    keywords: ['token', 'cost', 'footer', 'message', 'usage', 'per-message', 'inline'],
+    category: 'appearance',
+    categoryLabel: 'Appearance',
+  },
 
   // ── AI & Models: Models ──
   {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -79,6 +79,7 @@ export const SETTINGS_DEFAULTS = {
   fontSize: 'medium' as FontSize,
   showTokenUsage: true,
   showChatCost: true,
+  showMessageTokenCost: false,
   zenMode: false,
   // AI & Models
   defaultModel: 'claude-opus-4-6',
@@ -123,6 +124,7 @@ interface SettingsState {
   defaultPlanMode: boolean;
   autoConvertLongText: boolean;
   showChatCost: boolean;
+  showMessageTokenCost: boolean; // Whether to show compact token/cost footer below each assistant message
   // Appearance settings
   theme: ThemeOption; // App theme (system, light, dark)
   fontSize: FontSize;
@@ -198,6 +200,7 @@ interface SettingsState {
   setDefaultPlanMode: (value: boolean) => void;
   setAutoConvertLongText: (value: boolean) => void;
   setShowChatCost: (value: boolean) => void;
+  setShowMessageTokenCost: (value: boolean) => void;
   setTheme: (value: ThemeOption) => void;
   setFontSize: (value: FontSize) => void;
   setBranchSyncBanner: (value: boolean) => void;
@@ -294,6 +297,7 @@ export const useSettingsStore = create<SettingsState>()(
       setDefaultPlanMode: (value) => set({ defaultPlanMode: value }),
       setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),
       setShowChatCost: (value) => set({ showChatCost: value }),
+      setShowMessageTokenCost: (value) => set({ showMessageTokenCost: value }),
       setTheme: (value) => set({ theme: value }),
       setFontSize: (value) => set({ fontSize: value }),
       setBranchSyncBanner: (value) => set({ branchSyncBanner: value }),


### PR DESCRIPTION
## Summary

- Adds a compact inline footer below each assistant message showing input/output token counts, cache breakdown, and estimated cost
- New `MessageTokenFooter` component renders a subtle `text-2xs` line (e.g. "1.2K in · 340 out · 12.5K cached — $0.0032")
- Adds "Show per-message tokens & cost" toggle in Settings > Appearance > Display (default: off)
- When the footer is enabled, RunSummaryBlock's collapsed bar hides its token/cost to avoid duplication

Closes #816

## Test plan

- [ ] Send a message, wait for response to complete — verify token footer appears below assistant message
- [ ] Toggle "Show per-message tokens & cost" off in Settings > Appearance > Display — footer should disappear
- [ ] Verify RunSummaryBlock collapsed bar hides tokens/cost when footer is enabled, shows them when disabled
- [ ] Check messages without `runSummary` (user messages, streaming) don't show the footer
- [ ] Test with different models to ensure cost displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)