### PR TITLE
fix: handle async rejection in Tauri event listener cleanup

### DIFF
--- a/src/components/conversation/useChatInputAttachments.ts
+++ b/src/components/conversation/useChatInputAttachments.ts
@@ -233,7 +233,12 @@ export function useChatInputAttachments({ autoConvertLongText, showError, showIn
     let unlistenLeave: (() => void) | undefined;
 
     const safeUnlisten = (fn?: () => void): undefined => {
-      try { fn?.(); } catch { /* listener already removed */ }
+      try {
+        const result = fn?.() as unknown;
+        if (result && typeof (result as Promise<unknown>).catch === 'function') {
+          (result as Promise<unknown>).catch(() => {});
+        }
+      } catch { /* listener already removed */ }
       return undefined;
     };
 

--- a/src/components/shared/GlobalErrorHandler.tsx
+++ b/src/components/shared/GlobalErrorHandler.tsx
@@ -18,6 +18,7 @@ const BENIGN_ERROR_PATTERNS = [
   'NotAllowedError',
   'not allowed by ACL',
   'not allowed. Permissions associated with this command',
+  'listeners[eventId]',
 ];
 
 function isBenignError(message: string): boolean {


### PR DESCRIPTION
## Summary
- Fix `safeUnlisten` in `useChatInputAttachments` to catch async promise rejections from Tauri's internal `invoke()` call, not just synchronous throws
- Add `listeners[eventId]` to `GlobalErrorHandler` benign error patterns as defense-in-depth

## Problem
When `useChatInputAttachments` unmounts (React strict mode, navigation), Tauri's unlisten function tries to access `listeners[eventId].handlerId` on an already-cleaned-up listener map. The resulting TypeError becomes an unhandled promise rejection that `GlobalErrorHandler` surfaces as an error toast.

## Test plan
- [ ] Navigate between conversations or trigger component remount — no error toast should appear
- [ ] Drag and drop a file onto the chat input — should still attach correctly
- [ ] Check browser console for absence of `listeners[eventId].handlerId` TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)