### PR TITLE
test: add unit tests for 6 untested lib modules

### DIFF
--- a/src/lib/__tests__/conversationMarkers.test.ts
+++ b/src/lib/__tests__/conversationMarkers.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { extractMarkers } from '../conversationMarkers';
+import type { Message } from '@/lib/types';
+
+function makeMessage(overrides: Partial<Message> & { id: string; role: Message['role'] }): Message {
+  return {
+    content: '',
+    timestamp: Date.now(),
+    ...overrides,
+  } as Message;
+}
+
+describe('extractMarkers', () => {
+  it('returns empty array for no messages', () => {
+    expect(extractMarkers([])).toEqual([]);
+  });
+
+  it('creates user markers for user messages with content', () => {
+    const messages = [
+      makeMessage({ id: 'u1', role: 'user', content: 'Hello world' }),
+      makeMessage({ id: 'a1', role: 'assistant', content: 'Hi there' }),
+    ];
+    const markers = extractMarkers(messages);
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toEqual({
+      id: 'u1',
+      index: 0,
+      type: 'user',
+      title: 'Hello world',
+    });
+  });
+
+  it('skips user messages with only whitespace', () => {
+    const messages = [
+      makeMessage({ id: 'u1', role: 'user', content: '   ' }),
+    ];
+    expect(extractMarkers(messages)).toEqual([]);
+  });
+
+  it('creates plan markers from planContent', () => {
+    const messages = [
+      makeMessage({ id: 'a1', role: 'assistant', content: 'response', planContent: '# My Plan\nStep 1' }),
+    ];
+    const markers = extractMarkers(messages);
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toEqual({
+      id: 'a1-plan',
+      index: 0,
+      type: 'plan',
+      title: 'My Plan Step 1',
+    });
+  });
+
+  it('creates plan markers from timeline plan entries', () => {
+    const messages = [
+      makeMessage({
+        id: 'a1',
+        role: 'assistant',
+        content: '',
+        timeline: [{ type: 'plan', content: 'Plan from timeline' }],
+      }),
+    ];
+    const markers = extractMarkers(messages);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].type).toBe('plan');
+    expect(markers[0].title).toBe('Plan from timeline');
+  });
+
+  it('truncates long titles to 60 chars with ellipsis', () => {
+    const longContent = 'A'.repeat(100);
+    const messages = [
+      makeMessage({ id: 'u1', role: 'user', content: longContent }),
+    ];
+    const markers = extractMarkers(messages);
+    expect(markers[0].title).toHaveLength(61); // 60 chars + ellipsis
+    expect(markers[0].title.endsWith('…')).toBe(true);
+  });
+
+  it('strips markdown heading prefixes', () => {
+    const messages = [
+      makeMessage({ id: 'a1', role: 'assistant', content: '', planContent: '### My Plan Title' }),
+    ];
+    const markers = extractMarkers(messages);
+    expect(markers[0].title).toBe('My Plan Title');
+  });
+
+  it('creates both user and plan markers from same message list', () => {
+    const messages = [
+      makeMessage({ id: 'u1', role: 'user', content: 'Please plan' }),
+      makeMessage({ id: 'a1', role: 'assistant', content: 'Here is my plan', planContent: 'Step 1: do stuff' }),
+    ];
+    const markers = extractMarkers(messages);
+    expect(markers).toHaveLength(2);
+    expect(markers[0].type).toBe('user');
+    expect(markers[1].type).toBe('plan');
+  });
+
+  it('preserves message index correctly', () => {
+    const messages = [
+      makeMessage({ id: 'a0', role: 'assistant', content: 'greeting' }),
+      makeMessage({ id: 'u1', role: 'user', content: 'question' }),
+      makeMessage({ id: 'a1', role: 'assistant', content: 'answer' }),
+      makeMessage({ id: 'u2', role: 'user', content: 'follow up' }),
+    ];
+    const markers = extractMarkers(messages);
+    expect(markers).toHaveLength(2);
+    expect(markers[0].index).toBe(1);
+    expect(markers[1].index).toBe(3);
+  });
+});

--- a/src/lib/__tests__/diffCache.test.ts
+++ b/src/lib/__tests__/diffCache.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getDiffFromCache,
+  setDiffInCache,
+  invalidateDiffCache,
+  clearDiffCache,
+  MAX_ENTRIES,
+} from '../diffCache';
+import type { FileDiffDTO } from '../api';
+
+const makeDiff = (path: string): FileDiffDTO => ({
+  path,
+  oldContent: 'old',
+  newContent: 'new',
+  hunks: [],
+} as unknown as FileDiffDTO);
+
+describe('diffCache', () => {
+  beforeEach(() => {
+    clearDiffCache();
+  });
+
+  it('returns null for cache miss', () => {
+    expect(getDiffFromCache('w1', 's1', 'file.ts')).toBeNull();
+  });
+
+  it('stores and retrieves a cached diff', () => {
+    const diff = makeDiff('file.ts');
+    setDiffInCache('w1', 's1', 'file.ts', diff);
+    expect(getDiffFromCache('w1', 's1', 'file.ts')).toBe(diff);
+  });
+
+  it('returns null after entry expires', () => {
+    const baseTime = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(baseTime);
+
+    const diff = makeDiff('file.ts');
+    setDiffInCache('w1', 's1', 'file.ts', diff);
+
+    // Advance time past the 5 minute TTL
+    vi.mocked(Date.now).mockReturnValue(baseTime + 6 * 60 * 1000);
+    expect(getDiffFromCache('w1', 's1', 'file.ts')).toBeNull();
+    vi.restoreAllMocks();
+  });
+
+  it('invalidates a specific path', () => {
+    setDiffInCache('w1', 's1', 'a.ts', makeDiff('a.ts'));
+    setDiffInCache('w1', 's1', 'b.ts', makeDiff('b.ts'));
+
+    invalidateDiffCache('w1', 's1', 'a.ts');
+
+    expect(getDiffFromCache('w1', 's1', 'a.ts')).toBeNull();
+    expect(getDiffFromCache('w1', 's1', 'b.ts')).not.toBeNull();
+  });
+
+  it('invalidates all entries for a session when no path given', () => {
+    setDiffInCache('w1', 's1', 'a.ts', makeDiff('a.ts'));
+    setDiffInCache('w1', 's1', 'b.ts', makeDiff('b.ts'));
+    setDiffInCache('w1', 's2', 'c.ts', makeDiff('c.ts'));
+
+    invalidateDiffCache('w1', 's1');
+
+    expect(getDiffFromCache('w1', 's1', 'a.ts')).toBeNull();
+    expect(getDiffFromCache('w1', 's1', 'b.ts')).toBeNull();
+    expect(getDiffFromCache('w1', 's2', 'c.ts')).not.toBeNull();
+  });
+
+  it('clearDiffCache removes everything', () => {
+    setDiffInCache('w1', 's1', 'a.ts', makeDiff('a.ts'));
+    setDiffInCache('w2', 's2', 'b.ts', makeDiff('b.ts'));
+
+    clearDiffCache();
+
+    expect(getDiffFromCache('w1', 's1', 'a.ts')).toBeNull();
+    expect(getDiffFromCache('w2', 's2', 'b.ts')).toBeNull();
+  });
+
+  it('evicts oldest entry when exceeding max size', () => {
+    // Fill cache to MAX_ENTRIES
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      setDiffInCache('w1', 's1', `file${i}.ts`, makeDiff(`file${i}.ts`));
+    }
+
+    // Add one more — should evict file0.ts
+    setDiffInCache('w1', 's1', 'overflow.ts', makeDiff('overflow.ts'));
+
+    expect(getDiffFromCache('w1', 's1', 'file0.ts')).toBeNull();
+    expect(getDiffFromCache('w1', 's1', 'overflow.ts')).not.toBeNull();
+    // file1.ts should still be cached
+    expect(getDiffFromCache('w1', 's1', 'file1.ts')).not.toBeNull();
+  });
+
+  it('LRU: accessing an entry moves it to the end', () => {
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      setDiffInCache('w1', 's1', `file${i}.ts`, makeDiff(`file${i}.ts`));
+    }
+
+    // Access file0.ts to move it to end (LRU refresh)
+    getDiffFromCache('w1', 's1', 'file0.ts');
+
+    // Add new entry — should evict file1.ts (now oldest), not file0.ts
+    setDiffInCache('w1', 's1', 'new.ts', makeDiff('new.ts'));
+
+    expect(getDiffFromCache('w1', 's1', 'file0.ts')).not.toBeNull();
+    expect(getDiffFromCache('w1', 's1', 'file1.ts')).toBeNull();
+  });
+});

--- a/src/lib/__tests__/session-fields.test.ts
+++ b/src/lib/__tests__/session-fields.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPriorityOption,
+  getTaskStatusOption,
+  PRIORITY_OPTIONS,
+  TASK_STATUS_OPTIONS,
+} from '../session-fields';
+
+describe('getPriorityOption', () => {
+  it('returns correct option for each known priority value', () => {
+    expect(getPriorityOption(0).label).toBe('No priority');
+    expect(getPriorityOption(1).label).toBe('Urgent');
+    expect(getPriorityOption(2).label).toBe('High');
+    expect(getPriorityOption(3).label).toBe('Medium');
+    expect(getPriorityOption(4).label).toBe('Low');
+  });
+
+  it('falls back to first option for unknown value', () => {
+    expect(getPriorityOption(99)).toBe(PRIORITY_OPTIONS[0]);
+    expect(getPriorityOption(-1)).toBe(PRIORITY_OPTIONS[0]);
+  });
+});
+
+describe('getTaskStatusOption', () => {
+  it('returns correct option for each known status', () => {
+    expect(getTaskStatusOption('backlog').label).toBe('Backlog');
+    expect(getTaskStatusOption('in_progress').label).toBe('In Progress');
+    expect(getTaskStatusOption('in_review').label).toBe('In Review');
+    expect(getTaskStatusOption('done').label).toBe('Done');
+    expect(getTaskStatusOption('cancelled').label).toBe('Cancelled');
+  });
+
+  it('falls back to first option for unknown value', () => {
+    expect(getTaskStatusOption('unknown')).toBe(TASK_STATUS_OPTIONS[0]);
+    expect(getTaskStatusOption('')).toBe(TASK_STATUS_OPTIONS[0]);
+  });
+});

--- a/src/lib/__tests__/shortcuts.test.ts
+++ b/src/lib/__tests__/shortcuts.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getShortcutsByCategory,
+  getShortcutById,
+  formatShortcutKeys,
+  matchesShortcut,
+  SHORTCUTS,
+  type Shortcut,
+} from '../shortcuts';
+
+// Mock platform detection for consistent tests
+vi.mock('../platform', () => ({
+  isMacOS: vi.fn(() => true),
+  getPlatformKey: vi.fn(() => 'darwin'),
+}));
+
+import { isMacOS } from '../platform';
+const mockIsMacOS = vi.mocked(isMacOS);
+
+function makeKeyboardEvent(overrides: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: '',
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+const metaK: Shortcut = {
+  id: 'commandPalette',
+  key: 'k',
+  modifiers: ['meta'],
+  label: 'Open command palette',
+  category: 'General',
+};
+
+describe('getShortcutsByCategory', () => {
+  it('groups all shortcuts into their categories', () => {
+    const grouped = getShortcutsByCategory();
+    const totalGrouped = Object.values(grouped).flat().length;
+    expect(totalGrouped).toBe(SHORTCUTS.length);
+  });
+
+  it('returns empty arrays for categories with no shortcuts', () => {
+    const grouped = getShortcutsByCategory();
+    // Editor and Terminal categories exist but may be empty
+    expect(Array.isArray(grouped.Editor)).toBe(true);
+    expect(Array.isArray(grouped.Terminal)).toBe(true);
+  });
+});
+
+describe('getShortcutById', () => {
+  it('finds a shortcut by ID', () => {
+    const shortcut = getShortcutById('commandPalette');
+    expect(shortcut).toBeDefined();
+    expect(shortcut!.key).toBe('k');
+  });
+
+  it('returns undefined for unknown ID', () => {
+    expect(getShortcutById('nonexistent')).toBeUndefined();
+  });
+});
+
+describe('formatShortcutKeys', () => {
+  it('uses macOS symbols when on Mac', () => {
+    mockIsMacOS.mockReturnValue(true);
+    const keys = formatShortcutKeys(metaK);
+    expect(keys).toEqual(['⌘', 'K']);
+  });
+
+  it('uses text labels on non-Mac', () => {
+    mockIsMacOS.mockReturnValue(false);
+    const keys = formatShortcutKeys(metaK);
+    expect(keys).toEqual(['Ctrl', 'K']);
+  });
+
+  it('formats special keys', () => {
+    mockIsMacOS.mockReturnValue(true);
+    const shortcut: Shortcut = { id: 'test', key: 'Enter', modifiers: ['meta', 'shift'], label: 'Test', category: 'General' };
+    const keys = formatShortcutKeys(shortcut);
+    expect(keys).toEqual(['⌘', '⇧', '↵']);
+  });
+
+  it('formats alt modifier', () => {
+    mockIsMacOS.mockReturnValue(true);
+    const shortcut: Shortcut = { id: 'test', key: 'f', modifiers: ['alt'], label: 'Test', category: 'Navigation' };
+    const keys = formatShortcutKeys(shortcut);
+    expect(keys).toEqual(['⌥', 'F']);
+  });
+
+  it('avoids duplicating Ctrl on non-Mac when both meta and ctrl present', () => {
+    mockIsMacOS.mockReturnValue(false);
+    const shortcut: Shortcut = { id: 'test', key: 'f', modifiers: ['ctrl', 'meta'], label: 'Test', category: 'General' };
+    const keys = formatShortcutKeys(shortcut);
+    // meta → Ctrl, ctrl is skipped because meta already added Ctrl
+    expect(keys).toEqual(['Ctrl', 'F']);
+  });
+});
+
+describe('matchesShortcut', () => {
+  it('matches Cmd+K on Mac (metaKey)', () => {
+    const event = makeKeyboardEvent({ key: 'k', metaKey: true });
+    expect(matchesShortcut(event, metaK)).toBe(true);
+  });
+
+  it('matches Ctrl+K on Windows (ctrlKey for meta modifier)', () => {
+    const event = makeKeyboardEvent({ key: 'k', ctrlKey: true });
+    expect(matchesShortcut(event, metaK)).toBe(true);
+  });
+
+  it('rejects when required modifier is missing', () => {
+    const event = makeKeyboardEvent({ key: 'k' });
+    expect(matchesShortcut(event, metaK)).toBe(false);
+  });
+
+  it('rejects when extra modifier is pressed', () => {
+    const event = makeKeyboardEvent({ key: 'k', metaKey: true, shiftKey: true });
+    expect(matchesShortcut(event, metaK)).toBe(false);
+  });
+
+  it('matches multi-modifier shortcut', () => {
+    const shortcut: Shortcut = { id: 'test', key: 'n', modifiers: ['meta', 'shift'], label: 'Test', category: 'General' };
+    const event = makeKeyboardEvent({ key: 'n', metaKey: true, shiftKey: true });
+    expect(matchesShortcut(event, shortcut)).toBe(true);
+  });
+
+  it('handles Tab key via event.code', () => {
+    const shortcut: Shortcut = { id: 'test', key: 'Tab', modifiers: ['shift'], label: 'Test', category: 'Chat' };
+    const event = makeKeyboardEvent({ key: 'Tab', code: 'Tab', shiftKey: true });
+    expect(matchesShortcut(event, shortcut)).toBe(true);
+  });
+
+  it('handles Enter key via event.key', () => {
+    const shortcut: Shortcut = { id: 'test', key: 'Enter', modifiers: ['meta', 'shift'], label: 'Test', category: 'Chat' };
+    const event = makeKeyboardEvent({ key: 'Enter', metaKey: true, shiftKey: true });
+    expect(matchesShortcut(event, shortcut)).toBe(true);
+  });
+
+  it('uses event.code for Alt+letter (macOS special chars)', () => {
+    const shortcut: Shortcut = { id: 'test', key: 'f', modifiers: ['alt'], label: 'Test', category: 'Navigation' };
+    // On macOS, Alt+F produces 'ƒ' as event.key but code is still 'KeyF'
+    const event = makeKeyboardEvent({ key: 'ƒ', code: 'KeyF', altKey: true });
+    expect(matchesShortcut(event, shortcut)).toBe(true);
+  });
+
+  it('rejects wrong key', () => {
+    const event = makeKeyboardEvent({ key: 'j', metaKey: true });
+    expect(matchesShortcut(event, metaK)).toBe(false);
+  });
+
+  it('rejects extra alt modifier', () => {
+    const event = makeKeyboardEvent({ key: 'k', metaKey: true, altKey: true });
+    expect(matchesShortcut(event, metaK)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/slashCommands.test.ts
+++ b/src/lib/__tests__/slashCommands.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { filterSlashCommands } from '../slashCommands';
+import type { UnifiedSlashCommand } from '@/stores/slashCommandStore';
+import { Terminal } from 'lucide-react';
+
+function makeCommand(overrides: Partial<UnifiedSlashCommand> & { trigger: string }): UnifiedSlashCommand {
+  return {
+    id: overrides.trigger,
+    label: overrides.trigger,
+    description: '',
+    icon: Terminal,
+    source: 'builtin',
+    executionType: 'inline',
+    execute: () => {},
+    ...overrides,
+  };
+}
+
+const commands: UnifiedSlashCommand[] = [
+  makeCommand({ trigger: 'commit', label: 'Commit changes', description: 'Create a git commit', keywords: ['git', 'save'] }),
+  makeCommand({ trigger: 'review', label: 'Code review', description: 'Review code changes' }),
+  makeCommand({ trigger: 'compact', label: 'Compact context', description: 'Summarize conversation' }),
+  makeCommand({ trigger: 'help', label: 'Help', description: 'Show available commands' }),
+  makeCommand({ trigger: 'clear', label: 'Clear chat', description: 'Reset the conversation' }),
+];
+
+describe('filterSlashCommands', () => {
+  it('returns all commands when query is empty', () => {
+    expect(filterSlashCommands(commands, '')).toEqual(commands);
+  });
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterSlashCommands(commands, 'zzzzz')).toEqual([]);
+  });
+
+  it('exact trigger match ranks highest', () => {
+    const result = filterSlashCommands(commands, 'commit');
+    expect(result[0].trigger).toBe('commit');
+  });
+
+  it('prefix match ranks above substring match', () => {
+    // "com" is prefix of "commit" and "compact"; also matches "help" via description ("commands")
+    const result = filterSlashCommands(commands, 'com');
+    // commit and compact: prefix match (80), help: description match (10)
+    expect(result[0].trigger).toBe('commit');
+    expect(result[1].trigger).toBe('compact');
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('substring match in trigger ranks above label match', () => {
+    // "view" is substring of "review" trigger
+    const result = filterSlashCommands(commands, 'view');
+    expect(result[0].trigger).toBe('review');
+  });
+
+  it('label match ranks above keyword match', () => {
+    // "chat" matches label "Clear chat" and no trigger
+    const result = filterSlashCommands(commands, 'chat');
+    expect(result[0].trigger).toBe('clear');
+  });
+
+  it('keyword match ranks above description match', () => {
+    // "git" is keyword for commit, also in description for commit — keyword should take priority path
+    const cmds = [
+      makeCommand({ trigger: 'deploy', label: 'Deploy', description: 'Push git changes to prod' }),
+      makeCommand({ trigger: 'commit', label: 'Commit', description: 'Create a commit', keywords: ['git'] }),
+    ];
+    const result = filterSlashCommands(cmds, 'git');
+    // commit matches via keywords (20), deploy matches via description (10)
+    expect(result[0].trigger).toBe('commit');
+    expect(result[1].trigger).toBe('deploy');
+  });
+
+  it('description match is lowest priority', () => {
+    const result = filterSlashCommands(commands, 'summarize');
+    expect(result).toHaveLength(1);
+    expect(result[0].trigger).toBe('compact');
+  });
+
+  it('sorts alphabetically by trigger for same score', () => {
+    const cmds = [
+      makeCommand({ trigger: 'zebra', label: 'Zebra', description: 'Animal' }),
+      makeCommand({ trigger: 'apple', label: 'Apple', description: 'Animal' }),
+    ];
+    // Both match "Animal" in description (score 10)
+    const result = filterSlashCommands(cmds, 'animal');
+    expect(result.map((c) => c.trigger)).toEqual(['apple', 'zebra']);
+  });
+
+  it('is case-insensitive', () => {
+    const result = filterSlashCommands(commands, 'COMMIT');
+    expect(result[0].trigger).toBe('commit');
+  });
+});

--- a/src/lib/__tests__/thinkingLevels.test.ts
+++ b/src/lib/__tests__/thinkingLevels.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveThinkingParams,
+  clampThinkingLevel,
+  canDisableThinking,
+  THINKING_TOKEN_MAP,
+  type ModelThinkingCapabilities,
+  type ThinkingLevel,
+} from '../thinkingLevels';
+
+const opusModel: ModelThinkingCapabilities = { supportsEffort: true, supportsThinking: true };
+const sonnetModel: ModelThinkingCapabilities = { supportsEffort: false, supportsThinking: true };
+const noThinkingModel: ModelThinkingCapabilities = { supportsEffort: false, supportsThinking: false };
+
+describe('resolveThinkingParams', () => {
+  describe('effort-capable model (Opus)', () => {
+    it('maps "off" to effort "low" (cannot disable)', () => {
+      expect(resolveThinkingParams('off', opusModel)).toEqual({ effort: 'low' });
+    });
+
+    it('maps "low" to effort "low"', () => {
+      expect(resolveThinkingParams('low', opusModel)).toEqual({ effort: 'low' });
+    });
+
+    it('maps "medium" to effort "medium"', () => {
+      expect(resolveThinkingParams('medium', opusModel)).toEqual({ effort: 'medium' });
+    });
+
+    it('maps "high" to no effort param (default)', () => {
+      expect(resolveThinkingParams('high', opusModel)).toEqual({ effort: undefined });
+    });
+
+    it('maps "max" to effort "max"', () => {
+      expect(resolveThinkingParams('max', opusModel)).toEqual({ effort: 'max' });
+    });
+
+    it('never includes maxThinkingTokens', () => {
+      const levels: ThinkingLevel[] = ['off', 'low', 'medium', 'high', 'max'];
+      for (const level of levels) {
+        const result = resolveThinkingParams(level, opusModel);
+        expect(result.maxThinkingTokens).toBeUndefined();
+      }
+    });
+
+    it('ignores maxThinkingTokensCap', () => {
+      expect(resolveThinkingParams('medium', opusModel, 1000)).toEqual({ effort: 'medium' });
+    });
+  });
+
+  describe('token-budget model (Sonnet/Haiku)', () => {
+    it('maps "off" to empty params', () => {
+      expect(resolveThinkingParams('off', sonnetModel)).toEqual({});
+    });
+
+    it.each([
+      ['low', 8000],
+      ['medium', 10000],
+      ['high', 16000],
+      ['max', 32000],
+    ] as [ThinkingLevel, number][])('maps "%s" to maxThinkingTokens %d', (level, expected) => {
+      expect(resolveThinkingParams(level, sonnetModel)).toEqual({ maxThinkingTokens: expected });
+    });
+
+    it('never includes effort param', () => {
+      const levels: ThinkingLevel[] = ['low', 'medium', 'high', 'max'];
+      for (const level of levels) {
+        const result = resolveThinkingParams(level, sonnetModel);
+        expect(result.effort).toBeUndefined();
+      }
+    });
+
+    it('caps tokens with maxThinkingTokensCap', () => {
+      expect(resolveThinkingParams('max', sonnetModel, 5000)).toEqual({ maxThinkingTokens: 5000 });
+    });
+
+    it('does not increase tokens when cap is higher than level budget', () => {
+      expect(resolveThinkingParams('low', sonnetModel, 100000)).toEqual({ maxThinkingTokens: 8000 });
+    });
+  });
+
+  describe('model without thinking support', () => {
+    it('returns empty params for all levels', () => {
+      const levels: ThinkingLevel[] = ['off', 'low', 'medium', 'high', 'max'];
+      for (const level of levels) {
+        expect(resolveThinkingParams(level, noThinkingModel)).toEqual({});
+      }
+    });
+  });
+});
+
+describe('clampThinkingLevel', () => {
+  it('clamps "off" to "low" for effort-capable models', () => {
+    expect(clampThinkingLevel('off', opusModel)).toBe('low');
+  });
+
+  it('passes through other levels for effort-capable models', () => {
+    const levels: ThinkingLevel[] = ['low', 'medium', 'high', 'max'];
+    for (const level of levels) {
+      expect(clampThinkingLevel(level, opusModel)).toBe(level);
+    }
+  });
+
+  it('allows "off" for non-effort models', () => {
+    expect(clampThinkingLevel('off', sonnetModel)).toBe('off');
+  });
+});
+
+describe('canDisableThinking', () => {
+  it('returns false for effort-capable models', () => {
+    expect(canDisableThinking(opusModel)).toBe(false);
+  });
+
+  it('returns true for non-effort models', () => {
+    expect(canDisableThinking(sonnetModel)).toBe(true);
+  });
+
+  it('returns true for models without thinking support', () => {
+    expect(canDisableThinking(noThinkingModel)).toBe(true);
+  });
+});
+
+describe('THINKING_TOKEN_MAP', () => {
+  it('has undefined for "off"', () => {
+    expect(THINKING_TOKEN_MAP.off).toBeUndefined();
+  });
+
+  it('has increasing token budgets', () => {
+    const low = THINKING_TOKEN_MAP.low!;
+    const medium = THINKING_TOKEN_MAP.medium!;
+    const high = THINKING_TOKEN_MAP.high!;
+    const max = THINKING_TOKEN_MAP.max!;
+    expect(low).toBeLessThan(medium);
+    expect(medium).toBeLessThan(high);
+    expect(high).toBeLessThan(max);
+  });
+});

--- a/src/lib/conversationMarkers.ts
+++ b/src/lib/conversationMarkers.ts
@@ -44,8 +44,8 @@ export function extractMarkers(messages: readonly Message[]): ConversationMarker
 }
 
 function truncate(text: string, max: number): string {
-  // Strip markdown heading prefixes and trim
-  const cleaned = text.replace(/^#+\s+/, '').trim();
+  // Strip markdown heading prefixes, collapse newlines, and trim
+  const cleaned = text.replace(/^#+\s+/, '').replace(/\n+/g, ' ').trim();
   if (cleaned.length <= max) return cleaned;
   return cleaned.slice(0, max).trimEnd() + '…';
 }

--- a/src/lib/diffCache.ts
+++ b/src/lib/diffCache.ts
@@ -6,7 +6,7 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
-const MAX_ENTRIES = 100;
+export const MAX_ENTRIES = 100;
 const MAX_AGE_MS = 5 * 60 * 1000; // 5 min — staleness handled by explicit invalidation
 
 function makeKey(workspaceId: string, sessionId: string, path: string): string {


### PR DESCRIPTION
## Summary
- Add unit tests for **thinkingLevels**, **slashCommands**, **shortcuts**, **diffCache**, **conversationMarkers**, and **session-fields** — 74 new test cases
- These modules contained core business logic (thinking param resolution, command filtering/ranking, keyboard shortcut matching, LRU cache, marker extraction, field lookups) with zero prior test coverage
- Minor source adjustments: export `MAX_ENTRIES` from diffCache for testability, collapse newlines in conversationMarkers `truncate` function

## Test plan
- [x] All 74 new tests pass (`pnpm test:run`)
- [ ] Verify existing test suite still passes (`pnpm test:run`)
- [ ] Check coverage improvement (`pnpm test:coverage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)