### PR TITLE
perf: separate DataTable grouping from collapse state

### DIFF
--- a/src/components/data-table/DataTable.tsx
+++ b/src/components/data-table/DataTable.tsx
@@ -262,18 +262,19 @@ export function DataTable<T>({
     return groupBy ?? null;
   }, [displayOptions.groupBy, displayOptions.showEmptyGroups, groupBy]);
 
-  // Group data if grouping is configured
-  const groupedData = useMemo<GroupData<T>[]>(() => {
+  // Expensive: only recomputes when data or grouping config changes
+  const rawGroups = useMemo<Omit<GroupData<T>, 'collapsed'>[]>(() => {
     if (!effectiveGroupBy) {
-      return [{ key: '__all__', label: '', rows: processedData, collapsed: false }];
+      return [{ key: '__all__', label: '', rows: processedData }];
     }
-    const groups = groupRows(processedData, effectiveGroupBy);
-    // Apply collapsed state
-    return groups.map((g) => ({
-      ...g,
-      collapsed: collapsedGroups.has(g.key),
-    }));
-  }, [processedData, effectiveGroupBy, collapsedGroups]);
+    return groupRows(processedData, effectiveGroupBy);
+  }, [processedData, effectiveGroupBy]);
+
+  // Cheap: just maps collapse state onto existing groups
+  const groupedData = useMemo<GroupData<T>[]>(
+    () => rawGroups.map((g) => ({ ...g, collapsed: collapsedGroups.has(g.key) })),
+    [rawGroups, collapsedGroups],
+  );
 
   // Get grouped row IDs for selection
   const groupedRowIds = useMemo(() => {


### PR DESCRIPTION
## Summary
- Split the `groupedData` useMemo in `DataTable.tsx` into two memos: `rawGroups` (expensive O(n) grouping) and `groupedData` (cheap collapse-state mapping)
- Toggling group collapse no longer re-runs `groupRows()` on the entire dataset

Closes #925

## Test plan
- [ ] Toggle group collapse in sessions DataTable — should work identically
- [ ] Verify no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)