### PR TITLE
fix: clicking selected session while in module view navigates back to conversation

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -391,7 +391,13 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
       if (event && (event.metaKey || event.button === 1)) {
         navigateOrOpenTab({ workspaceId, sessionId, contentView: { type: 'conversation' } }, event);
       } else {
-        refreshPRStatus(workspaceId, sessionId).catch(() => {});
+        // If we're not in conversation view (e.g. Sessions module), navigate back to it
+        const { contentView: currentView } = useSettingsStore.getState();
+        if (currentView.type !== 'conversation') {
+          navigate({ workspaceId, sessionId, contentView: { type: 'conversation' } });
+        } else {
+          refreshPRStatus(workspaceId, sessionId).catch(() => {});
+        }
       }
       return;
     }


### PR DESCRIPTION
## Summary
- Fixes a bug where clicking an already-selected session in the sidebar while viewing a module (e.g. Sessions) would not navigate back to the conversation view
- Root cause: `handleSelectSession` short-circuited when `sessionId === selectedSessionId`, only refreshing PR status without checking whether `contentView` was still `conversation`
- Now checks `contentView.type` before deciding to skip navigation — if not in conversation view, navigates back to it

## Test plan
- [ ] Click a session in the sidebar
- [ ] Click the "Sessions" module button
- [ ] Click the same session in the sidebar → should return to conversation view
- [ ] Verify clicking an already-selected session in conversation view still refreshes PR status
- [ ] Verify back/forward navigation works correctly after this flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)