### PR TITLE
fix: remove non-functional View Summary menu item

### DIFF
--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -36,7 +36,6 @@ import {
   Copy,
   GitMerge,
   MessageSquare,
-  FileText,
   RefreshCw,
   Zap,
   Search,
@@ -624,9 +623,6 @@ export function SessionToolbarContent() {
               <DropdownMenuContent align="end" className="w-52">
                 <DropdownMenuItem onSelect={handleNewConversation}>
                   <MessageSquare /> New Conversation
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => handleGitActionMessage('Provide a summary of all work done in this session, including files changed, key decisions, and current status.')}>
-                  <FileText /> View Summary
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onSelect={handleCopyBranch}>


### PR DESCRIPTION
## Summary
- Removes the "View Summary" menu item from the session toolbar kebab menu
- The item silently failed when no active conversation existed, providing no user feedback
- Also removes the unused `FileText` lucide-react import

## Test plan
- [ ] Open the kebab menu (three dots) in the session toolbar
- [ ] Confirm "View Summary" is no longer listed
- [ ] Verify remaining menu items (New Conversation, Copy Branch Name, Create Pull Request, Sync with Main, Archive Session) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)