### PR TITLE
fix: improve error handling for review comment MCP tools

### DIFF
--- a/agent-runner/src/mcp/tools/comments.ts
+++ b/agent-runner/src/mcp/tools/comments.ts
@@ -2,7 +2,7 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { WorkspaceContext } from "../context.js";
-import { fetchWithRetry } from "./fetch-utils.js";
+import { fetchWithRetry, formatFetchError } from "./fetch-utils.js";
 
 // Backend URL from environment. This matches the default port used by the Go backend.
 // TODO: Consider adding backendUrl to WorkspaceContext for consistency with other tools
@@ -69,7 +69,7 @@ export function createCommentTools(context: WorkspaceContext) {
           return {
             content: [{
               type: "text",
-              text: `Error adding review comment: ${error}`,
+              text: `Error adding review comment: ${formatFetchError(error)}`,
             }],
           };
         }
@@ -141,7 +141,7 @@ export function createCommentTools(context: WorkspaceContext) {
           return {
             content: [{
               type: "text",
-              text: `Error listing review comments: ${error}`,
+              text: `Error listing review comments: ${formatFetchError(error)}`,
             }],
           };
         }
@@ -193,7 +193,7 @@ export function createCommentTools(context: WorkspaceContext) {
           return {
             content: [{
               type: "text" as const,
-              text: `Error resolving review comment: ${error}`,
+              text: `Error resolving review comment: ${formatFetchError(error)}`,
             }],
           };
         }
@@ -255,7 +255,7 @@ export function createCommentTools(context: WorkspaceContext) {
           return {
             content: [{
               type: "text",
-              text: `Error getting comment stats: ${error}`,
+              text: `Error getting comment stats: ${formatFetchError(error)}`,
             }],
           };
         }


### PR DESCRIPTION
## Summary
- Use `formatFetchError()` in all 4 review comment MCP tool catch blocks to surface root cause codes (e.g., `ECONNREFUSED`, `ENOTFOUND`) instead of bare `TypeError: fetch failed`
- Matches the pattern already applied to PR report tools in #996

## Test plan
- [ ] Stop the Go backend, trigger any review comment MCP tool (e.g., resolve_review_comment)
- [ ] Verify error message now includes the cause code (e.g., `fetch failed (ECONNREFUSED)`) instead of `TypeError: fetch failed`
- [ ] Build agent-runner: `cd agent-runner && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)