### PR TITLE
style: standardize branch name pill styling across modules

### DIFF
--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -38,6 +38,7 @@ import { resolveWorkspaceColor } from '@/lib/workspace-colors';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { PRNumberBadge } from '@/components/shared/PRNumberBadge';
+import { BranchPill } from '@/components/shared/BranchPill';
 
 interface BranchesDashboardProps {
   workspaceId: string;
@@ -72,18 +73,10 @@ function BranchNameCell({ branch, currentBranch }: { branch: BranchDTO; currentB
 
   return (
     <div className="flex items-center gap-2 min-w-0">
-      <span
-        className={cn(
-          'inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-xs truncate',
-          isRemote
-            ? 'bg-blue-500/10 text-blue-700 dark:text-blue-300/70'
-            : 'bg-purple-500/10 text-purple-700 dark:text-purple-300/70'
-        )}
-        title={displayName}
-      >
-        <GitBranch className="h-3.5 w-3.5 shrink-0" />
-        {displayName}
-      </span>
+      <BranchPill
+        name={displayName}
+        className={isRemote ? 'bg-blue-500/10 text-blue-700 dark:text-blue-300/70' : undefined}
+      />
 
       {isCurrentBranch && (
         <span className="flex items-center gap-1 px-1.5 py-0.5 text-2xs rounded bg-green-500/10 text-green-500 border border-green-500/20 shrink-0 whitespace-nowrap">

--- a/src/components/dashboards/PRDashboard.tsx
+++ b/src/components/dashboards/PRDashboard.tsx
@@ -24,6 +24,7 @@ import {
 import { isTauri, copyToClipboard } from '@/lib/tauri';
 import { useToast } from '@/components/ui/toast';
 import { getLabelStyles } from '@/lib/label-colors';
+import { BranchPill } from '@/components/shared/BranchPill';
 import { useTheme } from 'next-themes';
 import {
   RefreshCw,
@@ -98,10 +99,7 @@ function TitleCell({ pr }: { pr: PRWithStatus }) {
 function BranchCell({ pr }: { pr: PRWithStatus }) {
   return (
     <div className="flex items-center gap-1.5 text-xs">
-      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-700 dark:text-purple-300/70 font-mono truncate" title={pr.branch}>
-        <GitBranch className="h-3.5 w-3.5 shrink-0" />
-        {pr.branch}
-      </span>
+      <BranchPill name={pr.branch} />
     </div>
   );
 }

--- a/src/components/session-manager/cells/SessionNameCell.tsx
+++ b/src/components/session-manager/cells/SessionNameCell.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { GitBranch } from 'lucide-react';
 import type { WorktreeSession } from '@/lib/types';
 import { cn } from '@/lib/utils';
+import { BranchPill } from '@/components/shared/BranchPill';
 
 interface SessionNameCellProps {
   session: WorktreeSession;
@@ -18,10 +18,7 @@ export function SessionNameCell({ session }: SessionNameCellProps) {
         session.archived && 'text-muted-foreground'
       )}
     >
-      <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-      <span className="font-medium truncate shrink-0">
-        {session.branch || session.name}
-      </span>
+      <BranchPill name={session.branch || session.name} muted={session.archived} />
       {showPrTitle && (
         <>
           <span className="mx-1.5 text-muted-foreground/40 shrink-0">&middot;</span>

--- a/src/components/shared/BranchPill.tsx
+++ b/src/components/shared/BranchPill.tsx
@@ -1,0 +1,26 @@
+import { GitBranch } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface BranchPillProps {
+  name: string;
+  className?: string;
+  muted?: boolean;
+}
+
+export function BranchPill({ name, className, muted }: BranchPillProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-xs truncate',
+        muted
+          ? 'bg-muted/50 text-muted-foreground'
+          : 'bg-purple-500/10 text-purple-700 dark:text-purple-300/70',
+        className
+      )}
+      title={name}
+    >
+      <GitBranch className="h-3.5 w-3.5 shrink-0" />
+      {name}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract a shared `BranchPill` component (`src/components/shared/BranchPill.tsx`) from duplicated inline markup
- Update Sessions, Pull Requests, and Branches dashboards to use the shared component
- Sessions branch names now render with the same pill style (colored background, mono font, rounded) as PRs and Branches
- Supports `muted` prop for archived sessions and `className` override for remote branch coloring

## Test plan
- [ ] Open Sessions module — branch names show purple pill style with GitBranch icon; archived sessions show muted style
- [ ] Open Pull Requests module — branch pill renders identically to before
- [ ] Open Branches module — local branches purple, remote branches blue, HEAD/REMOTE badges intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)