### PR TITLE
fix: route CMD+V paste to PTY when terminal is focused

### DIFF
--- a/src/hooks/useMenuHandlers.ts
+++ b/src/hooks/useMenuHandlers.ts
@@ -136,6 +136,11 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
               const { readText } = await import('@tauri-apps/plugin-clipboard-manager');
               const text = await readText().catch(() => '');
               if (text) {
+                // If an xterm terminal is focused, paste directly to PTY
+                if (document.activeElement?.closest('.xterm') != null) {
+                  window.dispatchEvent(new CustomEvent('terminal-paste', { detail: { text } }));
+                  return;
+                }
                 // Auto-convert long text to attachment (mirrors handlePaste in useChatInputAttachments)
                 const { autoConvertLongText } = useSettingsStore.getState();
                 if (autoConvertLongText && text.length > 5000) {

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -395,6 +395,23 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
     };
   }, []);
 
+  // Handle CMD+V paste from Tauri menu accelerator
+  useEffect(() => {
+    const handlePaste = (e: Event) => {
+      const text = (e as CustomEvent).detail?.text;
+      if (!text || !ptyRef.current || ptyRef.current.stopped) return;
+      // Only handle if this terminal instance is focused
+      const el = terminalRef.current?.element;
+      if (el && el.contains(document.activeElement)) {
+        ptyRef.current.write(text).catch((e) => {
+          console.warn('PTY paste write error:', e);
+        });
+      }
+    };
+    window.addEventListener('terminal-paste', handlePaste);
+    return () => window.removeEventListener('terminal-paste', handlePaste);
+  }, []);
+
   // Sync terminal theme when app theme changes
   useEffect(() => {
     if (terminalRef.current) {


### PR DESCRIPTION
## Summary

- Tauri's menu accelerator captures CMD+V before xterm.js can handle it, causing paste to go to the chat input instead of the terminal
- Detects terminal focus via `.closest('.xterm')` in the paste handler and dispatches a `terminal-paste` CustomEvent
- `useTerminal` listens for the event, verifies the correct terminal instance has focus, and writes clipboard text to the PTY

## Test plan

- [ ] Focus a terminal pane and CMD+V — text should paste into the terminal
- [ ] Focus the chat input and CMD+V — text should paste into the chat input (existing behavior)
- [ ] Paste while terminal process has exited — should not throw (`.catch()` handles gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)