### PR TITLE
fix: resolve "mdx not found" language error in syntax highlighter

### DIFF
--- a/src/lib/languageMapping.ts
+++ b/src/lib/languageMapping.ts
@@ -27,7 +27,7 @@ const extensionMap: Record<string, string> = {
   xml: 'xml',
   // Documentation
   md: 'markdown',
-  mdx: 'mdx',
+  mdx: 'markdown',
   // Programming languages
   go: 'go',
   py: 'python',


### PR DESCRIPTION
## Summary
- Maps `.mdx` files to `'markdown'` instead of `'mdx'` in `languageMapping.ts`
- Shiki has no MDX grammar, so the previous mapping caused `resolveLanguage: "mdx" not found` console errors
- Aligns with `monacoLanguageMapping.ts` which already maps `.mdx` → `'markdown'`

## Test plan
- [ ] Open an `.mdx` file in the diff viewer or code viewer
- [ ] Confirm the `resolveLanguage: "mdx" not found` console error no longer appears
- [ ] Confirm syntax highlighting renders correctly (markdown-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)