### PR TITLE
fix: keep search box visible when branches search yields no results

### DIFF
--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -557,13 +557,11 @@ export function BranchesDashboard({
               Try Again
             </Button>
           </div>
-        ) : !branchData || allBranches.length === 0 ? (
+        ) : !branchData ? (
           <div className="text-center py-12 text-muted-foreground">
             <GitBranch className="h-12 w-12 mx-auto mb-4 opacity-50" />
             <p className="text-lg font-medium">No branches found</p>
-            <p className="text-sm mt-1">
-              {searchTerm ? 'Try adjusting your search.' : 'This repository has no branches.'}
-            </p>
+            <p className="text-sm mt-1">This repository has no branches.</p>
           </div>
         ) : (
           <>


### PR DESCRIPTION
## Summary
- Fixed the Branches module search box disappearing when a search query returns no matching branches
- The root cause was that the empty-state guard checked `allBranches.length === 0`, which becomes true after server-side filtering returns zero results, causing the entire DataTable (and its search box) to unmount
- Now the static empty state only renders when `branchData` is null (truly no data), while filtered-empty results are handled by the DataTable's own `emptyState` prop — keeping the search box visible so users can refine their query

## Test plan
- [ ] Open the Branches module with branches present
- [ ] Type a search term that matches no branches — search box should remain visible with empty state inside the table
- [ ] Clear the search — all branches should reappear
- [ ] Verify the empty state still shows correctly when the repository truly has no branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)