### PR TITLE
style: use Search icon for Find tool in conversation stream

### DIFF
--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -19,7 +19,7 @@ import {
   Pencil,
   Terminal,
   FileSearch,
-  FolderSearch2,
+  Search,
   Globe,
   FolderOpen,
   ClipboardCheck,
@@ -155,7 +155,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
       case 'search':
         return FileSearch;
       case 'Glob':
-        return FolderSearch2;
+        return Search;
       case 'WebFetch':
       case 'WebSearch':
       case 'web':


### PR DESCRIPTION
## Summary
- Replace `FolderSearch2` with `Search` (magnifying glass) icon for the Glob/Find tool in the conversation stream
- The previous icon was cluttered at small sizes; the new icon is cleaner and more universally recognizable
- Aligns with `ToolUsageHistory.tsx` which already uses `Search` for Glob

## Test plan
- [ ] Open a conversation that triggers a Find/Glob tool usage
- [ ] Verify the icon next to "Find" is now a clean magnifying glass

🤖 Generated with [Claude Code](https://claude.com/claude-code)