### PR TITLE
fix: position scroll-to-bottom pill closer to composer

### DIFF
--- a/src/components/conversation/ConversationMessagePane.tsx
+++ b/src/components/conversation/ConversationMessagePane.tsx
@@ -468,7 +468,7 @@ export function ConversationMessagePane({
       <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-chat-background to-transparent pointer-events-none z-10" />
       {/* Scroll to bottom button */}
       <div className={cn(
-        "absolute bottom-14 right-4 z-20 transition-opacity duration-200",
+        "absolute bottom-2 right-4 z-20 transition-opacity duration-200",
         showScrollButton && isActive ? "opacity-100" : "opacity-0 pointer-events-none"
       )}>
         <Button


### PR DESCRIPTION
## Summary
- Changed scroll-to-bottom pill positioning from `bottom-14` (56px) to `bottom-2` (8px) in `ConversationMessagePane`
- The old offset placed the pill ~266px from the viewport bottom when the composer area is tall (~210px), making it appear to float in the middle of the screen
- Now sits right above the composer boundary as intended

## Test plan
- [ ] Scroll up in a conversation to trigger the scroll-to-bottom pill
- [ ] Verify it appears close to the top edge of the composer input
- [ ] Test with different composer heights (empty single-line vs expanded multiline)
- [ ] Verify the pill still works (clicking scrolls to bottom and hides the pill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)