### PR TITLE
fix: prevent blank conversation area on navigation

### DIFF
--- a/src/components/conversation/CachedConversationPane.tsx
+++ b/src/components/conversation/CachedConversationPane.tsx
@@ -108,11 +108,17 @@ export function CachedConversationPane({
     if (!conversationId) return;
 
     const state = useAppStore.getState();
+    const messageCount = state.messagesByConversation[conversationId]?.length ?? 0;
     const existingPagination = state.messagePagination[conversationId];
-    if (existingPagination) return;
 
-    const hasInlineMessages = (state.messagesByConversation[conversationId]?.length ?? 0) > 0;
-    if (hasInlineMessages) return;
+    // Only skip if we have pagination AND messages in the store.
+    // removeWorkspace / removeSession clear messagesByConversation but may leave
+    // stale messagePagination entries, producing pagination-with-no-messages.
+    // Without this guard the effect would bail out and render a blank screen.
+    if (existingPagination && messageCount > 0) return;
+
+    // Messages arrived inline (e.g. via WebSocket) — skip paginated load.
+    if (messageCount > 0) return;
 
     let cancelled = false;
     async function loadMessages() {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -746,14 +746,16 @@ export const useAppStore = create<AppState>((set, get) => ({
         .map((c) => c.id)
     );
 
-    // Clean up streaming state, active tools, and agent todos
+    // Clean up streaming state, active tools, agent todos, and pagination
     const cleanedStreamingState = { ...state.streamingState };
     const cleanedActiveTools = { ...state.activeTools };
     const cleanedAgentTodos = { ...state.agentTodos };
+    const cleanedPagination = { ...state.messagePagination };
     for (const convId of workspaceConvIds) {
       delete cleanedStreamingState[convId];
       delete cleanedActiveTools[convId];
       delete cleanedAgentTodos[convId];
+      delete cleanedPagination[convId];
     }
 
     // Clean up custom todos, session outputs, terminal instances, terminal sessions, and last active conversation for all sessions
@@ -794,6 +796,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       streamingState: cleanedStreamingState,
       activeTools: cleanedActiveTools,
       agentTodos: cleanedAgentTodos,
+      messagePagination: cleanedPagination,
       customTodos: cleanedCustomTodos,
       sessionOutputs: cleanedSessionOutputs,
       terminalInstances: cleanedTerminalInstances,
@@ -857,12 +860,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       const cleanedAgentTodos = { ...state.agentTodos };
       const cleanedContextUsage = { ...state.contextUsage };
       const cleanedQueuedMessages = { ...state.queuedMessages };
+      const cleanedPagination = { ...state.messagePagination };
       for (const convId of convIds) {
         delete cleanedStreamingState[convId];
         delete cleanedActiveTools[convId];
         delete cleanedAgentTodos[convId];
         delete cleanedContextUsage[convId];
         delete cleanedQueuedMessages[convId];
+        delete cleanedPagination[convId];
       }
 
       // Clean up custom todos, session outputs, review comments, and last active conversation
@@ -906,6 +911,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         agentTodos: cleanedAgentTodos,
         contextUsage: cleanedContextUsage,
         queuedMessages: cleanedQueuedMessages,
+        messagePagination: cleanedPagination,
         customTodos: remainingCustomTodos,
         sessionOutputs: remainingSessionOutputs,
         reviewComments: remainingReviewComments,
@@ -1115,6 +1121,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { [id]: _context, ...remainingContextUsage } = state.contextUsage;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [id]: _queued, ...remainingQueuedMessages } = state.queuedMessages;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [id]: _pagination, ...remainingPagination } = state.messagePagination;
 
     const removedConv = state.conversations.find((c) => c.id === id);
     const newConversations = state.conversations.filter((c) => c.id !== id);
@@ -1159,6 +1167,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       interruptedState: remainingInterruptedState,
       contextUsage: remainingContextUsage,
       queuedMessages: remainingQueuedMessages,
+      messagePagination: remainingPagination,
     };
   });
   },


### PR DESCRIPTION
## Summary
- Fixed a race condition where navigating back to a previously-evicted conversation showed a blank screen (only first message bubble visible)
- The message loading `useEffect` guard in `CachedConversationPane` now requires both pagination **and** messages before skipping reload — previously it skipped on pagination alone, even if messages were empty after eviction
- Added `messagePagination` cleanup to `removeConversation`, `removeSession`, and `removeWorkspace` to prevent orphaned pagination entries

## Root Cause
When navigating away from a conversation with >100 messages, `selectConversation` evicts old messages (keeps 50 most recent) but preserves `messagePagination`. On return, the `useEffect` saw pagination existed and bailed out — even though messages could be empty or stale.

## Test plan
- [ ] Open a conversation with long message history, navigate away and back — should display all messages
- [ ] Rapidly switch between conversations/sessions — no blank screens
- [ ] Delete a conversation, create a new one — verify no stale pagination leaks
- [ ] Verify normal message loading still works (no duplicate API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)