### PR TITLE
fix: proactive AWS SSO token validation for Bedrock users

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -2137,6 +2137,8 @@ const AUTH_ERROR_PATTERNS = [
   "unable to locate credentials",
   "could not resolve credentials",
   "invalid identity token",
+  // Claude Code SDK patterns
+  "not logged in. please run",
 ];
 
 function detectAuthError(text: string): boolean {

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -336,6 +336,13 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 	envVars["CHATML_BACKEND_URL"] = fmt.Sprintf("http://127.0.0.1:%d", m.backendPort)
 	procOpts.EnvVars = envVars
 
+	// Pre-flight SSO token check for Bedrock users: logs a warning if the token
+	// is expired. The frontend handles refresh proactively via useClaudeAuthStatus
+	// and the pre-send check in ChatInput, or reactively via the error banner.
+	if envVars["CLAUDE_CODE_USE_BEDROCK"] == "true" {
+		m.ensureBedrockSSOToken(ctx)
+	}
+
 	// Load workspace MCP server configs from settings
 	mcpJSON, err := m.loadMcpServers(ctx, session.WorkspaceID)
 	if err != nil {
@@ -1850,6 +1857,11 @@ func (m *Manager) ResumeConversation(ctx context.Context, convID string) error {
 	}
 	opts.EnvVars = envVars
 
+	// Pre-flight SSO token check for Bedrock users (same as StartConversation).
+	if envVars != nil && envVars["CLAUDE_CODE_USE_BEDROCK"] == "true" {
+		m.ensureBedrockSSOToken(ctx)
+	}
+
 	mcpServersJSON, err := m.loadMcpServers(ctx, session.WorkspaceID)
 	if err != nil {
 		logger.Manager.Errorf("Failed to load MCP servers for resume %s: %v", convID, err)
@@ -2213,6 +2225,24 @@ func (m *Manager) newAIClient() ai.Provider {
 // packages that need an AI client (e.g. server handlers).
 func (m *Manager) CreateAIClient() ai.Provider {
 	return m.newAIClient()
+}
+
+// ensureBedrockSSOToken checks if the AWS SSO token is valid for Bedrock users.
+// This is a non-blocking validation check only — it logs a warning if the token is
+// expired but does NOT run the auth refresh command (which would block for up to 120s
+// with no UI feedback). The frontend handles refresh proactively via useClaudeAuthStatus
+// and the pre-send check in ChatInput, or reactively via the error banner.
+func (m *Manager) ensureBedrockSSOToken(ctx context.Context) {
+	status := ai.CheckSSOTokenStatus()
+	if status.Valid != nil && *status.Valid {
+		return // Token is valid, nothing to do
+	}
+
+	if status.Valid != nil && !*status.Valid {
+		logger.Manager.Warnf("Bedrock SSO token is expired — agent may fail with auth error (frontend should have prompted refresh)")
+	} else {
+		logger.Manager.Debugf("Bedrock SSO token status unknown (no cached tokens found)")
+	}
 }
 
 // tryBedrockFromClaudeSettings checks pre-loaded Claude Code settings for Bedrock configuration.

--- a/backend/ai/claude_settings.go
+++ b/backend/ai/claude_settings.go
@@ -1,10 +1,13 @@
 package ai
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"time"
 )
 
 // ClaudeCodeSettings represents the relevant fields from ~/.claude/settings.json.
@@ -46,4 +49,90 @@ func IsBedRockConfigured(settings *ClaudeCodeSettings) bool {
 		return false
 	}
 	return settings.Env["CLAUDE_CODE_USE_BEDROCK"] == "true"
+}
+
+// SSOTokenStatus describes the state of cached AWS SSO tokens.
+type SSOTokenStatus struct {
+	Applicable       bool       // true if Bedrock is configured
+	Valid            *bool      // nil if unknown/no tokens found, true/false otherwise
+	ExpiresAt        *time.Time // when the best token expires
+	ExpiresInMinutes float64
+}
+
+// CheckSSOTokenStatus scans ~/.aws/sso/cache/ for valid SSO tokens.
+// This is the shared logic used by both the HTTP handler and the agent manager pre-flight check.
+func CheckSSOTokenStatus() SSOTokenStatus {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return SSOTokenStatus{Applicable: true}
+	}
+
+	cacheDir := filepath.Join(home, ".aws", "sso", "cache")
+	entries, err := filepath.Glob(filepath.Join(cacheDir, "*.json"))
+	if err != nil || len(entries) == 0 {
+		return SSOTokenStatus{Applicable: true}
+	}
+
+	type ssoToken struct {
+		AccessToken string `json:"accessToken"`
+		ExpiresAt   string `json:"expiresAt"`
+	}
+
+	var bestExpiry time.Time
+	found := false
+
+	for _, entry := range entries {
+		data, readErr := os.ReadFile(entry)
+		if readErr != nil {
+			continue
+		}
+		var tok ssoToken
+		if jsonErr := json.Unmarshal(data, &tok); jsonErr != nil {
+			continue
+		}
+		if tok.AccessToken == "" || tok.ExpiresAt == "" {
+			continue
+		}
+		expiry, parseErr := time.Parse("2006-01-02T15:04:05UTC", tok.ExpiresAt)
+		if parseErr != nil {
+			expiry, parseErr = time.Parse(time.RFC3339, tok.ExpiresAt)
+		}
+		if parseErr != nil {
+			continue
+		}
+		if !found || expiry.After(bestExpiry) {
+			bestExpiry = expiry
+			found = true
+		}
+	}
+
+	if !found {
+		return SSOTokenStatus{Applicable: true}
+	}
+
+	now := time.Now().UTC()
+	valid := bestExpiry.After(now)
+	minutesLeft := bestExpiry.Sub(now).Minutes()
+
+	return SSOTokenStatus{
+		Applicable:       true,
+		Valid:            &valid,
+		ExpiresAt:        &bestExpiry,
+		ExpiresInMinutes: minutesLeft,
+	}
+}
+
+// RunAuthRefreshCommand executes the given AWS auth refresh command (e.g. "aws sso login --profile core-dev")
+// with the given context. Uses sh -c for shell parsing (PATH, quoting, env vars).
+//
+// SECURITY: authRefreshCmd is passed to a shell — callers must ensure the value comes from a
+// trusted, user-controlled source (ChatML settings store or ~/.claude/settings.json), never
+// from untrusted input such as agent output or API request bodies.
+func RunAuthRefreshCommand(ctx context.Context, authRefreshCmd string) error {
+	cmd := exec.CommandContext(ctx, "sh", "-c", authRefreshCmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("auth refresh command failed: %w (output: %s)", err, string(output))
+	}
+	return nil
 }

--- a/backend/server/settings_handlers.go
+++ b/backend/server/settings_handlers.go
@@ -8,8 +8,6 @@ import (
 	"math"
 	"net/http"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -668,18 +666,12 @@ func (h *Handlers) RefreshAWSCredentials(w http.ResponseWriter, r *http.Request)
 	cmdCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()
 
-	// Use sh -c so the command string is parsed by the shell, supporting quoting,
-	// pipes, env vars, and the user's PATH (important for macOS app bundles where
-	// the Go process may have a minimal PATH).
-	cmd := exec.CommandContext(cmdCtx, "sh", "-c", authRefreshCmd)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("AWS auth refresh failed: %v (output: %s)", err, string(output))
+	if err := ai.RunAuthRefreshCommand(cmdCtx, authRefreshCmd); err != nil {
+		log.Printf("AWS auth refresh failed: %v", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":  fmt.Sprintf("Auth refresh command failed: %v", err),
-			"output": string(output),
+			"error": err.Error(),
 		})
 		return
 	}
@@ -710,77 +702,22 @@ func (h *Handlers) GetAWSSSOTokenStatus(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Scan ~/.aws/sso/cache/*.json for valid tokens.
-	home, err := os.UserHomeDir()
-	if err != nil {
+	status := ai.CheckSSOTokenStatus()
+
+	if status.Valid == nil {
 		writeJSON(w, map[string]interface{}{"applicable": true, "valid": nil})
 		return
 	}
 
-	cacheDir := filepath.Join(home, ".aws", "sso", "cache")
-	entries, err := filepath.Glob(filepath.Join(cacheDir, "*.json"))
-	if err != nil || len(entries) == 0 {
-		writeJSON(w, map[string]interface{}{"applicable": true, "valid": nil})
-		return
-	}
-
-	// Find the most recent valid (non-registration) SSO token.
-	type ssoToken struct {
-		AccessToken string `json:"accessToken"`
-		ExpiresAt   string `json:"expiresAt"`
-		// Registration entries have clientId/clientSecret but no accessToken.
-		ClientID     string `json:"clientId"`
-		ClientSecret string `json:"clientSecret"`
-	}
-
-	var bestExpiry time.Time
-	found := false
-
-	for _, entry := range entries {
-		data, readErr := os.ReadFile(entry)
-		if readErr != nil {
-			continue
-		}
-		var tok ssoToken
-		if jsonErr := json.Unmarshal(data, &tok); jsonErr != nil {
-			continue
-		}
-		// Skip registration client entries (no access token).
-		if tok.AccessToken == "" {
-			continue
-		}
-		if tok.ExpiresAt == "" {
-			continue
-		}
-		// AWS SSO cache uses UTC format: "2024-01-15T10:30:00UTC" or RFC3339.
-		expiry, parseErr := time.Parse("2006-01-02T15:04:05UTC", tok.ExpiresAt)
-		if parseErr != nil {
-			expiry, parseErr = time.Parse(time.RFC3339, tok.ExpiresAt)
-		}
-		if parseErr != nil {
-			continue
-		}
-		if !found || expiry.After(bestExpiry) {
-			bestExpiry = expiry
-			found = true
-		}
-	}
-
-	if !found {
-		writeJSON(w, map[string]interface{}{"applicable": true, "valid": nil})
-		return
-	}
-
-	now := time.Now().UTC()
-	valid := bestExpiry.After(now)
-	minutesLeft := math.Floor(bestExpiry.Sub(now).Minutes())
-
-	writeJSON(w, map[string]interface{}{
+	resp := map[string]interface{}{
 		"applicable":       true,
-		"valid":            valid,
-		"expiresAt":        bestExpiry.Format(time.RFC3339),
-		"expiresInMinutes": minutesLeft,
-	})
+		"valid":            *status.Valid,
+		"expiresInMinutes": math.Floor(status.ExpiresInMinutes),
+	}
+	if status.ExpiresAt != nil {
+		resp["expiresAt"] = status.ExpiresAt.Format(time.RFC3339)
+	}
+	writeJSON(w, resp)
 }
 
 // settingKeyMcpServers returns the settings key for MCP servers in a workspace

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "chatml",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatml",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "@aptabase/web": "^0.5.0",
         "@ariakit/react": "^0.4.23",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -36,8 +37,8 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
-        "@shikijs/langs": "^3.22.0",
-        "@shikijs/types": "^3.22.0",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/types": "4.0.2",
         "@tailwindcss/typography": "^0.5.19",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
@@ -71,7 +72,7 @@
         "rehype-highlight": "^7.0.2",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
-        "shiki": "^3.21.0",
+        "shiki": "4.0.2",
         "tailwind-merge": "^3.5.0",
         "vscode-icons-js": "^11.6.1",
         "zustand": "^5.0.10"
@@ -140,6 +141,12 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@aptabase/web": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@aptabase/web/-/web-0.5.0.tgz",
+      "integrity": "sha512-+RFdaS0bLJtqTZyB1uG32S7tuTfJTGbG2bkdVMs3AT7yG7DP2yb6JY5rZoBf3UyW9sigFHGRkbXoAXdCMZibWA==",
+      "license": "MIT"
     },
     "node_modules/@ariakit/core": {
       "version": "0.4.18",
@@ -2037,6 +2044,71 @@
         "react-dom": "^18.3.1 || ^19.0.0"
       }
     },
+    "node_modules/@pierre/diffs/node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
     "node_modules/@pierre/theme": {
       "version": "0.0.22",
       "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-0.0.22.tgz",
@@ -3601,43 +3673,79 @@
         "hast-util-to-html": "^9.0.5"
       }
     },
-    "node_modules/@shikijs/engine-javascript": {
+    "node_modules/@shikijs/core/node_modules/@shikijs/types": {
       "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0"
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.23.0"
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/transformers": {
@@ -3650,7 +3758,7 @@
         "@shikijs/types": "3.23.0"
       }
     },
-    "node_modules/@shikijs/types": {
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
       "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
@@ -3658,6 +3766,19 @@
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
@@ -12839,19 +12960,38 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.23.0",
-        "@shikijs/engine-javascript": "3.23.0",
-        "@shikijs/engine-oniguruma": "3.23.0",
-        "@shikijs/langs": "3.23.0",
-        "@shikijs/themes": "3.23.0",
-        "@shikijs/types": "3.23.0",
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/shiki/node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/side-channel": {

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -8,7 +8,7 @@ import { useAppEventListener } from '@/lib/custom-events';
 import { useShortcut } from '@/hooks/useShortcut';
 import { Bot, Upload, Link, FolderSymlink } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
+import { useClaudeAuthStatus, refreshClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
 import { useToast } from '@/components/ui/toast';
 import { copyToClipboard } from '@/lib/tauri';
 import type { Attachment, SuggestionPill } from '@/lib/types';
@@ -677,6 +677,23 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           showError(`Failed to load attachment content: ${err instanceof Error ? err.message : 'Unknown error'}`);
           setIsSending(false);
           return;
+        }
+      }
+
+      // Pre-send SSO token check for Bedrock users — refresh expired tokens before
+      // sending so the backend doesn't block for 120s with no UI feedback.
+      // Applies to both new conversations and follow-up messages (token can expire mid-session).
+      if (claudeAuthStatus?.hasBedrock && claudeAuthStatus.ssoTokenValid === false) {
+        showInfo('AWS SSO token expired — refreshing credentials...');
+        try {
+          const { refreshAWSCredentials } = await import('@/lib/api');
+          await refreshAWSCredentials();
+          // Fire-and-forget: the server-side token is already refreshed; this updates
+          // the cached UI status asynchronously (won't be reflected in this render cycle).
+          refreshClaudeAuthStatus();
+        } catch (err) {
+          showError(`AWS credential refresh failed: ${err instanceof Error ? err.message : 'Unknown error'}. You can retry or continue — the agent will prompt if needed.`);
+          // Don't block — let the user continue, the backend/agent will handle the auth error
         }
       }
 

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -131,7 +131,8 @@ function ErrorDisplay({ error, onDismiss }: { error: string; onDismiss: () => vo
     lowerError.includes('unrecognizedclientexception') ||
     lowerError.includes('the security token included in the request is expired') ||
     lowerError.includes('aws credentials') || lowerError.includes('sso login') ||
-    (lowerError.includes('expired') && lowerError.includes('sso'));
+    (lowerError.includes('expired') && lowerError.includes('sso')) ||
+    lowerError.includes('not logged in. please run');
   const isAuthError = isAwsAuthError || lowerError.includes('authentication') || lowerError.includes('api key') || lowerError.includes('oauth');
 
   const handleAwsRefresh = async () => {

--- a/src/hooks/useClaudeAuthStatus.ts
+++ b/src/hooks/useClaudeAuthStatus.ts
@@ -51,6 +51,11 @@ export function refreshClaudeAuthStatus() {
     .catch(() => notify(DEFAULT_AUTH_STATUS));
 }
 
+// Re-check interval for Bedrock SSO token validity (5 minutes).
+// This ensures the expiry banner appears proactively mid-session,
+// before the token actually expires and breaks the running agent.
+const SSO_RECHECK_INTERVAL_MS = 5 * 60 * 1000;
+
 export function useClaudeAuthStatus(): ClaudeAuthStatus | null {
   const [status, setStatus] = useState<ClaudeAuthStatus | null>(cachedStatus);
 
@@ -62,6 +67,15 @@ export function useClaudeAuthStatus(): ClaudeAuthStatus | null {
     }
     return () => { listeners.delete(setStatus); };
   }, []);
+
+  // Periodic re-check when Bedrock is configured — keeps the SSO expiry banner current.
+  // Stabilize to a plain boolean so transient DEFAULT_AUTH_STATUS responses don't reset the interval.
+  const hasBedrock = !!status?.hasBedrock;
+  useEffect(() => {
+    if (!hasBedrock) return;
+    const id = setInterval(refreshClaudeAuthStatus, SSO_RECHECK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [hasBedrock]);
 
   return status;
 }


### PR DESCRIPTION
## Summary

- Extract SSO token checking (`CheckSSOTokenStatus`) and auth refresh (`RunAuthRefreshCommand`) from `settings_handlers.go` into shared functions in `ai/claude_settings.go` for reuse by both the HTTP handler and agent manager
- Add pre-flight SSO token validation in the agent manager (log-only warning, non-blocking) before spawning agents
- Add pre-send SSO token refresh in `ChatInput` that catches expired tokens before creating conversations **or** sending follow-up messages, preventing the backend from blocking 120s with no UI feedback
- Add periodic 5-minute re-check in `useClaudeAuthStatus` so the expiry banner surfaces proactively mid-session
- Detect `"not logged in. please run"` as an auth error pattern in both `agent-runner` and `StreamingMessage` error display

## Test plan

- [ ] With Bedrock configured and a valid SSO token, verify conversations start normally (no warnings in Go logs)
- [ ] With Bedrock configured and an expired SSO token, verify the pre-send check triggers a credential refresh toast before the conversation is created
- [ ] Verify follow-up messages in an existing conversation also trigger the refresh if the token expired mid-session
- [ ] Verify the 5-minute periodic re-check updates the SSO expiry banner without resetting the interval
- [ ] Verify the "not logged in. please run" error message is detected as an AWS auth error and shows the refresh button in the error banner
- [ ] Without Bedrock configured, verify no SSO-related checks or UI appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)