### PR TITLE
fix: prevent Fast Mode icon toggling back to unselected immediately

### DIFF
--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -157,6 +157,9 @@ type AgentEvent struct {
 	ServerName string `json:"serverName,omitempty"`
 	Enabled    *bool  `json:"enabled,omitempty"`
 
+	// Fast mode toggle confirmation (fast_mode_changed events from agent-runner)
+	FastMode *bool `json:"fastMode,omitempty"`
+
 	// Task lifecycle fields (SDK 0.2.51+ — task_started, task_progress, task_stopped)
 	TaskId       string                 `json:"taskId,omitempty"`
 	LastToolName string                 `json:"lastToolName,omitempty"`


### PR DESCRIPTION
## Summary
- Add missing `FastMode *bool` field to Go `AgentEvent` struct in `backend/agent/parser.go`
- Without this field, the `fastMode` boolean from agent-runner's `fast_mode_changed` JSON event was silently dropped during Go JSON unmarshaling
- The WebSocket forwarded an event without the field, so the frontend read `undefined` → `false` and reset the toggle

## Root Cause
Agent-runner emits `{ type: "fast_mode_changed", fastMode: true }` but the Go struct had no `FastMode` field to capture it. The confirmation event reached the frontend with `fastMode: undefined`, which the handler coerced to `false`, immediately overriding the optimistic local state.

## Test plan
- [ ] Open a conversation with an Opus 4.6 model
- [ ] Click the Fast Mode (⚡) icon — verify it stays selected
- [ ] Click again — verify it toggles off and stays off
- [ ] Test keyboard shortcut ⌥F works correctly
- [ ] Switch conversations and back — verify fast mode state is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)