### PR TITLE
feat: add Aptabase product analytics telemetry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,8 @@ jobs:
           # Tauri update signing
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Aptabase analytics (compile-time, read by option_env! in Rust)
+          APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
           # Apple code signing + notarization
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@aptabase/tauri": "github:aptabase/tauri-plugin-aptabase",
     "@ariakit/react": "^0.4.23",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aptabase/tauri':
+        specifier: github:aptabase/tauri-plugin-aptabase
+        version: https://codeload.github.com/aptabase/tauri-plugin-aptabase/tar.gz/de6df6b8671568aad53eabaf4b49207a3d6c5622
       '@ariakit/react':
         specifier: ^0.4.23
         version: 0.4.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -288,6 +291,10 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@aptabase/tauri@https://codeload.github.com/aptabase/tauri-plugin-aptabase/tar.gz/de6df6b8671568aad53eabaf4b49207a3d6c5622':
+    resolution: {tarball: https://codeload.github.com/aptabase/tauri-plugin-aptabase/tar.gz/de6df6b8671568aad53eabaf4b49207a3d6c5622}
+    version: 0.4.2
 
   '@ariakit/core@0.4.18':
     resolution: {integrity: sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==}
@@ -5089,6 +5096,11 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
+
+  '@aptabase/tauri@https://codeload.github.com/aptabase/tauri-plugin-aptabase/tar.gz/de6df6b8671568aad53eabaf4b49207a3d6c5622':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+      tslib: 2.8.1
 
   '@ariakit/core@0.4.18': {}
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tauri-plugin-mcp-bridge = "0.8"
 tauri-plugin-deep-link = "2"
 tauri-plugin-stronghold = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-aptabase = "1"
 sentry = { version = "0.46", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls"] }
 notify = { version = "8", features = ["serde"] }
 notify-debouncer-mini = "0.6"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -149,6 +149,7 @@
     "clipboard-manager:allow-write-text",
     "clipboard-manager:allow-read-image",
     "core:image:allow-rgba",
-    "core:image:allow-size"
+    "core:image:allow-size",
+    "aptabase:allow-track-event"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,6 +133,15 @@ pub fn run() {
         // Register shared state
         .manage(Arc::clone(&app_state));
 
+    // Aptabase analytics - release builds only, requires APTABASE_KEY env at compile time
+    #[cfg(not(debug_assertions))]
+    {
+        if let Some(key) = option_env!("APTABASE_KEY") {
+            builder = builder.plugin(tauri_plugin_aptabase::Builder::new(key).build());
+            log::info!("Aptabase analytics enabled");
+        }
+    }
+
     // MCP Bridge plugin - development only
     #[cfg(debug_assertions)]
     {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,6 +36,7 @@ import {
   mapSessionDTO, listConversations, type RepoDTO,
 } from '@/lib/api';
 import { registerSession, getSessionDirName, openFolderDialog } from '@/lib/tauri';
+import { trackEvent } from '@/lib/telemetry';
 import { useBranchCacheStore } from '@/stores/branchCacheStore';
 import { useRecentlyClosedStore } from '@/stores/recentlyClosedStore';
 import { captureClosedConversation, useRestoreConversation } from '@/hooks/useRecentlyClosed';
@@ -265,6 +266,7 @@ export default function Home() {
         conversationId: firstConvId ?? undefined,
         contentView: { type: 'conversation' },
       });
+      trackEvent('session_created');
     } catch (error) {
       console.error('Failed to create session:', error);
       showError(error instanceof Error ? error.message : 'Failed to create session. Please try again.', 'Session Error');
@@ -304,6 +306,7 @@ export default function Home() {
         updatedAt: newConv.updatedAt,
       });
       useAppStore.getState().selectConversation(newConv.id);
+      trackEvent('conversation_created');
     } catch (error) {
       console.error('Failed to create conversation:', error);
       showError(error instanceof Error ? error.message : 'Failed to create conversation. Please try again.', 'Conversation Error');
@@ -412,6 +415,7 @@ export default function Home() {
       conversationId: convs.length > 0 ? convs[0].id : undefined,
       contentView: { type: 'conversation' },
     });
+    trackEvent('workspace_added');
   }, [repoToWorkspace, expandWorkspace]);
 
   const handleOpenProject = useCallback(async () => {

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -26,6 +26,7 @@ import type { LinearIssueDTO } from '@/lib/api';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
 import { MODELS as SHARED_MODELS, type ModelEntry } from '@/lib/models';
 import type { MentionItem } from '@/components/ui/mention-node';
+import { trackEvent } from '@/lib/telemetry';
 import { listSessionFiles, type FileNodeDTO } from '@/lib/api';
 
 // Extracted modules
@@ -295,11 +296,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         conversationId: selectedConversationId,
         sessionId: selectedSessionId,
       });
+      trackEvent('slash_command_used', { command: cmd.trigger });
     } else if (cmd.executionType === 'skill') {
       // Skill commands: insert the trigger text for user to submit
       const text = `/${cmd.trigger}`;
       plateInputRef.current?.setText(text);
       setMessage(text);
+      trackEvent('skill_invoked', { skill_name: cmd.trigger });
     } else {
       // Prompt commands: set the prompt prefix
       cmd.execute({
@@ -311,6 +314,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         conversationId: selectedConversationId,
         sessionId: selectedSessionId,
       });
+      trackEvent('slash_command_used', { command: cmd.trigger });
     }
   }, [sendMessage, selectedConversationId, selectedSessionId]);
 
@@ -794,6 +798,13 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           planModeEnabled
         );
       }
+
+      // Track message sent
+      trackEvent('message_sent', {
+        model: selectedModel.id,
+        has_attachments: loadedAttachments.length > 0 ? 1 : 0,
+        has_mentions: mentionedFiles.length > 0 ? 1 : 0,
+      });
 
       // Clear attachments and linked context after successful send
       setAttachments([]);

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -20,6 +20,7 @@ import {
   mapSessionDTO, getConversationMessages, toStoreMessage,
   type RepoDTO, type ConversationDTO, type MessageDTO,
 } from '@/lib/api';
+import { trackEvent } from '@/lib/telemetry';
 import type { SetupInfo } from '@/lib/types';
 
 /**
@@ -408,6 +409,7 @@ export function useAppInitialization() {
       } finally {
         setShellReady(true);
         setContentReady(true);
+        trackEvent('app_opened');
       }
     }
 

--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/api';
 import { useSelectedIds } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { trackEvent } from '@/lib/telemetry';
 import { toBase64 } from '@/lib/utils';
 
 const MARKDOWN_INSTRUCTION =
@@ -259,6 +260,7 @@ export function useReviewTrigger() {
           model: reviewModel,
           attachments: [templateAttachment],
         });
+        trackEvent('review_started', { type: reviewType });
 
         // Always add the conversation and message to the store, even if the
         // user switched sessions. The conversation exists on the backend;

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -18,6 +18,7 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { useBranchCacheStore } from '@/stores/branchCacheStore';
 import { useSlashCommandStore } from '@/stores/slashCommandStore';
 import { notifyDesktop, getConversationLabel } from '@/hooks/useDesktopNotifications';
+import { trackEvent } from '@/lib/telemetry';
 
 // Import extracted modules
 import { markPlanModeExited, isInPlanModeExitCooldown, clearPlanModeState } from '@/hooks/useWebSocketPlanMode';
@@ -370,6 +371,9 @@ export function useWebSocket(enabled: boolean = true) {
         if (resultConv) {
           freshStore.setLastTurnCompletedAt(resultConv.sessionId, Date.now());
         }
+        trackEvent('conversation_completed', {
+          success: event.success !== false ? 1 : 0,
+        });
         notifyBackgroundSession(conversationId);
         notifyDesktop(
           conversationId,
@@ -1167,7 +1171,16 @@ export function useWebSocket(enabled: boolean = true) {
               updates.taskStatus = payload.taskStatus as import('@/lib/types').SessionTaskStatus;
             }
 
+            const prevPrStatus = getStore().sessions.find(
+              (s: { id: string }) => s.id === data.sessionId
+            )?.prStatus;
             getStore().updateSession(data.sessionId, updates);
+
+            if (updates.prStatus === 'open' && prevPrStatus !== 'open') {
+              trackEvent('pr_created');
+            } else if (updates.prStatus === 'merged' && prevPrStatus !== 'merged') {
+              trackEvent('pr_merged');
+            }
 
             // Clear stale input suggestions for conversations in this session
             const sessionConvs = getStore().conversations.filter(

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,25 @@
+/**
+ * Telemetry wrapper using Aptabase for privacy-first product analytics.
+ * Events are only sent in production builds and when strictPrivacy is disabled.
+ */
+
+import { useSettingsStore } from '@/stores/settingsStore';
+import { isTauri } from '@/lib/tauri';
+
+type EventProps = Record<string, string | number>;
+
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
+function isEnabled(): boolean {
+  return IS_PRODUCTION && isTauri() && !useSettingsStore.getState().strictPrivacy;
+}
+
+export async function trackEvent(name: string, props?: EventProps): Promise<void> {
+  if (!isEnabled()) return;
+  try {
+    const { trackEvent: track } = await import('@aptabase/tauri');
+    await track(name, props);
+  } catch {
+    // Silently fail — telemetry should never break the app
+  }
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -320,7 +320,15 @@ export const useSettingsStore = create<SettingsState>()(
           setNeverLoadDotMcp(value).catch(() => {});
         });
       },
-      setStrictPrivacy: (value) => set({ strictPrivacy: value }),
+      setStrictPrivacy: (value) => {
+        set({ strictPrivacy: value });
+        // Track when strict privacy is disabled (only fires if telemetry is now enabled)
+        if (!value) {
+          import('@/lib/telemetry').then(({ trackEvent }) => {
+            trackEvent('strict_privacy_disabled');
+          });
+        }
+      },
       setZenMode: (value) => set({ zenMode: value }),
       setSidebarBottomPanelMinimized: (value) => set({ sidebarBottomPanelMinimized: value }),
       toggleSidebarBottomPanel: () => set((state) => ({ sidebarBottomPanelMinimized: !state.sidebarBottomPanelMinimized })),


### PR DESCRIPTION
## Summary
- Add privacy-first product analytics using **Aptabase** (open-source, no PII, no cookies)
- Telemetry is gated by the existing `strictPrivacy` toggle and only active in **production builds**
- `APTABASE_KEY` is read from environment at compile time via `option_env!()` — no secrets in source code

## Events tracked (12)
| Event | Trigger |
|---|---|
| `app_opened` | App initialization complete |
| `session_created` | New session created |
| `conversation_created` | New conversation created |
| `workspace_added` | Workspace registered |
| `message_sent` | User sends a message (includes model, attachments, mentions) |
| `slash_command_used` | Slash command executed |
| `skill_invoked` | Skill command selected |
| `conversation_completed` | Agent run finishes (includes success flag) |
| `review_started` | Code review triggered (includes review type) |
| `pr_created` | PR status changes to open |
| `pr_merged` | PR status changes to merged |
| `strict_privacy_disabled` | User disables strict privacy |

## Changes
- **New**: `src/lib/telemetry.ts` — thin wrapper (~25 lines) with production + privacy gating
- **Rust**: `tauri-plugin-aptabase` registered in release builds only (`#[cfg(not(debug_assertions))]`)
- **CI**: `APTABASE_KEY` secret passed to release workflow build step
- **8 files** instrumented with 1-3 line `trackEvent()` calls each

## Test plan
- [x] All 1546 tests pass (`pnpm test`)
- [ ] Verify no events sent in dev mode (IS_PRODUCTION check)
- [ ] Verify no events sent when strictPrivacy is ON
- [ ] Production build with APTABASE_KEY → verify events in Aptabase dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)