### PR TITLE
fix: add --follow flag to file history git log for rename tracking

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -408,6 +408,7 @@ func (rm *RepoManager) GetFileCommitHistory(ctx context.Context, repoPath, fileP
 	// Format: SHA|ShortSHA|AuthorName|AuthorEmail|Timestamp|Subject
 	args := []string{
 		"log",
+		"--follow",
 		"-n", "51",
 		"--pretty=format:%H|%h|%an|%ae|%aI|%s",
 		"--numstat",


### PR DESCRIPTION
## Summary
- Adds the missing `--follow` flag to the `git log` command in `GetFileCommitHistory()` so file history tracks through renames
- The function's doc comment and numstat parsing logic already referenced `--follow` behavior, but the flag was never included in the args slice

## Test plan
- [ ] Open a file that has been renamed at some point and check the File History panel
- [ ] Verify commits from before the rename now appear in the history
- [ ] Confirm the additions/deletions stats are correct across rename boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)