### PR TITLE
fix: clean up orphaned mermaid error elements from DOM

### DIFF
--- a/src/components/shared/MermaidDiagram.tsx
+++ b/src/components/shared/MermaidDiagram.tsx
@@ -103,6 +103,11 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
           setError(err instanceof Error ? err.message : 'Failed to render diagram');
           setIsLoading(false);
         }
+        // Clean up orphaned mermaid error element from DOM
+        const errorElement = document.getElementById(`dmermaid-${uniqueId}`);
+        if (errorElement) {
+          errorElement.remove();
+        }
       }
     };
 
@@ -110,6 +115,11 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
 
     return () => {
       cancelled = true;
+      // Clean up any orphaned mermaid elements
+      const el = document.getElementById(`dmermaid-${uniqueId}`);
+      if (el) {
+        el.remove();
+      }
     };
   }, [code, uniqueId]);
 


### PR DESCRIPTION
## Summary
- When `mermaid.render()` fails on a syntax error, the Mermaid library leaves an orphaned error SVG element in the document body, causing a large visible error banner at the bottom of the app
- Added cleanup of these orphaned elements in both the `catch` block and the `useEffect` cleanup function in `MermaidDiagram.tsx`
- The inline error card still displays correctly within the message — only the leaked DOM banner is removed

## Test plan
- [ ] Trigger a mermaid syntax error (e.g., send a malformed mermaid code block)
- [ ] Confirm the inline red "Mermaid Error" card appears in the message
- [ ] Confirm no banner/overlay appears at the bottom of the app
- [ ] Confirm valid mermaid diagrams still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)