### PR TITLE
fix: improve Plate.js editor quality — types, perf, and correctness

### DIFF
--- a/src/components/conversation/PlateInput.tsx
+++ b/src/components/conversation/PlateInput.tsx
@@ -45,17 +45,20 @@ interface PlateInputProps {
   onBlur?: () => void;
 }
 
-// Helper to extract text from Plate value
-function extractText(value: Value): string {
+// Extract text and mentioned files from Plate value in a single pass
+function extractContent(value: Value): { text: string; mentionedFiles: string[] } {
   let text = '';
+  const mentionedFiles: string[] = [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plate nodes have dynamic structure
   const processNode = (node: any) => {
     if (node.text !== undefined) {
       text += node.text;
     } else if (node.type === 'mention') {
-      // Mention nodes store the value (file path)
       text += `@${node.value}`;
+      if (node.value) {
+        mentionedFiles.push(node.value);
+      }
     } else if (node.children) {
       node.children.forEach(processNode);
     }
@@ -69,25 +72,7 @@ function extractText(value: Value): string {
     }
   });
 
-  return text.trim();
-}
-
-// Helper to extract mentioned files from Plate value
-function extractMentionedFiles(value: Value): string[] {
-  const files: string[] = [];
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plate nodes have dynamic structure
-  const processNode = (node: any) => {
-    if (node.type === 'mention' && node.value) {
-      files.push(node.value);
-    } else if (node.children) {
-      node.children.forEach(processNode);
-    }
-  };
-
-  value.forEach(processNode);
-
-  return files;
+  return { text: text.trim(), mentionedFiles };
 }
 
 const emptyValue: Value = [{ type: 'p', children: [{ text: '' }] }];
@@ -133,7 +118,7 @@ export const PlateInput = forwardRef<PlateInputHandle, PlateInputProps>(
     // Track changes and notify parent
     const handleChange = useCallback(
       ({ value }: { value: Value }) => {
-        const text = extractText(value);
+        const { text } = extractContent(value);
         onInput?.(text);
       },
       [onInput]
@@ -146,37 +131,26 @@ export const PlateInput = forwardRef<PlateInputHandle, PlateInputProps>(
       },
       clear: () => {
         editor.tf.reset();
-        // Defer until React reconciles the DOM after reset
-        setTimeout(() => {
+        // Defer to allow synchronous Slate DOM updates to complete
+        queueMicrotask(() => {
           editor.tf.focus();
-        }, 0);
+        });
       },
       getText: () => {
-        return extractText(editor.children);
+        return extractContent(editor.children).text;
       },
       getContent: () => {
-        return {
-          text: extractText(editor.children),
-          mentionedFiles: extractMentionedFiles(editor.children),
-        };
+        return extractContent(editor.children);
       },
       setText: (text: string) => {
         editor.tf.reset();
-        // Defer until React reconciles the DOM after reset
-        setTimeout(() => {
+        // Defer to allow synchronous Slate DOM updates to complete
+        queueMicrotask(() => {
           editor.tf.focus();
           editor.tf.insertText(text);
-        }, 0);
+        });
       },
     }));
-
-    // Handle keyboard events
-    const handleKeyDown = useCallback(
-      (e: React.KeyboardEvent) => {
-        onKeyDown?.(e);
-      },
-      [onKeyDown]
-    );
 
     const mentionContextValue = React.useMemo(
       () => ({
@@ -198,25 +172,27 @@ export const PlateInput = forwardRef<PlateInputHandle, PlateInputProps>(
       <SlashCommandItemsContext.Provider value={slashCommandContextValue}>
         <MentionItemsContext.Provider value={mentionContextValue}>
           <Plate editor={editor} onChange={handleChange}>
-            <div onKeyDown={handleKeyDown} onPasteCapture={onPaste}>
-              <EditorContainer variant="default" className="p-0 rounded-none">
-                <Editor
-                  variant="none"
-                  placeholder={placeholder}
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  spellCheck={false}
-                  autoComplete="off"
-                  className={cn(
-                    'min-h-[100px] max-h-[200px] py-1 text-base rounded-none',
-                    'caret-foreground [&_[data-slate-editor]]:min-h-[1lh]',
-                    className
-                  )}
-                  onFocus={onFocus}
-                  onBlur={onBlur}
-                />
-              </EditorContainer>
-            </div>
+            {/* onPasteCapture runs in the capture phase, before Plate's
+                internal paste handler, so image interception via
+                preventDefault() works reliably. */}
+            <EditorContainer variant="default" className="p-0 rounded-none" onPasteCapture={onPaste}>
+              <Editor
+                variant="none"
+                placeholder={placeholder}
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                autoComplete="off"
+                className={cn(
+                  'min-h-[100px] max-h-[200px] py-1 text-base rounded-none',
+                  'caret-foreground [&_[data-slate-editor]]:min-h-[1lh]',
+                  className
+                )}
+                onKeyDown={onKeyDown}
+                onFocus={onFocus}
+                onBlur={onBlur}
+              />
+            </EditorContainer>
           </Plate>
         </MentionItemsContext.Provider>
       </SlashCommandItemsContext.Provider>

--- a/src/components/ui/inline-combobox.tsx
+++ b/src/components/ui/inline-combobox.tsx
@@ -115,8 +115,10 @@ const InlineCombobox = ({
   /**
    * Track the point just before the input element so we know where to
    * insertText if the combobox closes due to a selection change.
+   * We store the live pointRef (not a snapshot) so it stays up-to-date
+   * as the document changes (undo/redo, collaboration, etc.).
    */
-  const insertPoint = React.useRef<Point | null>(null);
+  const insertPointRef = React.useRef<{ current: Point | null; unref: () => Point | null } | null>(null);
 
   React.useEffect(() => {
     const path = editor.api.findPath(element);
@@ -128,10 +130,11 @@ const InlineCombobox = ({
     if (!point) return;
 
     const pointRef = editor.api.pointRef(point);
-    insertPoint.current = pointRef.current;
+    insertPointRef.current = pointRef;
 
     return () => {
       pointRef.unref();
+      insertPointRef.current = null;
     };
   }, [editor, element]);
 
@@ -143,7 +146,7 @@ const InlineCombobox = ({
     onCancelInput: (cause) => {
       if (cause !== 'backspace') {
         editor.tf.insertText(trigger + value, {
-          at: insertPoint?.current ?? undefined,
+          at: insertPointRef.current?.current ?? undefined,
         });
       }
       if (cause === 'arrowLeft' || cause === 'arrowRight') {
@@ -243,8 +246,8 @@ const InlineComboboxInput = ({
         const activeId = store.getState().activeId;
         if (activeId) {
           event.preventDefault();
-          // Find and click the active item to trigger selection
-          const activeItem = document.querySelector(`[data-active-item="true"]`) as HTMLElement;
+          // Find and click the active item by its ID
+          const activeItem = document.getElementById(activeId);
           activeItem?.click();
           return;
         }

--- a/src/components/ui/mention-node.tsx
+++ b/src/components/ui/mention-node.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import type { TComboboxInputElement, TMentionElement } from 'platejs';
 import type { PlateElementProps } from 'platejs/react';
 
+import { filterWords } from '@platejs/combobox';
 import { getMentionOnSelectItem } from '@platejs/mention';
 import { IS_APPLE, KEYS } from 'platejs';
 import {
@@ -30,7 +31,7 @@ import {
 export interface MentionItem {
   key: string;
   text: string;
-  data?: unknown;
+  data?: { path: string; directory: string };
 }
 
 interface MentionItemsContextValue {
@@ -106,6 +107,15 @@ export function MentionInputElement(
   const [search, setSearch] = React.useState('');
   const { items, isLoading } = React.useContext(MentionItemsContext);
 
+  const filteredItems = React.useMemo(() => {
+    if (!search) return items;
+    return items.filter(
+      (item) =>
+        filterWords(item.text, search) ||
+        (item.data?.path && filterWords(item.data.path, search))
+    );
+  }, [items, search]);
+
   return (
     <PlateElement {...props} as="span">
       <InlineCombobox
@@ -114,6 +124,7 @@ export function MentionInputElement(
         setValue={setSearch}
         showTrigger={true}
         trigger="@"
+        filter={false}
       >
         <InlineComboboxInput />
 
@@ -123,7 +134,7 @@ export function MentionInputElement(
           </InlineComboboxEmpty>
 
           <InlineComboboxGroup>
-            {items.map((item) => (
+            {filteredItems.map((item) => (
               <InlineComboboxItem
                 key={item.key}
                 value={item.text}
@@ -133,9 +144,9 @@ export function MentionInputElement(
                 <FileIcon filename={item.text} />
                 <span className="truncate">
                   {item.text}
-                  {(item.data as { directory?: string } | undefined)?.directory ? (
+                  {item.data?.directory ? (
                     <span className="ml-1.5 text-muted-foreground font-normal">
-                      {(item.data as { directory: string }).directory}
+                      {item.data.directory}
                     </span>
                   ) : null}
                 </span>


### PR DESCRIPTION
## Summary
- **Type safety**: Type `MentionItem.data` as `{ path: string; directory: string }` instead of `unknown`, eliminating unsafe casts in the template
- **Performance**: Combine `extractText` + `extractMentionedFiles` into a single-pass `extractContent` function; pre-filter mention items at the data level with `useMemo` instead of rendering all items and filtering per-component
- **Correctness**: Replace fragile `document.querySelector('[data-active-item="true"]')` with scoped `document.getElementById(activeId)`; fix `insertPoint` staleness by storing the live `pointRef` instead of a snapshot
- **Cleanup**: Remove unnecessary wrapper `<div>` and passthrough `handleKeyDown` in PlateInput; replace `setTimeout(0)` with `queueMicrotask` for more deterministic deferred focus

## Test plan
- [ ] Verify @ mentions open, filter, and select correctly
- [ ] Verify / slash commands open, filter, and execute correctly
- [ ] Verify Tab selects the active combobox item in both mentions and slash commands
- [ ] Verify editor clear and setText still work (focus should land correctly)
- [ ] Verify paste and keyboard events still propagate to ChatInput

🤖 Generated with [Claude Code](https://claude.com/claude-code)