### PR TITLE
fix: restore large text paste auto-conversion to attachment

### DIFF
--- a/src/components/conversation/useChatInputAttachments.ts
+++ b/src/components/conversation/useChatInputAttachments.ts
@@ -165,6 +165,42 @@ export function useChatInputAttachments({ autoConvertLongText, showError, showIn
     return () => window.removeEventListener('clipboard-paste-image', handleClipboardImage);
   }, [addImageAttachment]);
 
+  // Listen for clipboard-paste-long-text events from the Tauri menu paste handler
+  const autoConvertLongTextRef = useRef(autoConvertLongText);
+  useEffect(() => { autoConvertLongTextRef.current = autoConvertLongText; }, [autoConvertLongText]);
+
+  useEffect(() => {
+    const handleClipboardLongText = (e: Event) => {
+      const { text } = (e as CustomEvent).detail;
+      if (!autoConvertLongTextRef.current || !text || text.length <= 5000) return;
+
+      let base64Data: string;
+      try {
+        base64Data = btoa(unescape(encodeURIComponent(text)));
+      } catch {
+        showError('Pasted text is too large to convert to attachment');
+        return;
+      }
+
+      const attachment: Attachment = {
+        id: generateAttachmentId(),
+        type: 'file',
+        name: 'pasted-text.txt',
+        mimeType: 'text/plain',
+        size: new TextEncoder().encode(text).byteLength,
+        lineCount: text.split('\n').length,
+        base64Data,
+        preview: text.slice(0, 200),
+      };
+
+      setAttachments(prev => [...prev, attachment]);
+      showInfo(`Long text (${Math.round(text.length / 1000)}k chars) converted to attachment`);
+    };
+
+    window.addEventListener('clipboard-paste-long-text', handleClipboardLongText);
+    return () => window.removeEventListener('clipboard-paste-long-text', handleClipboardLongText);
+  }, [showError, showInfo]);
+
   // Handle attachment removal
   const handleRemoveAttachment = useCallback((id: string) => {
     setAttachments(prev => prev.filter(a => a.id !== id));

--- a/src/hooks/useMenuHandlers.ts
+++ b/src/hooks/useMenuHandlers.ts
@@ -136,6 +136,12 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
               const { readText } = await import('@tauri-apps/plugin-clipboard-manager');
               const text = await readText().catch(() => '');
               if (text) {
+                // Auto-convert long text to attachment (mirrors handlePaste in useChatInputAttachments)
+                const { autoConvertLongText } = useSettingsStore.getState();
+                if (autoConvertLongText && text.length > 5000) {
+                  window.dispatchEvent(new CustomEvent('clipboard-paste-long-text', { detail: { text } }));
+                  return;
+                }
                 document.execCommand('insertText', false, text);
                 return;
               }


### PR DESCRIPTION
## Summary
- The custom `edit_paste` Tauri menu handler (added for image paste support) replaced the native paste action bound to `Cmd+V`, using `document.execCommand('insertText')` which bypassed the React paste event entirely
- This meant the long-text auto-convert logic (>5000 chars → text attachment) in `useChatInputAttachments` never fired
- Now the `edit_paste` handler checks text length and dispatches a `clipboard-paste-long-text` custom event when appropriate, following the same pattern as `clipboard-paste-image`

## Test plan
- [ ] Copy large text (>5000 chars) and paste with Cmd+V — should create a text attachment
- [ ] Copy short text and paste — should insert inline as before
- [ ] Copy an image and paste — should create image attachment (no regression)
- [ ] Disable `autoConvertLongText` in settings — large text should insert inline
- [ ] Test Edit > Paste menu item with large text — should also create attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)