### PR TITLE
fix: improve error handling for PR report MCP tools

### DIFF
--- a/agent-runner/src/mcp/tools/fetch-utils.ts
+++ b/agent-runner/src/mcp/tools/fetch-utils.ts
@@ -6,6 +6,21 @@
 
 const RETRY_DELAYS_MS = [500, 1000, 2000];
 
+/** Extract a useful error message from a fetch TypeError, including the root cause. */
+export function formatFetchError(error: unknown): string {
+  if (error instanceof TypeError) {
+    const cause = (error as any).cause;
+    if (cause) {
+      const code = (cause as any).code;
+      if (code) return `${error.message} (${code})`;
+      const detail = cause.message || (typeof cause === 'object' ? JSON.stringify(cause) : String(cause));
+      return `${error.message} (${detail})`;
+    }
+    return error.message;
+  }
+  return String(error);
+}
+
 export async function fetchWithRetry(
   url: string,
   options?: RequestInit

--- a/agent-runner/src/mcp/tools/pr.ts
+++ b/agent-runner/src/mcp/tools/pr.ts
@@ -2,7 +2,7 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { WorkspaceContext } from "../context.js";
-import { fetchWithRetry } from "./fetch-utils.js";
+import { fetchWithRetry, formatFetchError } from "./fetch-utils.js";
 
 const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://127.0.0.1:9876";
 const AUTH_TOKEN = process.env.CHATML_AUTH_TOKEN || "";
@@ -66,7 +66,7 @@ export function createPRTools(context: WorkspaceContext) {
           return {
             content: [{
               type: "text" as const,
-              text: `Error reporting PR: ${error}`,
+              text: `Error reporting PR: ${formatFetchError(error)}. The PR may not appear in the ChatML sidebar immediately, but the PR watcher will pick it up.`,
             }],
           };
         }
@@ -110,10 +110,13 @@ export function createPRTools(context: WorkspaceContext) {
             }],
           };
         } catch (error) {
+          // Best-effort notification — the PR watcher will detect merges via polling.
           return {
             content: [{
               type: "text" as const,
-              text: `Error reporting PR merge: ${error}`,
+              text: prNumber
+                ? `Failed to report PR #${prNumber} merge to backend (${formatFetchError(error)}), but the PR watcher will detect the merge automatically.`
+                : `Failed to report PR merge to backend (${formatFetchError(error)}), but the PR watcher will detect the merge automatically.`,
             }],
           };
         }


### PR DESCRIPTION
## Summary
- Extract root cause from Node.js fetch `TypeError` (e.g., `ECONNREFUSED`) instead of showing the opaque "TypeError: fetch failed" message
- Make `report_pr_merged` gracefully degrade when the backend is unreachable — it's a best-effort notification since the PR watcher detects merges via polling anyway
- Improve `report_pr_created` error message to include the root cause and reassure the agent that the PR watcher will pick it up

## Test plan
- [ ] Kill the Go backend, invoke `report_pr_merged` via MCP — should return a non-alarming message with the underlying cause
- [ ] Restart backend, invoke again — should return normal success message
- [ ] Verify `report_pr_created` also shows improved error with cause when backend is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)