### PR TITLE
fix: dequeue message into timeline when agent picks it up

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -150,11 +150,21 @@ export function useWebSocket(enabled: boolean = true) {
 
     switch (data.type) {
       case 'init':
-        // If an init event arrives for an already-streaming conversation, it means the
-        // process was restarted. Clear stale content but preserve isStreaming and startTime
-        // so the "Agent is working" timer continues uninterrupted.
+        // If an init event arrives for an already-streaming conversation, finalize
+        // the previous turn. When queued messages exist, this is the earliest signal
+        // that the agent picked up the queued message — commit it to the timeline.
         if (store.streamingState[conversationId]?.isStreaming) {
-          store.clearStreamingContent(conversationId);
+          const hasQueued = (store.queuedMessages[conversationId] ?? []).length > 0;
+          if (hasQueued) {
+            // Agent picked up a queued message. Finalize previous turn's streaming
+            // content as an assistant message and commit the queued user message.
+            // Idempotent: if result/turn_complete already committed, queue is empty.
+            store.finalizeStreamingMessage(conversationId, { commitQueued: true });
+          } else {
+            // No queued messages — process restart recovery. Clear stale content
+            // without creating a message.
+            store.clearStreamingContent(conversationId);
+          }
           store.clearActiveTools(conversationId);
           store.clearThinking(conversationId);
           store.clearSubAgents(conversationId);

--- a/src/stores/__tests__/appStore.queuedMessages.test.ts
+++ b/src/stores/__tests__/appStore.queuedMessages.test.ts
@@ -266,6 +266,124 @@ describe('appStore - queued message ordering', () => {
     expect(messages[2].content).toBe('Second user message');
   });
 
+  it('commits queued message on init-triggered finalize (streaming text still present)', () => {
+    // Scenario: result/turn_complete was missed, init fires for the new turn
+    // while the queued message is still in the queue and streaming text remains.
+    useAppStore.setState({
+      messagesByConversation: {
+        [conversationId]: [
+          {
+            id: 'msg-user1',
+            conversationId,
+            role: 'user',
+            content: 'First user message',
+            timestamp: '2025-07-01T12:00:00Z',
+          },
+        ],
+      },
+      streamingState: {
+        [conversationId]: {
+          text: 'Assistant response to first message.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {
+        [conversationId]: [
+          {
+            id: 'msg-user2',
+            content: 'Second user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:05Z',
+          },
+        ],
+      },
+    });
+
+    // Simulate what the init handler does when queued messages exist
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      commitQueued: true,
+    });
+
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe('user');
+    expect(messages[0].content).toBe('First user message');
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[1].content).toBe('Assistant response to first message.');
+    expect(messages[2].role).toBe('user');
+    expect(messages[2].content).toBe('Second user message');
+
+    const queued = useAppStore.getState().queuedMessages[conversationId] ?? [];
+    expect(queued).toHaveLength(0);
+  });
+
+  it('commits queued message on init-triggered finalize without creating empty assistant message', () => {
+    // Scenario: result already finalized the assistant message and cleared streaming text,
+    // but did NOT commit the queued message. Init fires with empty streaming text.
+    useAppStore.setState({
+      messagesByConversation: {
+        [conversationId]: [
+          {
+            id: 'msg-user1',
+            conversationId,
+            role: 'user',
+            content: 'First user message',
+            timestamp: '2025-07-01T12:00:00Z',
+          },
+          {
+            id: 'msg-assistant1',
+            conversationId,
+            role: 'assistant',
+            content: 'Already finalized response.',
+            timestamp: '2025-07-01T12:00:03Z',
+          },
+        ],
+      },
+      streamingState: {
+        [conversationId]: {
+          text: '',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {
+        [conversationId]: [
+          {
+            id: 'msg-user2',
+            content: 'Second user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:05Z',
+          },
+        ],
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      commitQueued: true,
+    });
+
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe('user');
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[1].content).toBe('Already finalized response.');
+    expect(messages[2].role).toBe('user');
+    expect(messages[2].content).toBe('Second user message');
+  });
+
   it('does not add queued message when none exists', () => {
     useAppStore.setState({
       streamingState: {


### PR DESCRIPTION
## Summary
- When a user submits a message while the agent is streaming, the message gets queued and shown in the footer as "Queued"
- The agent eventually picks up the queued message and starts a new turn (emitting an `init` event), but the message stayed visually queued because the `init` handler only called `clearStreamingContent()` without committing queued messages
- Now when `init` fires with queued messages present, we call `finalizeStreamingMessage(commitQueued: true)` to atomically save the previous turn's streaming content as an assistant message and move the queued user message into the timeline
- The fix is idempotent: if `result`/`turn_complete` already committed the message, the queue will be empty by the time `init` fires and the existing code path runs

## Test plan
- [ ] Start a conversation, wait for agent to stream, submit a second message while streaming
- [ ] Verify the queued message moves from the footer into the timeline as a user message bubble when the agent starts the new turn
- [ ] Verify normal (non-queued) conversations are unaffected
- [ ] Verify crash recovery still works (init with no queued messages still clears stale content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)