### PR TITLE
feat: add gzip compression middleware to API responses

### DIFF
--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -26,6 +26,7 @@ func NewRouter(ctx context.Context, s *store.SQLiteStore, hub *Hub, agentMgr *ag
 	auth := NewAuthHandlers(ghClient, s)
 	linearAuth := NewLinearAuthHandlers(linearClient, s)
 
+	r.Use(middleware.Compress(5))
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(TokenAuthMiddleware)


### PR DESCRIPTION
## Summary
- Adds chi's built-in `middleware.Compress(5)` to the router in `backend/server/router.go`
- Compresses all API responses (JSON, etc.) when the client sends `Accept-Encoding: gzip`
- No frontend changes needed — browsers and Tauri's webview handle decompression transparently

## Test plan
- [ ] Build backend: `cd backend && go build ./...`
- [ ] Start the app and verify API responses include `Content-Encoding: gzip` header
- [ ] Confirm frontend works normally with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)