### PR TITLE
fix: persist conversation timeline on app quit mid-turn

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -135,11 +135,19 @@ func NewManager(ctx context.Context, s *store.SQLiteStore, wm *git.WorktreeManag
 }
 
 // Init performs startup cleanup tasks such as resetting stale conversation
-// statuses from a previous unclean shutdown. Call after NewManager and before
-// the HTTP server starts accepting requests.
+// statuses and recovering interrupted messages from a previous unclean shutdown.
+// Call after NewManager and before the HTTP server starts accepting requests.
 func (m *Manager) Init(ctx context.Context) error {
 	if err := m.store.CleanupStaleConversations(ctx); err != nil {
 		return fmt.Errorf("failed to cleanup stale conversations: %w", err)
+	}
+	// Convert orphaned streaming snapshots into persisted assistant messages.
+	// This recovers partial agent responses that were lost when the app was
+	// killed mid-turn (safety net for when the output handler's flush fails).
+	if converted, err := m.store.ConvertSnapshotsToMessages(ctx); err != nil {
+		logger.Manager.Errorf("Failed to convert snapshots to messages: %v", err)
+	} else if converted > 0 {
+		logger.Manager.Infof("Recovered %d interrupted assistant messages from snapshots", converted)
 	}
 	return nil
 }
@@ -517,8 +525,10 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	snapshotTimer.Stop() // Don't start until first state change
 	defer snapshotTimer.Stop()
 
-	// flushSnapshot writes the current streaming state to the DB
-	flushSnapshot := func() {
+	// flushSnapshot writes the current streaming state to the DB.
+	// Accepts an explicit context so callers can provide a detached context
+	// during shutdown (when the app-level ctx is already cancelled).
+	flushSnapshot := func(flushCtx context.Context) {
 		if !snapshotDirty {
 			return
 		}
@@ -569,7 +579,7 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 			logger.Manager.Errorf("Failed to marshal streaming snapshot for conv %s: %v", convID, err)
 			return
 		}
-		if err := m.store.SetStreamingSnapshot(ctx, convID, data); err != nil {
+		if err := m.store.SetStreamingSnapshot(flushCtx, convID, data); err != nil {
 			logger.Manager.Errorf("Failed to store streaming snapshot for conv %s: %v", convID, err)
 			return
 		}
@@ -972,7 +982,7 @@ outer:
 					Timestamp: time.Now().UnixMilli(),
 				}
 				markSnapshotDirty()
-				flushSnapshot() // Force immediate flush — don't wait for debounce
+				flushSnapshot(ctx) // Force immediate flush — don't wait for debounce
 
 			case EventTypePlanApprovalRequest:
 				pendingPlanContent = event.PlanContent
@@ -984,7 +994,7 @@ outer:
 					Timestamp:   time.Now().UnixMilli(),
 				}
 				markSnapshotDirty()
-				flushSnapshot() // Force immediate flush — don't wait for debounce
+				flushSnapshot(ctx) // Force immediate flush — don't wait for debounce
 
 			case EventTypeCheckpointCreated:
 				if event.CheckpointUuid != "" {
@@ -1275,7 +1285,7 @@ outer:
 
 		case <-snapshotTimer.C:
 			// Debounce timer fired — flush snapshot to DB
-			flushSnapshot()
+			flushSnapshot(ctx)
 
 		case <-dropCheckTicker.C:
 			// Check for new drops and emit warning out-of-band
@@ -1293,14 +1303,31 @@ outer:
 					})
 				}
 			}
+
+		case <-ctx.Done():
+			// App shutting down — force-flush the latest snapshot state with a
+			// detached context so ConvertSnapshotsToMessages can recover it on
+			// next startup (safety net for SIGKILL after this point).
+			logger.Manager.Warnf("Conversation %s: context cancelled, force-flushing snapshot before exit", convID)
+			shutdownFlushCtx, shutdownFlushCancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+			snapshotDirty = true
+			flushSnapshot(shutdownFlushCtx)
+			shutdownFlushCancel()
+			break outer
 		}
 	}
+
+	// Use a detached context for final persistence — the app-level context may
+	// already be cancelled due to SIGTERM, but we need to fit within the 2-second
+	// sidecar grace period (shared with handleConversationCompletion's goroutine).
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer flushCancel()
 
 	// Atomically clear active turn flag and flush any remaining deferred user
 	// message. Store BEFORE the assistant message so the DB position ordering
 	// is: [queued_user_N, assistant_N+1].
 	pendingFinal := proc.EndTurnAndTakePending()
-	m.storePendingUserMessage(ctx, convID, pendingFinal)
+	m.storePendingUserMessage(flushCtx, convID, pendingFinal)
 
 	// Store any remaining assistant message (with full enrichment)
 	if currentAssistantMessage != "" {
@@ -1362,7 +1389,7 @@ outer:
 
 		durationMs := int(time.Since(turnStartTime).Milliseconds())
 
-		if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
+		if err := m.store.AddMessageToConversation(flushCtx, convID, models.Message{
 			ID:              uuid.New().String()[:8],
 			Role:            "assistant",
 			Content:         currentAssistantMessage,
@@ -1386,7 +1413,7 @@ outer:
 	isStaleHandler := exists && currentProc != proc
 	m.mu.RUnlock()
 	if !isStaleHandler {
-		if err := m.store.ClearStreamingSnapshot(ctx, convID); err != nil {
+		if err := m.store.ClearStreamingSnapshot(flushCtx, convID); err != nil {
 			logger.Manager.Errorf("Failed to clear streaming snapshot on exit for conv %s: %v", convID, err)
 		}
 	}
@@ -1408,15 +1435,28 @@ outer:
 }
 
 // handleConversationCompletion handles process completion.
-// Note: Uses the app-level context so background work is cancelled on shutdown.
+// Uses a detached context for persistence so data is flushed even during shutdown.
 func (m *Manager) handleConversationCompletion(convID string, proc *Process) {
 	ctx := m.ctx
+	appShutdown := false
 	select {
 	case <-proc.Done():
 	case <-ctx.Done():
-		logger.Manager.Warnf("App shutting down, abandoning completion wait for conversation %s", convID)
-		return
+		// App shutting down — don't return immediately. Give the process a brief
+		// window to exit so we can still synthesize error messages if needed.
+		logger.Manager.Warnf("App shutting down, waiting briefly for process exit on conversation %s", convID)
+		appShutdown = true
+		select {
+		case <-proc.Done():
+		case <-time.After(300 * time.Millisecond):
+			logger.Manager.Warnf("Process for conversation %s did not exit in time during shutdown", convID)
+		}
 	}
+
+	// Use a detached context for persistence — fits within the 2-second sidecar
+	// grace period (shared with handleConversationOutput's goroutine).
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer flushCancel()
 
 	exitErr := proc.ExitError()
 	var synthesizedError string
@@ -1433,6 +1473,8 @@ func (m *Manager) handleConversationCompletion(convID string, proc *Process) {
 				synthesizedError += ": " + strings.Join(stderrLines, "\n")
 			}
 		}
+	} else if appShutdown {
+		logger.Manager.Infof("Conversation %s process exited during app shutdown, skipping error synthesis", convID)
 	} else {
 		logger.Manager.Infof("Conversation %s process exited cleanly", convID)
 	}
@@ -1441,7 +1483,8 @@ func (m *Manager) handleConversationCompletion(convID string, proc *Process) {
 	// assistant output AND without an error event, synthesize a user-visible error.
 	// This prevents the conversation from going silently idle with zero feedback.
 	// Only fires if the crash fallback above didn't already synthesize an error.
-	if synthesizedError == "" && !proc.ProducedOutput() && !proc.SawErrorEvent() {
+	// Skip during app shutdown — the partial output is handled by handleConversationOutput.
+	if synthesizedError == "" && !appShutdown && !proc.ProducedOutput() && !proc.SawErrorEvent() {
 		stderrLines := proc.LastStderrLines()
 		synthesizedError = "The agent process exited without producing any response"
 		if len(stderrLines) > 0 {
@@ -1453,7 +1496,7 @@ func (m *Manager) handleConversationCompletion(convID string, proc *Process) {
 	// Persist the synthesized error as an assistant message so it survives app
 	// restarts, and broadcast it via WebSocket for immediate display.
 	if synthesizedError != "" {
-		if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
+		if err := m.store.AddMessageToConversation(flushCtx, convID, models.Message{
 			ID:        uuid.New().String()[:8],
 			Role:      "assistant",
 			Content:   synthesizedError,

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chatml/chatml-backend/appdir"
 	"github.com/chatml/chatml-backend/logger"
 	"github.com/chatml/chatml-backend/models"
+	"github.com/google/uuid"
 	_ "modernc.org/sqlite"
 )
 
@@ -2024,6 +2025,113 @@ func (s *SQLiteStore) CleanupStaleConversations(ctx context.Context) error {
 			 WHERE status = 'active' AND updated_at < datetime('now', '-30 seconds')`)
 		return err
 	})
+}
+
+// ConvertSnapshotsToMessages converts orphaned streaming snapshots into persisted
+// assistant messages. This recovers partial agent responses that were lost when
+// the app was killed mid-turn (e.g., SIGKILL before the output handler could flush).
+// Returns the number of conversations whose snapshots were converted.
+func (s *SQLiteStore) ConvertSnapshotsToMessages(ctx context.Context) (int, error) {
+	interrupted, err := s.GetInterruptedConversations(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("ConvertSnapshotsToMessages: %w", err)
+	}
+
+	// Minimal struct for deserializing snapshot JSON within the store package
+	// (cannot import agent package due to circular dependency).
+	// Intentionally ignores: activeTools, isThinking, planModeActive, subAgents,
+	// pendingPlanApproval, pendingUserQuestion — these are transient UI state
+	// that is not meaningful to recover as a persisted message.
+	type snapshotTextSegment struct {
+		Text      string `json:"text"`
+		Timestamp int64  `json:"timestamp"`
+	}
+	type snapshot struct {
+		Text         string                `json:"text"`
+		TextSegments []snapshotTextSegment `json:"textSegments"`
+		Thinking     string                `json:"thinking"`
+	}
+
+	converted := 0
+	for _, ic := range interrupted {
+		var snap snapshot
+		if err := json.Unmarshal(ic.SnapshotJSON, &snap); err != nil {
+			logger.Store.Errorf("ConvertSnapshotsToMessages: failed to unmarshal snapshot for conv %s, clearing corrupt snapshot: %v", ic.ID, err)
+			// Clear corrupt snapshots to prevent retry on every startup
+			if clearErr := s.ClearStreamingSnapshot(ctx, ic.ID); clearErr != nil {
+				logger.Store.Errorf("ConvertSnapshotsToMessages: failed to clear corrupt snapshot for conv %s: %v", ic.ID, clearErr)
+			}
+			continue
+		}
+
+		// Skip empty snapshots (agent started but hadn't produced any text or thinking)
+		if snap.Text == "" && snap.Thinking == "" {
+			// Clear the empty snapshot
+			if err := s.ClearStreamingSnapshot(ctx, ic.ID); err != nil {
+				logger.Store.Errorf("ConvertSnapshotsToMessages: failed to clear empty snapshot for conv %s: %v", ic.ID, err)
+			}
+			continue
+		}
+
+		// Dedup: check if the last message is already an assistant message with matching content.
+		// This handles the case where the output handler successfully flushed (Change 1) but
+		// ClearStreamingSnapshot failed (e.g., timeout).
+		var lastRole, lastContent sql.NullString
+		row := s.db.QueryRowContext(ctx,
+			`SELECT role, content FROM messages WHERE conversation_id = ? ORDER BY position DESC LIMIT 1`,
+			ic.ID)
+		if err := row.Scan(&lastRole, &lastContent); err != nil && err != sql.ErrNoRows {
+			logger.Store.Errorf("ConvertSnapshotsToMessages: failed to check last message for conv %s: %v", ic.ID, err)
+			continue
+		}
+		if lastRole.Valid && lastRole.String == "assistant" && lastContent.Valid && lastContent.String == snap.Text {
+			// Already persisted — just clear the snapshot
+			if err := s.ClearStreamingSnapshot(ctx, ic.ID); err != nil {
+				logger.Store.Errorf("ConvertSnapshotsToMessages: failed to clear duplicate snapshot for conv %s: %v", ic.ID, err)
+			}
+			continue
+		}
+
+		// Build timeline from text segments and thinking blocks.
+		// Thinking is prepended since it typically precedes text output.
+		var timeline []models.TimelineEntry
+		if snap.Thinking != "" {
+			timeline = append(timeline, models.TimelineEntry{Type: "thinking", Content: snap.Thinking})
+		}
+		if len(snap.TextSegments) > 0 {
+			for _, seg := range snap.TextSegments {
+				if seg.Text != "" {
+					timeline = append(timeline, models.TimelineEntry{Type: "text", Content: seg.Text})
+				}
+			}
+		} else if snap.Text != "" {
+			// Fallback: single text entry if no segments
+			timeline = append(timeline, models.TimelineEntry{Type: "text", Content: snap.Text})
+		}
+
+		msg := models.Message{
+			ID:              uuid.New().String()[:8],
+			Role:            "assistant",
+			Content:         snap.Text,
+			ThinkingContent: snap.Thinking,
+			Timeline:        timeline,
+			Timestamp:       time.Now(),
+		}
+
+		if err := s.AddMessageToConversation(ctx, ic.ID, msg); err != nil {
+			logger.Store.Errorf("ConvertSnapshotsToMessages: failed to persist recovered message for conv %s: %v", ic.ID, err)
+			continue
+		}
+
+		if err := s.ClearStreamingSnapshot(ctx, ic.ID); err != nil {
+			logger.Store.Errorf("ConvertSnapshotsToMessages: failed to clear snapshot after conversion for conv %s: %v", ic.ID, err)
+		}
+
+		converted++
+		logger.Store.Infof("ConvertSnapshotsToMessages: recovered interrupted assistant message for conv %s (%d chars)", ic.ID, len(snap.Text))
+	}
+
+	return converted, nil
 }
 
 // ============================================================================

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -979,6 +979,13 @@ export function useWebSocket(enabled: boolean = true) {
           hadPendingQuestion: !!item.snapshot?.pendingUserQuestion,
           snapshot: item.snapshot,
         });
+        // Inject the snapshot's text as a visible assistant message so the user
+        // can see what the agent produced before the interruption. The dedup
+        // inside injectInterruptedAssistantMessage prevents duplicates if the
+        // backend's ConvertSnapshotsToMessages already persisted it.
+        if (item.snapshot?.text) {
+          store.injectInterruptedAssistantMessage(item.id, item.snapshot);
+        }
       }
     } catch (err) {
       console.warn('Failed to reconcile interrupted conversations:', err);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -589,6 +589,7 @@ interface AppState {
   setInterruptedState: (conversationId: string, info: InterruptedInfo | null) => void;
   setInterruptedResuming: (conversationId: string, resuming: boolean) => void;
   clearInterruptedState: (conversationId: string) => void;
+  injectInterruptedAssistantMessage: (conversationId: string, snapshot: { text: string; textSegments?: { text: string; timestamp: number }[]; thinking?: string }) => void;
 
   // File watcher actions
   setLastFileChange: (event: { workspaceId: string; path: string; fullPath: string }) => void;
@@ -2535,7 +2536,45 @@ updateFileTabContent: (id, content) => set((state) => ({
       [conversationId]: null,
     },
   })),
-
+  injectInterruptedAssistantMessage: (conversationId, snapshot) => set((state) => {
+    if (!snapshot.text) return state;
+    const existing = state.messagesByConversation[conversationId] ?? [];
+    // Dedup: skip if the last message is already an assistant message with matching content
+    // (backend's ConvertSnapshotsToMessages may have already persisted it)
+    const lastMsg = existing[existing.length - 1];
+    if (lastMsg && lastMsg.role === 'assistant' && lastMsg.content === snapshot.text) {
+      return state;
+    }
+    // Build timeline from text segments
+    const timeline: import('@/lib/types').TimelineEntry[] = snapshot.textSegments?.length
+      ? snapshot.textSegments.filter(s => s.text).map(s => ({ type: 'text' as const, content: s.text }))
+      : [{ type: 'text' as const, content: snapshot.text }];
+    const message: import('@/lib/types').Message = {
+      id: `interrupted-${conversationId}-${Date.now()}`,
+      conversationId,
+      role: 'assistant',
+      content: snapshot.text,
+      thinkingContent: snapshot.thinking,
+      timeline,
+      timestamp: new Date().toISOString(),
+    };
+    const convPagination = state.messagePagination[conversationId];
+    return {
+      messagesByConversation: {
+        ...state.messagesByConversation,
+        [conversationId]: [...existing, message],
+      },
+      ...(convPagination ? {
+        messagePagination: {
+          ...state.messagePagination,
+          [conversationId]: {
+            ...convPagination,
+            totalCount: convPagination.totalCount + 1,
+          },
+        },
+      } : {}),
+    };
+  }),
   // File watcher actions
   setLastFileChange: (event) => set({
     lastFileChange: { ...event, timestamp: Date.now() },


### PR DESCRIPTION
## Summary

- **Root cause**: When the app quits mid-agent-turn, `handleConversationOutput` uses a cancelled context (`m.ctx`) for the final `AddMessageToConversation` call, so the DB write silently fails. The streaming snapshot survives but is never converted to a visible message on restart.
- Uses detached `context.Background()` with timeouts for all shutdown persistence paths (output handler, completion handler)
- Force-flushes the streaming snapshot on SIGTERM so the latest state is available for recovery
- New `ConvertSnapshotsToMessages()` on startup converts orphaned snapshots into real assistant messages (safety net for SIGKILL/crash)
- Frontend `injectInterruptedAssistantMessage` renders snapshot content immediately with dedup against backend recovery

## Test plan

- [ ] Start a session, submit a message, wait for agent to produce visible output (text + tools), then Cmd+Q
- [ ] Restart — verify conversation shows user message AND assistant's partial response in timeline
- [ ] Verify InterruptedBanner appears with Resume/Dismiss options
- [ ] Quit immediately after sending (before agent output) — verify only user message shows, no empty assistant bubble
- [ ] Quit and restart twice — verify no duplicate messages
- [ ] Normal conversation flow (no quit) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)