### PR TITLE
feat: clean up SDK model display names and add Auto model option

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -24,7 +24,7 @@ import { LinearIssuePicker } from './LinearIssuePicker';
 import { WorkspacePicker } from './WorkspacePicker';
 import type { LinearIssueDTO } from '@/lib/api';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
-import { MODELS as SHARED_MODELS, type ModelEntry } from '@/lib/models';
+import { MODELS as SHARED_MODELS, type ModelEntry, AUTO_MODEL_ID, resolveModelName, isAutoModel } from '@/lib/models';
 import type { MentionItem } from '@/components/ui/mention-node';
 import { trackEvent } from '@/lib/telemetry';
 import { listSessionFiles, type FileNodeDTO } from '@/lib/api';
@@ -64,27 +64,33 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
 }
 
 /** Static fallback model list (used when no SDK models are available). */
-const STATIC_MODELS: ModelEntry[] = SHARED_MODELS.map((m) => ({
-  id: m.id,
-  name: m.name,
-  icon: Bot,
-  supportsThinking: m.supportsThinking,
-  supportsEffort: m.supportsEffort,
-  supportsFastMode: m.supportsFastMode,
-}));
+const STATIC_MODELS: ModelEntry[] = [
+  { id: AUTO_MODEL_ID, name: 'Auto', icon: Bot, supportsThinking: true, supportsEffort: true, supportsFastMode: true },
+  ...SHARED_MODELS.map((m) => ({
+    id: m.id,
+    name: m.name,
+    icon: Bot,
+    supportsThinking: m.supportsThinking,
+    supportsEffort: m.supportsEffort,
+    supportsFastMode: m.supportsFastMode,
+  })),
+];
 
 /** Build the model list from SDK-reported dynamic models, with static fallback. */
 function buildModelList(dynamic: ReturnType<typeof useAppStore.getState>['supportedModels']): ModelEntry[] {
   if (dynamic.length === 0) return STATIC_MODELS;
-  return dynamic.map((m) => ({
-    id: m.value,
-    name: m.displayName,
-    icon: Bot,
-    supportsThinking: m.supportsAdaptiveThinking ?? true,
-    supportsEffort: m.supportsEffort ?? false,
-    supportedEffortLevels: m.supportedEffortLevels,
-    supportsFastMode: m.supportsFastMode,
-  }));
+  return dynamic.map((m) => {
+    const name = resolveModelName(m.value, m.displayName);
+    return {
+      id: isAutoModel(m.displayName) ? AUTO_MODEL_ID : m.value,
+      name,
+      icon: Bot,
+      supportsThinking: m.supportsAdaptiveThinking ?? true,
+      supportsEffort: m.supportsEffort ?? false,
+      supportedEffortLevels: m.supportedEffortLevels,
+      supportsFastMode: m.supportsFastMode,
+    };
+  });
 }
 
 
@@ -534,7 +540,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
         type: 'task',
         message: pendingPlanApproval.planContent,
-        model: selectedModel.id,
+        model: selectedModel.id === AUTO_MODEL_ID ? undefined : selectedModel.id,
       });
 
       addConversation({
@@ -692,7 +698,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
           type: convType,
           message: trimmedContent,
-          model: selectedModel.id,
+          model: selectedModel.id === AUTO_MODEL_ID ? undefined : selectedModel.id,
           planMode: planModeEnabled ? true : undefined,
           fastMode: fastModeEnabled ? true : undefined,
           maxThinkingTokens: thinkingParams.maxThinkingTokens,

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -19,7 +19,7 @@ import { navigate } from '@/lib/navigation';
 import { copyToClipboard } from '@/lib/tauri';
 import { useToast } from '@/components/ui/toast';
 import { getShortcutById, formatShortcutKeys } from '@/lib/shortcuts';
-import { MODELS } from '@/lib/models';
+import { MODELS, AUTO_MODEL_ID, isAutoModel } from '@/lib/models';
 import type { LucideIcon } from 'lucide-react';
 import {
   // Navigation
@@ -314,8 +314,11 @@ const COMMANDS: Command[] = [
     action: () => {
       const store = useSettingsStore.getState();
       const dynamic = useAppStore.getState().supportedModels;
-      // Use SDK-reported models if available, fall back to static list
-      const models = dynamic.length > 0 ? dynamic.map((m) => m.value) : MODELS.map((m) => m.id);
+      // Use SDK-reported models if available, fall back to static list.
+      // Map SDK "Default (recommended)" → AUTO_MODEL_ID sentinel.
+      const models = dynamic.length > 0
+        ? dynamic.map((m) => isAutoModel(m.displayName) ? AUTO_MODEL_ID : m.value)
+        : [AUTO_MODEL_ID, ...MODELS.map((m) => m.id)];
       const idx = models.indexOf(store.defaultModel);
       const next = models[(idx + 1) % models.length];
       store.setDefaultModel(next);

--- a/src/components/settings/sections/AIModelSettings.tsx
+++ b/src/components/settings/sections/AIModelSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import {
@@ -12,6 +12,8 @@ import {
 } from '@/components/ui/select';
 import { Eye, EyeOff } from 'lucide-react';
 import { useSettingsStore, SETTINGS_DEFAULTS } from '@/stores/settingsStore';
+import { useAppStore } from '@/stores/appStore';
+import { MODELS as SHARED_MODELS, AUTO_MODEL_ID, resolveModelName, isAutoModel } from '@/lib/models';
 import type { ThinkingLevel } from '@/lib/thinkingLevels';
 import { getAnthropicApiKey, setAnthropicApiKey } from '@/lib/api';
 import { useToast } from '@/components/ui/toast';
@@ -31,6 +33,26 @@ export function AIModelSettings() {
   const setDefaultFastMode = useSettingsStore((s) => s.setDefaultFastMode);
   const maxThinkingTokens = useSettingsStore((s) => s.maxThinkingTokens);
   const setMaxThinkingTokens = useSettingsStore((s) => s.setMaxThinkingTokens);
+
+  // Build model options from SDK-reported models, with static fallback.
+  // Always include "Auto" so the setting is selectable even before SDK connects.
+  const dynamicModels = useAppStore((s) => s.supportedModels);
+  const modelOptions = useMemo(() => {
+    const autoOption = { id: AUTO_MODEL_ID, name: 'Auto' };
+    if (dynamicModels.length === 0) {
+      return [autoOption, ...SHARED_MODELS.map((m) => ({ id: m.id, name: m.name }))];
+    }
+    const mapped = dynamicModels.map((m) => {
+      const name = resolveModelName(m.value, m.displayName);
+      return { id: isAutoModel(m.displayName) ? AUTO_MODEL_ID : m.value, name };
+    });
+    // Ensure Auto is present (SDK may not always include a "Default" entry)
+    if (!mapped.some((m) => m.id === AUTO_MODEL_ID)) {
+      return [autoOption, ...mapped];
+    }
+    return mapped;
+  }, [dynamicModels]);
+
   return (
     <div>
       <h2 className="text-xl font-semibold mb-5">AI & Models</h2>
@@ -48,9 +70,9 @@ export function AIModelSettings() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
-              <SelectItem value="claude-sonnet-4-6">Claude Sonnet 4.6</SelectItem>
-              <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
+              {modelOptions.map((m) => (
+                <SelectItem key={m.id} value={m.id}>{m.name}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </SettingsRow>
@@ -67,9 +89,9 @@ export function AIModelSettings() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="claude-opus-4-6">Claude Opus 4.6</SelectItem>
-              <SelectItem value="claude-sonnet-4-6">Claude Sonnet 4.6</SelectItem>
-              <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
+              {modelOptions.map((m) => (
+                <SelectItem key={m.id} value={m.id}>{m.name}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </SettingsRow>

--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -10,6 +10,7 @@ import { useSelectedIds } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { trackEvent } from '@/lib/telemetry';
 import { toBase64 } from '@/lib/utils';
+import { AUTO_MODEL_ID } from '@/lib/models';
 
 const MARKDOWN_INSTRUCTION =
   '\nWhen writing comment content, use Markdown formatting for detailed comments that include code examples, lists, or structured explanations (use fenced code blocks for code, bullet lists for multiple points, **bold** for emphasis). Keep simple one-sentence comments as plain text.';
@@ -257,7 +258,7 @@ export function useReviewTrigger() {
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
           type: 'review',
           message: shortContent,
-          model: reviewModel,
+          model: reviewModel === AUTO_MODEL_ID ? undefined : reviewModel,
           attachments: [templateAttachment],
         });
         trackEvent('review_started', { type: reviewType });

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/stores/appStore', () => ({
   },
 }));
 
-const { getModelDisplayName, getModelInfo, buildTurnConfigLabel, MODELS } = await import('../models');
+const { getModelDisplayName, getModelInfo, buildTurnConfigLabel, MODELS, AUTO_MODEL_ID, resolveModelName, isAutoModel } = await import('../models');
 
 describe('getModelDisplayName', () => {
   it('returns display name for known static models', () => {
@@ -120,6 +120,97 @@ describe('getModelInfo', () => {
       expect(info!.supportsThinking).toBe(model.supportsThinking);
       expect(info!.supportsEffort).toBe(model.supportsEffort);
       expect(info!.supportsFastMode).toBe(model.supportsFastMode);
+    }
+  });
+});
+
+describe('isAutoModel', () => {
+  it('returns true for "Default (recommended)"', () => {
+    expect(isAutoModel('Default (recommended)')).toBe(true);
+  });
+
+  it('returns true for display names containing "default"', () => {
+    expect(isAutoModel('The default model')).toBe(true);
+  });
+
+  it('returns true for display names containing "recommended"', () => {
+    expect(isAutoModel('Recommended model')).toBe(true);
+  });
+
+  it('returns false for regular model names', () => {
+    expect(isAutoModel('Claude Opus 4.6')).toBe(false);
+    expect(isAutoModel('Claude Sonnet 4.6')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isAutoModel('DEFAULT (RECOMMENDED)')).toBe(true);
+  });
+});
+
+describe('resolveModelName', () => {
+  it('returns "Auto" for SDK default/recommended model', () => {
+    expect(resolveModelName('claude-opus-4-6', 'Default (recommended)')).toBe('Auto');
+  });
+
+  it('returns clean name for known static models', () => {
+    expect(resolveModelName('claude-opus-4-6', 'Claude Opus 4.6')).toBe('Claude Opus 4.6');
+    expect(resolveModelName('claude-sonnet-4-6', 'Claude Sonnet 4.6')).toBe('Claude Sonnet 4.6');
+  });
+
+  it('returns SDK displayName for unknown models', () => {
+    expect(resolveModelName('custom-model', 'My Custom Model')).toBe('My Custom Model');
+  });
+});
+
+describe('AUTO_MODEL_ID', () => {
+  it('getModelDisplayName returns "Auto"', () => {
+    expect(getModelDisplayName(AUTO_MODEL_ID)).toBe('Auto');
+  });
+
+  it('getModelInfo returns fallback capabilities when no SDK models', () => {
+    const info = getModelInfo(AUTO_MODEL_ID);
+    expect(info).toBeDefined();
+    expect(info!.id).toBe(AUTO_MODEL_ID);
+    expect(info!.name).toBe('Auto');
+    expect(info!.supportsThinking).toBe(true);
+    expect(info!.supportsEffort).toBe(true);
+    expect(info!.supportsFastMode).toBe(true);
+  });
+
+  it('getModelInfo resolves from SDK default model when available', async () => {
+    const { useAppStore } = await import('@/stores/appStore');
+
+    const spy = vi.spyOn(useAppStore, 'getState').mockReturnValue({
+      ...useAppStore.getState(),
+      supportedModels: [
+        {
+          value: 'claude-opus-4-6',
+          displayName: 'Default (recommended)',
+          description: 'Most capable',
+          supportsAdaptiveThinking: true,
+          supportsEffort: true,
+          supportedEffortLevels: ['low', 'medium', 'high', 'max'],
+          supportsFastMode: true,
+        },
+        {
+          value: 'claude-sonnet-4-6',
+          displayName: 'Claude Sonnet 4.6',
+          description: 'Fast',
+          supportsAdaptiveThinking: true,
+          supportsEffort: true,
+          supportsFastMode: true,
+        },
+      ],
+    } as ReturnType<typeof useAppStore.getState>);
+
+    try {
+      const info = getModelInfo(AUTO_MODEL_ID);
+      expect(info).toBeDefined();
+      expect(info!.id).toBe(AUTO_MODEL_ID);
+      expect(info!.name).toBe('Auto');
+      expect(info!.supportsThinking).toBe(true);
+    } finally {
+      spy.mockRestore();
     }
   });
 });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,6 +1,9 @@
 import React from 'react';
 import { useAppStore } from '@/stores/appStore';
 
+/** Sentinel model ID meaning "let the SDK choose the best model". */
+export const AUTO_MODEL_ID = 'auto';
+
 /** Static fallback model definitions used when no agent is connected. */
 export const MODELS = [
   { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
@@ -9,6 +12,26 @@ export const MODELS = [
 ] as const;
 
 export type ModelId = (typeof MODELS)[number]['id'];
+
+/** Check whether an SDK display name represents the auto/default model. */
+export function isAutoModel(sdkDisplayName: string): boolean {
+  return /\bdefault\b/i.test(sdkDisplayName) || /\brecommended\b/i.test(sdkDisplayName);
+}
+
+/**
+ * Resolve a clean display name for an SDK-reported model.
+ * - SDK "Default (recommended)" → "Auto"
+ * - Known static models → our clean name (e.g. "Claude Opus 4.6")
+ * - Unknown models → SDK displayName as-is
+ */
+export function resolveModelName(sdkValue: string, sdkDisplayName: string): string {
+  if (isAutoModel(sdkDisplayName)) {
+    return 'Auto';
+  }
+  const staticMatch = MODELS.find((m) => m.id === sdkValue);
+  if (staticMatch) return staticMatch.name;
+  return sdkDisplayName;
+}
 
 /** Model entry used for UI model selectors and keyboard shortcut cycling. */
 export interface ModelEntry {
@@ -38,16 +61,31 @@ export interface DynamicModelInfo {
 export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
   // Check dynamic models from SDK
   const dynamic = useAppStore.getState().supportedModels;
-  const sdkModel = dynamic.find((m) => m.value === modelId);
+  // For 'auto', find the SDK's default/recommended model
+  const sdkModel = modelId === AUTO_MODEL_ID
+    ? dynamic.find((m) => isAutoModel(m.displayName))
+    : dynamic.find((m) => m.value === modelId);
   if (sdkModel) {
     return {
-      id: sdkModel.value,
-      name: sdkModel.displayName,
+      id: modelId === AUTO_MODEL_ID ? AUTO_MODEL_ID : sdkModel.value,
+      name: resolveModelName(sdkModel.value, sdkModel.displayName),
       provider: 'claude',
       supportsThinking: sdkModel.supportsAdaptiveThinking ?? true,
       supportsEffort: sdkModel.supportsEffort ?? false,
       supportedEffortLevels: sdkModel.supportedEffortLevels,
       supportsFastMode: sdkModel.supportsFastMode,
+    };
+  }
+
+  // Auto fallback when SDK hasn't connected yet
+  if (modelId === AUTO_MODEL_ID) {
+    return {
+      id: AUTO_MODEL_ID,
+      name: 'Auto',
+      provider: 'claude',
+      supportsThinking: true,
+      supportsEffort: true,
+      supportsFastMode: true,
     };
   }
 
@@ -68,6 +106,7 @@ export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
 }
 
 export function getModelDisplayName(modelId: string): string {
+  if (modelId === AUTO_MODEL_ID) return 'Auto';
   const info = getModelInfo(modelId);
   if (info) return info.name;
 

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -32,12 +32,12 @@ describe('settingsStore', () => {
 
   describe('reviewModel', () => {
     beforeEach(() => {
-      useSettingsStore.setState({ reviewModel: 'claude-opus-4-6' });
+      useSettingsStore.setState({ reviewModel: 'auto' });
     });
 
-    it('should have a default value of claude-opus-4-6', () => {
+    it('should have a default value of auto', () => {
       const { reviewModel } = useSettingsStore.getState();
-      expect(reviewModel).toBe('claude-opus-4-6');
+      expect(reviewModel).toBe('auto');
     });
 
     it('should update reviewModel when setReviewModel is called', () => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -83,11 +83,11 @@ export const SETTINGS_DEFAULTS = {
   autoExpandEditDiffs: true,
   zenMode: false,
   // AI & Models
-  defaultModel: 'claude-opus-4-6',
+  defaultModel: 'auto',
   defaultThinkingLevel: 'high' as ThinkingLevel,
   maxThinkingTokens: 16000,
   showThinkingBlocks: true,
-  reviewModel: 'claude-opus-4-6',
+  reviewModel: 'auto',
   reviewActionableOnly: false,
   defaultPlanMode: false,
   defaultFastMode: false,


### PR DESCRIPTION
## Summary

- The SDK now returns model names like "Sonnet (1M context)", "Opus (1M context)", "Default (recommended)" — these raw names were showing in the model selector
- Replace SDK names with clean display names (e.g. "Claude Sonnet 4.6") using `resolveModelName()` which matches by model ID against our static list
- SDK's "Default (recommended)" entry is surfaced as **"Auto"** — a new `AUTO_MODEL_ID = 'auto'` sentinel meaning "let the SDK pick the best model"
- Default model setting changed from `claude-opus-4-6` → `auto` on fresh installs
- Settings page model selectors now use the same dynamic SDK model list as the chat input (with "Auto" always present as fallback)

## Changes

- `src/lib/models.ts` — `AUTO_MODEL_ID`, `isAutoModel()`, `resolveModelName()` helpers; `getModelInfo` handles 'auto' sentinel with SDK lookup + static fallback
- `src/components/conversation/ChatInput.tsx` — `buildModelList()` uses `resolveModelName()`; SDK default → `auto` id; `createConversation` converts `auto` → `undefined` so backend omits `--model`
- `src/components/settings/sections/AIModelSettings.tsx` — dynamic model options from SDK with "Auto" always present
- `src/hooks/useReviewTrigger.ts` — converts `auto` → `undefined` for review conversations
- `src/components/dialogs/CommandPalette.tsx` — cycle-model shortcut includes Auto
- `src/stores/settingsStore.ts` — `defaultModel` and `reviewModel` default to `'auto'`

## Test plan

- [ ] Open model selector — should show: Auto, Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5
- [ ] Open Settings → AI & Models — same model list in both dropdowns
- [ ] Fresh install (or reset settings): default model should be "Auto"
- [ ] Select Auto and send a message — agent should use the SDK's recommended model
- [ ] Select a specific model (e.g. Claude Sonnet 4.6) and send — should use that model
- [ ] ⌥M keyboard shortcut cycles through all models including Auto
- [ ] Run `vitest src/lib/__tests__/models.test.ts` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)