### PR TITLE
feat: add Create Session from option to header plus menu

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -593,15 +593,29 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                   </DropdownMenuContent>
                 </DropdownMenu>
                 {workspaces.length <= 1 ? (
-                  <button
-                    className="text-foreground hover:text-foreground transition-colors p-0.5 rounded hover:bg-surface-1"
-                    onClick={() => {
-                      const targetId = selectedWorkspaceId || workspaces[0]?.id;
-                      if (targetId) handleCreateSession(targetId);
-                    }}
-                  >
-                    <Plus className="h-4 w-4" />
-                  </button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button className="text-foreground hover:text-foreground transition-colors p-0.5 rounded hover:bg-surface-1">
+                        <Plus className="h-4 w-4" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-52">
+                      <DropdownMenuItem onClick={() => {
+                        const targetId = selectedWorkspaceId || workspaces[0]?.id;
+                        if (targetId) handleCreateSession(targetId);
+                      }}>
+                        <Bot className="h-4 w-4" />
+                        New Session
+                        <DropdownMenuShortcut>⌘N</DropdownMenuShortcut>
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={() => window.dispatchEvent(new CustomEvent('create-session'))}>
+                        <Link className="h-4 w-4" />
+                        Create Session from...
+                        <DropdownMenuShortcut>⌘⇧O</DropdownMenuShortcut>
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 ) : (
                   <DropdownMenu open={newSessionMenuOpen} onOpenChange={setNewSessionMenuOpen}>
                     <DropdownMenuTrigger asChild>
@@ -629,6 +643,12 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                           <DropdownMenuShortcut>{i + 1}</DropdownMenuShortcut>
                         </DropdownMenuItem>
                       ))}
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={() => window.dispatchEvent(new CustomEvent('create-session'))}>
+                        <Link className="h-4 w-4" />
+                        Create Session from...
+                        <DropdownMenuShortcut>⌘⇧O</DropdownMenuShortcut>
+                      </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )}
@@ -959,7 +979,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                 </Button>
               </DropdownMenuTrigger>
             </TooltipTrigger>
-            <DropdownMenuContent align="start" side="top" className="w-52">
+            <DropdownMenuContent align="start" side="top" className="w-56">
               {/* Session creation group */}
               {workspaces.length > 0 && (
                 <>


### PR DESCRIPTION
## Summary
- Added "Create Session from..." (⌘⇧O) to the SESSIONS header "+" dropdown menu, separated from workspace items
- Converted the single-workspace "+" button into a dropdown with "New Session" and "Create Session from..." options
- Widened the footer "New..." menu from `w-52` to `w-56` to prevent "Create Session from..." text wrapping

## Test plan
- [ ] With multiple workspaces: click header "+" → verify "Create Session from..." appears below separator after workspace list
- [ ] Click "Create Session from..." → verify CreateSessionModal opens
- [ ] With single workspace: click header "+" → verify dropdown with "New Session" and "Create Session from..." appears
- [ ] Verify footer "New..." menu no longer wraps "Create Session from..."
- [ ] Verify ⌘⇧O global shortcut still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)