### PR TITLE
fix: remove broken paint gate that left previous conversations invisible

### DIFF
--- a/src/components/conversation/ConversationArea.tsx
+++ b/src/components/conversation/ConversationArea.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useReducer, startTransition } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { useAppStore, setCachedSessionIds } from '@/stores/appStore';
+import { useAppStore, setCachedSessionIds, setOnConversationEvict } from '@/stores/appStore';
 import { captureClosedConversation, useRestoreConversation } from '@/hooks/useRecentlyClosed';
 import {
   useConversationState,
@@ -253,6 +253,15 @@ export function ConversationArea({ children }: ConversationAreaProps) {
   // A useEffect would run post-paint, creating a race where eviction sees stale IDs.
   const cachedIds = useMemo(() => new Set(recentSessions.map(s => s.sessionId)), [recentSessions]);
   setCachedSessionIds(cachedIds);
+
+  // Wire up store eviction → CachedConversationPane LRU cleanup so stale
+  // conversation entries are removed when messages are evicted.
+  useEffect(() => {
+    setOnConversationEvict((convIds) => {
+      for (const id of convIds) clearScrollPosition(id);
+    });
+    return () => setOnConversationEvict(null);
+  }, []);
 
   // Only the last-active tab from each recently-viewed session is kept mounted
   // (hidden) so its Pierre Shadow DOM survives session switches. This caps

--- a/src/components/conversation/ConversationMessagePane.tsx
+++ b/src/components/conversation/ConversationMessagePane.tsx
@@ -228,35 +228,6 @@ export function ConversationMessagePane({
   const userScrolledUpRef = useRef(false);
   const isActiveRef = useRef(isActive);
 
-  // Paint gate: hide the measurement frame on initial mount only.
-  // Unlike the old approach (which fired on every conversation switch via key=),
-  // this only fires once when ConversationMessagePane first mounts with messages.
-  // Uses visibility:hidden instead of opacity:0 to prevent scrollbar artifacts.
-  const [paintReady, setPaintReady] = useState(false);
-  const paintGateFiredRef = useRef(false);
-
-  useEffect(() => {
-    if (!hasMessages || paintGateFiredRef.current) return;
-    paintGateFiredRef.current = true;
-
-    // Gate: hide immediately, reveal after double-rAF once Virtuoso finishes measuring.
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: synchronous gate before async reveal
-    setPaintReady(false);
-    let inner: number;
-    const outer = requestAnimationFrame(() => {
-      inner = requestAnimationFrame(() => {
-        setPaintReady(true);
-      });
-    });
-    return () => {
-      cancelAnimationFrame(outer);
-      cancelAnimationFrame(inner);
-    };
-  }, [hasMessages]);
-
-  // If no messages yet (loading), ensure paint is hidden until the gate fires
-  // after messages arrive. Once gate has fired, paintReady is managed by the effect.
-
   /** Reset all follow-state refs atomically. */
   const resetFollowState = useCallback(() => {
     forceFollowRef.current = false;
@@ -453,7 +424,6 @@ export function ConversationMessagePane({
         'absolute inset-0 flex flex-col',
         isActive ? 'z-10' : 'invisible pointer-events-none z-0'
       )}
-      style={{ visibility: paintReady || !hasMessages ? undefined : 'hidden' }}
     >
       {/* Chat Search Bar */}
       <ChatSearchBar


### PR DESCRIPTION
## Summary
- Removed the paint gate (`visibility: hidden` + double-rAF reveal) from `ConversationMessagePane` that was permanently hiding previous conversations. The rAF callbacks were being cancelled by React's effect cleanup, leaving `paintReady` stuck at `false`.
- Wired up the missing `setOnConversationEvict` callback in `ConversationArea` so the `CachedConversationPane` LRU properly evicts stale entries when messages are pruned from the store.

Fixes the regression from #1029 where switching to any previous session showed a completely blank conversation pane.

## Test plan
- [ ] Switch between sessions with existing conversations — messages should appear
- [ ] Start a new conversation — streaming should still work
- [ ] Switch back to the new conversation — messages should persist
- [ ] Switch between 4+ sessions (beyond LRU limit) — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)