### PR TITLE
fix: suppress "No newline at end of file" warning in inline diff viewer

### DIFF
--- a/src/components/conversation/tool-details/EditToolDetail.tsx
+++ b/src/components/conversation/tool-details/EditToolDetail.tsx
@@ -14,6 +14,9 @@ import { getShikiLanguage } from '@/lib/languageMapping';
 
 const PIERRE_THEMES = { dark: 'pierre-dark', light: 'pierre-light' } as const;
 
+// Ensure strings end with newline to suppress Pierre's "No newline at end of file" marker
+const ensureTrailingNewline = (s: string) => s.endsWith('\n') ? s : s + '\n';
+
 interface EditToolDetailProps {
   oldString: string;
   newString: string;
@@ -36,14 +39,14 @@ export const EditToolDetail = memo(function EditToolDetail({
 
   const oldFile: FileContents = useMemo(() => ({
     name: filename,
-    contents: oldString,
+    contents: ensureTrailingNewline(oldString),
     lang: language as FileContents['lang'],
     cacheKey: `tool-edit-old:${filePath}:${oldString.length}:${oldString.slice(0, 64)}`,
   }), [filename, filePath, oldString, language]);
 
   const newFile: FileContents = useMemo(() => ({
     name: filename,
-    contents: newString,
+    contents: ensureTrailingNewline(newString),
     lang: language as FileContents['lang'],
     cacheKey: `tool-edit-new:${filePath}:${newString.length}:${newString.slice(0, 64)}`,
   }), [filename, filePath, newString, language]);


### PR DESCRIPTION
## Summary
- Normalize Edit tool `old_string`/`new_string` with a trailing newline before passing to Pierre's `parseDiffFromFile`, preventing the "No newline at end of file" marker from cluttering inline conversation diffs

## Test plan
- [ ] Trigger an Edit tool call in a conversation
- [ ] Expand the inline diff viewer and confirm the "No newline at end of file" warning no longer appears
- [ ] Verify diff content is still accurate (no extra blank lines added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)