### PR TITLE
fix: re-enable Pierre worker pool for off-thread Shiki tokenization

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,7 @@ import { useMenuState } from '@/hooks/useMenuState';
 import { useMessagePrefetch } from '@/hooks/useMessagePrefetch';
 import { useDotMcpTrustCheck } from '@/hooks/useDotMcpTrustCheck';
 import { PierreWarmup } from '@/components/shared/PierreWarmup';
+import { PierreWorkerPoolProvider } from '@/components/shared/PierreWorkerPoolProvider';
 import { useToast } from '@/components/ui/toast';
 import {
   createSession, createConversation, addRepo,
@@ -537,6 +538,7 @@ export default function Home() {
     <>
       <StreamingWarningHandler />
       <ConnectionStatusHandler />
+      <PierreWorkerPoolProvider>
       <PierreWarmup />
       <TooltipProvider>
         <div className="h-screen overflow-hidden flex relative bg-background">
@@ -789,6 +791,7 @@ export default function Home() {
 
         </div>
       </TooltipProvider>
+      </PierreWorkerPoolProvider>
     </>
   );
 }

--- a/src/components/shared/PierreWorkerPoolProvider.tsx
+++ b/src/components/shared/PierreWorkerPoolProvider.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { WorkerPoolContextProvider, PIERRE_THEMES } from '@/lib/pierre';
+import type { ReactNode } from 'react';
+
+// Stable references — defined outside the component so they survive remounts
+// and WorkerPoolContextProvider doesn't re-create the pool on every render.
+const poolOptions = {
+  workerFactory: () =>
+    new Worker(
+      new URL('@pierre/diffs/worker/worker-portable.js', import.meta.url),
+      { type: 'module' },
+    ),
+  poolSize: 2,
+};
+
+const highlighterOptions = {
+  theme: PIERRE_THEMES,
+  tokenizeMaxLineLength: 500,
+  lineDiffType: 'word' as const,
+};
+
+/**
+ * Initializes Pierre's built-in Web Worker pool for Shiki syntax tokenization.
+ *
+ * Without this provider, Pierre tokenizes every line synchronously on the main
+ * thread — which blocks the UI for 30+ seconds on large files.
+ *
+ * Uses worker-portable.js, a fully self-contained bundle (no external imports,
+ * no WASM) that works in Tauri's asset protocol. The WorkerPoolManager on the
+ * main thread resolves languages from ResolvedLanguages (pre-populated by
+ * pierrePreload.ts) and sends the resolved grammar data to workers via
+ * postMessage — workers never need bundledLanguages.
+ */
+export function PierreWorkerPoolProvider({ children }: { children: ReactNode }) {
+  return (
+    <WorkerPoolContextProvider
+      poolOptions={poolOptions}
+      highlighterOptions={highlighterOptions}
+    >
+      {children}
+    </WorkerPoolContextProvider>
+  );
+}

--- a/src/lib/pierre.ts
+++ b/src/lib/pierre.ts
@@ -18,10 +18,7 @@ import '@/lib/pierrePreload';
 export const PIERRE_THEMES = { dark: 'pierre-dark', light: 'pierre-light' } as const;
 
 // React components
-// NOTE: Pierre's WorkerPoolContextProvider is NOT used because workers run in
-// isolated JS contexts without access to the pre-loaded language/theme Maps
-// from pierrePreload.ts, and the shiki shim stubs bundledLanguages as empty.
-export { File, FileDiff } from '@pierre/diffs/react';
+export { File, FileDiff, WorkerPoolContextProvider } from '@pierre/diffs/react';
 
 // Types from react entry
 export type { FileContents, FileOptions, DiffLineAnnotation } from '@pierre/diffs/react';


### PR DESCRIPTION
## Summary

- Re-enables Pierre's built-in Web Worker pool for Shiki syntax tokenization, which was previously reverted in fc9bbcae
- Switching from Edit back to Diff mode on large files (e.g. `backend/agent/parser.go`) previously blocked the main thread for **30+ seconds**; now it's **instant** with syntax highlighting loading asynchronously
- The previous revert was based on a misdiagnosis: `worker-portable.js` is a self-contained bundle with its own Shiki, and the `WorkerPoolManager` sends resolved language data from the main thread to workers via `postMessage` — workers never need `bundledLanguages`

## Changes

| File | Change |
|------|--------|
| `src/lib/pierre.ts` | Re-export `WorkerPoolContextProvider` from Pierre |
| `src/components/shared/PierreWorkerPoolProvider.tsx` | New wrapper component with 2-worker pool config |
| `src/app/page.tsx` | Wrap app content with `PierreWorkerPoolProvider` |

## How it works

1. **Instant**: Pierre renders plain-text diff immediately (no main thread block)
2. **Background**: Worker pool tokenizes with Shiki off the main thread
3. **Update**: Worker sends highlighted AST back, Pierre re-renders with syntax colors

## Test plan

- [ ] Open a session with file changes (e.g. `backend/agent/parser.go`)
- [ ] Switch to Diff view — should render instantly with syntax highlighting appearing shortly after
- [ ] Switch to Edit mode, then back to Diff — UI should remain responsive (no freezing)
- [ ] Verify syntax highlighting appears (colored keywords, types, strings, comments)
- [ ] Check console for any worker-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)