### PR TITLE
fix: add pattern-based fallback for model display names

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -30,6 +30,13 @@ export function resolveModelName(sdkValue: string, sdkDisplayName: string): stri
   }
   const staticMatch = MODELS.find((m) => m.id === sdkValue);
   if (staticMatch) return staticMatch.name;
+
+  // Pattern-based fallback for unknown SDK model IDs (e.g. future versions)
+  const val = sdkValue.toLowerCase();
+  if (val.includes('opus')) return 'Claude Opus 4.6';
+  if (val.includes('sonnet')) return 'Claude Sonnet 4.6';
+  if (val.includes('haiku')) return 'Claude Haiku 4.5';
+
   return sdkDisplayName;
 }
 


### PR DESCRIPTION
## Summary
- Model picker was showing raw SDK display names like "Sonnet (1M context)", "Opus (1M context)", "Haiku" instead of friendly names
- Added keyword-based pattern matching in `resolveModelName()` as a fallback when the SDK model ID doesn't exactly match our static `MODELS` array
- Falls through to the raw SDK name only for truly unknown models

## Test plan
- [ ] Open the model picker in the chat input — verify it shows "Claude Sonnet 4.6", "Claude Opus 4.6", "Claude Haiku 4.5"
- [ ] Check Settings > AI Model dropdown for same clean names
- [ ] Verify "Auto" model still shows "Auto"

🤖 Generated with [Claude Code](https://claude.com/claude-code)