### PR TITLE
release: v0.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatml",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@10.30.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "chatml"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -789,6 +789,7 @@ dependencies = [
  "serial_test",
  "tauri",
  "tauri-build",
+ "tauri-plugin-aptabase",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-decorum",
  "tauri-plugin-deep-link",
@@ -848,7 +849,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -981,7 +982,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -994,7 +995,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1783,12 +1784,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1801,6 +1811,12 @@ dependencies = [
  "quote",
  "syn 2.0.116",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1850,6 +1866,21 @@ checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -1927,6 +1958,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2293,6 +2325,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2518,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2496,6 +2548,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,9 +2581,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3302,6 +3372,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,10 +4102,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -4931,17 +5056,22 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4952,6 +5082,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -6105,6 +6236,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6321,6 +6482,26 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-aptabase"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075ebe083b5f311bdfbf436f8383d316dfb12267be5fd977b57d7701bdb99987"
+dependencies = [
+ "futures",
+ "log",
+ "os_info",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -6898,6 +7079,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chatml"
-version = "0.1.15"
+version = "0.1.16"
 description = "ChatML"
 authors = ["you"]
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "chatml",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "identifier": "com.chatml.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## What's Changed

### Features
- add collapsible built-in default preview to review settings (#1045)
- clean up SDK model display names and add Auto model option (#1043)
- add gzip compression middleware to API responses (#1023)
- add Aptabase product analytics telemetry (#1022)
- add fast mode support (Opus 4.6 fast output) (#1016)
- enable 1M context window for Opus 4.6 and Sonnet 4.6 (#1015)
- auto-expand Edit tool blocks to show diffs inline by default (#1003)
- add specialized renderers for Grep and Glob tool blocks (#1000)
- upgrade Claude Agent SDK to 0.2.76 (#999)
- add in-app AWS SSO token refresh for Bedrock users (#989)
- add "Sessions Needing Attention" command and deferred update restart (#980)
- add "Create Session from..." option to header plus menu (#967)
- show per-message token count and cost below AI responses (#816) (#962)
- reorder Create Session tabs and focus search on tab click (#954)
- add fullscreen expand for Mermaid diagrams (#814) (#952)
- improve session naming with issue context (#935)
- add LRU eviction to PRCache to bound memory usage (#930)
- attach GitHub/Linear issue content to sessions and rename CreateFromPR to CreateSession (#889)
- unify "Create from..." modal with PR, branch, and issue tabs (#886)
- add image paste support via Cmd+V in chat input (#885)
- workspace-level conversation endpoint to eliminate N+1 queries (#879)
- upgrade Claude Agent SDK to 0.2.72 with new hooks and message types (#880)

### Fixes
- add pattern-based fallback for model display names (#1049)
- show correct 1M context window for extended context models (#1047)
- deduplicate Auto model entries and fix auto model API passthrough (#1046)
- eliminate blank conversation area on navigation by using synchronous LRU dispatch (#1044)
- position scroll-to-bottom pill closer to composer (#1042)
- handle async rejection in Tauri event listener cleanup (#1041)
- reduce notification focus-navigate window from 3s to 1s to prevent unwanted session switching (#1040)
- move Fast toggle before Thinking in composer toolbar (#1039)
- re-enable Pierre worker pool for off-thread Shiki tokenization (#1038)
- dequeue message into timeline when agent picks it up on init (#1036)
- revert Pierre worker pool to restore Shiki syntax highlighting (#1033) (#1034)
- remove broken paint gate that left previous conversations invisible (#1035)
- use Pierre's built-in worker pool for off-thread Shiki tokenization (#1033)
- eliminate conversation tab scroll flash with per-conversation Virtuoso caching (#1032)
- move diff computation to Web Worker to prevent UI blocking (#1031)
- restore large text paste auto-conversion to attachment (#1030)
- make session switching instant for recently-viewed sessions (#1029)
- scroll to bottom when switching back to a session (#1028)
- prevent Fast Mode icon toggling back to unselected immediately (#1027)
- prevent Merge PR button showing while CI checks run on new PR (#1026)
- scroll to bottom when first opening a session (#1025)
- eliminate jarring scroll jump when switching conversations (#1024)
- clicking selected session while in module view navigates back to conversation (#1021)
- terminal respects version managers (mise, asdf, rbenv, nvm, pyenv) (#1019)
- show Fast Mode toggle in composer by requesting supported models from SDK (#1020)
- prevent blank conversation pane on session/conversation switch (#1018)
- resolve "mdx not found" language error in syntax highlighter (#1017)
- prevent blank conversation pane on session switch during streaming (#1014)
- improve Plate.js editor quality — types, perf, and correctness (#1013)
- suppress "No newline at end of file" warning in inline diff viewer (#1012)
- render auto-compact notification inline in streaming timeline (#1011)
- clean up orphaned temp files on startup to prevent disk accumulation (#897) (#1010)
- prevent conversation area from going blank by keeping inactive panes measurable (#1009)
- resolve auto-scroll race condition during streaming (#1008)
- remove manual "Attach conversation context" UI (#1007)
- remove non-functional "View Summary" menu item from session toolbar (#1006)
- restore auto-scroll to bottom when Edit tool blocks auto-expand (#1005)
- align icons and prevent text wrapping in new session popover (#1004)
- persist conversation timeline on app quit mid-turn (#1002)
- prevent duplicate key error in TabBar conversation list (#997)
- improve error handling for review comment MCP tools when backend is unreachable (#1001)
- improve error handling for PR report MCP tools when backend is unreachable (#996)
- prevent blank conversation area when navigating back to evicted conversations (#995)
- show specific reasons for merge blockers instead of generic "PR is blocked" (#992)
- commit queued messages on result event to prevent stuck queue (#993)
- use real-time WebSocket checkStatus for PR merge button visibility (#991)
- improve action templates and review prompts for robustness (#987)
- add --follow flag to file history git log for rename tracking (#986)
- polish Merge PR popover to match Review popover styling (#985)
- audit and improve Command Palette — fix broken commands, add 13 new entries (#984)
- use generic text for review item "Add to chat" action (#983)
- eliminate diff file opening lag caused by FileHistoryPanel (#982)
- reduce session state sync lag for PR/check status updates (#971)
- keep search box visible when branches search yields no results (#969)
- add double-unlock guard to SessionLockManager (#917) (#958)
- polish sessions table layout by removing redundant columns (#957)
- add retry with exponential backoff for GitHub API rate limits (#907) (#953)
- close useMessagePrefetch subscription leak on abort (#951)
- use server-scoped context for background goroutines (#908) (#945)
- use content-based key in FileTree to prevent unnecessary expanded state resets (#920) (#940)
- add 1MB size guard to GetFileDiff to prevent unbounded JSON responses (#893) (#932)
- add tiered git command timeouts and clone retry with backoff (#936)
- resolve plan mode stuck state caused by SDK Zod validation errors (#891)
- defer editor focus in clear() to prevent undefined node error (#890)
- rename "Create from..." to "Create Session from..." and fix duplicate dots (#888)
- expose comment id and title in MCP review comment tools (#887)
- improve merge PR dropdown with icons and group separators (#884)
- robust remote prefix stripping and template fallback in fix-issues action (#883)
- use absolute path for Turbopack shiki alias to fix release builds (#882)

### Other
- fix stale and incorrect information across documentation (#1048)
- upgrade shiki to v4.0.2 and @shikijs/* packages (#1037)
- enrich all 6 review templates with structured workflows and severity guidance (#998)
- upgrade Go and Node dependency patches (#994)
- split 3 largest files into focused domain modules (#990)
- add file content cache and proactive prefetch for instant file opening (#988)
- cache conversation panes for instant session switching (#981)
- debounce chat search input to reduce unnecessary re-renders (#970)
- separate DataTable grouping from collapse state (#968)
- extract shared BranchPill component for consistent branch name styling (#966)
- use Search icon for Find tool in conversation stream (#965)
- improve sessions datatable with workspace names, branch icons, and action padding (#964)
- add unit tests for 6 untested lib modules (#963)
- optimize session switching, search, and long conversation memory (#960)
- parallelize GitHub avatar lookups with bounded concurrency (#898) (#961)
- add max node count limit to buildFileTree (#919) (#959)
- optimize useSidebarSessions workspace grouping from O(w×n) to O(w+n) (#956)
- split StreamingMessage timeline into structural + text merge (#906) (#955)
- reduce git process concurrency and add shutdown-aware context (#896) (#950)
- use Set for O(1) active session lookups in useActiveSessions (#912) (#949)
- add compact mode to message pagination (#904) (#948)
- eliminate redundant string clones in file watcher event loop (#947)
- deduplicate branchCacheStore background refresh (#946)
- stabilize VirtualizedMessageList itemContent callback (#918) (#944)
- replace global scriptOutputVersion with per-run version map (#923) (#943)
- batch-fetch repos by ID in ListAllSessions instead of loading all (#905) (#942)
- eliminate duplicate COUNT query in paginated message fetch (#901) (#941)
- add composite indexes for file_tabs and summaries hot queries (#902) (#939)
- remove unused recharts dependency (~800KB) (#938)
- replace bulk useConversationsWithUserMessages with scoped selectors (#937)
- split streaming selectors for fine-grained re-renders (#933)
- add conversationsBySession index for O(1) session lookups (#931)
- upgrade claude-agent-sdk from 0.2.72 to 0.2.75 (#929)
- optimize initial session loading with parallel fetches and scoped queries (#878)