### PR TITLE
fix: eliminate diff file opening lag caused by FileHistoryPanel

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -408,7 +408,7 @@ func (rm *RepoManager) GetFileCommitHistory(ctx context.Context, repoPath, fileP
 	// Format: SHA|ShortSHA|AuthorName|AuthorEmail|Timestamp|Subject
 	args := []string{
 		"log",
-		"--follow",
+		"-n", "51",
 		"--pretty=format:%H|%h|%an|%ae|%aI|%s",
 		"--numstat",
 		"--",

--- a/backend/server/session_git_handlers.go
+++ b/backend/server/session_git_handlers.go
@@ -299,8 +299,9 @@ func (h *Handlers) GetSessionDiffSummary(w http.ResponseWriter, r *http.Request)
 
 // FileHistoryResponse represents the commit history for a file
 type FileHistoryResponse struct {
-	Commits []git.FileCommit `json:"commits"`
-	Total   int              `json:"total"`
+	Commits   []git.FileCommit `json:"commits"`
+	Total     int              `json:"total"`
+	Truncated bool             `json:"truncated"`
 }
 
 // GetSessionFileHistory returns the commit history for a specific file in a session's worktree
@@ -337,9 +338,17 @@ func (h *Handlers) GetSessionFileHistory(w http.ResponseWriter, r *http.Request)
 		commits = []git.FileCommit{}
 	}
 
+	// Backend fetches 51 commits; if we got more than 50, the history is truncated
+	const maxCommits = 50
+	truncated := len(commits) > maxCommits
+	if truncated {
+		commits = commits[:maxCommits]
+	}
+
 	writeJSON(w, FileHistoryResponse{
-		Commits: commits,
-		Total:   len(commits),
+		Commits:   commits,
+		Total:     len(commits),
+		Truncated: truncated,
 	})
 }
 

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -880,9 +880,10 @@ export function ChangesPanel() {
                   <McpServersPanel />
                 </ErrorBoundary>
               </div>
+              {/* CSS 'hidden' keeps the component mounted; isVisible gates network fetches */}
               <div className={cn("h-full", bottomTab !== 'file-history' && 'hidden')}>
                 <ErrorBoundary section="FileHistory" fallback={<InlineErrorFallback message="Unable to display file history" />}>
-                  <FileHistoryPanel />
+                  <FileHistoryPanel isVisible={bottomTab === 'file-history'} />
                 </ErrorBoundary>
               </div>
             </div>

--- a/src/components/panels/FileHistoryPanel.tsx
+++ b/src/components/panels/FileHistoryPanel.tsx
@@ -42,11 +42,16 @@ function formatRelativeTime(isoTimestamp: string): string {
   }
 }
 
-export function FileHistoryPanel() {
+interface FileHistoryPanelProps {
+  isVisible?: boolean;
+}
+
+export function FileHistoryPanel({ isVisible = true }: FileHistoryPanelProps) {
   const { selectedWorkspaceId, selectedSessionId } = useSelectedIds();
   const { fileTabs, selectedFileTabId, openFileTab, updateFileTab } = useFileTabState();
 
   const [commits, setCommits] = useState<FileCommitDTO[]>([]);
+  const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -57,6 +62,8 @@ export function FileHistoryPanel() {
 
   // Track if component is mounted
   const isMountedRef = useRef(false);
+  // Track which file we last successfully fetched to avoid redundant requests
+  const lastFetchedKeyRef = useRef<string | null>(null);
 
   // Get current file from selected tab
   const currentFileTab = useMemo(() => {
@@ -66,12 +73,17 @@ export function FileHistoryPanel() {
 
   const currentFilePath = currentFileTab?.path;
 
+  const fetchKey = `${selectedWorkspaceId}:${selectedSessionId}:${currentFilePath}`;
+
   // Fetch function that handles all state updates
-  const fetchHistory = useCallback(async () => {
+  const fetchHistory = useCallback(async (signal?: AbortSignal) => {
     if (!selectedWorkspaceId || !selectedSessionId || !currentFilePath) {
-      setCommits([]);
-      setLoading(false);
-      setError(null);
+      if (!signal?.aborted) {
+        setCommits([]);
+        setLoading(false);
+        setError(null);
+        lastFetchedKeyRef.current = null;
+      }
       return;
     }
 
@@ -79,31 +91,43 @@ export function FileHistoryPanel() {
     setError(null);
 
     try {
-      const data = await getFileCommitHistory(selectedWorkspaceId, selectedSessionId, currentFilePath);
-      if (isMountedRef.current) {
+      const data = await getFileCommitHistory(selectedWorkspaceId, selectedSessionId, currentFilePath, signal);
+      if (isMountedRef.current && !signal?.aborted) {
         setCommits(data.commits ?? []);
+        setTruncated(data.truncated ?? false);
+        lastFetchedKeyRef.current = fetchKey;
       }
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       if (isMountedRef.current) {
         setError(err instanceof Error ? err.message : 'Failed to load history');
         setCommits([]);
+        lastFetchedKeyRef.current = null;
       }
     } finally {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && !signal?.aborted) {
         setLoading(false);
       }
     }
-  }, [selectedWorkspaceId, selectedSessionId, currentFilePath]);
+  }, [selectedWorkspaceId, selectedSessionId, currentFilePath, fetchKey]);
 
-  // Fetch file history when file changes
+  // Fetch file history when file changes — only when the panel is visible.
+  // Skip if we already have data for this exact file (e.g. toggling the panel tab).
   useEffect(() => {
+    if (!isVisible) return;
     isMountedRef.current = true;
-    fetchHistory();
+
+    // Already have data for this file — no need to re-fetch
+    if (lastFetchedKeyRef.current === fetchKey) return;
+
+    const controller = new AbortController();
+    fetchHistory(controller.signal);
 
     return () => {
       isMountedRef.current = false;
+      controller.abort();
     };
-  }, [fetchHistory]);
+  }, [fetchHistory, fetchKey, isVisible]);
 
   // Handle container resize
   useEffect(() => {
@@ -269,7 +293,7 @@ export function FileHistoryPanel() {
             }}
             className="flex items-center justify-center text-xs text-muted-foreground/60"
           >
-            — Beginning of file history —
+            {truncated ? `Showing last ${commits.length} commits` : '— Beginning of file history —'}
           </div>
         )}
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -675,16 +675,19 @@ export interface FileCommitDTO {
 export interface FileHistoryResponse {
   commits: FileCommitDTO[];
   total: number;
+  truncated: boolean;
 }
 
 export async function getFileCommitHistory(
   workspaceId: string,
   sessionId: string,
-  filePath: string
+  filePath: string,
+  signal?: AbortSignal
 ): Promise<FileHistoryResponse> {
   const params = new URLSearchParams({ path: filePath });
   const res = await fetchWithAuth(
-    `${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/file-history?${params.toString()}`
+    `${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/file-history?${params.toString()}`,
+    { signal }
   );
   return handleResponse<FileHistoryResponse>(res);
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `FileHistoryPanel` was always mounted (hidden via CSS) and fired `git log --follow --numstat` on every file tab change — even when the panel wasn't visible. For files with deep history (e.g., `websocket.go`), this caused 10-20 second lag when opening any diff file.
- **Fix**: Gate history fetches on panel visibility (`isVisible` prop), add `AbortController` for cancellation, cache last-fetched key to avoid redundant requests, remove `--follow`, and limit to 50 commits.
- **Backend**: Added `truncated` flag to `FileHistoryResponse` so the UI can indicate when history is capped.

## Test plan
- [ ] Open a file with deep git history (e.g., `websocket.go`) — should open instantly with no lag
- [ ] Switch to File History tab — history loads only then, should be sub-second
- [ ] Switch between diff tabs rapidly — no lag, previous requests are cancelled
- [ ] Toggle away from File History and back to same file — no re-fetch (cached)
- [ ] Verify footer shows "Showing last 50 commits" when history is truncated
- [ ] Verify no console errors from aborted requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)