### PR TITLE
fix: render auto-compact notification inline in streaming timeline

### DIFF
--- a/src/components/conversation/CompactBoundaryCard.tsx
+++ b/src/components/conversation/CompactBoundaryCard.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState, memo } from 'react';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Scissors, ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { PROSE_CLASSES_COMPACT } from '@/lib/constants';
+import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
+
+interface CompactBoundaryCardProps {
+  cacheKey: string;
+  content: string;
+  compactSummary?: string;
+}
+
+export const CompactBoundaryCard = memo(function CompactBoundaryCard({
+  cacheKey,
+  content,
+  compactSummary,
+}: CompactBoundaryCardProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // When there's no summary to expand, render a plain non-interactive divider
+  if (!compactSummary) {
+    return (
+      <div className="flex items-center gap-2 py-1">
+        <div className="flex-1 border-t border-border/50" />
+        <div className="flex items-center gap-1.5 text-xs px-2 py-0.5 text-muted-foreground">
+          <Scissors className="w-3 h-3 shrink-0" />
+          <span>{content}</span>
+        </div>
+        <div className="flex-1 border-t border-border/50" />
+      </div>
+    );
+  }
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="flex items-center gap-2 py-1">
+        {/* Left divider line */}
+        <div className="flex-1 border-t border-border/50" />
+
+        <CollapsibleTrigger
+          className={cn(
+            'flex items-center gap-1.5 text-xs rounded px-2 py-0.5 transition-colors',
+            'hover:bg-surface-2',
+            'text-muted-foreground',
+          )}
+        >
+          <Scissors className="w-3 h-3 shrink-0" />
+          <span>{content}</span>
+          <span className="text-muted-foreground/50">·</span>
+          <span className="text-muted-foreground/70">
+            {isOpen ? 'Hide' : 'Show'} summary
+          </span>
+          <span className="shrink-0">
+            {isOpen ? (
+              <ChevronDown className="w-2.5 h-2.5" />
+            ) : (
+              <ChevronRight className="w-2.5 h-2.5" />
+            )}
+          </span>
+        </CollapsibleTrigger>
+
+        {/* Right divider line */}
+        <div className="flex-1 border-t border-border/50" />
+      </div>
+
+      <CollapsibleContent>
+        <div className={cn(PROSE_CLASSES_COMPACT, 'mt-1 mx-4 px-3 py-2 rounded-md bg-surface-2/50 border border-border/30')}>
+          <CachedMarkdown cacheKey={cacheKey} content={compactSummary} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+});

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -32,6 +32,7 @@ import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
 import { AttachmentPreviewModal } from '@/components/conversation/AttachmentPreviewModal';
 import { MentionText } from '@/components/conversation/MentionText';
 import { ApprovedPlanBlock } from '@/components/conversation/ApprovedPlanBlock';
+import { CompactBoundaryCard } from '@/components/conversation/CompactBoundaryCard';
 import { TurnStatusIndicator } from '@/components/conversation/TurnStatusIndicator';
 import { MessageTokenFooter } from '@/components/conversation/MessageTokenFooter';
 
@@ -253,6 +254,15 @@ export const MessageBlock = memo(function MessageBlock({
                         key={`tl-status-${idx}`}
                         content={entry.content}
                         variant={entry.variant}
+                      />
+                    );
+                  } else if (entry.type === 'compact') {
+                    return (
+                      <CompactBoundaryCard
+                        key={`tl-compact-${idx}`}
+                        cacheKey={`compact:${message.id}`}
+                        content={entry.content}
+                        compactSummary={entry.summary}
                       />
                     );
                   }

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -8,6 +8,7 @@ import { ToolUsageBlock } from '@/components/conversation/ToolUsageBlock';
 import { ThinkingNode } from '@/components/conversation/ThinkingNode';
 import { SubAgentRow, SubAgentGroupedRow } from '@/components/conversation/SubAgentGroup';
 import { ApprovedPlanBlock } from '@/components/conversation/ApprovedPlanBlock';
+import { CompactBoundaryCard } from '@/components/conversation/CompactBoundaryCard';
 import { TurnStatusIndicator } from '@/components/conversation/TurnStatusIndicator';
 import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
 import { StreamingMarkdown } from '@/components/shared/StreamingMarkdown';
@@ -24,6 +25,7 @@ type TimelineItem =
   | { type: 'thinking'; id: string; isActive: boolean; timestamp: number }
   | { type: 'plan'; id: string; content: string; timestamp: number }
   | { type: 'status'; id: string; content: string; variant?: string; timestamp: number }
+  | { type: 'compact'; id: string; content: string; summary?: string; timestamp: number }
   | { type: 'subagent'; agent: import('@/lib/types').SubAgent }
   | { type: 'subagent_group'; agents: import('@/lib/types').SubAgent[] };
 
@@ -35,6 +37,7 @@ function getItemTime(item: TimelineItem): number {
     case 'thinking': return item.timestamp;
     case 'plan': return item.timestamp;
     case 'status': return item.timestamp;
+    case 'compact': return item.timestamp;
     case 'subagent': return item.agent.startTime;
     case 'subagent_group': return item.agents[0].startTime;
     default: return item.startTime;
@@ -283,6 +286,9 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
   const approvedPlanTimestamp = meta?.approvedPlanTimestamp;
   const pendingPlanApproval = meta?.pendingPlanApproval;
   const turnStartMeta = meta?.turnStartMeta;
+  const compactLabel = meta?.compactBoundary?.label;
+  const compactSummary = meta?.compactBoundary?.summary;
+  const compactTimestamp = meta?.compactBoundary?.timestamp;
 
   // Stage 1: Structural timeline — everything except text segments.
   // Only recomputes when tools/subAgents/structural meta fields change (rare during streaming).
@@ -359,6 +365,17 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
       }
     }
 
+    // Add compact boundary at its chronological position
+    if (compactLabel && compactTimestamp) {
+      items.push({
+        type: 'compact',
+        id: 'compact-boundary',
+        content: compactLabel,
+        summary: compactSummary,
+        timestamp: compactTimestamp,
+      });
+    }
+
     // Add sub-agents into the timeline
     for (const agent of subAgents) {
       items.push({ type: 'subagent', agent });
@@ -368,7 +385,7 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
     items.sort((a, b) => getItemTime(a) - getItemTime(b));
 
     return items;
-  }, [hasThinking, isThinkingActive, metaStartTime, approvedPlanContent, approvedPlanTimestamp, pendingPlanApproval, turnStartMeta, tools, subAgents]);
+  }, [hasThinking, isThinkingActive, metaStartTime, approvedPlanContent, approvedPlanTimestamp, pendingPlanApproval, turnStartMeta, compactLabel, compactSummary, compactTimestamp, tools, subAgents]);
 
   // Stage 2: Merge structural timeline with text segments via two-pointer merge,
   // then group consecutive sub-agents. Both inputs are pre-sorted by timestamp,
@@ -496,6 +513,15 @@ export function StreamingMessage({ conversationId, worktreePath }: StreamingMess
                   key={item.id}
                   content={item.content}
                   variant={item.variant}
+                />
+              );
+            } else if (item.type === 'compact') {
+              return (
+                <CompactBoundaryCard
+                  key={item.id}
+                  cacheKey={`compact:${conversationId}`}
+                  content={item.content}
+                  compactSummary={item.summary}
                 />
               );
             } else if (item.type === 'subagent_group') {

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -43,9 +43,6 @@ export function cleanupConversationState(conversationId: string) {
   clearPlanModeState(conversationId);
 }
 
-// Tracks the most recent compact_boundary system message ID so post_compact can
-// enrich it with the compaction summary instead of creating a duplicate message.
-let lastCompactMessageId: string | null = null;
 
 export function useWebSocket(enabled: boolean = true) {
   const wsRef = useRef<WebSocket | null>(null);
@@ -599,24 +596,12 @@ export function useWebSocket(enabled: boolean = true) {
             conversationId,
           }
         }));
-        {
-          const compactContent = event?.trigger
-            ? `Context was compacted (${event.trigger}).`
-            : 'Context was compacted to stay within limits.';
-          addSystemMessage(conversationId, compactContent)
-            .then(({ id }) => {
-              store.addMessage({
-                id,
-                conversationId,
-                role: 'system',
-                content: compactContent,
-                timestamp: new Date().toISOString(),
-              });
-              // Stash the message ID so post_compact can enrich it with the summary
-              lastCompactMessageId = id;
-            })
-            .catch((err) => console.warn('Failed to persist compact message:', err));
-        }
+        // Inject compact boundary into the streaming timeline so it appears
+        // inline at the correct chronological position (not as a separate system message).
+        store.setCompactBoundary(conversationId, {
+          timestamp: Date.now(),
+          trigger: typeof event?.trigger === 'string' ? event.trigger : undefined,
+        });
         break;
 
       case 'pre_compact':
@@ -624,13 +609,9 @@ export function useWebSocket(enabled: boolean = true) {
 
       case 'post_compact':
         // SDK 0.2.76: PostCompact hook fires after compaction with the conversation summary.
-        // Enrich the existing compact_boundary message instead of adding a duplicate.
-        if (event?.compactSummary && lastCompactMessageId) {
-          const enrichedContent = event.trigger
-            ? `Context was compacted (${event.trigger}). Summary: ${event.compactSummary}`
-            : `Context was compacted. Summary: ${event.compactSummary}`;
-          store.updateMessage(conversationId, lastCompactMessageId, { content: enrichedContent });
-          lastCompactMessageId = null;
+        // Enrich the compact boundary in the streaming state with the summary.
+        if (typeof event?.compactSummary === 'string' && event.compactSummary) {
+          store.setCompactSummary(conversationId, event.compactSummary);
         }
         break;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -162,7 +162,8 @@ export type TimelineEntry =
   | { type: 'tool'; toolId: string }
   | { type: 'thinking'; content: string }
   | { type: 'plan'; content: string }
-  | { type: 'status'; content: string; variant: 'thinking_enabled' | 'config' | 'info' };
+  | { type: 'status'; content: string; variant: 'thinking_enabled' | 'config' | 'info' }
+  | { type: 'compact'; content: string; summary?: string };
 
 // Active tool during streaming (real-time tracking)
 export interface ActiveTool {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -242,6 +242,7 @@ interface StreamingState {
   approvedPlanTimestamp?: number; // When the plan was approved (for timeline ordering)
   recovery?: { attempt: number; maxAttempts: number }; // Agent crash recovery in progress
   turnStartMeta?: { model?: string; effort?: string; permissionMode?: string }; // Turn-start config from init event
+  compactBoundary?: { timestamp: number; trigger?: string; summary?: string; label: string }; // Auto-compact boundary from SDK
 }
 
 // Info about a conversation interrupted by app shutdown, detected on restart
@@ -461,6 +462,8 @@ interface AppState {
   setAgentRecovering: (conversationId: string, attempt: number, maxAttempts: number) => void;
   clearAgentRecovery: (conversationId: string) => void;
   setTurnStartMeta: (conversationId: string, meta: { model?: string; effort?: string; permissionMode?: string }) => void;
+  setCompactBoundary: (conversationId: string, boundary: { timestamp: number; trigger?: string }) => void;
+  setCompactSummary: (conversationId: string, summary: string) => void;
   clearStreamingText: (conversationId: string) => void;
   clearStreamingContent: (conversationId: string) => void;
   appendThinkingText: (conversationId: string, text: string) => void;
@@ -1642,6 +1645,27 @@ updateFileTabContent: (id, content) => set((state) => ({
       turnStartMeta: meta,
     }),
   })),
+  setCompactBoundary: (conversationId, boundary) => set((state) => ({
+    streamingState: updateStreamingConv(state.streamingState, conversationId, {
+      compactBoundary: {
+        ...boundary,
+        label: boundary.trigger
+          ? `Context was compacted (${boundary.trigger}).`
+          : 'Context was compacted.',
+      },
+      // Force a new text segment so the compact marker appears between pre/post text
+      currentSegmentId: null,
+    }),
+  })),
+  setCompactSummary: (conversationId, summary) => set((state) => {
+    const current = state.streamingState[conversationId];
+    if (!current?.compactBoundary) return state;
+    return {
+      streamingState: updateStreamingConv(state.streamingState, conversationId, {
+        compactBoundary: { ...current.compactBoundary, summary },
+      }),
+    };
+  }),
   clearStreamingText: (conversationId) => set((state) => ({
     streamingState: updateStreamingConv(state.streamingState, conversationId, {
       text: '',
@@ -1653,6 +1677,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       isThinking: false,
       pendingPlanApproval: null,
       startTime: undefined,
+      compactBoundary: undefined,
     }),
   })),
   // Clear stale content on process restart while preserving isStreaming and startTime
@@ -1665,6 +1690,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       error: null,
       thinking: null,
       isThinking: false,
+      compactBoundary: undefined,
     }),
   })),
   appendThinkingText: (conversationId, text) => set((state) => {
@@ -2083,6 +2109,13 @@ updateFileTabContent: (id, content) => set((state) => ({
       // Add approved plan content at its chronological position
       if (streaming.approvedPlanContent && streaming.approvedPlanTimestamp) {
         timelineItems.push({ timestamp: streaming.approvedPlanTimestamp, entry: { type: 'plan', content: streaming.approvedPlanContent } });
+      }
+      // Add compact boundary at its chronological position
+      if (streaming.compactBoundary) {
+        timelineItems.push({
+          timestamp: streaming.compactBoundary.timestamp,
+          entry: { type: 'compact', content: streaming.compactBoundary.label, summary: streaming.compactBoundary.summary },
+        });
       }
       timelineItems.sort((a, b) => a.timestamp - b.timestamp);
       const timeline: TimelineEntry[] | undefined =

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -244,6 +244,7 @@ export const useStreamingMeta = (conversationId: string | null) =>
         approvedPlanTimestamp: st.approvedPlanTimestamp,
         recovery: st.recovery,
         turnStartMeta: st.turnStartMeta,
+        compactBoundary: st.compactBoundary,
       };
     })
   );


### PR DESCRIPTION
## Summary
- Auto-compact events were creating a system message **above** the streaming area, breaking chronological order and dumping the compact summary as a massive wall of plain text
- Now the compact boundary is injected **inline in the streaming timeline** at its correct chronological position, using a collapsible divider card
- Summary is collapsed by default and renders as markdown when expanded

## Changes
- **New `CompactBoundaryCard` component** — divider-style card with scissors icon, "Show/Hide summary" toggle, and markdown-rendered summary via `CachedMarkdown`
- **`StreamingState`** — added `compactBoundary` field with `timestamp`, `trigger`, and `summary`
- **WebSocket handler** — `compact_boundary` and `post_compact` events now inject into streaming state instead of creating a system message
- **`StreamingMessage`** — added `'compact'` timeline item type, injected into structural timeline at correct position
- **`MessageBlock`** — renders `CompactBoundaryCard` for finalized compact timeline entries
- **`TimelineEntry`** — added `'compact'` type to the union

## Test plan
- [ ] Trigger auto-compact in a long-running conversation
- [ ] Verify compact divider appears inline in the streaming timeline at the correct chronological position
- [ ] Verify summary is collapsed by default
- [ ] Click "Show summary" — verify markdown renders correctly
- [ ] After turn completes, verify compact entry persists in finalized message timeline
- [ ] Verify no orphaned system messages appear above the streaming area

🤖 Generated with [Claude Code](https://claude.com/claude-code)