### PR TITLE
fix: clean up orphaned temp files on startup (#897)

### DIFF
--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/chatml/chatml-backend/appdir"
 	"github.com/chatml/chatml-backend/logger"
 	"github.com/chatml/chatml-backend/models"
 )
@@ -227,7 +228,7 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	var instructionsFile string
 	if opts.Instructions != "" {
 		// Write to temp file to avoid shell arg length limits
-		tmpFile, err := os.CreateTemp("", "chatml-instructions-*.txt")
+		tmpFile, err := os.CreateTemp(appdir.TempDir(), "chatml-instructions-*.txt")
 		if err != nil {
 			logger.Process.Errorf("[%s] Failed to create instructions temp file: %v", opts.ID, err)
 		} else {
@@ -248,7 +249,7 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	// Add MCP servers config (write to temp file like instructions)
 	var mcpServersFile string
 	if opts.McpServersJSON != "" {
-		tmpFile, err := os.CreateTemp("", "chatml-mcp-servers-*.json")
+		tmpFile, err := os.CreateTemp(appdir.TempDir(), "chatml-mcp-servers-*.json")
 		if err != nil {
 			logger.Process.Errorf("[%s] Failed to create MCP servers temp file: %v", opts.ID, err)
 		} else {
@@ -269,7 +270,7 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	// Add programmatic agent definitions (write to temp file like MCP servers)
 	var agentsFile string
 	if opts.AgentsJSON != "" {
-		tmpFile, err := os.CreateTemp("", "chatml-agents-*.json")
+		tmpFile, err := os.CreateTemp(appdir.TempDir(), "chatml-agents-*.json")
 		if err != nil {
 			logger.Process.Errorf("[%s] Failed to create agents temp file: %v", opts.ID, err)
 		} else {
@@ -517,7 +518,7 @@ func (p *Process) SendMessageWithAttachments(content string, attachments []model
 			ext = ".webp"
 		}
 
-		tmpFile, err := os.CreateTemp("", "chatml-img-*"+ext)
+		tmpFile, err := os.CreateTemp(appdir.TempDir(), "chatml-img-*"+ext)
 		if err != nil {
 			logger.Process.Errorf("[%s] Failed to create temp file for image: %v", p.ID, err)
 			continue // Fall back to inline base64

--- a/backend/agent/testmain_test.go
+++ b/backend/agent/testmain_test.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/chatml/chatml-backend/appdir"
+)
+
+func TestMain(m *testing.M) {
+	tmpHome, err := os.MkdirTemp("", "chatml-test-home-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp home: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HOME", tmpHome)
+	appdir.Init()
+
+	code := m.Run()
+	os.RemoveAll(tmpHome)
+	os.Exit(code)
+}

--- a/backend/appdir/appdir.go
+++ b/backend/appdir/appdir.go
@@ -35,6 +35,7 @@ func Init() {
 		for _, dir := range []string{
 			filepath.Join(root, "state"),
 			filepath.Join(root, "workspaces"),
+			filepath.Join(root, "tmp"),
 		} {
 			if err := os.MkdirAll(dir, 0755); err != nil {
 				panic("appdir: failed to create directory " + dir + ": " + err.Error())
@@ -93,6 +94,43 @@ func DBPath() string {
 func WorkspacesDir() string {
 	mustInit()
 	return filepath.Join(root, "workspaces")
+}
+
+// TempDir returns Root()/tmp — a dedicated directory for temporary files
+// that can be swept on startup to clean up after crashes.
+func TempDir() string {
+	mustInit()
+	return filepath.Join(root, "tmp")
+}
+
+// CleanupTempDir removes all entries in TempDir(). It is intended to be called
+// once at application startup, before any processes are created, so every entry
+// present is an orphan from a previous run. Returns the number of entries
+// removed and the number of errors encountered.
+func CleanupTempDir() (removed int, failed int, err error) {
+	dir := TempDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+	for _, e := range entries {
+		p := filepath.Join(dir, e.Name())
+		var removeErr error
+		if e.IsDir() {
+			removeErr = os.RemoveAll(p)
+		} else {
+			removeErr = os.Remove(p)
+		}
+		if removeErr != nil {
+			failed++
+		} else {
+			removed++
+		}
+	}
+	return removed, failed, nil
 }
 
 // DataPath returns StateDir()/data.json.

--- a/backend/main.go
+++ b/backend/main.go
@@ -87,6 +87,18 @@ func main() {
 
 	appdir.Init()
 
+	// Clean up orphaned temp files from any previous crash before starting processes.
+	if removed, failed, err := appdir.CleanupTempDir(); err != nil {
+		logger.Main.Warnf("Temp file cleanup: %v", err)
+	} else {
+		if removed > 0 {
+			logger.Main.Infof("Cleaned up %d orphaned temp files", removed)
+		}
+		if failed > 0 {
+			logger.Main.Warnf("Failed to remove %d orphaned temp files", failed)
+		}
+	}
+
 	s, err := store.NewSQLiteStore()
 	if err != nil {
 		logger.Main.Fatalf("Failed to initialize store: %v", err)


### PR DESCRIPTION
## Summary
- Route all `chatml-*` temp files to a dedicated app-owned directory (`Root()/tmp`) instead of the OS temp dir
- Sweep all files in that directory on startup, before any processes are created — everything present is an orphan from a previous crash
- Add `appdir.TempDir()` and `appdir.CleanupTempDir()` functions
- Update all 4 `os.CreateTemp` call sites in `process.go` to use the new directory

Fixes #897

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (added `TestMain` to agent package for `appdir.Init()`)
- [ ] Manual: send a message with image attachment, verify temp file lands in `Root()/tmp`
- [ ] Manual: force-kill app, restart, check logs for "Cleaned up N orphaned temp files"

🤖 Generated with [Claude Code](https://claude.com/claude-code)