### PR TITLE
feat: auto-expand Edit tool diffs in conversation timeline

### DIFF
--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -32,6 +32,7 @@ import { cn, toRelativePath } from '@/lib/utils';
 import { parseMcpToolName, formatToolDuration, stripCdPrefix } from '@/lib/format';
 import { TOOL_TARGET_TRUNCATE, TOOL_COMMAND_TRUNCATE } from '@/lib/constants';
 import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { CopyButton } from '@/components/shared/CopyButton';
 import { TodoToolDetail } from '@/components/conversation/tool-details/TodoToolDetail';
@@ -114,7 +115,8 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   messageId,
   compacted,
 }: ToolUsageBlockProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const autoExpandEditDiffs = useSettingsStore((s) => s.autoExpandEditDiffs);
+  const [isOpen, setIsOpen] = useState(() => ['Edit', 'edit_file'].includes(tool) && autoExpandEditDiffs && !compacted);
   const [isHydrating, setIsHydrating] = useState(false);
   const isHydratingRef = useRef(false);
 

--- a/src/components/settings/sections/AppearanceSettings.tsx
+++ b/src/components/settings/sections/AppearanceSettings.tsx
@@ -111,6 +111,8 @@ export function AppearanceSettings() {
   const setShowChatCost = useSettingsStore((s) => s.setShowChatCost);
   const showMessageTokenCost = useSettingsStore((s) => s.showMessageTokenCost);
   const setShowMessageTokenCost = useSettingsStore((s) => s.setShowMessageTokenCost);
+  const autoExpandEditDiffs = useSettingsStore((s) => s.autoExpandEditDiffs);
+  const setAutoExpandEditDiffs = useSettingsStore((s) => s.setAutoExpandEditDiffs);
   const { theme, setTheme } = useTheme();
 
   return (
@@ -201,6 +203,16 @@ export function AppearanceSettings() {
           onReset={() => setShowMessageTokenCost(SETTINGS_DEFAULTS.showMessageTokenCost)}
         >
           <Switch checked={showMessageTokenCost} onCheckedChange={setShowMessageTokenCost} aria-label="Show per-message tokens and cost" />
+        </SettingsRow>
+
+        <SettingsRow
+          settingId="autoExpandEditDiffs"
+          title="Auto-expand edit diffs"
+          description="Show Edit tool diffs expanded by default in the conversation timeline"
+          isModified={autoExpandEditDiffs !== SETTINGS_DEFAULTS.autoExpandEditDiffs}
+          onReset={() => setAutoExpandEditDiffs(SETTINGS_DEFAULTS.autoExpandEditDiffs)}
+        >
+          <Switch checked={autoExpandEditDiffs} onCheckedChange={setAutoExpandEditDiffs} aria-label="Auto-expand edit diffs" />
         </SettingsRow>
       </SettingsGroup>
     </div>

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -161,6 +161,14 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
     category: 'appearance',
     categoryLabel: 'Appearance',
   },
+  {
+    id: 'autoExpandEditDiffs',
+    title: 'Auto-expand edit diffs',
+    description: 'Automatically expand Edit tool blocks to show diffs inline in the conversation timeline',
+    keywords: ['edit', 'diff', 'expand', 'tool', 'collapse', 'auto', 'inline'],
+    category: 'appearance',
+    categoryLabel: 'Appearance',
+  },
 
   // ── AI & Models: Models ──
   {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -80,6 +80,7 @@ export const SETTINGS_DEFAULTS = {
   showTokenUsage: true,
   showChatCost: true,
   showMessageTokenCost: false,
+  autoExpandEditDiffs: true,
   zenMode: false,
   // AI & Models
   defaultModel: 'claude-opus-4-6',
@@ -125,6 +126,7 @@ interface SettingsState {
   autoConvertLongText: boolean;
   showChatCost: boolean;
   showMessageTokenCost: boolean; // Whether to show compact token/cost footer below each assistant message
+  autoExpandEditDiffs: boolean; // Whether to auto-expand Edit tool blocks to show diffs inline
   // Appearance settings
   theme: ThemeOption; // App theme (system, light, dark)
   fontSize: FontSize;
@@ -201,6 +203,7 @@ interface SettingsState {
   setAutoConvertLongText: (value: boolean) => void;
   setShowChatCost: (value: boolean) => void;
   setShowMessageTokenCost: (value: boolean) => void;
+  setAutoExpandEditDiffs: (value: boolean) => void;
   setTheme: (value: ThemeOption) => void;
   setFontSize: (value: FontSize) => void;
   setBranchSyncBanner: (value: boolean) => void;
@@ -298,6 +301,7 @@ export const useSettingsStore = create<SettingsState>()(
       setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),
       setShowChatCost: (value) => set({ showChatCost: value }),
       setShowMessageTokenCost: (value) => set({ showMessageTokenCost: value }),
+      setAutoExpandEditDiffs: (value) => set({ autoExpandEditDiffs: value }),
       setTheme: (value) => set({ theme: value }),
       setFontSize: (value) => set({ fontSize: value }),
       setBranchSyncBanner: (value) => set({ branchSyncBanner: value }),


### PR DESCRIPTION
## Summary
- Edit tool blocks in the conversation timeline now render **expanded by default**, showing the Pierre diff inline as changes appear
- Adds a new **"Auto-expand edit diffs"** toggle in Settings > Appearance > Display (enabled by default)
- Compacted (history) messages stay collapsed to avoid unnecessary hydration requests

## Changes
- `settingsStore.ts` — new `autoExpandEditDiffs` setting (default: `true`)
- `settingsRegistry.ts` — registered for search/discovery
- `AppearanceSettings.tsx` — Switch toggle in Display section
- `ToolUsageBlock.tsx` — reads setting to initialize Edit blocks as expanded

## Test plan
- [ ] Open a conversation and trigger an Edit tool call — diff should be visible without clicking
- [ ] Toggle the setting off in Settings > Appearance > Display — new Edit blocks should appear collapsed
- [ ] Verify non-Edit tool blocks (Read, Bash, etc.) remain collapsed
- [ ] Search "edit diff" in Settings — the new setting should appear
- [ ] Reload the app — setting should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)