### PR TITLE
feat: enable 1M context window for Opus 4.6 and Sonnet 4.6

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -312,6 +312,9 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 		procOpts.Model = opts.Model
 	}
 
+	// Enable 1M context window for models that support it
+	procOpts.Betas = betasForModel(procOpts.Model)
+
 	// Build combined system instructions: app context + custom instructions + conversation summaries
 	var existingInstructions string
 	if opts != nil {
@@ -1820,6 +1823,9 @@ func (m *Manager) ResumeConversation(ctx context.Context, convID string) error {
 		SettingSources:      "project,user,local",
 	}
 
+	// Enable 1M context window for models that support it
+	opts.Betas = betasForModel(opts.Model)
+
 	// Apply target branch from session
 	sessionWithWs, err := m.store.GetSessionWithWorkspace(ctx, conv.SessionID)
 	if err != nil {
@@ -2046,6 +2052,15 @@ func (m *Manager) GetActiveStreamingConversations() []string {
 		}
 	}
 	return active
+}
+
+// betasForModel returns comma-separated beta flags for the given model.
+// Opus 4.6 and Sonnet 4.6 support 1M context window via the context-1m beta.
+func betasForModel(model string) string {
+	if strings.Contains(model, "opus-4-6") || strings.Contains(model, "sonnet-4-6") {
+		return "context-1m-2025-08-07"
+	}
+	return ""
 }
 
 // formatSessionName converts a human-readable name into a branch-friendly format.


### PR DESCRIPTION
## Summary

- Pass `context-1m-2025-08-07` beta flag to the Claude Agent SDK for Opus 4.6 and Sonnet 4.6 models
- The plumbing already existed end-to-end (Go backend → `--betas` CLI arg → agent-runner → SDK), but `ProcessOptions.Betas` was never populated
- Context Meter will now correctly show `X / 1,000.0k` instead of `X / 200.0k` for these models

## Test plan

- [ ] Start a conversation with Opus 4.6 — Context Meter should show 1M max after first turn
- [ ] Start a conversation with Sonnet 4.6 — same behavior
- [ ] Verify non-4.6 models still show 200K context window
- [ ] Check agent-runner debug logs: `[context_usage] result modelUsage:` should contain `contextWindow: 1000000`
- [ ] Verify resumed conversations also retain the 1M context window

🤖 Generated with [Claude Code](https://claude.com/claude-code)