### PR TITLE
fix: use real-time WebSocket checkStatus for PR merge button visibility

### DIFF
--- a/src/components/shared/PrimaryActionButton/index.tsx
+++ b/src/components/shared/PrimaryActionButton/index.tsx
@@ -8,18 +8,10 @@ import { ActionButton } from './ActionButton';
 import { useAppStore } from '@/stores/appStore';
 import type { GitStatusDTO, PRDetails } from '@/lib/api';
 import { getGlobalActionTemplates, getWorkspaceActionTemplates } from '@/lib/api';
+import type { WorktreeSession } from '@/lib/types';
 import { ACTION_TEMPLATES, getTemplateKey, fetchMergedActionTemplates } from '@/lib/action-templates';
 import type { ActionTemplateKey } from '@/lib/action-templates';
 import type { PrimaryActionType } from './types';
-
-interface WorktreeSession {
-  id: string;
-  status?: string;
-  prStatus?: string;
-  prNumber?: number;
-  prUrl?: string;
-  checkStatus?: string;
-}
 
 interface PrimaryActionButtonProps {
   workspaceId: string | null;

--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -14,14 +14,10 @@ import {
   Download,
 } from 'lucide-react';
 import type { GitStatusDTO, PRDetails } from '@/lib/api';
+import type { WorktreeSession } from '@/lib/types';
 import type { PrimaryAction } from './types';
 
-interface Session {
-  id?: string;
-  status?: string;
-  prStatus?: string;
-  prUrl?: string;
-}
+type Session = Pick<Partial<WorktreeSession>, 'id' | 'status' | 'prStatus' | 'prUrl' | 'checkStatus'>;
 
 /**
  * Hook that determines the primary action based on git status, session state, and PR details.
@@ -49,6 +45,17 @@ export function useActionState(
   prDetails: PRDetails | null,
 ): PrimaryAction | null {
   return useMemo(() => {
+    // Merge WebSocket-updated store value (session.checkStatus) with polled API value
+    // (prDetails.checkStatus). WebSocket is real-time but updates can be missed, while
+    // prDetails polls every 90s but is reliable. If the session is still 'pending' but
+    // polling already shows a terminal state, prefer the terminal state.
+    const sessionCheck = session?.checkStatus ?? null;
+    const prCheck = prDetails?.checkStatus ?? null;
+    const isTerminal = (s: string | null) => s === 'success' || s === 'failure';
+    const effectiveCheckStatus =
+      sessionCheck === 'pending' && isTerminal(prCheck) ? prCheck
+      : sessionCheck ?? prCheck;
+
     const archiveAction: PrimaryAction = {
       type: 'archive-session',
       tier: 'complete',
@@ -120,7 +127,7 @@ export function useActionState(
     }
 
     // Priority 2: CI check failures (only if we have PR details)
-    if (prDetails?.checkStatus === 'failure') {
+    if (effectiveCheckStatus === 'failure') {
       return {
         type: 'fix-issues',
         tier: 'alert',
@@ -223,7 +230,7 @@ export function useActionState(
     // Note: checks failed is caught by Priority 2 above
     if (hasOpenPR) {
       // Don't show merge button while CI is still running
-      if (prDetails?.checkStatus === 'pending') {
+      if (effectiveCheckStatus === 'pending') {
         return null;
       }
 


### PR DESCRIPTION
## Summary
- The "Merge PR" primary action button relied solely on `prDetails.checkStatus` from API polling (90s interval), while the sidebar used `session.checkStatus` from real-time WebSocket updates
- This caused the sidebar to correctly show "Ready to merge" while the button remained hidden because `prDetails` still had stale `checkStatus: 'pending'`
- Derives `effectiveCheckStatus` that merges both sources — prefers the most up-to-date terminal state from either WebSocket or polling, so the button now appears in sync with the sidebar

## Test plan
- [ ] Open a session with an open PR where CI checks are running
- [ ] Wait for checks to complete — sidebar "Ready to merge" and "Merge PR" button should appear simultaneously
- [ ] Verify CI failure state still shows "Fix Issues" button
- [ ] Verify pending checks still correctly hide the merge button

🤖 Generated with [Claude Code](https://claude.com/claude-code)