### PR TITLE
fix: use generic text for review item Add to chat action

### DIFF
--- a/src/components/panels/ReviewPanel.tsx
+++ b/src/components/panels/ReviewPanel.tsx
@@ -447,7 +447,7 @@ function commentToAttachment(comment: ReviewComment): Attachment {
 function handleAddToChat(comment: ReviewComment) {
   const attachment = commentToAttachment(comment);
   dispatchAppEvent('compose-action', {
-    text: `Fix this review comment in ${comment.filePath}:${comment.lineNumber}`,
+    text: `Fix the attached review comments`,
     attachments: [attachment],
   });
 }


### PR DESCRIPTION
## Summary
- Changed the "Add to chat" action in the Reviews Panel to use generic text (`Fix the attached review comments`) instead of file-specific text (`Fix this review comment in path:line`)
- The attachment already contains all details (file, line, severity, content), so the input text doesn't need to duplicate them
- Works correctly when adding multiple review items — the first sets the text, subsequent ones only add attachments (existing empty-check guard in ChatInput)

## Test plan
- [ ] Open Reviews Panel with review comments
- [ ] Click "Add to chat" on a comment → verify input shows generic text + attachment
- [ ] Click "Add to chat" on another comment → verify text unchanged, second attachment added
- [ ] Type in input first, then click "Add to chat" → verify text not overwritten, attachment added

🤖 Generated with [Claude Code](https://claude.com/claude-code)