### PR TITLE
fix: polish Merge PR popover to match Review popover styling

### DIFF
--- a/src/components/shared/PrimaryActionButton/ActionButton.tsx
+++ b/src/components/shared/PrimaryActionButton/ActionButton.tsx
@@ -1,19 +1,22 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef, Fragment } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Loader2, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { ActionButtonProps } from './types';
+import type { ActionButtonProps, DropdownAction, DropdownColor } from './types';
 
 const PENDING_TIMEOUT_MS = 8000;
+
+const DROPDOWN_COLOR_CLASSES: Record<DropdownColor, { icon: string; bg: string; hoverBg: string }> = {
+  blue:   { icon: 'text-blue-500',   bg: 'bg-blue-500/10',   hoverBg: 'group-hover:bg-blue-500/20' },
+  purple: { icon: 'text-purple-500', bg: 'bg-purple-500/10', hoverBg: 'group-hover:bg-purple-500/20' },
+  teal:   { icon: 'text-teal-500',   bg: 'bg-teal-500/10',   hoverBg: 'group-hover:bg-teal-500/20' },
+  green:  { icon: 'text-green-500',  bg: 'bg-green-500/10',  hoverBg: 'group-hover:bg-green-500/20' },
+  amber:  { icon: 'text-amber-500',  bg: 'bg-amber-500/10',  hoverBg: 'group-hover:bg-amber-500/20' },
+  red:    { icon: 'text-red-500',    bg: 'bg-red-500/10',    hoverBg: 'group-hover:bg-red-500/20' },
+};
 
 export function ActionButton({
   action,
@@ -22,26 +25,22 @@ export function ActionButton({
   onArchiveSession,
   className,
 }: ActionButtonProps) {
-  // Pending action state — blocks duplicate clicks and shows spinner feedback.
-  // pendingActionKey tracks which action was clicked. When the action identity changes
-  // (type or label), the mismatch means the click has been processed → not pending.
   const [pendingActionKey, setPendingActionKey] = useState<string | null>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
   const actionKey = action ? `${action.type}:${action.label}` : null;
   const pendingAction = pendingActionKey !== null && pendingActionKey === actionKey;
 
-  // Safety timeout: reset after timeout in case the action object doesn't change
   useEffect(() => {
     if (!pendingActionKey) return;
     const timer = setTimeout(() => setPendingActionKey(null), PENDING_TIMEOUT_MS);
     return () => clearTimeout(timer);
   }, [pendingActionKey]);
 
-  // Mark as pending for the current action
   const markPending = useCallback(() => {
     setPendingActionKey(actionKey);
   }, [actionKey]);
 
-  // Replay enter animation when the tier changes by removing and re-adding the class
+  // Replay enter animation when the tier changes
   const containerRef = useRef<HTMLDivElement>(null);
   const prevTierRef = useRef(action?.tier);
   useEffect(() => {
@@ -49,85 +48,116 @@ export function ActionButton({
     if (prevTierRef.current !== action.tier) {
       const el = containerRef.current;
       el.classList.remove('animate-action-enter');
-      // Force reflow so the browser registers the removal
       void el.offsetWidth;
       el.classList.add('animate-action-enter');
     }
     prevTierRef.current = action.tier;
   }, [action?.tier, action]);
 
-  // Nothing to render if action is null (e.g., clean state)
   if (!action) {
     return null;
   }
 
   const Icon = action.icon;
 
-  // Handle click based on action type
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (pendingAction) return;
 
-    // For actions that send a message to the agent, block subsequent clicks
     const isMessageAction = action.type === 'fix-issues' || (action.message != null);
     if (isMessageAction) {
       markPending();
     }
 
     if (action.type === 'fix-issues' && onFixIssues) {
-      // Fetch CI failure context and forward to agent
       onFixIssues();
     } else if (action.type === 'merge-pr') {
-      // Merge PR: send the merge instruction to the agent
       if (action.message) {
         onSendMessage(action.message, action.type);
       }
     } else if (action.type === 'view-pr' && action.prUrl) {
-      // Open PR in browser
       window.open(action.prUrl, '_blank');
     } else if (action.type === 'create-pr') {
-      // Create PR: send the instruction to the agent
       if (action.message) {
         onSendMessage(action.message, action.type);
       }
     } else if (action.type === 'archive-session' && action.sessionId && onArchiveSession) {
-      // Archive the session
       onArchiveSession(action.sessionId);
     } else if (action.message) {
-      // Send message to agent
       onSendMessage(action.message, action.type);
     }
   };
 
-  // Handle dropdown action click — uses the parent action.type (not per-item) so
-  // all dropdown items resolve to the same template (e.g. all merge strategies → 'merge-pr').
   const handleDropdownClick = (message: string) => {
     if (pendingAction) return;
     markPending();
+    setPopoverOpen(false);
     onSendMessage(message, action.type);
   };
 
-  // Handle secondary action click (legacy single action)
   const handleSecondaryClick = () => {
     if (pendingAction) return;
     markPending();
+    setPopoverOpen(false);
     if (action.secondaryAction) {
       onSendMessage(action.secondaryAction.message, action.type);
     }
   };
 
-  // Check if we have dropdown actions (array) or secondary action (single)
   const hasDropdown = action.dropdownActions?.length || action.secondaryAction;
 
-  // If action has dropdown actions, render split button with dropdown
   if (hasDropdown) {
-    // Determine the separator color based on variant
     const separatorColor = {
       default: 'border-l-primary/30',
       destructive: 'border-l-red-400/40',
       success: 'border-l-emerald-400/40',
       warning: 'border-l-yellow-400/40',
     }[action.variant] || 'border-l-primary/30';
+
+    // Split actions into simple (no color) and rich (with color) for rendering
+    const simpleActions: DropdownAction[] = [];
+    const richActions: DropdownAction[] = [];
+    for (const da of action.dropdownActions ?? []) {
+      if (da.color) richActions.push(da);
+      else simpleActions.push(da);
+    }
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      // Number shortcuts for rich actions
+      const num = parseInt(e.key, 10);
+      if (num >= 1 && num <= richActions.length) {
+        e.preventDefault();
+        handleDropdownClick(richActions[num - 1].message);
+        return;
+      }
+
+      // Arrow-key / Home / End navigation across menu items
+      const container = e.currentTarget;
+      const items = Array.from(container.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+      if (items.length === 0) return;
+      const active = document.activeElement as HTMLElement | null;
+      const currentIdx = active ? items.indexOf(active) : -1;
+
+      let nextIdx: number | null = null;
+      switch (e.key) {
+        case 'ArrowDown':
+          nextIdx = currentIdx < items.length - 1 ? currentIdx + 1 : 0;
+          break;
+        case 'ArrowUp':
+          nextIdx = currentIdx > 0 ? currentIdx - 1 : items.length - 1;
+          break;
+        case 'Home':
+          nextIdx = 0;
+          break;
+        case 'End':
+          nextIdx = items.length - 1;
+          break;
+      }
+      if (nextIdx !== null) {
+        e.preventDefault();
+        items[nextIdx].focus();
+      }
+    };
 
     return (
       <div ref={containerRef} className={cn("inline-flex rounded-sm shadow-sm animate-action-enter", className)}>
@@ -145,8 +175,8 @@ export function ActionButton({
           )}
           {pendingAction ? 'Sending...' : action.label}
         </Button>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
+        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+          <PopoverTrigger asChild>
             <Button
               variant={action.variant}
               size="sm"
@@ -158,39 +188,78 @@ export function ActionButton({
             >
               <ChevronDown className="size-2.5" />
             </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {action.dropdownActions?.map((dropdownAction, index) => {
-              const DropdownIcon = dropdownAction.icon;
-              const prevAction = action.dropdownActions?.[index - 1];
-              const showSeparator = index > 0 && !!dropdownAction.description !== !!prevAction?.description;
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-80 p-1.5" role="menu" onKeyDown={handleKeyDown}>
+            {/* Simple actions (e.g. "Push Latest Changes") rendered as plain items */}
+            {simpleActions.map((da) => {
+              const SimpleIcon = da.icon;
               return (
-                <Fragment key={dropdownAction.label}>
-                  {showSeparator && <DropdownMenuSeparator />}
-                  <DropdownMenuItem
-                    onClick={() => handleDropdownClick(dropdownAction.message)}
-                    className={dropdownAction.description ? 'flex-col items-start py-2' : ''}
-                  >
-                    <div className="flex items-center gap-2">
-                      {DropdownIcon && <DropdownIcon className="size-4" />}
-                      <span className="font-medium">{dropdownAction.label}</span>
-                    </div>
-                    {dropdownAction.description && (
-                      <p className="text-xs text-muted-foreground mt-1 pl-6 leading-relaxed">
-                        {dropdownAction.description}
-                      </p>
+                <button
+                  type="button"
+                  role="menuitem"
+                  tabIndex={-1}
+                  key={da.label}
+                  className="group w-full text-left rounded-md px-2.5 py-2 hover:bg-accent transition-colors flex items-center gap-2.5"
+                  onClick={() => handleDropdownClick(da.message)}
+                >
+                  {SimpleIcon && <SimpleIcon className="h-3.5 w-3.5 text-muted-foreground" />}
+                  <span className="text-sm font-medium">{da.label}</span>
+                </button>
+              );
+            })}
+            {simpleActions.length > 0 && richActions.length > 0 && (
+              <div className="mx-2.5 my-1 border-t border-border/50" />
+            )}
+            {/* Rich actions with colored icon backgrounds */}
+            {richActions.map((da) => {
+              const RichIcon = da.icon;
+              const colors = da.color ? DROPDOWN_COLOR_CLASSES[da.color] : null;
+              return (
+                <button
+                  type="button"
+                  role="menuitem"
+                  tabIndex={-1}
+                  key={da.label}
+                  className="group w-full text-left rounded-md px-2.5 py-2 hover:bg-accent transition-colors"
+                  onClick={() => handleDropdownClick(da.message)}
+                >
+                  <div className="flex items-center gap-2.5">
+                    {RichIcon && colors && (
+                      <div className={cn(
+                        'flex items-center justify-center h-7 w-7 rounded-lg shrink-0 transition-colors',
+                        colors.bg, colors.hoverBg,
+                      )}>
+                        <RichIcon className={cn('h-3.5 w-3.5', colors.icon)} />
+                      </div>
                     )}
-                  </DropdownMenuItem>
-                </Fragment>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium leading-tight">{da.label}</div>
+                      {da.description && (
+                        <div className="text-xs text-muted-foreground mt-0.5 leading-tight">{da.description}</div>
+                      )}
+                    </div>
+                    {da.shortcut && (
+                      <kbd className="inline-flex items-center justify-center w-5 h-5 text-[10px] font-medium bg-muted/50 border border-border/40 rounded text-muted-foreground/60 shrink-0">
+                        {da.shortcut}
+                      </kbd>
+                    )}
+                  </div>
+                </button>
               );
             })}
             {action.secondaryAction && (
-              <DropdownMenuItem onClick={handleSecondaryClick}>
-                {action.secondaryAction.label}
-              </DropdownMenuItem>
+              <button
+                type="button"
+                role="menuitem"
+                tabIndex={-1}
+                className="group w-full text-left rounded-md px-2.5 py-2 hover:bg-accent transition-colors"
+                onClick={handleSecondaryClick}
+              >
+                <span className="text-sm font-medium">{action.secondaryAction.label}</span>
+              </button>
             )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+          </PopoverContent>
+        </Popover>
       </div>
     );
   }

--- a/src/components/shared/PrimaryActionButton/types.ts
+++ b/src/components/shared/PrimaryActionButton/types.ts
@@ -17,11 +17,15 @@ export type ButtonVariant = 'default' | 'destructive' | 'success' | 'warning';
 
 export type ActionTier = 'alert' | 'action' | 'complete';
 
+export type DropdownColor = 'blue' | 'purple' | 'teal' | 'green' | 'amber' | 'red';
+
 export interface DropdownAction {
   label: string;
   message: string;
   description?: string;
   icon?: LucideIcon;
+  color?: DropdownColor;
+  shortcut?: string;
 }
 
 export interface PrimaryAction {

--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -242,18 +242,24 @@ export function useActionState(
           message: 'Merge the pull request with a merge commit',
           description: 'All commits from this branch will be added to the base branch via a merge commit.',
           icon: GitMerge,
+          color: 'blue',
+          shortcut: '1',
         },
         {
           label: 'Squash and merge',
           message: 'Squash and merge the pull request',
           description: 'The commits from this branch will be combined into one commit in the base branch.',
           icon: Combine,
+          color: 'purple',
+          shortcut: '2',
         },
         {
           label: 'Rebase and merge',
           message: 'Rebase and merge the pull request',
           description: 'The commits from this branch will be rebased and added to the base branch.',
           icon: GitBranch,
+          color: 'teal',
+          shortcut: '3',
         },
       );
 


### PR DESCRIPTION
## Summary
- Replace `DropdownMenu` with `Popover` in the Merge PR split button to match the Review popover's polished UX
- Add colored icon backgrounds (blue, purple, teal), title+description layout, and `<kbd>` shortcut badges for merge strategies
- Add keyboard shortcut support (1-3) and arrow-key navigation within the popover
- "Push Latest Changes" renders as a simple item above a separator when present

## Test plan
- [ ] Open a session with an open PR, click the Merge PR chevron dropdown
- [ ] Verify popover matches Review popover style: colored icon backgrounds, stacked title+description, kbd badges
- [ ] Press keys 1-3 to verify keyboard shortcuts trigger the correct merge strategy
- [ ] Verify arrow keys navigate between items
- [ ] Verify "Push Latest Changes" renders correctly when there are unpushed commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)