### PR TITLE
fix: show specific reasons for merge blockers

### DIFF
--- a/backend/github/pr_status.go
+++ b/backend/github/pr_status.go
@@ -22,6 +22,16 @@ const (
 	CheckStatusNone    CheckStatus = "none"
 )
 
+// ReviewDecision represents the computed review decision for a PR
+type ReviewDecision string
+
+const (
+	ReviewApproved         ReviewDecision = "approved"
+	ReviewChangesRequested ReviewDecision = "changes_requested"
+	ReviewRequired         ReviewDecision = "review_required"
+	ReviewNone             ReviewDecision = "none"
+)
+
 // CheckDetail represents a single CI check run
 type CheckDetail struct {
 	Name            string `json:"name"`
@@ -32,16 +42,18 @@ type CheckDetail struct {
 
 // PRDetails contains detailed information about a pull request
 type PRDetails struct {
-	Number         int           `json:"number"`
-	State          string        `json:"state"`         // "open", "closed"
-	Title          string        `json:"title"`
-	Body           string        `json:"body"`
-	HTMLURL        string        `json:"htmlUrl"`
-	Merged         bool          `json:"merged"`         // true if the PR has been merged
-	Mergeable      *bool         `json:"mergeable"`      // Can be null while GitHub computes it
-	MergeableState string        `json:"mergeableState"` // "clean", "dirty", "blocked", "unknown", "unstable"
-	CheckStatus    CheckStatus   `json:"checkStatus"`
-	CheckDetails   []CheckDetail `json:"checkDetails"`
+	Number             int            `json:"number"`
+	State              string         `json:"state"`              // "open", "closed"
+	Title              string         `json:"title"`
+	Body               string         `json:"body"`
+	HTMLURL            string         `json:"htmlUrl"`
+	Merged             bool           `json:"merged"`             // true if the PR has been merged
+	Mergeable          *bool          `json:"mergeable"`          // Can be null while GitHub computes it
+	MergeableState     string         `json:"mergeableState"`     // "clean", "dirty", "blocked", "unknown", "unstable"
+	CheckStatus        CheckStatus    `json:"checkStatus"`
+	CheckDetails       []CheckDetail  `json:"checkDetails"`
+	ReviewDecision     ReviewDecision `json:"reviewDecision"`     // "approved", "changes_requested", "review_required", "none"
+	RequestedReviewers int            `json:"requestedReviewers"` // Count of pending reviewer requests
 }
 
 // githubPR represents the GitHub API response for a pull request
@@ -57,6 +69,9 @@ type githubPR struct {
 	Head           struct {
 		SHA string `json:"sha"`
 	} `json:"head"`
+	RequestedReviewers []struct {
+		Login string `json:"login"`
+	} `json:"requested_reviewers"`
 }
 
 // githubCheckRuns represents the GitHub API response for check runs
@@ -69,6 +84,52 @@ type githubCheckRuns struct {
 		StartedAt   *string `json:"started_at"`
 		CompletedAt *string `json:"completed_at"`
 	} `json:"check_runs"`
+}
+
+// githubReview represents a single review from the GitHub API
+type githubReview struct {
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	State string `json:"state"` // "APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED", "PENDING"
+}
+
+// computeReviewDecision determines the effective review decision from a list of reviews
+// and the count of pending reviewer requests.
+func computeReviewDecision(reviews []githubReview, requestedReviewers int) ReviewDecision {
+	// Track the latest substantive review per user
+	latestByUser := make(map[string]string)
+	for _, r := range reviews {
+		state := r.State
+		switch state {
+		case "APPROVED", "CHANGES_REQUESTED":
+			latestByUser[r.User.Login] = state
+		case "DISMISSED":
+			// Dismissed cancels the user's previous review
+			delete(latestByUser, r.User.Login)
+		}
+		// COMMENTED and PENDING are not decisions — skip
+	}
+
+	hasApproval := false
+	for _, state := range latestByUser {
+		if state == "CHANGES_REQUESTED" {
+			return ReviewChangesRequested
+		}
+		if state == "APPROVED" {
+			hasApproval = true
+		}
+	}
+
+	if hasApproval {
+		return ReviewApproved
+	}
+
+	if requestedReviewers > 0 {
+		return ReviewRequired
+	}
+
+	return ReviewNone
 }
 
 // GetPRDetails fetches detailed information about a pull request including CI status
@@ -112,16 +173,18 @@ func (c *Client) GetPRDetails(ctx context.Context, owner, repo string, prNumber 
 	}
 
 	details := &PRDetails{
-		Number:         pr.Number,
-		State:          pr.State,
-		Title:          pr.Title,
-		Body:           pr.Body,
-		HTMLURL:        pr.HTMLURL,
-		Merged:         pr.Merged,
-		Mergeable:      pr.Mergeable,
-		MergeableState: pr.MergeableState,
-		CheckStatus:    CheckStatusNone,
-		CheckDetails:   []CheckDetail{},
+		Number:             pr.Number,
+		State:              pr.State,
+		Title:              pr.Title,
+		Body:               pr.Body,
+		HTMLURL:            pr.HTMLURL,
+		Merged:             pr.Merged,
+		Mergeable:          pr.Mergeable,
+		MergeableState:     pr.MergeableState,
+		CheckStatus:        CheckStatusNone,
+		CheckDetails:       []CheckDetail{},
+		ReviewDecision:     ReviewNone,
+		RequestedReviewers: len(pr.RequestedReviewers),
 	}
 
 	// Fetch check runs for the PR's head commit
@@ -190,6 +253,29 @@ func (c *Client) GetPRDetails(ctx context.Context, owner, repo string, prNumber 
 			} else {
 				details.CheckStatus = CheckStatusSuccess
 			}
+		}
+	}
+
+	// Fetch PR reviews to determine review decision
+	reviewsURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews?per_page=100", c.apiURL, owner, repo, pr.Number)
+	reviewsReq, err := http.NewRequestWithContext(ctx, "GET", reviewsURL, nil)
+	if err != nil {
+		return details, nil
+	}
+
+	reviewsReq.Header.Set("Authorization", "Bearer "+token)
+	reviewsReq.Header.Set("Accept", "application/vnd.github+json")
+
+	reviewsResp, err := c.httpClient.Do(reviewsReq)
+	if err != nil {
+		return details, nil
+	}
+	defer reviewsResp.Body.Close()
+
+	if reviewsResp.StatusCode == http.StatusOK {
+		var reviews []githubReview
+		if err := json.NewDecoder(reviewsResp.Body).Decode(&reviews); err == nil {
+			details.ReviewDecision = computeReviewDecision(reviews, details.RequestedReviewers)
 		}
 	}
 

--- a/backend/github/pr_status_test.go
+++ b/backend/github/pr_status_test.go
@@ -467,6 +467,166 @@ func TestClient_FindPRForBranch_NotAuthenticated(t *testing.T) {
 // GetPRFullDetails Tests
 // ============================================================================
 
+// ============================================================================
+// computeReviewDecision Tests
+// ============================================================================
+
+func TestComputeReviewDecision_Approved(t *testing.T) {
+	reviews := []githubReview{
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "APPROVED"},
+	}
+	require.Equal(t, ReviewApproved, computeReviewDecision(reviews, 0))
+}
+
+func TestComputeReviewDecision_ChangesRequested(t *testing.T) {
+	reviews := []githubReview{
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "CHANGES_REQUESTED"},
+	}
+	require.Equal(t, ReviewChangesRequested, computeReviewDecision(reviews, 0))
+}
+
+func TestComputeReviewDecision_LatestPerUserWins(t *testing.T) {
+	// Alice first requests changes, then approves
+	reviews := []githubReview{
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "CHANGES_REQUESTED"},
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "APPROVED"},
+	}
+	require.Equal(t, ReviewApproved, computeReviewDecision(reviews, 0))
+}
+
+func TestComputeReviewDecision_MixedReviewers(t *testing.T) {
+	// Alice approves, Bob requests changes → changes_requested wins
+	reviews := []githubReview{
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "APPROVED"},
+		{User: struct{ Login string `json:"login"` }{Login: "bob"}, State: "CHANGES_REQUESTED"},
+	}
+	require.Equal(t, ReviewChangesRequested, computeReviewDecision(reviews, 0))
+}
+
+func TestComputeReviewDecision_DismissedCancelsReview(t *testing.T) {
+	// Alice requests changes, then her review is dismissed
+	reviews := []githubReview{
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "CHANGES_REQUESTED"},
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "DISMISSED"},
+	}
+	require.Equal(t, ReviewNone, computeReviewDecision(reviews, 0))
+}
+
+func TestComputeReviewDecision_CommentedIsIgnored(t *testing.T) {
+	// Only comments, no substantive review
+	reviews := []githubReview{
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "COMMENTED"},
+		{User: struct{ Login string `json:"login"` }{Login: "bob"}, State: "COMMENTED"},
+	}
+	require.Equal(t, ReviewNone, computeReviewDecision(reviews, 0))
+}
+
+func TestComputeReviewDecision_PendingReviewersNoReviews(t *testing.T) {
+	require.Equal(t, ReviewRequired, computeReviewDecision(nil, 2))
+}
+
+func TestComputeReviewDecision_ApprovedWithPendingReviewers(t *testing.T) {
+	// One approved but still has pending reviewers → approved (review exists)
+	reviews := []githubReview{
+		{User: struct{ Login string `json:"login"` }{Login: "alice"}, State: "APPROVED"},
+	}
+	require.Equal(t, ReviewApproved, computeReviewDecision(reviews, 1))
+}
+
+func TestComputeReviewDecision_NoReviewsNoReviewers(t *testing.T) {
+	require.Equal(t, ReviewNone, computeReviewDecision(nil, 0))
+}
+
+func TestClient_GetPRDetails_WithReviews(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/testowner/testrepo/pulls/1":
+			pr := map[string]interface{}{
+				"number":          1,
+				"state":           "open",
+				"title":           "Test PR",
+				"html_url":        "https://github.com/testowner/testrepo/pull/1",
+				"mergeable":       false,
+				"mergeable_state": "blocked",
+				"head":            map[string]string{"sha": "abc123"},
+				"requested_reviewers": []map[string]string{
+					{"login": "bob"},
+				},
+			}
+			json.NewEncoder(w).Encode(pr)
+		case "/repos/testowner/testrepo/commits/abc123/check-runs":
+			checks := map[string]interface{}{
+				"total_count": 1,
+				"check_runs": []map[string]interface{}{
+					{"name": "build", "status": "completed", "conclusion": "success"},
+				},
+			}
+			json.NewEncoder(w).Encode(checks)
+		case "/repos/testowner/testrepo/pulls/1/reviews":
+			reviews := []map[string]interface{}{
+				{"user": map[string]string{"login": "alice"}, "state": "APPROVED"},
+			}
+			json.NewEncoder(w).Encode(reviews)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	details, err := client.GetPRDetails(context.Background(), "testowner", "testrepo", 1)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+	require.Equal(t, ReviewApproved, details.ReviewDecision)
+	require.Equal(t, 1, details.RequestedReviewers)
+}
+
+func TestClient_GetPRDetails_ReviewsFetchFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/testowner/testrepo/pulls/1":
+			pr := map[string]interface{}{
+				"number":          1,
+				"state":           "open",
+				"title":           "Test PR",
+				"html_url":        "https://github.com/testowner/testrepo/pull/1",
+				"mergeable":       true,
+				"mergeable_state": "clean",
+				"head":            map[string]string{"sha": "abc123"},
+			}
+			json.NewEncoder(w).Encode(pr)
+		case "/repos/testowner/testrepo/commits/abc123/check-runs":
+			checks := map[string]interface{}{
+				"total_count": 0,
+				"check_runs":  []map[string]interface{}{},
+			}
+			json.NewEncoder(w).Encode(checks)
+		case "/repos/testowner/testrepo/pulls/1/reviews":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.apiURL = server.URL
+	client.SetToken("test_token")
+
+	details, err := client.GetPRDetails(context.Background(), "testowner", "testrepo", 1)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+	// Should gracefully degrade to ReviewNone
+	require.Equal(t, ReviewNone, details.ReviewDecision)
+}
+
+// ============================================================================
+// GetPRFullDetails Tests
+// ============================================================================
+
 func TestClient_GetPRFullDetails_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/repos/testowner/testrepo/pulls/42", r.URL.Path)

--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -52,7 +52,7 @@ export interface ChecksPanelHandle {
 }
 
 interface BlockingItem {
-  type: 'ci-failure' | 'conflict' | 'behind-base' | 'not-mergeable' | 'in-progress-op';
+  type: 'ci-failure' | 'conflict' | 'behind-base' | 'not-mergeable' | 'in-progress-op' | 'review-required' | 'changes-requested';
   label: string;
   severity: 'error' | 'warning';
 }
@@ -126,13 +126,35 @@ function computeMergeReadiness(
   }
 
   // GitHub says not mergeable
-  if (pr.mergeableState === 'dirty' || pr.mergeableState === 'blocked') {
-    // Avoid duplicating if we already have specific blockers
-    const hasSpecificBlocker = blockers.some((b) => b.type === 'ci-failure' || b.type === 'conflict');
-    if (!hasSpecificBlocker) {
+  if (pr.mergeableState === 'dirty') {
+    if (!blockers.some((b) => b.type === 'conflict')) {
+      blockers.push({ type: 'conflict', label: 'PR has conflicts', severity: 'error' });
+    }
+  } else if (pr.mergeableState === 'blocked') {
+    // Show specific reasons for the block
+    if (pr.reviewDecision === 'changes_requested') {
+      blockers.push({
+        type: 'changes-requested',
+        label: 'Changes requested by reviewer',
+        severity: 'error',
+      });
+    } else if (pr.reviewDecision === 'review_required' || (pr.reviewDecision === 'none' && pr.requestedReviewers > 0)) {
+      blockers.push({
+        type: 'review-required',
+        label: pr.requestedReviewers > 0
+          ? `Review required (${pr.requestedReviewers} pending)`
+          : 'Review required',
+        severity: 'error',
+      });
+    }
+    // Fallback: if blocked but no specific reason identified
+    if (!blockers.some((b) =>
+      b.type === 'ci-failure' || b.type === 'conflict' ||
+      b.type === 'review-required' || b.type === 'changes-requested'
+    )) {
       blockers.push({
         type: 'not-mergeable',
-        label: pr.mergeableState === 'dirty' ? 'PR has conflicts' : 'PR is blocked',
+        label: 'Blocked by branch protection',
         severity: 'error',
       });
     }
@@ -405,18 +427,30 @@ function MergeReadinessBanner({
   }
 
   return (
-    <div className={cn('flex items-center gap-2 px-3 py-2 border-b min-w-0', bgClass, borderClass)}>
-      {icon}
-      <span className="text-xs font-medium flex-1 truncate" title={message}>{message}</span>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-5 w-5 shrink-0"
-        onClick={onRefresh}
-        disabled={isLoading}
-      >
-        <RefreshCw className={cn('h-3 w-3', isLoading && 'animate-spin')} />
-      </Button>
+    <div className={cn('px-3 py-2 border-b', bgClass, borderClass)}>
+      <div className="flex items-center gap-2 min-w-0">
+        {icon}
+        <span className="text-xs font-medium flex-1 truncate" title={message}>{message}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-5 w-5 shrink-0"
+          onClick={onRefresh}
+          disabled={isLoading}
+        >
+          <RefreshCw className={cn('h-3 w-3', isLoading && 'animate-spin')} />
+        </Button>
+      </div>
+      {blockers.length > 0 && (
+        <div className="mt-1 space-y-0.5 pl-5">
+          {blockers.map((b) => (
+            <div key={b.type} className="flex items-center gap-1.5">
+              <span className={cn('text-2xs', b.severity === 'error' ? 'text-red-400' : 'text-yellow-400')}>•</span>
+              <span className="text-2xs text-muted-foreground">{b.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/api/pr.ts
+++ b/src/lib/api/pr.ts
@@ -9,6 +9,8 @@ export interface CheckDetail {
   durationSeconds?: number;
 }
 
+export type ReviewDecision = 'approved' | 'changes_requested' | 'review_required' | 'none';
+
 export interface PRDetails {
   number: number;
   state: string;
@@ -20,6 +22,8 @@ export interface PRDetails {
   mergeableState: string;
   checkStatus: CheckStatus;
   checkDetails: CheckDetail[];
+  reviewDecision: ReviewDecision;
+  requestedReviewers: number;
 }
 
 export async function getPRStatus(workspaceId: string, sessionId: string): Promise<PRDetails | null> {


### PR DESCRIPTION
## Summary
- When GitHub reports `mergeableState='blocked'`, the merge readiness banner now shows **specific reasons** instead of the generic "PR is blocked" message
- Backend fetches PR reviews from GitHub API and computes a `reviewDecision` field (approved, changes_requested, review_required, none)
- Banner now lists individual blocker details below the summary line (e.g., "Review required (2 pending)", "Changes requested by reviewer", "Blocked by branch protection")

## Test plan
- [ ] Open a PR with pending review requirements → banner shows "Review required (N pending)"
- [ ] Open a PR with changes requested → banner shows "Changes requested by reviewer"
- [ ] Open a PR with all checks passing and approved reviews → banner shows "Ready to merge"
- [ ] Verify `go test ./github/...` passes (17 tests including 9 unit tests for `computeReviewDecision`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)