### PR TITLE
fix: reduce session state sync lag for PR/check status updates

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -397,9 +397,9 @@ func (w *PRWatcher) Close() error {
 func (w *PRWatcher) run() {
 	// Two-tier polling:
 	// - Sessions without PR: check every 30 seconds (eager detection)
-	// - Sessions with open PR: check every 2 minutes (lifecycle monitoring)
+	// - Sessions with open PR: check every 45 seconds (lifecycle monitoring)
 	fastTicker := time.NewTicker(30 * time.Second)
-	slowTicker := time.NewTicker(2 * time.Minute)
+	slowTicker := time.NewTicker(45 * time.Second)
 	defer fastTicker.Stop()
 	defer slowTicker.Stop()
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -345,7 +345,7 @@ func main() {
 	go hub.Run()
 
 	// Shared PR cache used by both PRWatcher and HTTP handlers
-	prCache := github.NewPRCache(2*time.Minute, 10*time.Minute, 100)
+	prCache := github.NewPRCache(45*time.Second, 10*time.Minute, 100)
 	defer prCache.Close()
 
 	// PR watcher for background GitHub PR status monitoring

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -21,7 +21,7 @@ import { useAppStore } from '@/stores/appStore';
 import { navigate, navigateOrOpenTab } from '@/lib/navigation';
 import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix, type ContentView, type SidebarSortBy } from '@/stores/settingsStore';
 import { useSidebarSessions, isSidebarGroupExpanded, type SidebarGroup } from '@/hooks/useSidebarSessions';
-import { createSession as createSessionApi, listConversations as listConversationsApi, updateSession as updateSessionApi, deleteRepo as deleteRepoApi, addRepo as addRepoApi, mapSessionDTO } from '@/lib/api';
+import { createSession as createSessionApi, listConversations as listConversationsApi, updateSession as updateSessionApi, deleteRepo as deleteRepoApi, addRepo as addRepoApi, mapSessionDTO, refreshPRStatus } from '@/lib/api';
 import { registerSession, getSessionDirName } from '@/lib/tauri';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -383,6 +383,19 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
   };
 
   const handleSelectSession = (workspaceId: string, sessionId: string, event?: React.MouseEvent) => {
+    const { selectedSessionId } = useAppStore.getState();
+
+    // Re-click on already-selected session: force-refresh PR status (bypass throttle)
+    if (sessionId === selectedSessionId) {
+      // Cmd+Click / middle-click should still open a new tab
+      if (event && (event.metaKey || event.button === 1)) {
+        navigateOrOpenTab({ workspaceId, sessionId, contentView: { type: 'conversation' } }, event);
+      } else {
+        refreshPRStatus(workspaceId, sessionId).catch(() => {});
+      }
+      return;
+    }
+
     navigateOrOpenTab({
       workspaceId,
       sessionId,

--- a/src/hooks/usePRStatus.ts
+++ b/src/hooks/usePRStatus.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getPRStatus, refreshPRStatus, ApiError, type PRDetails } from '@/lib/api';
 
-const PR_STATUS_FALLBACK_POLL_MS = 300000; // 5 minutes (fallback, WebSocket is primary)
+const PR_STATUS_FALLBACK_POLL_MS = 90_000; // 90 seconds (fallback, WebSocket is primary)
 
 interface UsePRStatusResult {
   prDetails: PRDetails | null;

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1262,15 +1262,16 @@ export function useWebSocket(enabled: boolean = true) {
       console.warn('Failed to reconcile streaming state after reconnect:', err);
     }
 
-    // Refresh PR status for the selected session to catch events missed during disconnect.
-    // Best-effort: the result arrives via WebSocket session_pr_update event.
+    // Refresh PR status for ALL sessions with open PRs to catch events missed during disconnect.
+    // Best-effort: results arrive via WebSocket session_pr_update events.
+    // Stagger requests to avoid flooding the backend on reconnect.
     try {
-      const { selectedSessionId, sessions } = getStore();
-      if (selectedSessionId) {
-        const session = sessions.find(s => s.id === selectedSessionId);
-        if (session) {
-          refreshPRStatus(session.workspaceId, selectedSessionId).catch(() => {});
-        }
+      const { sessions } = getStore();
+      const openPRSessions = sessions.filter(s => s.prStatus === 'open');
+      for (const session of openPRSessions) {
+        refreshPRStatus(session.workspaceId, session.id).catch(() => {});
+        // Small delay between requests to avoid a burst of concurrent POSTs
+        await new Promise(r => setTimeout(r, 150));
       }
     } catch {
       // Silently ignore — PR status will catch up on next poll cycle

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -38,7 +38,7 @@ import { cleanupConversationState } from '@/hooks/useWebSocket';
 // Throttle on-select PR refresh to avoid excessive API calls.
 // Entries are pruned when the map exceeds MAX_PR_REFRESH_ENTRIES to prevent unbounded growth.
 const lastPRRefreshMap = new Map<string, number>();
-const PR_REFRESH_THROTTLE_MS = 30_000; // 30 seconds
+const PR_REFRESH_THROTTLE_MS = 15_000; // 15 seconds
 const MAX_PR_REFRESH_ENTRIES = 100;
 
 function pruneRefreshMap() {


### PR DESCRIPTION
## Summary
- **Backend**: Reduced open-PR poll interval from 2 minutes to 45 seconds and PR cache fresh TTL from 2 minutes to 45 seconds, so check status changes are detected ~3x faster
- **Frontend**: Reduced fallback poll from 5 minutes to 90 seconds and select-session throttle from 30s to 15s for more responsive session switching
- **Re-click-to-refresh**: Clicking an already-selected session now force-refreshes its PR status (bypassing throttle), giving users a manual escape hatch for stale state
- **WebSocket reconnect**: Now refreshes ALL sessions with open PRs (staggered 150ms apart) instead of only the selected session, preventing stale state after network interruptions

## Test plan
- [ ] Create a session with an open PR that has running CI checks
- [ ] Wait for checks to complete on GitHub — sidebar should update within ~45s without interaction
- [ ] Click on the already-selected session — status should refresh immediately
- [ ] Simulate WebSocket disconnect/reconnect — all open-PR sessions should refresh
- [ ] Monitor `gh api /rate_limit` to confirm API usage stays within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)