### PR TITLE
perf: cache conversation panes for instant session switching

### DIFF
--- a/src/components/conversation/CachedConversationPane.tsx
+++ b/src/components/conversation/CachedConversationPane.tsx
@@ -41,25 +41,17 @@ function DeferredConversationMarkers({ messages, onScrollToIndex }: {
   return <ConversationMarkers messages={deferredMessages} onScrollToIndex={onScrollToIndex} />;
 }
 
-// Tiny gate that reads a ref to conditionally render StreamingMessage.
-// This avoids putting `isActive` in the messageListFooter useMemo deps,
-// keeping the footer reference stable across session switches (prevents
-// Virtuoso re-measure on the hidden pane).
+// Gate that conditionally renders StreamingMessage based on pane visibility.
 function StreamingMessageGate({
-  isActiveRef,
+  isActive,
   conversationId,
   worktreePath,
 }: {
-  isActiveRef: React.RefObject<boolean>;
+  isActive: boolean;
   conversationId: string;
   worktreePath?: string;
 }) {
-  // Subscribe to isActive changes via a minimal state sync
-  const [visible, setVisible] = useState(isActiveRef.current);
-  useEffect(() => {
-    setVisible(isActiveRef.current);
-  });
-  if (!visible) return null;
+  if (!isActive) return null;
   return (
     <ErrorBoundary
       section="StreamingMessage"
@@ -241,7 +233,9 @@ export function CachedConversationPane({
   const isAtBottomRef = useRef(true);
   const forceFollowRef = useRef(false);
   const isActiveRef = useRef(isActive);
-  isActiveRef.current = isActive;
+  useEffect(() => {
+    isActiveRef.current = isActive;
+  }, [isActive]);
 
   // Continuously track the visible range
   const handleRangeChanged = useCallback((range: { startIndex: number; endIndex: number }) => {
@@ -279,14 +273,13 @@ export function CachedConversationPane({
     messageListRef.current?.scrollToBottom('auto');
   }, []);
 
-  // Stable footer for VirtualizedMessageList — isActive is read via ref inside
-  // StreamingMessageGate so the footer identity stays stable across session switches.
+  // Footer for VirtualizedMessageList
   const messageListFooter = useMemo(() => {
     if (!conversationId) return undefined;
     return (
       <div className="pl-5 pr-12 pb-16">
         <StreamingMessageGate
-          isActiveRef={isActiveRef}
+          isActive={isActive}
           conversationId={conversationId}
           worktreePath={worktreePath}
         />
@@ -302,7 +295,7 @@ export function CachedConversationPane({
         )}
       </div>
     );
-  }, [conversationId, queuedMessages, removeQueuedMessage, worktreePath]);
+  }, [conversationId, isActive, queuedMessages, removeQueuedMessage, worktreePath]);
 
   // Listen for message submit events to force scroll to bottom.
   // Only the active pane registers the listener to avoid redundant work.

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -291,10 +291,6 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     return result;
   }, [fileTabs, recentSessions]);
 
-  const currentSession = useMemo(
-    () => sessions.find((s) => s.id === selectedSessionId),
-    [sessions, selectedSessionId]
-  );
   const sessionConversations = useMemo(
     () => conversations.filter((c) => c.sessionId === selectedSessionId),
     [conversations, selectedSessionId]


### PR DESCRIPTION
## Summary

- **Root cause**: `VirtualizedMessageList` was keyed by `selectedConversationId`, forcing a full Virtuoso unmount/remount on every session switch — even when messages were already in the store
- **Fix**: Apply the same LRU caching pattern used for file tabs (Pierre Shadow DOMs) to conversation message lists. Up to 3 `CachedConversationPane` instances stay mounted but hidden (`display:none`). Switching sessions just toggles CSS visibility — instant
- **Resource efficiency**: Hidden panes gate CPU-intensive work (streaming, markers, pagination, search shortcuts) via an `isActive` prop, consuming near-zero resources

## Changes

| File | Change |
|------|--------|
| `CachedConversationPane.tsx` | **New** — self-contained conversation pane with per-session message list, search, scroll tracking, and `isActive` gating |
| `ConversationArea.tsx` | Extract conversation section into cached panes loop; extend `RecentSession` to track `activeConversationId`; remove ~490 lines of moved state/hooks |

## Test plan

- [ ] Open 2+ sessions with messages, switch between them — conversation area should update instantly without lag or flicker
- [ ] Scroll to middle of a conversation, switch away and back — scroll position should be preserved
- [ ] Start a streaming response, switch away and back — streaming continues correctly
- [ ] Open search in a conversation, switch away and back — search state preserved per-pane
- [ ] Switch between conversations within a session — still works correctly (Virtuoso remounts via key)
- [ ] Session with >100 messages — switch away and back, verify messages load correctly after eviction

🤖 Generated with [Claude Code](https://claude.com/claude-code)