### PR TITLE
fix: remove AUTO_MODEL_ID, deduplicate models, and fix context meter

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -6,7 +6,7 @@ import { createConversation, sendConversationMessage, stopConversation, setConve
 import { markPlanModeExited } from '@/hooks/useWebSocket';
 import { dispatchAppEvent, useAppEventListener } from '@/lib/custom-events';
 import { useShortcut } from '@/hooks/useShortcut';
-import { Bot, Upload, Link, FolderSymlink } from 'lucide-react';
+import { Sparkles, Upload, Link, FolderSymlink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useClaudeAuthStatus, refreshClaudeAuthStatus } from '@/hooks/useClaudeAuthStatus';
 import { useToast } from '@/components/ui/toast';
@@ -25,7 +25,7 @@ import { LinearIssuePicker } from './LinearIssuePicker';
 import { WorkspacePicker } from './WorkspacePicker';
 import type { LinearIssueDTO } from '@/lib/api';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
-import { MODELS as SHARED_MODELS, type ModelEntry, AUTO_MODEL_ID, resolveModelName, isAutoModel, normalizeModelId, deduplicateById } from '@/lib/models';
+import { MODELS as SHARED_MODELS, type ModelEntry, toShortDisplayName, isNewModel, isDefaultRecommended, deduplicateById, deduplicateByName } from '@/lib/models';
 import type { MentionItem } from '@/components/ui/mention-node';
 import { trackEvent } from '@/lib/telemetry';
 import { listSessionFiles, type FileNodeDTO } from '@/lib/api';
@@ -65,34 +65,37 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
 }
 
 /** Static fallback model list (used when no SDK models are available). */
-const STATIC_MODELS: ModelEntry[] = [
-  { id: AUTO_MODEL_ID, name: 'Auto', icon: Bot, supportsThinking: true, supportsEffort: true, supportsFastMode: true },
-  ...SHARED_MODELS.map((m) => ({
-    id: m.id,
-    name: m.name,
-    icon: Bot,
-    supportsThinking: m.supportsThinking,
-    supportsEffort: m.supportsEffort,
-    supportsFastMode: m.supportsFastMode,
-  })),
-];
+const STATIC_MODELS: ModelEntry[] = SHARED_MODELS.map((m) => ({
+  id: m.id,
+  name: m.name,
+  icon: Sparkles,
+  supportsThinking: m.supportsThinking,
+  supportsEffort: m.supportsEffort,
+  supportsFastMode: m.supportsFastMode,
+}));
 
 /** Build the model list from SDK-reported dynamic models, with static fallback. */
 function buildModelList(dynamic: ReturnType<typeof useAppStore.getState>['supportedModels']): ModelEntry[] {
   if (dynamic.length === 0) return STATIC_MODELS;
-  // Dedup keeps first occurrence. Auto entries from the SDK always carry the same
-  // capability flags, so first-wins is safe.
-  return deduplicateById(
-    dynamic.map((m) => ({
-      id: normalizeModelId(m),
-      name: resolveModelName(m.value, m.displayName),
-      icon: Bot,
-      supportsThinking: m.supportsAdaptiveThinking ?? true,
-      supportsEffort: m.supportsEffort ?? false,
-      supportedEffortLevels: m.supportedEffortLevels,
-      supportsFastMode: m.supportsFastMode,
-    }))
+  // Filter out SDK "Default (recommended)" pseudo-model and deduplicate.
+  const entries = deduplicateById(
+    dynamic
+      .filter((m) => !isDefaultRecommended(m.displayName))
+      .map((m) => ({
+        id: m.value,
+        name: toShortDisplayName(m.value, m.displayName),
+        icon: Sparkles,
+        supportsThinking: m.supportsAdaptiveThinking ?? true,
+        supportsEffort: m.supportsEffort ?? false,
+        supportedEffortLevels: m.supportedEffortLevels,
+        supportsFastMode: m.supportsFastMode,
+        isNew: isNewModel(m.value),
+      }))
   );
+  // Also deduplicate by display name — SDK may report dated variants
+  // (e.g. claude-sonnet-4-6 and claude-sonnet-4-6-20260301) that resolve
+  // to the same friendly name.
+  return deduplicateByName(entries);
 }
 
 
@@ -548,7 +551,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
         type: 'task',
         message: pendingPlanApproval.planContent,
-        model: selectedModel.id === AUTO_MODEL_ID ? undefined : selectedModel.id,
+        model: selectedModel.id,
       });
 
       addConversation({
@@ -557,7 +560,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         type: conv.type,
         name: conv.name,
         status: conv.status,
-        model: selectedModel.id === AUTO_MODEL_ID ? AUTO_MODEL_ID : (conv.model || selectedModel.id),
+        model: conv.model || selectedModel.id,
         messages: [],
         toolSummary: [],
         createdAt: conv.createdAt,
@@ -723,7 +726,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
           type: convType,
           message: trimmedContent,
-          model: selectedModel.id === AUTO_MODEL_ID ? undefined : selectedModel.id,
+          model: selectedModel.id,
           planMode: planModeEnabled ? true : undefined,
           fastMode: fastModeEnabled ? true : undefined,
           maxThinkingTokens: thinkingParams.maxThinkingTokens,
@@ -752,7 +755,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           type: conv.type,
           name: conv.name,
           status: conv.status,
-          model: selectedModel.id === AUTO_MODEL_ID ? AUTO_MODEL_ID : (conv.model || selectedModel.id),
+          model: conv.model || selectedModel.id,
           messages: [],
           toolSummary: [],
           createdAt: conv.createdAt,
@@ -821,7 +824,6 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
         // Always send to backend (it queues in agent-runner if busy)
         const modelChanged = selectedModel.id !== currentConversation?.model;
-        // AUTO_MODEL_ID ("auto") signals the backend to clear the model override.
         // Omitting the field (undefined) leaves the current model unchanged.
         const modelToSend = selectedModel.id;
         await sendConversationMessage(

--- a/src/components/conversation/ChatInputToolbar.tsx
+++ b/src/components/conversation/ChatInputToolbar.tsx
@@ -21,6 +21,7 @@ import {
   FolderSymlink,
   Check,
   Star,
+  Sparkles,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
@@ -96,14 +97,17 @@ export function ChatInputToolbar({
       {/* Model Selector */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" className="h-7 gap-1.5 text-xs" title={`Model: ${model.selected.name}${model.selected.id === model.defaultId ? ' (default)' : ''} (⌥M to cycle)`}>
-            <model.selected.icon className="h-3.5 w-3.5" />
+          <Button variant="ghost" size="sm" className="h-7 gap-1.5 text-xs" title={`Model: ${model.selected.name}${model.selected.id === model.defaultId ? ' (default)' : ''}`}>
+            <Sparkles className="h-3.5 w-3.5" />
             {model.selected.name}
             <ChevronDown className="h-3 w-3" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-64">
-          {model.models.map((m) => {
+          <DropdownMenuLabel className="text-2xs font-normal text-muted-foreground uppercase tracking-wider">
+            Claude Code
+          </DropdownMenuLabel>
+          {model.models.map((m, index) => {
             const isDefault = m.id === model.defaultId;
             const isSelected = m.id === model.selected.id;
             return (
@@ -113,7 +117,13 @@ export function ChatInputToolbar({
                 onClick={() => model.setSelected(m)}
               >
                 <span className="flex flex-1 items-center gap-1.5 min-w-0">
+                  <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
                   <span className="truncate">{m.name}</span>
+                  {m.isNew && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted font-medium leading-none">
+                      NEW
+                    </span>
+                  )}
                 </span>
                 <span className="ml-auto flex shrink-0 items-center gap-1">
                   {isSelected && <Check className="h-3.5 w-3.5" />}
@@ -141,6 +151,9 @@ export function ChatInputToolbar({
                       </TooltipTrigger>
                       <TooltipContent side="right" sideOffset={8}>Set as default</TooltipContent>
                     </Tooltip>
+                  )}
+                  {index < 9 && (
+                    <kbd className="text-[10px] text-muted-foreground/50 min-w-[1ch] text-right ml-1">{index + 1}</kbd>
                   )}
                 </span>
               </DropdownMenuItem>

--- a/src/components/conversation/useChatInputKeyboardShortcuts.ts
+++ b/src/components/conversation/useChatInputKeyboardShortcuts.ts
@@ -41,13 +41,16 @@ export function useChatInputKeyboardShortcuts({
         e.preventDefault();
         plateInputRef.current?.focus();
       }
-      // Alt+M to cycle models
-      if (e.code === 'KeyM' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
-        e.preventDefault();
-        setSelectedModel(prev => {
-          const idx = MODELS.findIndex(m => m.id === prev.id);
-          return MODELS[(idx + 1) % MODELS.length];
-        });
+      // Alt+1..9 to select model by index
+      if (e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+        const digit = e.code.match(/^Digit([1-9])$/)?.[1];
+        if (digit) {
+          const idx = parseInt(digit, 10) - 1;
+          if (idx >= 0 && idx < MODELS.length) {
+            e.preventDefault();
+            setSelectedModel(MODELS[idx]);
+          }
+        }
       }
       // Alt+T to cycle thinking levels
       if (e.code === 'KeyT' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -19,7 +19,7 @@ import { navigate } from '@/lib/navigation';
 import { copyToClipboard } from '@/lib/tauri';
 import { useToast } from '@/components/ui/toast';
 import { getShortcutById, formatShortcutKeys } from '@/lib/shortcuts';
-import { MODELS, AUTO_MODEL_ID, isAutoModel } from '@/lib/models';
+import { buildDeduplicatedModelIds } from '@/lib/models';
 import type { LucideIcon } from 'lucide-react';
 import {
   // Navigation
@@ -314,11 +314,7 @@ const COMMANDS: Command[] = [
     action: () => {
       const store = useSettingsStore.getState();
       const dynamic = useAppStore.getState().supportedModels;
-      // Use SDK-reported models if available, fall back to static list.
-      // Map SDK "Default (recommended)" → AUTO_MODEL_ID sentinel.
-      const models = dynamic.length > 0
-        ? dynamic.map((m) => isAutoModel(m.displayName) ? AUTO_MODEL_ID : m.value)
-        : [AUTO_MODEL_ID, ...MODELS.map((m) => m.id)];
+      const models = buildDeduplicatedModelIds(dynamic);
       const idx = models.indexOf(store.defaultModel);
       const next = models[(idx + 1) % models.length];
       store.setDefaultModel(next);

--- a/src/components/settings/sections/AIModelSettings.tsx
+++ b/src/components/settings/sections/AIModelSettings.tsx
@@ -13,7 +13,7 @@ import {
 import { Eye, EyeOff } from 'lucide-react';
 import { useSettingsStore, SETTINGS_DEFAULTS } from '@/stores/settingsStore';
 import { useAppStore } from '@/stores/appStore';
-import { MODELS as SHARED_MODELS, AUTO_MODEL_ID, resolveModelName, normalizeModelId, deduplicateById } from '@/lib/models';
+import { MODELS as SHARED_MODELS, toShortDisplayName, isDefaultRecommended, deduplicateById, deduplicateByName } from '@/lib/models';
 import type { ThinkingLevel } from '@/lib/thinkingLevels';
 import { getAnthropicApiKey, setAnthropicApiKey } from '@/lib/api';
 import { useToast } from '@/components/ui/toast';
@@ -35,21 +35,15 @@ export function AIModelSettings() {
   const setMaxThinkingTokens = useSettingsStore((s) => s.setMaxThinkingTokens);
 
   // Build model options from SDK-reported models, with static fallback.
-  // Always include "Auto" so the setting is selectable even before SDK connects.
   const dynamicModels = useAppStore((s) => s.supportedModels);
   const modelOptions = useMemo(() => {
-    const autoOption = { id: AUTO_MODEL_ID, name: 'Auto' };
     if (dynamicModels.length === 0) {
-      return [autoOption, ...SHARED_MODELS.map((m) => ({ id: m.id, name: m.name }))];
+      return SHARED_MODELS.map((m) => ({ id: m.id, name: m.name }));
     }
-    const deduped = deduplicateById(
-      dynamicModels.map((m) => ({ id: normalizeModelId(m), name: resolveModelName(m.value, m.displayName) }))
-    );
-    // Ensure Auto is present (SDK may not always include a "Default" entry)
-    if (!deduped.some((m) => m.id === AUTO_MODEL_ID)) {
-      return [autoOption, ...deduped];
-    }
-    return deduped;
+    const entries = dynamicModels
+      .filter((m) => !isDefaultRecommended(m.displayName))
+      .map((m) => ({ id: m.value, name: toShortDisplayName(m.value, m.displayName) }));
+    return deduplicateByName(deduplicateById(entries));
   }, [dynamicModels]);
 
   return (

--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -10,7 +10,6 @@ import { useSelectedIds } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { trackEvent } from '@/lib/telemetry';
 import { toBase64 } from '@/lib/utils';
-import { AUTO_MODEL_ID } from '@/lib/models';
 
 const MARKDOWN_INSTRUCTION =
   '\nWhen writing comment content, use Markdown formatting for detailed comments that include code examples, lists, or structured explanations (use fenced code blocks for code, bullet lists for multiple points, **bold** for emphasis). Keep simple one-sentence comments as plain text.';
@@ -258,7 +257,7 @@ export function useReviewTrigger() {
         const conv = await createConversation(selectedWorkspaceId, selectedSessionId, {
           type: 'review',
           message: shortContent,
-          model: reviewModel === AUTO_MODEL_ID ? undefined : reviewModel,
+          model: reviewModel,
           attachments: [templateAttachment],
         });
         trackEvent('review_started', { type: reviewType });

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -9,13 +9,13 @@ vi.mock('@/stores/appStore', () => ({
   },
 }));
 
-const { getModelDisplayName, getModelInfo, buildTurnConfigLabel, MODELS, AUTO_MODEL_ID, resolveModelName, isAutoModel } = await import('../models');
+const { getModelDisplayName, getModelInfo, buildTurnConfigLabel, MODELS, toShortDisplayName, isNewModel, isDefaultRecommended } = await import('../models');
 
 describe('getModelDisplayName', () => {
-  it('returns display name for known static models', () => {
-    expect(getModelDisplayName('claude-opus-4-6')).toBe('Claude Opus 4.6');
-    expect(getModelDisplayName('claude-sonnet-4-6')).toBe('Claude Sonnet 4.6');
-    expect(getModelDisplayName('claude-haiku-4-5-20251001')).toBe('Claude Haiku 4.5');
+  it('returns short display name for known static models', () => {
+    expect(getModelDisplayName('claude-opus-4-6')).toBe('Opus 4.6');
+    expect(getModelDisplayName('claude-sonnet-4-6')).toBe('Sonnet 4.6');
+    expect(getModelDisplayName('claude-haiku-4-5-20251001')).toBe('Haiku 4.5');
   });
 
   it('returns raw model ID for unknown models', () => {
@@ -54,12 +54,70 @@ describe('getModelDisplayName', () => {
   });
 });
 
+describe('toShortDisplayName', () => {
+  it('returns short name for known models', () => {
+    expect(toShortDisplayName('claude-opus-4-6', 'Claude Opus 4.6')).toBe('Opus 4.6');
+    expect(toShortDisplayName('claude-sonnet-4-6', 'Claude Sonnet 4.6')).toBe('Sonnet 4.6');
+    expect(toShortDisplayName('claude-haiku-4-5-20251001', 'Claude Haiku 4.5')).toBe('Haiku 4.5');
+  });
+
+  it('appends 1M for extended context models', () => {
+    expect(toShortDisplayName('claude-opus-4-6[1m]', 'Claude Opus 4.6 1M')).toBe('Opus 4.6 1M');
+  });
+
+  it('handles dated model variants', () => {
+    expect(toShortDisplayName('claude-sonnet-4-6-20260301', 'Claude Sonnet 4.6')).toBe('Sonnet 4.6');
+  });
+
+  it('strips Claude prefix for unknown models', () => {
+    expect(toShortDisplayName('claude-future-model', 'Claude Future Model')).toBe('Future Model');
+  });
+
+  it('returns SDK displayName for non-Claude models', () => {
+    expect(toShortDisplayName('custom-model', 'My Custom Model')).toBe('My Custom Model');
+  });
+});
+
+describe('isNewModel', () => {
+  it('returns true for models in NEW_MODEL_IDS', () => {
+    expect(isNewModel('claude-opus-4-6[1m]')).toBe(true);
+  });
+
+  it('returns false for regular models', () => {
+    expect(isNewModel('claude-opus-4-6')).toBe(false);
+    expect(isNewModel('claude-sonnet-4-6')).toBe(false);
+  });
+});
+
+describe('isDefaultRecommended', () => {
+  it('returns true for "Default (recommended)"', () => {
+    expect(isDefaultRecommended('Default (recommended)')).toBe(true);
+  });
+
+  it('returns true for display names containing "default"', () => {
+    expect(isDefaultRecommended('The default model')).toBe(true);
+  });
+
+  it('returns true for display names containing "recommended"', () => {
+    expect(isDefaultRecommended('Recommended model')).toBe(true);
+  });
+
+  it('returns false for regular model names', () => {
+    expect(isDefaultRecommended('Claude Opus 4.6')).toBe(false);
+    expect(isDefaultRecommended('Claude Sonnet 4.6')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isDefaultRecommended('DEFAULT (RECOMMENDED)')).toBe(true);
+  });
+});
+
 describe('getModelInfo', () => {
   it('returns info for known static models', () => {
     const opus = getModelInfo('claude-opus-4-6');
     expect(opus).toBeDefined();
     expect(opus!.id).toBe('claude-opus-4-6');
-    expect(opus!.name).toBe('Claude Opus 4.6');
+    expect(opus!.name).toBe('Opus 4.6');
     expect(opus!.supportsThinking).toBe(true);
     expect(opus!.supportsEffort).toBe(true);
   });
@@ -124,104 +182,13 @@ describe('getModelInfo', () => {
   });
 });
 
-describe('isAutoModel', () => {
-  it('returns true for "Default (recommended)"', () => {
-    expect(isAutoModel('Default (recommended)')).toBe(true);
-  });
-
-  it('returns true for display names containing "default"', () => {
-    expect(isAutoModel('The default model')).toBe(true);
-  });
-
-  it('returns true for display names containing "recommended"', () => {
-    expect(isAutoModel('Recommended model')).toBe(true);
-  });
-
-  it('returns false for regular model names', () => {
-    expect(isAutoModel('Claude Opus 4.6')).toBe(false);
-    expect(isAutoModel('Claude Sonnet 4.6')).toBe(false);
-  });
-
-  it('is case-insensitive', () => {
-    expect(isAutoModel('DEFAULT (RECOMMENDED)')).toBe(true);
-  });
-});
-
-describe('resolveModelName', () => {
-  it('returns "Auto" for SDK default/recommended model', () => {
-    expect(resolveModelName('claude-opus-4-6', 'Default (recommended)')).toBe('Auto');
-  });
-
-  it('returns clean name for known static models', () => {
-    expect(resolveModelName('claude-opus-4-6', 'Claude Opus 4.6')).toBe('Claude Opus 4.6');
-    expect(resolveModelName('claude-sonnet-4-6', 'Claude Sonnet 4.6')).toBe('Claude Sonnet 4.6');
-  });
-
-  it('returns SDK displayName for unknown models', () => {
-    expect(resolveModelName('custom-model', 'My Custom Model')).toBe('My Custom Model');
-  });
-});
-
-describe('AUTO_MODEL_ID', () => {
-  it('getModelDisplayName returns "Auto"', () => {
-    expect(getModelDisplayName(AUTO_MODEL_ID)).toBe('Auto');
-  });
-
-  it('getModelInfo returns fallback capabilities when no SDK models', () => {
-    const info = getModelInfo(AUTO_MODEL_ID);
-    expect(info).toBeDefined();
-    expect(info!.id).toBe(AUTO_MODEL_ID);
-    expect(info!.name).toBe('Auto');
-    expect(info!.supportsThinking).toBe(true);
-    expect(info!.supportsEffort).toBe(true);
-    expect(info!.supportsFastMode).toBe(true);
-  });
-
-  it('getModelInfo resolves from SDK default model when available', async () => {
-    const { useAppStore } = await import('@/stores/appStore');
-
-    const spy = vi.spyOn(useAppStore, 'getState').mockReturnValue({
-      ...useAppStore.getState(),
-      supportedModels: [
-        {
-          value: 'claude-opus-4-6',
-          displayName: 'Default (recommended)',
-          description: 'Most capable',
-          supportsAdaptiveThinking: true,
-          supportsEffort: true,
-          supportedEffortLevels: ['low', 'medium', 'high', 'max'],
-          supportsFastMode: true,
-        },
-        {
-          value: 'claude-sonnet-4-6',
-          displayName: 'Claude Sonnet 4.6',
-          description: 'Fast',
-          supportsAdaptiveThinking: true,
-          supportsEffort: true,
-          supportsFastMode: true,
-        },
-      ],
-    } as ReturnType<typeof useAppStore.getState>);
-
-    try {
-      const info = getModelInfo(AUTO_MODEL_ID);
-      expect(info).toBeDefined();
-      expect(info!.id).toBe(AUTO_MODEL_ID);
-      expect(info!.name).toBe('Auto');
-      expect(info!.supportsThinking).toBe(true);
-    } finally {
-      spy.mockRestore();
-    }
-  });
-});
-
 describe('buildTurnConfigLabel', () => {
   it('returns null for empty metadata', () => {
     expect(buildTurnConfigLabel({})).toBeNull();
   });
 
   it('returns model display name only', () => {
-    expect(buildTurnConfigLabel({ model: 'claude-opus-4-6' })).toBe('Claude Opus 4.6');
+    expect(buildTurnConfigLabel({ model: 'claude-opus-4-6' })).toBe('Opus 4.6');
   });
 
   it('returns effort only', () => {
@@ -234,12 +201,12 @@ describe('buildTurnConfigLabel', () => {
 
   it('combines model and effort with separator', () => {
     const label = buildTurnConfigLabel({ model: 'claude-sonnet-4-6', effort: 'max' });
-    expect(label).toBe('Claude Sonnet 4.6 \u00b7 max effort');
+    expect(label).toBe('Sonnet 4.6 \u00b7 max effort');
   });
 
   it('combines all three parts', () => {
     const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', effort: 'high', permissionMode: 'plan' });
-    expect(label).toBe('Claude Opus 4.6 \u00b7 high effort \u00b7 plan mode');
+    expect(label).toBe('Opus 4.6 \u00b7 high effort \u00b7 plan mode');
   });
 
   it('handles Bedrock ARN in label', () => {
@@ -260,7 +227,7 @@ describe('buildTurnConfigLabel', () => {
 
   it('shows fast label when fastModeState is on', () => {
     const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', fastModeState: 'on' });
-    expect(label).toBe('Claude Opus 4.6 \u00b7 fast');
+    expect(label).toBe('Opus 4.6 \u00b7 fast');
   });
 
   it('shows cooldown label when fastModeState is cooldown', () => {
@@ -270,6 +237,6 @@ describe('buildTurnConfigLabel', () => {
 
   it('omits fast label when fastModeState is off', () => {
     const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', fastModeState: 'off' });
-    expect(label).toBe('Claude Opus 4.6');
+    expect(label).toBe('Opus 4.6');
   });
 });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,57 +1,74 @@
 import React from 'react';
 import { useAppStore } from '@/stores/appStore';
 
-/** Sentinel model ID meaning "let the SDK choose the best model". */
-export const AUTO_MODEL_ID = 'auto';
+// ---------------------------------------------------------------------------
+// Short name mapping
+// ---------------------------------------------------------------------------
 
-/** Static fallback model definitions used when no agent is connected. */
+/** Map known base model IDs → short display names (no "Claude" prefix). */
+const SHORT_NAME_MAP: Record<string, string> = {
+  'claude-opus-4-6': 'Opus 4.6',
+  'claude-sonnet-4-6': 'Sonnet 4.6',
+  'claude-haiku-4-5-20251001': 'Haiku 4.5',
+  'claude-haiku-4-5': 'Haiku 4.5',
+};
+
+/** Models that should show a "NEW" badge in the selector. */
+const NEW_MODEL_IDS = new Set(['claude-opus-4-6[1m]']);
+
+/**
+ * Convert an SDK model value + displayName to a short display name.
+ *
+ * Examples:
+ *   ("claude-opus-4-6", "Claude Opus 4.6")        → "Opus 4.6"
+ *   ("claude-opus-4-6[1m]", "Claude Opus 4.6 1M") → "Opus 4.6 1M"
+ *   ("claude-sonnet-4-6-20260301", "Sonnet 4.6")   → "Sonnet 4.6"
+ *   ("custom-model", "My Custom Model")             → "My Custom Model"
+ */
+export function toShortDisplayName(sdkValue: string, sdkDisplayName: string): string {
+  const has1M = sdkValue.includes('[1m]');
+  // Strip [1m] suffix and any trailing date (e.g. -20260301) to find the base ID
+  const baseId = sdkValue.replace(/\[1m\]$/, '').replace(/-20\d{6}$/, '');
+
+  let name = SHORT_NAME_MAP[baseId];
+  if (!name) {
+    // Fallback: strip "Claude " prefix from SDK display name
+    name = sdkDisplayName.replace(/^Claude\s+/i, '');
+  }
+  if (has1M && !name.includes('1M')) {
+    name += ' 1M';
+  }
+  return name;
+}
+
+/** Check whether a model should show the "NEW" badge. */
+export function isNewModel(sdkValue: string): boolean {
+  return NEW_MODEL_IDS.has(sdkValue);
+}
+
+/** Check whether an SDK entry is the "Default (recommended)" pseudo-model. */
+export function isDefaultRecommended(sdkDisplayName: string): boolean {
+  return /\bdefault\b/i.test(sdkDisplayName) || /\brecommended\b/i.test(sdkDisplayName);
+}
+
+// ---------------------------------------------------------------------------
+// Static fallback models (used before SDK connects)
+// ---------------------------------------------------------------------------
+
 export const MODELS = [
-  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
-  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
-  { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5', provider: 'claude', supportsThinking: true, supportsEffort: false, supportsFastMode: false },
+  { id: 'claude-opus-4-6', name: 'Opus 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
+  { id: 'claude-sonnet-4-6', name: 'Sonnet 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
+  { id: 'claude-haiku-4-5-20251001', name: 'Haiku 4.5', provider: 'claude', supportsThinking: true, supportsEffort: false, supportsFastMode: false },
 ] as const;
 
 export type ModelId = (typeof MODELS)[number]['id'];
 
-/** Check whether an SDK display name represents the auto/default model. */
-export function isAutoModel(sdkDisplayName: string): boolean {
-  return /\bdefault\b/i.test(sdkDisplayName) || /\brecommended\b/i.test(sdkDisplayName);
-}
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
 
 /**
- * Resolve a clean display name for an SDK-reported model.
- * - SDK "Default (recommended)" → "Auto"
- * - Known static models → our clean name (e.g. "Claude Opus 4.6")
- * - Unknown models → SDK displayName as-is
- */
-export function resolveModelName(sdkValue: string, sdkDisplayName: string): string {
-  if (isAutoModel(sdkDisplayName) || sdkValue === AUTO_MODEL_ID) {
-    return 'Auto';
-  }
-  const staticMatch = MODELS.find((m) => m.id === sdkValue);
-  if (staticMatch) return staticMatch.name;
-
-  // Pattern-based fallback for unknown SDK model IDs (e.g. future versions)
-  const val = sdkValue.toLowerCase();
-  if (val.includes('opus')) return 'Claude Opus 4.6';
-  if (val.includes('sonnet')) return 'Claude Sonnet 4.6';
-  if (val.includes('haiku')) return 'Claude Haiku 4.5';
-
-  return sdkDisplayName;
-}
-
-/**
- * Normalize an SDK-reported model value to the canonical ID used in the UI.
- * Models matching the "auto/default/recommended" heuristic map to AUTO_MODEL_ID.
- */
-export function normalizeModelId(m: { value: string; displayName: string }): string {
-  return isAutoModel(m.displayName) || m.value === AUTO_MODEL_ID ? AUTO_MODEL_ID : m.value;
-}
-
-/**
- * Deduplicate an array of objects by their `id` field, keeping the first occurrence.
- * The SDK may report the same logical model under multiple entries (e.g. both
- * "Default (recommended)" and the explicit auto sentinel).
+ * Deduplicate an array of objects by a given field, keeping the first occurrence.
  */
 export function deduplicateById<T extends { id: string }>(entries: T[]): T[] {
   const seen = new Set<string>();
@@ -62,6 +79,46 @@ export function deduplicateById<T extends { id: string }>(entries: T[]): T[] {
   });
 }
 
+/** Deduplicate by name, keeping the first occurrence. */
+export function deduplicateByName<T extends { name: string }>(entries: T[]): T[] {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    if (seen.has(entry.name)) return false;
+    seen.add(entry.name);
+    return true;
+  });
+}
+
+/** SDK model entry as reported by the agent. */
+interface SdkModelEntry {
+  value: string;
+  displayName: string;
+  supportsAdaptiveThinking?: boolean;
+  supportsEffort?: boolean;
+  supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
+  supportsFastMode?: boolean;
+}
+
+/**
+ * Build a deduplicated model ID list from SDK-reported models.
+ * Filters out the "Default (recommended)" pseudo-model, deduplicates by ID,
+ * then deduplicates by resolved display name (dated variants collapse).
+ * Falls back to static MODELS when no SDK models are available.
+ */
+export function buildDeduplicatedModelIds(dynamic: SdkModelEntry[]): string[] {
+  if (dynamic.length === 0) return MODELS.map((m) => m.id);
+  const entries = deduplicateById(
+    dynamic
+      .filter((m) => !isDefaultRecommended(m.displayName))
+      .map((m) => ({ id: m.value, name: toShortDisplayName(m.value, m.displayName) }))
+  );
+  return deduplicateByName(entries).map((e) => e.id);
+}
+
+// ---------------------------------------------------------------------------
+// Model entry types
+// ---------------------------------------------------------------------------
+
 /** Model entry used for UI model selectors and keyboard shortcut cycling. */
 export interface ModelEntry {
   id: string;
@@ -71,6 +128,7 @@ export interface ModelEntry {
   supportsEffort: boolean;
   supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
   supportsFastMode?: boolean;
+  isNew?: boolean;
 }
 
 export interface DynamicModelInfo {
@@ -83,38 +141,26 @@ export interface DynamicModelInfo {
   supportsFastMode?: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Model info lookups
+// ---------------------------------------------------------------------------
+
 /**
  * Get model info by ID. Checks SDK-reported dynamic models first,
  * falls back to hardcoded MODELS for offline/pre-connection state.
  */
 export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
-  // Check dynamic models from SDK
   const dynamic = useAppStore.getState().supportedModels;
-  // For 'auto', find the SDK's default/recommended model
-  const sdkModel = modelId === AUTO_MODEL_ID
-    ? dynamic.find((m) => isAutoModel(m.displayName))
-    : dynamic.find((m) => m.value === modelId);
+  const sdkModel = dynamic.find((m) => m.value === modelId);
   if (sdkModel) {
     return {
-      id: modelId === AUTO_MODEL_ID ? AUTO_MODEL_ID : sdkModel.value,
-      name: resolveModelName(sdkModel.value, sdkModel.displayName),
+      id: sdkModel.value,
+      name: toShortDisplayName(sdkModel.value, sdkModel.displayName),
       provider: 'claude',
       supportsThinking: sdkModel.supportsAdaptiveThinking ?? true,
       supportsEffort: sdkModel.supportsEffort ?? false,
       supportedEffortLevels: sdkModel.supportedEffortLevels,
       supportsFastMode: sdkModel.supportsFastMode,
-    };
-  }
-
-  // Auto fallback when SDK hasn't connected yet
-  if (modelId === AUTO_MODEL_ID) {
-    return {
-      id: AUTO_MODEL_ID,
-      name: 'Auto',
-      provider: 'claude',
-      supportsThinking: true,
-      supportsEffort: true,
-      supportsFastMode: true,
     };
   }
 
@@ -135,7 +181,6 @@ export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
 }
 
 export function getModelDisplayName(modelId: string): string {
-  if (modelId === AUTO_MODEL_ID) return 'Auto';
   const info = getModelInfo(modelId);
   if (info) return info.name;
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -83,11 +83,11 @@ export const SETTINGS_DEFAULTS = {
   autoExpandEditDiffs: true,
   zenMode: false,
   // AI & Models
-  defaultModel: 'auto',
+  defaultModel: 'claude-sonnet-4-6',
   defaultThinkingLevel: 'high' as ThinkingLevel,
   maxThinkingTokens: 16000,
   showThinkingBlocks: true,
-  reviewModel: 'auto',
+  reviewModel: 'claude-haiku-4-5-20251001',
   reviewActionableOnly: false,
   defaultPlanMode: false,
   defaultFastMode: false,
@@ -504,6 +504,14 @@ export const useSettingsStore = create<SettingsState>()(
         if (merged.layoutVertical && 'bottom-terminal' in merged.layoutVertical) {
           const { 'bottom-terminal': _, ...rest } = merged.layoutVertical;
           merged.layoutVertical = Object.keys(rest).length > 0 ? rest : undefined;
+        }
+
+        // Migrate legacy 'auto' model to concrete model ID
+        if (merged.defaultModel === 'auto') {
+          merged.defaultModel = 'claude-sonnet-4-6';
+        }
+        if (merged.reviewModel === 'auto') {
+          merged.reviewModel = 'claude-haiku-4-5-20251001';
         }
 
         return merged;


### PR DESCRIPTION
## Summary

- **Remove the "Auto" pseudo-model** — all model selections are now concrete IDs. The SDK's "Default (recommended)" pseudo-entry is filtered out instead of being mapped to a synthetic `AUTO_MODEL_ID` sentinel.
- **Short display names** — model names in the UI now show "Opus 4.6" instead of "Claude Opus 4.6" via `toShortDisplayName()`, saving horizontal space in the toolbar.
- **Centralized dedup** — extracted `deduplicateByName()` and `buildDeduplicatedModelIds()` into `models.ts` so ChatInput, AIModelSettings, and CommandPalette all share the same filtering/dedup pipeline. Previously CommandPalette was missing name-based dedup, which could cycle through invisible dated variants.
- **Alt+1..9 model shortcuts** — replaced Alt+M cycling with direct Alt+1..9 selection, with kbd hints in the dropdown (capped at 9 to match available shortcuts).
- **Context meter fix** — removed `model?.includes('opus')` heuristic that incorrectly set 1M context window for standard Opus (200K). Only the `[1m]` suffix correctly signals extended context.
- **Settings migration** — persisted `'auto'` values are migrated to `claude-sonnet-4-6` (default model) and `claude-haiku-4-5-20251001` (review model).
- **UI polish** — "Claude Code" section label in model dropdown, Sparkles icon, NEW badge support.

## Test plan

- [ ] Verify model dropdown shows deduplicated short names (Opus 4.6, Sonnet 4.6, Haiku 4.5)
- [ ] Verify Alt+1, Alt+2, Alt+3 select models correctly
- [ ] Verify CommandPalette "Cycle Model" cycles through the same list as the dropdown
- [ ] Verify context meter shows 200K for standard Opus, 1M only for `[1m]` models
- [ ] Verify settings page model selectors show correct options
- [ ] Verify existing users with `'auto'` setting get migrated on app launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)