### PR TITLE
style: improve sessions datatable styling

### DIFF
--- a/src/components/session-manager/SessionsDataTable.tsx
+++ b/src/components/session-manager/SessionsDataTable.tsx
@@ -101,11 +101,11 @@ export function SessionsDataTable({
     () => [
       {
         id: 'workspace',
-        header: '',
-        width: '40px',
+        header: 'Workspace',
+        width: '140px',
         sortable: true,
         accessorKey: 'workspaceName',
-        cell: (row) => <WorkspaceCell workspaceId={row.workspace.id} workspaceName={row.workspaceName} archived={row.session.archived} compact />,
+        cell: (row) => <WorkspaceCell workspaceId={row.workspace.id} workspaceName={row.workspaceName} archived={row.session.archived} />,
       },
       {
         id: 'name',
@@ -145,7 +145,7 @@ export function SessionsDataTable({
       {
         id: 'actions',
         header: '',
-        width: '40px',
+        width: '56px',
         align: 'right',
         cell: (row) => (
           <ActionsCell

--- a/src/components/session-manager/cells/SessionNameCell.tsx
+++ b/src/components/session-manager/cells/SessionNameCell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { GitBranch } from 'lucide-react';
 import type { WorktreeSession } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
@@ -13,10 +14,11 @@ export function SessionNameCell({ session }: SessionNameCellProps) {
   return (
     <span
       className={cn(
-        'text-sm truncate flex items-center min-w-0',
+        'text-sm truncate flex items-center gap-1.5 min-w-0',
         session.archived && 'text-muted-foreground'
       )}
     >
+      <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       <span className="font-medium truncate shrink-0">
         {session.branch || session.name}
       </span>

--- a/src/components/session-manager/cells/WorkspaceCell.tsx
+++ b/src/components/session-manager/cells/WorkspaceCell.tsx
@@ -8,10 +8,9 @@ interface WorkspaceCellProps {
   workspaceId: string;
   workspaceName: string;
   archived?: boolean;
-  compact?: boolean;
 }
 
-export function WorkspaceCell({ workspaceId, workspaceName, archived, compact }: WorkspaceCellProps) {
+export function WorkspaceCell({ workspaceId, workspaceName, archived }: WorkspaceCellProps) {
   const workspaceColors = useSettingsStore((s) => s.workspaceColors);
   return (
     <div className={cn(
@@ -22,11 +21,9 @@ export function WorkspaceCell({ workspaceId, workspaceName, archived, compact }:
         className="w-2.5 h-2.5 rounded-full shrink-0"
         style={{ backgroundColor: resolveWorkspaceColor(workspaceId, workspaceColors) }}
       />
-      {!compact && (
-        <span className="text-sm text-muted-foreground truncate">
-          {workspaceName}
-        </span>
-      )}
+      <span className="text-sm text-muted-foreground truncate">
+        {workspaceName}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Show workspace name alongside color dot instead of dot-only compact mode
- Add GitBranch icon to the branch/session name column
- Widen actions column from 40px to 56px for better right-edge spacing

## Test plan
- [ ] Open Sessions view and verify workspace column shows color dot + name
- [ ] Verify branch column displays GitBranch icon before branch name
- [ ] Verify actions column (preview icon) has proper spacing from right edge
- [ ] Check truncation works for long workspace and branch names

🤖 Generated with [Claude Code](https://claude.com/claude-code)