### PR TITLE
fix: always show scroll-to-bottom pill when scrolled away from bottom

### DIFF
--- a/src/components/conversation/ConversationMessagePane.tsx
+++ b/src/components/conversation/ConversationMessagePane.tsx
@@ -226,6 +226,7 @@ export function ConversationMessagePane({
   const isAtBottomRef = useRef(true);
   const forceFollowRef = useRef(false);
   const userScrolledUpRef = useRef(false);
+  const isStreamingRef = useRef(selectedStreaming.isStreaming);
   const isActiveRef = useRef(isActive);
 
   /** Reset all follow-state refs atomically. */
@@ -237,6 +238,9 @@ export function ConversationMessagePane({
   useEffect(() => {
     isActiveRef.current = isActive;
   }, [isActive]);
+  useEffect(() => {
+    isStreamingRef.current = selectedStreaming.isStreaming;
+  }, [selectedStreaming.isStreaming]);
 
   // When the pane becomes active after being hidden (e.g. session switch where
   // the parent container was display:none), Virtuoso may need a scroll nudge.
@@ -364,6 +368,47 @@ export function ConversationMessagePane({
       scrollerEl.removeEventListener('keydown', handleKeyDown);
     };
   }, [selectedStreaming.isStreaming, isActive]);
+
+  // Supplementary scroll listener: ensures the scroll-to-bottom pill shows
+  // even when Virtuoso's atBottomStateChange doesn't fire on initial scroll
+  // away from bottom (it requires a true→false transition cycle).
+  // This listener is unidirectional — it only SHOWS the pill. Virtuoso's
+  // atBottomStateChange remains the sole authority for hiding it.
+  useEffect(() => {
+    if (!isActive || !hasMessages) return;
+
+    let scrollCleanup: (() => void) | null = null;
+
+    // Poll until Virtuoso mounts and exposes the scroller element
+    const timerId = setInterval(() => {
+      const scrollerEl = messageListRef.current?.getScrollerElement();
+      if (!scrollerEl) return;
+      clearInterval(timerId);
+
+      const handleScroll = () => {
+        const threshold = isStreamingRef.current ? 200 : 50;
+        const atBottom = scrollerEl.scrollHeight - scrollerEl.scrollTop - scrollerEl.clientHeight <= threshold;
+        // Only override to show the pill; let Virtuoso handle the "returned to bottom" case
+        if (!atBottom && isAtBottomRef.current) {
+          isAtBottomRef.current = false;
+          setShowScrollButton(true);
+        }
+      };
+
+      scrollerEl.addEventListener('scroll', handleScroll, { passive: true });
+      // Check immediately in case we're already not at bottom
+      handleScroll();
+
+      scrollCleanup = () => {
+        scrollerEl.removeEventListener('scroll', handleScroll);
+      };
+    }, 100);
+
+    return () => {
+      clearInterval(timerId);
+      scrollCleanup?.();
+    };
+  }, [isActive, hasMessages]);
 
   // Scroll handler for conversation markers minimap
   const handleMarkerScrollToIndex = useCallback((index: number) => {


### PR DESCRIPTION
## Summary

- Adds a supplementary native scroll listener on the Virtuoso scroller to reliably show the "scroll to bottom" pill when the user first scrolls away from the bottom
- Virtuoso's `atBottomStateChange` requires a `true→false` transition cycle to fire, so the initial scroll-away was sometimes missed
- The listener is **unidirectional** — it only shows the pill. Virtuoso's callback remains the sole authority for hiding it, preventing threshold disagreements between two detectors
- Shared `isStreamingRef` at component level for both the streaming scroll-pinning effect and this listener
- Uses `setInterval` polling to wait for Virtuoso's scroller element to mount (instead of a one-shot `setTimeout`)

## Test plan

- [ ] Open a conversation with enough messages to scroll
- [ ] Scroll up — the "Scroll to bottom" pill should appear immediately
- [ ] Scroll back down — the pill should disappear
- [ ] During streaming, scroll up — pill appears, auto-follow stops
- [ ] Click the pill — scrolls to bottom and pill disappears
- [ ] Switch sessions and back — pill state should be correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)