### PR TITLE
fix: reduce notification focus-navigate window to prevent unwanted session switching

### DIFF
--- a/src/hooks/__tests__/useDesktopNotifications.test.ts
+++ b/src/hooks/__tests__/useDesktopNotifications.test.ts
@@ -167,16 +167,15 @@ describe('useDesktopNotifications', () => {
     vi.useRealTimers();
   });
 
-  it('navigates to conversation when window is focused within 3 seconds of notification', () => {
+  it('navigates to conversation when window is focused within 1 second of notification', () => {
     vi.spyOn(document, 'hasFocus').mockReturnValue(false);
 
     const { unmount } = renderHook(() => useDesktopNotifications());
 
-    // Trigger a notification (use unique ID to avoid debounce from other tests)
     notifyDesktop('conv-1', 'Task completed', 'Fix auth');
 
-    // Simulate window gaining focus within 3 seconds
-    vi.advanceTimersByTime(1000);
+    // Simulate window gaining focus within 1 second (e.g. clicking notification)
+    vi.advanceTimersByTime(500);
     act(() => {
       window.dispatchEvent(new Event('focus'));
     });
@@ -188,15 +187,15 @@ describe('useDesktopNotifications', () => {
     unmount();
   });
 
-  it('does not navigate if focus happens after 3 seconds', () => {
+  it('does not navigate if focus happens after 1 second (casual alt-tab)', () => {
     vi.spyOn(document, 'hasFocus').mockReturnValue(false);
 
     const { unmount } = renderHook(() => useDesktopNotifications());
 
     notifyDesktop('conv-1', 'Task completed', 'Fix auth');
 
-    // Focus after the 3-second window
-    vi.advanceTimersByTime(4000);
+    // Focus after the 1-second window (e.g. user alt-tabbed back)
+    vi.advanceTimersByTime(1500);
     act(() => {
       window.dispatchEvent(new Event('focus'));
     });

--- a/src/hooks/useDesktopNotifications.ts
+++ b/src/hooks/useDesktopNotifications.ts
@@ -7,7 +7,9 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { useAppStore } from '@/stores/appStore';
 
 const DEBOUNCE_MS = 5000;
-const FOCUS_NAVIGATE_WINDOW_MS = 3000;
+// Short window so only actual notification clicks (near-instant focus) trigger navigation,
+// not casual alt-tabs back to the app.
+const FOCUS_NAVIGATE_WINDOW_MS = 1000;
 
 // Module-level state so notifyDesktop can be called outside of React hooks
 let lastNotification: { conversationId: string; time: number } | null = null;
@@ -90,6 +92,9 @@ function navigateToConversation(conversationId: string): void {
 /**
  * Hook that listens for window focus events and navigates to the conversation
  * that triggered the most recent notification. Mount once at the app level.
+ *
+ * Uses a 1s window so only near-instant focus events (clicking a notification)
+ * trigger navigation, not casual alt-tabs.
  */
 export function useDesktopNotifications(): void {
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Reduced `FOCUS_NAVIGATE_WINDOW_MS` from 3000ms to 1000ms in `useDesktopNotifications.ts`
- When an agent completes in a background session while the app is unfocused, the previous 3s window was too generous — casual alt-tabs back to the app would auto-navigate to the completed session
- Notification clicks trigger focus near-instantly (~50-100ms), so 1s is plenty of headroom while filtering out unintentional switches
- Updated tests to reflect the new 1s window

## Test plan

- [ ] Start an agent task in session B while viewing session A
- [ ] Switch to another app (unfocus ChatML)
- [ ] Wait for agent to complete — should hear sound + see desktop notification
- [ ] Click the notification — should navigate to session B
- [ ] Repeat, but alt-tab back to ChatML instead of clicking notification — should stay on session A

🤖 Generated with [Claude Code](https://claude.com/claude-code)