### PR TITLE
feat: sessions needing attention + deferred update restart

### DIFF
--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -29,6 +29,7 @@ import {
   GitPullRequest,
   Link,
   Archive,
+  AlertTriangle,
   // Actions
   Plus,
   Bot,
@@ -93,6 +94,17 @@ interface SubmenuItem {
 }
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+function getSessionsNeedingAttention() {
+  const { sessions } = useAppStore.getState();
+  return sessions.filter(
+    (s) => !s.archived && (s.hasCheckFailures || s.hasMergeConflict || s.status === 'error')
+  );
+}
+
+// ============================================================================
 // Command Definitions
 // ============================================================================
 
@@ -129,6 +141,17 @@ const COMMANDS: Command[] = [
     hasSubmenu: true,
     submenuId: 'conversations',
     available: () => useAppStore.getState().conversations.length > 0,
+    action: () => {},
+  },
+  {
+    id: 'sessions-attention',
+    category: 'Navigation',
+    label: 'Sessions Needing Attention',
+    icon: AlertTriangle,
+    keywords: ['problems', 'failures', 'conflicts', 'errors', 'issues', 'broken'],
+    hasSubmenu: true,
+    submenuId: 'attention',
+    available: () => getSessionsNeedingAttention().length > 0,
     action: () => {},
   },
   {
@@ -469,6 +492,32 @@ const SUBMENU_PAGES: Record<string, SubmenuPage> = {
         icon: MessageSquare,
         action: () => navigate({ conversationId: c.id }),
       }));
+    },
+  },
+  attention: {
+    title: 'Sessions Needing Attention',
+    icon: AlertTriangle,
+    getItems: () => {
+      return getSessionsNeedingAttention()
+        .map((s) => {
+          const issues: string[] = [];
+          if (s.hasCheckFailures) issues.push('CI failures');
+          if (s.hasMergeConflict) issues.push('Merge conflict');
+          if (s.status === 'error') issues.push('Agent error');
+
+          return {
+            id: s.id,
+            label: s.name || s.branch,
+            description: issues.join(' · '),
+            icon: AlertTriangle,
+            action: () =>
+              navigate({
+                workspaceId: s.workspaceId,
+                sessionId: s.id,
+                contentView: { type: 'conversation' },
+              }),
+          };
+        });
     },
   },
 };

--- a/src/components/shared/UpdatePill.tsx
+++ b/src/components/shared/UpdatePill.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useEffect } from 'react';
-import { Download, Loader2, RefreshCw, RotateCcw } from 'lucide-react';
+import { Clock, Download, Loader2, RefreshCw, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUpdateStore } from '@/stores/updateStore';
+import { useAppStore } from '@/stores/appStore';
 import { UPDATE_CHECK_DELAY_MS } from '@/lib/constants';
 import {
   Tooltip,
@@ -20,6 +21,8 @@ export function UpdatePill() {
   const checkForUpdates = useUpdateStore((s) => s.checkForUpdates);
   const downloadAndInstall = useUpdateStore((s) => s.downloadAndInstall);
   const relaunch = useUpdateStore((s) => s.relaunch);
+  const waitForAgents = useUpdateStore((s) => s.waitForAgents);
+  const streamingState = useAppStore((s) => s.streamingState);
 
   // Auto-check for updates on mount and periodically
   useEffect(() => {
@@ -36,6 +39,20 @@ export function UpdatePill() {
     };
   }, [checkForUpdates]);
 
+  // Auto-relaunch when all agents finish while in 'waiting' state
+  useEffect(() => {
+    if (status !== 'waiting') return;
+    const entries = Object.values(streamingState);
+    if (entries.length === 0) return; // State not populated yet
+    const hasActive = entries.some((s) => s.isStreaming);
+    if (!hasActive) {
+      relaunch().catch(() => {
+        // IPC failure — fall back to ready so user can retry
+        useUpdateStore.getState().cancelWait();
+      });
+    }
+  }, [status, streamingState, relaunch]);
+
   // Don't render when there's nothing to show
   if (status === 'idle' || status === 'checking') {
     return null;
@@ -46,7 +63,17 @@ export function UpdatePill() {
       case 'available':
         downloadAndInstall();
         break;
-      case 'ready':
+      case 'ready': {
+        const hasActive = Object.values(streamingState).some((s) => s.isStreaming);
+        if (hasActive) {
+          waitForAgents();
+        } else {
+          relaunch();
+        }
+        break;
+      }
+      case 'waiting':
+        // Force restart — user clicked again while waiting
         relaunch();
         break;
       case 'error':
@@ -63,6 +90,8 @@ export function UpdatePill() {
         return `Updating ${Math.round(progress)}%`;
       case 'ready':
         return 'Restart';
+      case 'waiting':
+        return 'Waiting...';
       case 'error':
         return 'Retry';
       default:
@@ -78,6 +107,8 @@ export function UpdatePill() {
         return <Loader2 className="h-3 w-3 animate-spin" />;
       case 'ready':
         return <RefreshCw className="h-3 w-3" />;
+      case 'waiting':
+        return <Clock className="h-3 w-3" />;
       case 'error':
         return <RotateCcw className="h-3 w-3" />;
       default:
@@ -93,6 +124,8 @@ export function UpdatePill() {
         return 'Downloading update...';
       case 'ready':
         return 'Update installed. Click to restart the app.';
+      case 'waiting':
+        return 'Waiting for agents to finish. Click to restart now.';
       case 'error':
         return 'Update failed. Click to retry.';
       default:
@@ -107,6 +140,8 @@ export function UpdatePill() {
         return 'bg-blue-500/15 text-blue-400 border-blue-500/25 hover:bg-blue-500/25';
       case 'ready':
         return 'bg-emerald-500/15 text-emerald-400 border-emerald-500/25 hover:bg-emerald-500/25';
+      case 'waiting':
+        return 'bg-amber-500/15 text-amber-400 border-amber-500/25 hover:bg-amber-500/25';
       case 'error':
         return 'bg-red-500/15 text-red-400 border-red-500/25 hover:bg-red-500/25';
       default:

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import type { Update } from '@tauri-apps/plugin-updater';
 
-export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error';
+export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'waiting' | 'error';
 
 interface UpdateState {
   status: UpdateStatus;
@@ -12,6 +12,8 @@ interface UpdateState {
   checkForUpdates: () => Promise<'up-to-date' | 'available' | null>;
   downloadAndInstall: () => Promise<void>;
   relaunch: () => Promise<void>;
+  waitForAgents: () => void;
+  cancelWait: () => void;
 }
 
 // Hold the Update object outside of Zustand state (not serializable)
@@ -31,7 +33,7 @@ export const useUpdateStore = create<UpdateState>()((set, get) => ({
     if (!isTauri()) return null;
 
     const { status } = get();
-    if (status === 'checking' || status === 'downloading') return null;
+    if (status === 'checking' || status === 'downloading' || status === 'waiting') return null;
 
     try {
       set({ status: 'checking', error: null });
@@ -96,5 +98,19 @@ export const useUpdateStore = create<UpdateState>()((set, get) => ({
   relaunch: async () => {
     const { relaunch } = await import('@tauri-apps/plugin-process');
     await relaunch();
+  },
+
+  waitForAgents: () => {
+    const { status } = get();
+    if (status === 'ready') {
+      set({ status: 'waiting' });
+    }
+  },
+
+  cancelWait: () => {
+    const { status } = get();
+    if (status === 'waiting') {
+      set({ status: 'ready' });
+    }
   },
 }));


### PR DESCRIPTION
## Summary
- **Sessions Needing Attention (⌘K)**: New command palette entry that surfaces sessions with CI failures, merge conflicts, or agent errors — lets users quickly jump to problems. Only appears when issues exist.
- **Deferred Update Restart**: When clicking "Restart" while agents are running, the update pill enters an amber "Waiting..." state and auto-relaunches once all agents finish. Clicking again force-restarts immediately.

Inspired by [Conductor 0.39.0](https://www.conductor.build/changelog/0.39.0-insta-summarize-command-palette-opus-4-6) changelog analysis.

## Test plan
- [ ] Open ⌘K with a session that has check failures → "Sessions Needing Attention" appears
- [ ] Select the command → submenu shows affected sessions with issue descriptions
- [ ] Remove all issues → command disappears from palette
- [ ] With an agent running, trigger update ready → click Restart → pill shows amber "Waiting..."
- [ ] Agent finishes → app auto-relaunches
- [ ] Click "Waiting..." pill → force restart works immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)