### PR TITLE
fix: prevent conversation area from going blank on pane switch

### DIFF
--- a/src/components/conversation/CachedConversationPane.tsx
+++ b/src/components/conversation/CachedConversationPane.tsx
@@ -244,6 +244,7 @@ export function CachedConversationPane({
   // will still suppress auto-scroll. Use resetFollowState() to do both.
   const userScrolledUpRef = useRef(false);
   const isActiveRef = useRef(isActive);
+  const prevIsActiveRef = useRef(isActive);
 
   /** Reset all follow-state refs atomically. Call when the user submits a
    *  message, clicks "scroll to bottom", or switches conversations. */
@@ -254,6 +255,29 @@ export function CachedConversationPane({
   useEffect(() => {
     isActiveRef.current = isActive;
   }, [isActive]);
+
+  // Force Virtuoso to recalculate its viewport when the pane becomes active.
+  // While inactive, measurements may have gone stale (e.g. container was in a
+  // display:none ancestor like the file-viewer wrapper). Scrolling to a position
+  // forces Virtuoso to re-scan the viewport and re-measure visible items.
+  useEffect(() => {
+    if (isActive && !prevIsActiveRef.current) {
+      const targetId = conversationId ?? '';
+      const handle = requestAnimationFrame(() => {
+        // Bail if conversation changed before rAF fired
+        if ((conversationId ?? '') !== targetId) return;
+        const saved = scrollPositions.get(targetId);
+        if (!saved || saved.wasAtBottom) {
+          messageListRef.current?.scrollToBottom('auto');
+        } else {
+          messageListRef.current?.scrollToIndex(saved.dataIndex, { align: 'start' });
+        }
+      });
+      prevIsActiveRef.current = isActive;
+      return () => cancelAnimationFrame(handle);
+    }
+    prevIsActiveRef.current = isActive;
+  }, [isActive, conversationId]);
 
   // Continuously track the visible range
   const handleRangeChanged = useCallback((range: { startIndex: number; endIndex: number }) => {
@@ -454,7 +478,10 @@ export function CachedConversationPane({
   }, [isActive, clampedMatchIndex, debouncedSearchQuery, searchMatches]);
 
   return (
-    <div className={isActive ? 'flex flex-col flex-1 min-h-0' : 'hidden'}>
+    <div className={cn(
+      'flex flex-col absolute inset-0',
+      isActive ? 'z-10' : 'invisible pointer-events-none z-0'
+    )}>
       {/* Messages */}
       <div className="relative flex-1 min-h-0">
         {/* Chat Search Bar */}

--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -987,30 +987,36 @@ export function ConversationArea({ children }: ConversationAreaProps) {
       )}
 
       {/* Conversation panes — LRU cached across session switches.
-           Each recent session keeps its VirtualizedMessageList mounted (hidden)
-           so switching back is instant (no Virtuoso remount/measure cycle). */}
-      {recentSessions.map((cached) => {
-        const isCachedActive = cached.sessionId === selectedSessionId && !isFileActive;
-        const cachedSession = sessionMap.get(cached.sessionId);
-        const hasConvs = conversationsBySession.has(cached.sessionId);
-        return (
-          <CachedConversationPane
-            key={cached.sessionId}
-            conversationId={
-              cached.sessionId === selectedSessionId
-                ? selectedConversationId
-                : cached.activeConversationId
-            }
-            isActive={isCachedActive}
-            worktreePath={cachedSession?.worktreePath}
-            sessionName={cachedSession?.name}
-            sessionBranch={cachedSession?.branch}
-            hasConversations={hasConvs}
-          >
-            {isCachedActive ? children : null}
-          </CachedConversationPane>
-        );
-      })}
+           During session switches, inactive panes use visibility:hidden (not
+           display:none) so react-virtuoso can still measure item heights.
+           When the file viewer is active the whole container is hidden
+           (display:none); CachedConversationPane compensates with a rAF-based
+           remeasurement when re-activated. The relative container provides
+           real dimensions for absolutely-positioned child panes. */}
+      <div className={isFileActive ? 'hidden' : 'relative flex-1 min-h-0'}>
+        {recentSessions.map((cached) => {
+          const isCachedActive = cached.sessionId === selectedSessionId && !isFileActive;
+          const cachedSession = sessionMap.get(cached.sessionId);
+          const hasConvs = conversationsBySession.has(cached.sessionId);
+          return (
+            <CachedConversationPane
+              key={cached.sessionId}
+              conversationId={
+                cached.sessionId === selectedSessionId
+                  ? selectedConversationId
+                  : cached.activeConversationId
+              }
+              isActive={isCachedActive}
+              worktreePath={cachedSession?.worktreePath}
+              sessionName={cachedSession?.name}
+              sessionBranch={cachedSession?.branch}
+              hasConversations={hasConvs}
+            >
+              {isCachedActive ? children : null}
+            </CachedConversationPane>
+          );
+        })}
+      </div>
 
       {/* Rename Conversation Dialog */}
       <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>


### PR DESCRIPTION
## Summary

- Replace `display: none` with `visibility: hidden` + absolute positioning for inactive conversation panes so react-virtuoso can still measure item heights and container dimensions
- Wrap cached panes in a relative container that collapses when the file viewer is active
- Add a `requestAnimationFrame`-based re-measure effect that forces Virtuoso to recalculate its viewport when a pane transitions from inactive to active

## Problem

The conversation area intermittently becomes partially blank — a user message bubble is visible but everything below it is empty. Switching to another tab and back fixes it.

**Root cause**: Inactive panes used `display: none` (Tailwind `hidden` class). In this state, react-virtuoso's internal ResizeObserver reports zero dimensions. When the pane becomes visible again, Virtuoso uses stale zero-height measurements, causing it to render items at wrong positions or skip them entirely.

## Test plan

- [ ] Switch between sessions rapidly — content should never go blank
- [ ] Start streaming, switch to file tab, switch back — verify scroll position and content preserved
- [ ] Switch between conversation and file tabs — verify content persists
- [ ] Verify inactive panes don't intercept mouse/keyboard events
- [ ] Test with 3+ sessions to exercise LRU cache eviction

🤖 Generated with [Claude Code](https://claude.com/claude-code)