### PR TITLE
fix: remove redundant Clean Up Branches button

### DIFF
--- a/backend/server/branch_handlers.go
+++ b/backend/server/branch_handlers.go
@@ -352,64 +352,6 @@ func (h *Handlers) ExecuteBranchCleanup(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, result)
 }
 
-// PruneStaleBranches cleans up branches: prunes stale remote-tracking refs
-// and deletes local branches that are fully merged into main.
-// POST /api/repos/{id}/branches/prune
-func (h *Handlers) PruneStaleBranches(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	workspaceID := chi.URLParam(r, "id")
-
-	repo, err := h.store.GetRepo(ctx, workspaceID)
-	if err != nil {
-		writeDBError(w, err)
-		return
-	}
-	if repo == nil {
-		writeNotFound(w, "workspace")
-		return
-	}
-
-	// Step 1: Prune stale remote-tracking refs
-	if err := h.repoManager.FetchAndPrune(ctx, repo.Path); err != nil {
-		writeInternalError(w, "failed to prune stale branches", err)
-		return
-	}
-
-	// Step 2: Clean up merged local branches (protect session-linked branches)
-	sessionBranchMap, err := h.getSessionBranchMap(ctx, workspaceID)
-	if err != nil {
-		writeDBError(w, err)
-		return
-	}
-	// Convert to simple set for CleanMergedLocalBranches
-	protectedBranches := make(map[string]bool)
-	for branchName := range sessionBranchMap {
-		protectedBranches[branchName] = true
-	}
-
-	deletedBranches, cleanErr := h.repoManager.CleanMergedLocalBranches(ctx, repo.Path, protectedBranches)
-	if cleanErr != nil {
-		logger.Handlers.Warnf("Merged branch cleanup failed for %s: %v", repo.Path, cleanErr)
-	}
-
-	h.branchCache.MarkPruned(repo.Path)
-	h.branchCache.InvalidateRepo(repo.Path)
-
-	if h.hub != nil {
-		h.hub.Broadcast(Event{
-			Type: "branch_dashboard_update",
-			Payload: map[string]interface{}{
-				"reason": "prune_complete",
-			},
-		})
-	}
-
-	writeJSON(w, map[string]interface{}{
-		"success":              true,
-		"deletedLocalBranches": deletedBranches,
-	})
-}
-
 // GetAvatars returns GitHub avatar URLs for a batch of email addresses
 // GET /api/avatars?emails=email1@example.com,email2@example.com
 func (h *Handlers) GetAvatars(w http.ResponseWriter, r *http.Request) {

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -110,7 +110,6 @@ func NewRouter(ctx context.Context, s *store.SQLiteStore, hub *Hub, agentMgr *ag
 		r.Delete("/{id}", h.DeleteRepo)
 		r.Get("/{id}/remotes", h.GetRepoRemotes)
 		r.Get("/{id}/branches", h.ListBranches)
-		r.Post("/{id}/branches/prune", h.PruneStaleBranches)
 		r.Post("/{id}/branches/analyze-cleanup", h.AnalyzeBranchCleanup)
 		r.Post("/{id}/branches/cleanup", h.ExecuteBranchCleanup)
 		r.Get("/{id}/conversations", h.ListWorkspaceConversations)

--- a/src/components/dashboards/BranchesDashboard.tsx
+++ b/src/components/dashboards/BranchesDashboard.tsx
@@ -7,7 +7,7 @@ import { navigate } from '@/lib/navigation';
 import { FullContentLayout } from '@/components/layout/FullContentLayout';
 import { useMainToolbarContent } from '@/hooks/useMainToolbarContent';
 import { DataTable, type Column, type ContextMenuItem, type FilterOption, type DisplayOptionsConfig, type DisplayOptions } from '@/components/data-table';
-import { listBranches, pruneStaleBranches, type BranchDTO, type BranchListResponse } from '@/lib/api';
+import { listBranches, type BranchDTO, type BranchListResponse } from '@/lib/api';
 import { useAvatars } from '@/hooks/useAvatars';
 import { Button } from '@/components/ui/button';
 import { AuthorAvatar } from '@/components/ui/author-avatar';
@@ -28,7 +28,6 @@ import {
   Copy,
   Cloud,
   Wand2,
-  Scissors,
 } from 'lucide-react';
 import { BranchCleanupDialog } from '@/components/dialogs/branch-cleanup/BranchCleanupDialog';
 import { copyToClipboard } from '@/lib/tauri';
@@ -178,7 +177,6 @@ export function BranchesDashboard({
   const [searchTerm, setSearchTerm] = useState('');
   const [showRemote, setShowRemote] = useState(false);
   const [cleanupOpen, setCleanupOpen] = useState(false);
-  const [pruning, setPruning] = useState(false);
 
   const fetchBranchesRef = useRef<(isRefresh?: boolean) => void>(() => {});
   const hasFetchedRef = useRef(false);
@@ -193,25 +191,6 @@ export function BranchesDashboard({
     setLastRepoDashboardWorkspaceId(newWorkspaceId);
     navigate({ contentView: { type: 'branches', workspaceId: newWorkspaceId } });
   }, [setLastRepoDashboardWorkspaceId]);
-
-  const handlePrune = useCallback(async () => {
-    setPruning(true);
-    try {
-      const result = await pruneStaleBranches(workspaceId);
-      const deletedCount = result.deletedLocalBranches?.length ?? 0;
-      if (deletedCount > 0) {
-        toast.success(`Cleaned up ${deletedCount} merged local ${deletedCount === 1 ? 'branch' : 'branches'} and pruned stale refs`);
-      } else {
-        toast.success('Pruned stale remote refs (no merged local branches to clean)');
-      }
-      // Directly refresh instead of relying solely on WebSocket event
-      fetchBranchesRef.current(true);
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to clean up branches');
-    } finally {
-      setPruning(false);
-    }
-  }, [workspaceId, toast]);
 
   // Set dynamic toolbar content (Flutter AppBar-style)
   const toolbarConfig = useMemo(() => ({
@@ -275,17 +254,6 @@ export function BranchesDashboard({
             variant="ghost"
             size="sm"
             className="h-6 gap-1 px-2 text-xs"
-            onClick={handlePrune}
-            disabled={pruning}
-            title="Prune stale remote refs and delete merged local branches"
-          >
-            <Scissors className={cn('h-3.5 w-3.5', pruning && 'animate-spin')} />
-            {pruning ? 'Cleaning...' : 'Clean Up Branches'}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 gap-1 px-2 text-xs"
             onClick={() => setCleanupOpen(true)}
           >
             <Wand2 className="h-3.5 w-3.5" />
@@ -304,7 +272,7 @@ export function BranchesDashboard({
         </>
       ),
     },
-  }), [workspace, workspaces, workspaceId, branchData, refreshing, handleWorkspaceChange, handlePrune, pruning, workspaceColors]);
+  }), [workspace, workspaces, workspaceId, branchData, refreshing, handleWorkspaceChange, workspaceColors]);
   useMainToolbarContent(toolbarConfig);
 
   const fetchBranches = useCallback(async (isRefresh = false) => {

--- a/src/lib/api/branches.ts
+++ b/src/lib/api/branches.ts
@@ -163,13 +163,6 @@ export async function executeBranchCleanup(
   return handleResponse<CleanupResult>(res);
 }
 
-export async function pruneStaleBranches(workspaceId: string): Promise<{ success: boolean; deletedLocalBranches?: string[] }> {
-  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/branches/prune`, {
-    method: 'POST',
-  });
-  return handleResponse<{ success: boolean; deletedLocalBranches?: string[] }>(res);
-}
-
 // Branch sync DTOs and functions
 export interface SyncCommitDTO {
   sha: string;


### PR DESCRIPTION
## Summary
- Removes the "Clean Up Branches" (scissors) button from the Branches dashboard toolbar
- Its functionality was a strict subset of the "Smart Branch Cleanup" wizard (merged-only local cleanup vs full categorized cleanup with remote deletion support)
- Removes the frontend button, `handlePrune` callback, `pruneStaleBranches` API function, backend handler, and route registration
- Git helpers (`FetchAndPrune`, `CleanMergedLocalBranches`) are retained as they're used by the analyze/cleanup flow

## Test plan
- [ ] Open Branches dashboard — only "Smart Branch Cleanup" and Refresh buttons should appear in toolbar
- [ ] Run Smart Branch Cleanup wizard end-to-end to confirm it still works
- [ ] Verify Go backend builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)