### PR TITLE
fix: show Fast Mode toggle in composer

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -23,7 +23,7 @@ import (
 )
 
 const snapshotDebounceInterval = 500 * time.Millisecond
-const supportedCommandsRetryDelay = 3 * time.Second
+const initRetryDelay = 3 * time.Second
 
 // prURLPattern matches GitHub PR URLs in tool output (e.g., "https://github.com/owner/repo/pull/123")
 // Capture group 1 = PR number.
@@ -1259,16 +1259,22 @@ outer:
 				if err := proc.GetSupportedCommands(); err != nil {
 					logger.Manager.Errorf("Conversation %s: failed to request supported commands: %v", convID, err)
 				}
+				if err := proc.GetSupportedModels(); err != nil {
+					logger.Manager.Errorf("Conversation %s: failed to request supported models: %v", convID, err)
+				}
 				// Retry after delay — plugins may still be loading during init.
 				// The frontend merges responses, so a second call enriches rather
 				// than overwrites the first result.
 				// Look up proc by convID instead of capturing the reference so
 				// the goroutine doesn't keep a terminated process alive.
 				go func(cID string) {
-					time.Sleep(supportedCommandsRetryDelay)
+					time.Sleep(initRetryDelay)
 					if p := m.GetConversationProcess(cID); p != nil && p.IsRunning() {
 						if err := p.GetSupportedCommands(); err != nil {
 							logger.Manager.Debugf("Conversation %s: retry GetSupportedCommands failed: %v", cID, err)
+						}
+						if err := p.GetSupportedModels(); err != nil {
+							logger.Manager.Debugf("Conversation %s: retry GetSupportedModels failed: %v", cID, err)
 						}
 					}
 				}(convID)

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -69,6 +69,7 @@ const STATIC_MODELS: ModelEntry[] = SHARED_MODELS.map((m) => ({
   icon: Bot,
   supportsThinking: m.supportsThinking,
   supportsEffort: m.supportsEffort,
+  supportsFastMode: m.supportsFastMode,
 }));
 
 /** Build the model list from SDK-reported dynamic models, with static fallback. */

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -119,6 +119,7 @@ describe('getModelInfo', () => {
       expect(info!.provider).toBe('claude');
       expect(info!.supportsThinking).toBe(model.supportsThinking);
       expect(info!.supportsEffort).toBe(model.supportsEffort);
+      expect(info!.supportsFastMode).toBe(model.supportsFastMode);
     }
   });
 });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -3,9 +3,9 @@ import { useAppStore } from '@/stores/appStore';
 
 /** Static fallback model definitions used when no agent is connected. */
 export const MODELS = [
-  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true },
-  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true },
-  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', provider: 'claude', supportsThinking: true, supportsEffort: false },
+  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
+  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
+  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', provider: 'claude', supportsThinking: true, supportsEffort: false, supportsFastMode: false },
 ] as const;
 
 export type ModelId = (typeof MODELS)[number]['id'];
@@ -60,6 +60,7 @@ export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
       provider: staticModel.provider,
       supportsThinking: staticModel.supportsThinking,
       supportsEffort: staticModel.supportsEffort,
+      supportsFastMode: staticModel.supportsFastMode,
     };
   }
 


### PR DESCRIPTION
## Summary

- The Go backend called `GetSupportedCommands()` on SDK init but never called `GetSupportedModels()`, so the frontend never received model capabilities like `supportsFastMode` — the Fast Mode button was always hidden
- Added `GetSupportedModels()` call (with retry) alongside `GetSupportedCommands()` in `manager.go` on SDK init
- Added `supportsFastMode` to static fallback MODELS so the button shows immediately before the SDK connects

## Test plan

- [ ] Open a new conversation — the Fast button (⚡) should appear in the composer toolbar
- [ ] Click the Fast button — should toggle on/off with amber highlight
- [ ] Verify `Alt+F` keyboard shortcut works
- [ ] Verify the button shows for Opus 4.6 and Sonnet 4.6 but not Haiku 4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)