### PR TITLE
fix: prevent Merge PR button showing while CI checks run on new PR

### DIFF
--- a/src/components/shared/PrimaryActionButton/useActionState.ts
+++ b/src/components/shared/PrimaryActionButton/useActionState.ts
@@ -47,13 +47,16 @@ export function useActionState(
   return useMemo(() => {
     // Merge WebSocket-updated store value (session.checkStatus) with polled API value
     // (prDetails.checkStatus). WebSocket is real-time but updates can be missed, while
-    // prDetails polls every 90s but is reliable. If the session is still 'pending' but
-    // polling already shows a terminal state, prefer the terminal state.
+    // prDetails polls every 90s but is reliable.
+    // - If polling says 'pending', trust it — it fetches the *current* PR, so session
+    //   may be stale from a previous PR cycle (e.g. after merge → new PR).
+    // - If session is still 'pending' but polling shows a terminal state, prefer terminal.
     const sessionCheck = session?.checkStatus ?? null;
     const prCheck = prDetails?.checkStatus ?? null;
     const isTerminal = (s: string | null) => s === 'success' || s === 'failure';
     const effectiveCheckStatus =
-      sessionCheck === 'pending' && isTerminal(prCheck) ? prCheck
+      prCheck === 'pending' ? 'pending'                              // polling says pending → trust it (current PR)
+      : sessionCheck === 'pending' && isTerminal(prCheck) ? prCheck  // polling caught up first
       : sessionCheck ?? prCheck;
 
     const archiveAction: PrimaryAction = {


### PR DESCRIPTION
## Summary
- When a PR is merged and a new PR is created in the same session, the "Merge PR" button incorrectly appeared enabled while CI checks were still running on the new PR
- Root cause: `session.checkStatus` retained `'success'` from the merged PR, and the `effectiveCheckStatus` logic preferred this stale value over the polling data which correctly showed `'pending'`
- Fix: always trust `prCheck` when it reports `'pending'`, since it fetches directly for the current PR

## Test plan
- [ ] Merge a PR, make new changes in the same session, create a new PR
- [ ] While CI runs: verify Merge PR button does NOT appear
- [ ] After CI passes: verify Merge PR button appears normally
- [ ] Single PR lifecycle (no prior merge) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)