### PR TITLE
perf: add file content cache and proactive prefetch for instant file opening

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -39,6 +39,7 @@ import { TabBar, type TabItemData } from '@/components/tabs';
 import { CachedConversationPane } from '@/components/conversation/CachedConversationPane';
 import { getSessionFileContent, getSessionFileDiff, updateReviewComment, deleteReviewComment as deleteReviewCommentApi, listReviewComments, createConversation, createReviewComment, generateSummary, getConversationSummary } from '@/lib/api';
 import { getDiffFromCache, setDiffInCache } from '@/lib/diffCache';
+import { getFileContentFromCache, setFileContentInCache } from '@/lib/fileContentCache';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { BlockErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { BranchSyncBanner } from '@/components/BranchSyncBanner';
@@ -449,10 +450,24 @@ export function ConversationArea({ children }: ConversationAreaProps) {
     // For regular file view without content, load it from session's worktree
     // Use content === undefined to differentiate "not loaded" from "loaded but empty"
     if (currentFileTab.viewMode !== 'diff' && currentFileTab.content === undefined && !currentFileTab.isBinary && !currentFileTab.isTooLarge && !currentFileTab.isEmpty && !currentFileTab.loadError && currentFileTab.sessionId) {
+      // Check file content cache first — avoids HTTP round-trip on re-open
+      const cached = getFileContentFromCache(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path);
+      if (cached) {
+        const isEmpty = cached.content === '' || cached.content === undefined;
+        updateFileTab(currentFileTab.id, {
+          content: cached.content ?? '',
+          originalContent: cached.content ?? '',
+          isEmpty,
+          isLoading: false,
+        });
+        return;
+      }
+
       const loadContent = async () => {
         updateFileTab(currentFileTab.id, { isLoading: true });
         try {
           const fileData = await getSessionFileContent(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path);
+          setFileContentInCache(currentFileTab.workspaceId, currentFileTab.sessionId, currentFileTab.path, fileData);
           const isEmpty = fileData.content === '' || fileData.content === undefined;
           updateFileTab(currentFileTab.id, {
             content: fileData.content ?? '',

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '@/stores/appStore';
 import { useSelectedIds, useFileTabState, useTodoState, useFileCommentStats, useReviewComments } from '@/stores/selectors';
 import { listSessionFiles, getSessionFileContent, getSessionChanges, getSessionBranchCommits, getSessionFileDiff, sendConversationMessage, updateReviewComment as apiUpdateReviewComment, ApiError, ErrorCode, type FileChangeDTO, type BranchStatsDTO } from '@/lib/api';
 import { getDiffFromCache, setDiffInCache, invalidateDiffCache } from '@/lib/diffCache';
+import { getFileContentFromCache, setFileContentInCache, invalidateFileContentCache } from '@/lib/fileContentCache';
 import { getSessionData, setSessionData, invalidateSessionData } from '@/lib/sessionDataCache';
 import { formatReviewFeedback } from '@/lib/formatReviewFeedback';
 import { dispatchAppEvent } from '@/lib/custom-events';
@@ -81,6 +82,7 @@ import {
 } from '@/components/ui/tooltip';
 import { isBinaryFile } from '@/lib/fileUtils';
 import { useDiffPrefetch } from '@/hooks/useDiffPrefetch';
+import { useFileContentPrefetch } from '@/hooks/useFileContentPrefetch';
 
 // Maximum file size for diff viewing (2MB)
 const MAX_DIFF_SIZE = 2 * 1024 * 1024;
@@ -120,12 +122,10 @@ export function ChangesPanel() {
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const bottomPanelRef = useRef<PanelImperativeHandle>(null);
 
-  // Prefetch diffs for top changed files during idle time
-  useDiffPrefetch(
-    selectedWorkspaceId,
-    selectedSessionId,
-    changesView === 'all' ? allChanges : changes,
-  );
+  // Prefetch diffs and file content for top changed files during idle time
+  const prefetchChanges = changesView === 'all' ? allChanges : changes;
+  useDiffPrefetch(selectedWorkspaceId, selectedSessionId, prefetchChanges);
+  useFileContentPrefetch(selectedWorkspaceId, selectedSessionId, prefetchChanges);
 
   // Immediately clear stale data when session changes.
   // Without this, the previous session's files/changes render for 150ms+
@@ -196,10 +196,11 @@ export function ChangesPanel() {
     try {
       const data = await getSessionChanges(selectedWorkspaceId, selectedSessionId);
       setChanges(data || []);
-      // Always invalidate diff cache when changes are refetched — the additions/
+      // Always invalidate caches when changes are refetched — the additions/
       // deletions counts alone can't detect content changes within the same line
-      // count. The prefetch hook re-populates the cache quickly via idle callbacks.
+      // count. The prefetch hooks re-populate the caches quickly via idle callbacks.
       invalidateDiffCache(selectedWorkspaceId, selectedSessionId);
+      invalidateFileContentCache(selectedWorkspaceId, selectedSessionId);
     } catch (error) {
       console.error('Failed to fetch changes:', error);
     } finally {
@@ -283,6 +284,28 @@ export function ChangesPanel() {
     // Include sessionId in tab ID to allow same file open in different sessions
     const tabId = `${selectedWorkspaceId}-${selectedSessionId}-${path}`;
 
+    // Check file content cache — avoids HTTP round-trip on re-open
+    // Skip cache for binary files (shouldn't be cached, but guard defensively)
+    const cached = !isBinaryFile(filename)
+      ? getFileContentFromCache(selectedWorkspaceId, selectedSessionId, path)
+      : null;
+    if (cached) {
+      const isEmpty = cached.content === '' || cached.content === undefined;
+      openFileTab({
+        id: tabId,
+        workspaceId: selectedWorkspaceId,
+        sessionId: selectedSessionId,
+        path,
+        name: filename,
+        isLoading: false,
+        viewMode: 'file',
+        content: cached.content ?? '',
+        originalContent: cached.content ?? '',
+        isEmpty,
+      });
+      return;
+    }
+
     // Create tab with loading state (session-scoped for complete isolation)
     const newTab: FileTab = {
       id: tabId,
@@ -302,6 +325,7 @@ export function ChangesPanel() {
     // Fetch file content from session's worktree (not main repo)
     try {
       const fileData = await getSessionFileContent(selectedWorkspaceId, selectedSessionId, path);
+      setFileContentInCache(selectedWorkspaceId, selectedSessionId, path, fileData);
       const isEmpty = fileData.content === '' || fileData.content === undefined;
       updateFileTab(tabId, {
         content: fileData.content ?? '',
@@ -668,9 +692,10 @@ export function ChangesPanel() {
     onCollapseAllFiles: () => fileTreeRef.current?.collapseAll(),
     onExpandAllFiles: () => fileTreeRef.current?.expandAll(),
     onRefreshChanges: () => {
-      // Invalidate cache on explicit refresh so stale data isn't re-shown
+      // Invalidate caches on explicit refresh so stale data isn't re-shown
       if (selectedWorkspaceId && selectedSessionId) {
         invalidateSessionData(selectedWorkspaceId, selectedSessionId);
+        invalidateFileContentCache(selectedWorkspaceId, selectedSessionId);
       }
       fetchChanges();
       fetchBranchData();

--- a/src/hooks/useFileContentPrefetch.ts
+++ b/src/hooks/useFileContentPrefetch.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect } from 'react';
+import { getSessionFileContent, type FileChangeDTO } from '@/lib/api';
+import { getFileContentFromCache, setFileContentInCache } from '@/lib/fileContentCache';
+import { isBinaryFile } from '@/lib/fileUtils';
+
+const PREFETCH_LIMIT = 10;
+const BATCH_SIZE = 3;
+
+/**
+ * Prefetch file content for the top N changed files during idle time so
+ * they're cached by the time the user clicks them. Follows the same
+ * idle-callback + batch pattern as useDiffPrefetch.
+ */
+export function useFileContentPrefetch(
+  workspaceId: string | null,
+  sessionId: string | null,
+  changes: FileChangeDTO[] | null,
+) {
+  useEffect(() => {
+    if (!workspaceId || !sessionId || !changes || changes.length === 0) return;
+
+    // Narrowed to string by the guard above — avoids non-null assertions later
+    const wId = workspaceId;
+    const sId = sessionId;
+
+    const ac = new AbortController();
+
+    const filesToPrefetch = changes
+      .filter(f => f.status !== 'deleted')
+      .filter(f => !isBinaryFile(f.path.split('/').pop() || f.path))
+      .filter(f => !getFileContentFromCache(wId, sId, f.path))
+      .slice(0, PREFETCH_LIMIT);
+
+    if (filesToPrefetch.length === 0) return;
+
+    async function prefetch() {
+      for (let i = 0; i < filesToPrefetch.length; i += BATCH_SIZE) {
+        if (ac.signal.aborted) return;
+
+        const batch = filesToPrefetch.slice(i, i + BATCH_SIZE);
+        await Promise.allSettled(
+          batch.map(async (file) => {
+            if (ac.signal.aborted) return;
+            // Re-check cache (may have been populated by user action)
+            if (getFileContentFromCache(wId, sId, file.path)) return;
+            try {
+              const fileData = await getSessionFileContent(wId, sId, file.path, ac.signal);
+              if (!ac.signal.aborted) {
+                setFileContentInCache(wId, sId, file.path, fileData);
+              }
+            } catch {
+              // Silently ignore — user will fetch on demand
+            }
+          })
+        );
+
+        // Yield to main thread between batches
+        if (i + BATCH_SIZE < filesToPrefetch.length) {
+          await new Promise<void>((resolve) => {
+            if (typeof requestIdleCallback === 'function') {
+              requestIdleCallback(() => resolve(), { timeout: 3000 });
+            } else {
+              setTimeout(resolve, 200);
+            }
+          });
+        }
+      }
+    }
+
+    let idleHandle: number | undefined;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    if (typeof requestIdleCallback === 'function') {
+      idleHandle = requestIdleCallback(() => { prefetch(); }, { timeout: 5000 });
+    } else {
+      timeoutHandle = setTimeout(() => { prefetch(); }, 2000);
+    }
+
+    return () => {
+      ac.abort();
+      if (idleHandle !== undefined) cancelIdleCallback(idleHandle);
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+    };
+  }, [workspaceId, sessionId, changes]);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -247,10 +247,12 @@ export async function getSessionFileDiff(
 export async function getSessionFileContent(
   workspaceId: string,
   sessionId: string,
-  filePath: string
+  filePath: string,
+  signal?: AbortSignal,
 ): Promise<FileContentDTO> {
   const res = await fetchWithAuth(
-    `${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/file?path=${encodeURIComponent(filePath)}`
+    `${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/file?path=${encodeURIComponent(filePath)}`,
+    signal ? { signal } : undefined,
   );
   return handleResponse<FileContentDTO>(res);
 }

--- a/src/lib/fileContentCache.ts
+++ b/src/lib/fileContentCache.ts
@@ -1,0 +1,68 @@
+import type { FileContentDTO } from '@/lib/api';
+
+interface CacheEntry {
+  data: FileContentDTO;
+  cachedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+export const MAX_ENTRIES = 100;
+const MAX_AGE_MS = 5 * 60 * 1000; // 5 min — staleness handled by explicit invalidation
+
+function makeKey(workspaceId: string, sessionId: string, path: string): string {
+  return `${workspaceId}:${sessionId}:${path}`;
+}
+
+export function getFileContentFromCache(
+  workspaceId: string,
+  sessionId: string,
+  path: string
+): FileContentDTO | null {
+  const key = makeKey(workspaceId, sessionId, path);
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.cachedAt > MAX_AGE_MS) {
+    cache.delete(key);
+    return null;
+  }
+  // Move to end for LRU ordering
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry.data;
+}
+
+export function setFileContentInCache(
+  workspaceId: string,
+  sessionId: string,
+  path: string,
+  data: FileContentDTO
+): void {
+  const key = makeKey(workspaceId, sessionId, path);
+  cache.delete(key); // Remove if exists (for LRU reorder)
+  cache.set(key, { data, cachedAt: Date.now() });
+  // Evict oldest if over limit
+  if (cache.size > MAX_ENTRIES) {
+    const firstKey = cache.keys().next().value;
+    if (firstKey) cache.delete(firstKey);
+  }
+}
+
+export function invalidateFileContentCache(
+  workspaceId: string,
+  sessionId: string,
+  path?: string
+): void {
+  if (path) {
+    cache.delete(makeKey(workspaceId, sessionId, path));
+  } else {
+    // Invalidate all entries for this session
+    const prefix = `${workspaceId}:${sessionId}:`;
+    for (const key of cache.keys()) {
+      if (key.startsWith(prefix)) cache.delete(key);
+    }
+  }
+}
+
+export function clearFileContentCache(): void {
+  cache.clear();
+}


### PR DESCRIPTION
## Summary

- Adds an LRU file content cache (`fileContentCache.ts`) and idle-time prefetch hook (`useFileContentPrefetch.ts`) so changed files are pre-fetched before the user clicks them
- Both file loading paths (ChangesPanel tree click + ConversationArea tab restore) now check the cache first, eliminating the loading spinner on cache hit
- Cache is invalidated alongside the existing diff cache when files change or on explicit refresh
- Adds `AbortSignal` support to `getSessionFileContent()` for clean prefetch cancellation

## Test plan

- [ ] Open a session with changed files, wait ~3s for idle prefetch, then click a changed file — should open instantly (no spinner)
- [ ] Close and re-open the same file tab — should open instantly from cache
- [ ] Make a file change via agent, then re-open — should re-fetch (cache invalidated)
- [ ] Open a file via Cmd+P (FilePicker) — should also benefit from cache
- [ ] Verify diff view still works correctly (separate cache, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)