### PR TITLE
feat: add tool approval system for non-bypass permission modes

### DIFF
--- a/agent-runner/pnpm-lock.yaml
+++ b/agent-runner/pnpm-lock.yaml
@@ -1,0 +1,232 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.76
+        version: 0.2.81(zod@4.3.6)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@anthropic-ai/claude-agent-sdk@0.2.81':
+    resolution: {integrity: sha512-CBeebgibBEN/DWOQGZN67vhuTG55RbI1hlsFSSoZ4uA/Io3lw04eHTE2ISCmdbqyJaefYTt6GKZei1nP0TQMNw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@anthropic-ai/claude-agent-sdk@0.2.81(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
+
+  zod@4.3.6: {}

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -49,8 +49,10 @@ import {
   type ElicitationResultHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 import * as readline from "readline";
+import * as fs from "fs";
 import { WorkspaceContext } from "./mcp/context.js";
 import { createChatMLMcpServer } from "./mcp/server.js";
+import { buildSpecifier, evaluateRules, type PermissionRule } from "./rules.js";
 
 function resolveToolPreset(preset: string): { allowedTools?: string[]; disallowedTools?: string[] } {
   switch (preset) {
@@ -173,7 +175,8 @@ let prePlanPermissionMode: PermissionMode = "bypassPermissions";
     if ((validPermissionModes as readonly string[]).includes(value)) {
       initialPermissionMode = value as PermissionMode;
     } else {
-      console.error(`Invalid --permission-mode value: "${value}". Using default "bypassPermissions".`);
+      console.error(`Invalid --permission-mode value: "${value}". Falling back to "default" (fail-closed).`);
+      initialPermissionMode = "default";
     }
   }
   currentPermissionMode = initialPermissionMode;
@@ -251,7 +254,7 @@ interface Attachment {
 
 // Input message types from Go backend
 interface InputMessage {
-  type: "message" | "stop" | "interrupt" | "set_model" | "set_permission_mode" | "set_max_thinking_tokens" | "set_fast_mode" | "get_supported_models" | "get_supported_commands" | "get_mcp_status" | "get_account_info" | "rewind_files" | "user_question_response" | "plan_approval_response" | "sprint_phase_response" | "reconnect_mcp_server" | "toggle_mcp_server" | "stop_task" | "get_supported_agents" | "set_mcp_servers" | "get_initialization_result" | "fork_session" | "cancel_message";
+  type: "message" | "stop" | "interrupt" | "set_model" | "set_permission_mode" | "set_max_thinking_tokens" | "set_fast_mode" | "get_supported_models" | "get_supported_commands" | "get_mcp_status" | "get_account_info" | "rewind_files" | "user_question_response" | "plan_approval_response" | "sprint_phase_response" | "tool_approval_response" | "reconnect_mcp_server" | "toggle_mcp_server" | "stop_task" | "get_supported_agents" | "set_mcp_servers" | "get_initialization_result" | "fork_session" | "cancel_message";
   content?: string;
   model?: string;
   permissionMode?: string;
@@ -264,6 +267,10 @@ interface InputMessage {
   planApprovalRequestId?: string;
   planApproved?: boolean;
   planApprovalReason?: string;
+  // Tool approval response fields
+  toolApprovalRequestId?: string;
+  toolApprovalAction?: string;
+  toolApprovalSpecifier?: string;
   // Max thinking tokens override
   maxThinkingTokens?: number;
   // MCP server management fields (SDK v0.2.21+)
@@ -422,6 +429,50 @@ let sprintPhaseRequestCounter = 0;
 let lastSprintPhaseApprovalTime = 0;
 let lastApprovedSprintPhase: string | null = null;
 const SPRINT_PHASE_COOLDOWN_MS = 5_000; // 5 seconds — tight window for SDK retries only
+
+// Pending tool approval requests (for non-bypass permission modes)
+const TOOL_APPROVAL_TIMEOUT_MS = 60_000; // 60 seconds — matches SDK's canUseTool timeout
+
+interface ToolApprovalResult {
+  action: "allow_once" | "allow_session" | "allow_always" | "deny_once" | "deny_always";
+  specifier?: string;
+}
+interface PendingToolApprovalRequest {
+  resolve: (result: ToolApprovalResult) => void;
+  reject: (error: Error) => void;
+}
+const pendingToolApprovalRequests = new Map<string, PendingToolApprovalRequest>();
+let toolApprovalRequestCounter = 0;
+
+// Session-scoped approvals: populated when user chooses "allow_session" or "deny_session".
+// Key format: "ToolName" or "ToolName:specifier" — value is the decision.
+const sessionApprovals = new Map<string, "allow" | "deny">();
+
+// Persistent permission rules loaded at startup from --permission-rules-file.
+let persistentRules: PermissionRule[] = [];
+{
+  const rulesFilePath = getArg("--permission-rules-file");
+  if (rulesFilePath) {
+    try {
+      const raw = fs.readFileSync(rulesFilePath, "utf-8");
+      persistentRules = JSON.parse(raw) as PermissionRule[];
+    } catch (err) {
+      console.error(`Failed to load permission rules from ${rulesFilePath}:`, err);
+    }
+  }
+}
+
+// Read-only and meta tools that never need approval in interactive modes.
+// NOTE: These bypass ALL permission rules (including deny rules). Users cannot
+// configure deny rules for these tools — they are always auto-allowed.
+const READ_ONLY_TOOLS = new Set([
+  "Read", "Glob", "Grep", "TodoWrite",
+  "AskUserQuestion", "ExitPlanMode", "EnterPlanMode",
+]);
+
+// Tools that make external network calls — auto-allowed in most modes but
+// blocked in dontAsk mode to prevent data exfiltration.
+const NETWORK_TOOLS = new Set(["WebSearch"]);
 
 // Track the last file written during plan mode so we can include plan content
 // in the plan_approval_request event when ExitPlanMode fires.
@@ -789,6 +840,24 @@ function setupInputQueue(): void {
           emit({
             type: "warning",
             message: `Received response for unknown sprint phase request: ${input.questionRequestId}`,
+          });
+        }
+        return;
+      }
+
+      // Handle tool approval responses from the Go backend
+      if (input.type === "tool_approval_response" && input.toolApprovalRequestId) {
+        const pending = pendingToolApprovalRequests.get(input.toolApprovalRequestId);
+        if (pending) {
+          pendingToolApprovalRequests.delete(input.toolApprovalRequestId);
+          pending.resolve({
+            action: (input.toolApprovalAction || "deny_once") as ToolApprovalResult["action"],
+            specifier: input.toolApprovalSpecifier,
+          });
+        } else {
+          emit({
+            type: "warning",
+            message: `Received response for unknown tool approval request: ${input.toolApprovalRequestId}`,
           });
         }
         return;
@@ -1771,9 +1840,10 @@ const PLAN_MODE_DENIED_TOOLS = new Set([
   "Write", "Edit", "Bash", "NotebookEdit",
 ]);
 
-// Permission callback — enforces plan mode restrictions as defense-in-depth.
-// In bypassPermissions mode the SDK auto-allows all tools before reaching this.
-// In plan mode the SDK should enforce restrictions natively, but we double-check here.
+// Permission callback — enforces plan mode restrictions and tool approval flow.
+// In bypassPermissions mode all tools are auto-allowed (existing behavior).
+// In other modes, tools are checked against session approvals, persistent rules,
+// and if no rule matches, the user is prompted via tool_approval_request events.
 const canUseTool: CanUseTool = async (toolName, toolInput, _options) => {
   // Defense-in-depth: if AskUserQuestion reaches canUseTool with cached answers,
   // provide them via updatedInput. In bypassPermissions mode (the default), the SDK
@@ -1784,11 +1854,102 @@ const canUseTool: CanUseTool = async (toolName, toolInput, _options) => {
     lastQuestionAnswers = null; // Consume once
     return { behavior: "allow", updatedInput: { ...toolInput, answers } };
   }
+
+  // Plan mode: block write/execute tools
   if (currentPermissionMode === "plan" && PLAN_MODE_DENIED_TOOLS.has(toolName)) {
     return { behavior: "deny", message: "This tool is not available in plan mode. Present your plan using ExitPlanMode first." };
   }
-  // SDK 0.2.72: updatedInput is still required in PermissionResult — pass through toolInput
-  return { behavior: "allow", updatedInput: toolInput };
+
+  // Bypass mode: allow everything (existing behavior, unchanged)
+  if (currentPermissionMode === "bypassPermissions") {
+    return { behavior: "allow", updatedInput: toolInput };
+  }
+
+  // Read-only and meta tools never need approval
+  if (READ_ONLY_TOOLS.has(toolName)) {
+    return { behavior: "allow", updatedInput: toolInput };
+  }
+
+  // Network tools (e.g., WebSearch) are auto-allowed except in dontAsk mode
+  // where they could exfiltrate codebase context via search queries.
+  if (NETWORK_TOOLS.has(toolName) && currentPermissionMode !== "dontAsk") {
+    return { behavior: "allow", updatedInput: toolInput };
+  }
+
+  // Build specifier for rule matching
+  const specifier = buildSpecifier(toolName, toolInput);
+  const ruleKey = specifier ? `${toolName}:${specifier}` : toolName;
+
+  // Check session-scoped approvals (populated by allow_session/deny_session responses)
+  const sessionResult = sessionApprovals.get(ruleKey);
+  if (sessionResult === "allow") {
+    return { behavior: "allow", updatedInput: toolInput };
+  }
+  if (sessionResult === "deny") {
+    return { behavior: "deny", message: `Denied by session rule: ${ruleKey}` };
+  }
+
+  // Check persistent rules (deny → ask → allow, per Claude Code convention)
+  const ruleResult = evaluateRules(persistentRules, toolName, specifier);
+  if (ruleResult === "deny") {
+    return { behavior: "deny", message: `Denied by permission rule` };
+  }
+  if (ruleResult === "allow") {
+    return { behavior: "allow", updatedInput: toolInput };
+  }
+
+  // acceptEdits mode: auto-allow file modifications, prompt for Bash/MCP/other
+  if (currentPermissionMode === "acceptEdits") {
+    if (["Write", "Edit", "NotebookEdit"].includes(toolName)) {
+      return { behavior: "allow", updatedInput: toolInput };
+    }
+  }
+
+  // dontAsk mode: deny anything not pre-approved by rules above
+  if (currentPermissionMode === "dontAsk") {
+    return { behavior: "deny", message: "Tool not pre-approved in dontAsk mode" };
+  }
+
+  // default mode (or acceptEdits for non-edit tools): prompt the user
+  const requestId = `tar-${++toolApprovalRequestCounter}-${Date.now()}`;
+  emit({
+    type: "tool_approval_request",
+    requestId,
+    toolName,
+    toolInput,
+    specifier: specifier || undefined,
+  });
+
+  try {
+    const result = await new Promise<ToolApprovalResult>((resolve, reject) => {
+      pendingToolApprovalRequests.set(requestId, { resolve, reject });
+      setTimeout(() => {
+        if (pendingToolApprovalRequests.has(requestId)) {
+          pendingToolApprovalRequests.delete(requestId);
+          reject(new Error("Tool approval timed out after 60 seconds"));
+        }
+      }, TOOL_APPROVAL_TIMEOUT_MS);
+    });
+
+    // Process the user's decision
+    if (result.action === "allow_session" || result.action === "allow_always") {
+      // Cache in session so subsequent calls don't re-prompt.
+      // TODO: allow_always should also be persisted to the permission rules file by the Go backend.
+      sessionApprovals.set(ruleKey, "allow");
+    } else if (result.action === "deny_always" || result.action === "deny_once") {
+      if (result.action === "deny_always") {
+        // TODO: deny_always should also be persisted to the permission rules file by the Go backend.
+        sessionApprovals.set(ruleKey, "deny");
+      }
+      return { behavior: "deny", message: "User denied tool execution" };
+    }
+
+    // allow_once, allow_session, allow_always all result in allow
+    return { behavior: "allow", updatedInput: toolInput };
+  } catch {
+    // Timeout or cancellation — deny
+    return { behavior: "deny", message: "Tool approval timed out or was cancelled" };
+  }
 };
 
 // Hooks configuration - all always enabled

--- a/agent-runner/src/rules.ts
+++ b/agent-runner/src/rules.ts
@@ -1,0 +1,147 @@
+/**
+ * Permission rule evaluation for tool approval.
+ *
+ * Rules follow Claude Code's convention:
+ *   - Format: Tool or Tool(specifier)
+ *   - Evaluation order: deny → ask → allow (first match wins)
+ *   - Specifiers support glob wildcards (*)
+ */
+
+export interface PermissionRule {
+  id: string;
+  tool: string; // "Bash", "Read", "Write", "Edit", etc.
+  specifier: string; // "npm run *", "./.env", "domain:example.com", "" for match-all
+  action: "allow" | "deny" | "ask";
+  scope: "user" | "workspace";
+  workspaceId?: string;
+}
+
+/**
+ * Build a specifier string from a tool's input, used for rule matching.
+ * Returns null if no meaningful specifier can be extracted.
+ */
+export function buildSpecifier(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): string | null {
+  switch (toolName) {
+    case "Bash":
+      return (toolInput.command as string) || null;
+    case "Read":
+    case "Write":
+    case "Edit":
+    case "NotebookEdit":
+      return (toolInput.file_path as string) || null;
+    case "WebFetch": {
+      const url = toolInput.url as string;
+      if (!url) return null;
+      try {
+        return `domain:${new URL(url).hostname}`;
+      } catch {
+        return null;
+      }
+    }
+    case "Glob":
+      return (toolInput.pattern as string) || null;
+    case "Grep":
+      return (toolInput.pattern as string) || null;
+    default:
+      // MCP tools: mcp__server__tool — use tool name as specifier
+      if (toolName.startsWith("mcp__")) return toolName;
+      return null;
+  }
+}
+
+/**
+ * Evaluate rules against a tool invocation.
+ * Returns the matching action or null if no rule matches.
+ * Evaluation order: deny → ask → allow (first match wins within each tier).
+ */
+export function evaluateRules(
+  rules: PermissionRule[],
+  toolName: string,
+  specifier: string | null,
+): "allow" | "deny" | "ask" | null {
+  // Phase 1: deny rules
+  for (const rule of rules) {
+    if (rule.action === "deny" && matchesRule(rule, toolName, specifier)) {
+      return "deny";
+    }
+  }
+  // Phase 2: ask rules
+  for (const rule of rules) {
+    if (rule.action === "ask" && matchesRule(rule, toolName, specifier)) {
+      return "ask";
+    }
+  }
+  // Phase 3: allow rules
+  for (const rule of rules) {
+    if (rule.action === "allow" && matchesRule(rule, toolName, specifier)) {
+      return "allow";
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a single rule matches the given tool name and specifier.
+ */
+function matchesRule(
+  rule: PermissionRule,
+  toolName: string,
+  specifier: string | null,
+): boolean {
+  if (rule.tool !== toolName) return false;
+  // Bare tool name (no specifier) matches all uses of the tool
+  if (!rule.specifier) return true;
+  // If rule has a specifier but the tool call has none, no match
+  if (!specifier) return false;
+  return wildcardMatch(rule.specifier, specifier);
+}
+
+/**
+ * Glob-style wildcard matching (iterative, no regex — immune to ReDoS).
+ * Supports `*` as a wildcard that matches any sequence of characters.
+ *
+ * Following Claude Code conventions:
+ *   - `Bash(ls *)` matches "ls -la" but not "lsof" (space before * = word boundary)
+ *   - `Bash(ls*)` matches both "ls -la" and "lsof"
+ *   - Multiple wildcards are supported: `git * main` matches "git checkout main"
+ *
+ * Uses a two-pointer greedy algorithm with backtracking anchored at the last `*`.
+ */
+export function wildcardMatch(pattern: string, value: string): boolean {
+  let pi = 0; // pattern index
+  let vi = 0; // value index
+  let starPi = -1; // last * position in pattern
+  let matchVi = -1; // value index when last * was seen
+
+  while (vi < value.length) {
+    if (pi < pattern.length && pattern[pi] === "*") {
+      // Record * position and advance pattern
+      starPi = pi;
+      matchVi = vi;
+      pi++;
+    } else if (pi < pattern.length && pattern[pi] === value[vi]) {
+      // Characters match — advance both
+      pi++;
+      vi++;
+    } else if (starPi !== -1) {
+      // Mismatch but we have a prior * — backtrack:
+      // let * consume one more character from value
+      pi = starPi + 1;
+      matchVi++;
+      vi = matchVi;
+    } else {
+      // Mismatch with no * to fall back on
+      return false;
+    }
+  }
+
+  // Consume any trailing *s in the pattern
+  while (pi < pattern.length && pattern[pi] === "*") {
+    pi++;
+  }
+
+  return pi === pattern.length;
+}

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -191,6 +191,7 @@ type StartConversationOptions struct {
 	FastMode          bool                // Enable fast output mode (Opus 4.6+)
 	Instructions      string              // Additional instructions (e.g., from conversation summaries)
 	Model             string              // Model name override (e.g., "claude-opus-4-6", "claude-sonnet-4-6")
+	PermissionMode    string              // Permission mode: default, acceptEdits, bypassPermissions, dontAsk (empty = bypassPermissions)
 }
 
 // StartConversation creates and starts a new conversation within a session
@@ -310,6 +311,7 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 		procOpts.MaxThinkingTokens = opts.MaxThinkingTokens
 		procOpts.Effort = opts.Effort
 		procOpts.PlanMode = opts.PlanMode
+		procOpts.PermissionMode = opts.PermissionMode
 		procOpts.FastMode = opts.FastMode
 		procOpts.Model = opts.Model
 	}

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -142,6 +142,10 @@ type AgentEvent struct {
 	// Sprint phase proposal fields (update_sprint_phase tool)
 	Phase string `json:"phase,omitempty"`
 
+	// Tool approval fields (non-bypass permission modes)
+	ToolInput interface{} `json:"toolInput,omitempty"`
+	Specifier string     `json:"specifier,omitempty"`
+
 	// Input suggestion fields (Haiku-generated prompt suggestions)
 	GhostText string              `json:"ghostText,omitempty"`
 	Pills     []ai.SuggestionPill `json:"pills,omitempty"`
@@ -355,6 +359,9 @@ const (
 	// Plan approval events (ExitPlanMode tool)
 	EventTypePlanApprovalRequest  = "plan_approval_request"
 	EventTypeSprintPhaseProposal = "sprint_phase_proposal"
+
+	// Tool approval events (non-bypass permission modes)
+	EventTypeToolApprovalRequest = "tool_approval_request"
 
 	// Command error (SDK runtime command failed)
 	EventTypeCommandError = "command_error"

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -50,6 +50,7 @@ type ProcessOptions struct {
 	MaxThinkingTokens   int
 	Effort              string // Reasoning effort: low, medium, high, max
 	PlanMode            bool   // Start agent in plan mode
+	PermissionMode      string // Permission mode: default, acceptEdits, bypassPermissions, dontAsk (empty = bypassPermissions)
 	FastMode            bool   // Enable fast output mode (Opus 4.6+)
 	Instructions        string // Additional instructions for the agent (e.g., conversation summaries)
 	StructuredOutput    string
@@ -62,6 +63,7 @@ type ProcessOptions struct {
 	EnvVars             map[string]string // Custom environment variables to inject
 	McpServersJSON      string            // JSON array of MCP server configs
 	AgentsJSON          string            // JSON object of programmatic agent definitions (SDK 0.2.62+)
+	PermissionRulesFile string            // Path to JSON file with persistent permission rules
 }
 
 type Process struct {
@@ -117,6 +119,10 @@ type InputMessage struct {
 	FastMode *bool `json:"fastMode,omitempty"`
 	// Sprint phase response fields (for update_sprint_phase tool)
 	Approved *bool `json:"approved,omitempty"`
+	// Tool approval response fields (for non-bypass permission modes)
+	ToolApprovalRequestID string `json:"toolApprovalRequestId,omitempty"`
+	ToolApprovalAction    string `json:"toolApprovalAction,omitempty"`
+	ToolApprovalSpecifier string `json:"toolApprovalSpecifier,omitempty"`
 }
 
 // findAgentRunner locates the agent-runner executable
@@ -227,6 +233,21 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	}
 	if opts.PlanMode {
 		args = append(args, "--permission-mode", "plan")
+	} else if opts.PermissionMode != "" && opts.PermissionMode != "bypassPermissions" {
+		// Non-default permission mode (e.g., "default", "acceptEdits", "dontAsk")
+		args = append(args, "--permission-mode", opts.PermissionMode)
+	}
+	// Pass permission rules file if provided.
+	// SECURITY: Validate the path is absolute and doesn't escape via symlinks.
+	// Currently unused (no caller sets PermissionRulesFile) — validation is
+	// defense-in-depth for when persistence is wired up.
+	if opts.PermissionRulesFile != "" {
+		cleanPath := filepath.Clean(opts.PermissionRulesFile)
+		if !filepath.IsAbs(cleanPath) {
+			fmt.Printf("WARNING: PermissionRulesFile must be an absolute path, got %q — skipping\n", opts.PermissionRulesFile)
+		} else {
+			args = append(args, "--permission-rules-file", cleanPath)
+		}
 	}
 	if opts.FastMode {
 		args = append(args, "--fast-mode")
@@ -687,6 +708,17 @@ func (p *Process) SendSprintPhaseResponse(requestId string, approved bool) error
 		Type:              "sprint_phase_response",
 		QuestionRequestID: requestId,
 		Approved:          &approved,
+	})
+}
+
+// SendToolApprovalResponse sends the user's approval/denial decision for a tool execution request.
+// Used in non-bypass permission modes (default, acceptEdits) when a tool needs user approval.
+func (p *Process) SendToolApprovalResponse(requestId, action, specifier string) error {
+	return p.sendInput(InputMessage{
+		Type:                  "tool_approval_response",
+		ToolApprovalRequestID: requestId,
+		ToolApprovalAction:    action,
+		ToolApprovalSpecifier: specifier,
 	})
 }
 

--- a/backend/server/conversation_handlers.go
+++ b/backend/server/conversation_handlers.go
@@ -48,6 +48,7 @@ type CreateConversationRequest struct {
 	Message           string              `json:"message"`           // Initial message (optional)
 	Model             string              `json:"model"`             // Model name override (optional)
 	PlanMode          bool                `json:"planMode"`          // Start in plan mode (optional)
+	PermissionMode    string              `json:"permissionMode"`    // Permission mode: default, acceptEdits, bypassPermissions, dontAsk (optional)
 	FastMode          bool                `json:"fastMode"`          // Enable fast output mode (optional)
 	MaxThinkingTokens int                 `json:"maxThinkingTokens"` // Enable extended thinking (optional)
 	Effort            string              `json:"effort"`            // Reasoning effort: low, medium, high, max (optional)
@@ -189,14 +190,27 @@ func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
 		req.Effort = ""
 	}
 
+	// Validate permissionMode if provided
+	if req.PermissionMode != "" {
+		validPermissionModes := map[string]bool{
+			"default": true, "acceptEdits": true,
+			"bypassPermissions": true, "dontAsk": true,
+		}
+		if !validPermissionModes[req.PermissionMode] {
+			writeValidationError(w, "permissionMode must be one of: default, acceptEdits, bypassPermissions, dontAsk")
+			return
+		}
+	}
+
 	// Build options for starting the conversation
 	var opts *agent.StartConversationOptions
-	if req.MaxThinkingTokens > 0 || len(req.Attachments) > 0 || req.PlanMode || req.FastMode || instructions != "" || req.Model != "" || req.Effort != "" {
+	if req.MaxThinkingTokens > 0 || len(req.Attachments) > 0 || req.PlanMode || req.FastMode || instructions != "" || req.Model != "" || req.Effort != "" || req.PermissionMode != "" {
 		opts = &agent.StartConversationOptions{
 			MaxThinkingTokens: req.MaxThinkingTokens,
 			Effort:            req.Effort,
 			Attachments:       req.Attachments,
 			PlanMode:          req.PlanMode,
+			PermissionMode:    req.PermissionMode,
 			FastMode:          req.FastMode,
 			Instructions:      instructions,
 			Model:             req.Model,
@@ -751,6 +765,52 @@ func (h *Handlers) ApprovePlan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, map[string]bool{"approved": req.Approved})
+}
+
+// ToolApprovalRequest represents user approval/denial of a tool execution request
+type ToolApprovalRequest struct {
+	RequestID string `json:"requestId"`
+	Action    string `json:"action"`              // allow_once, allow_session, allow_always, deny_once, deny_always
+	Specifier string `json:"specifier,omitempty"` // Tool-specific specifier (e.g., "npm run *")
+}
+
+func (h *Handlers) ApproveTool(w http.ResponseWriter, r *http.Request) {
+	convID := chi.URLParam(r, "convId")
+
+	var req ToolApprovalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	if req.RequestID == "" {
+		writeValidationError(w, "requestId is required")
+		return
+	}
+
+	validActions := map[string]bool{
+		"allow_once": true, "allow_session": true, "allow_always": true,
+		"deny_once": true, "deny_always": true,
+	}
+	if !validActions[req.Action] {
+		writeValidationError(w, "action must be one of: allow_once, allow_session, allow_always, deny_once, deny_always")
+		return
+	}
+
+	// Get the process for this conversation
+	proc := h.agentManager.GetConversationProcess(convID)
+	if proc == nil {
+		writeNotFound(w, "no active process for conversation")
+		return
+	}
+
+	// Send the approval/denial to the agent process
+	if err := proc.SendToolApprovalResponse(req.RequestID, req.Action, req.Specifier); err != nil {
+		writeInternalError(w, "failed to send tool approval", err)
+		return
+	}
+
+	writeJSON(w, map[string]string{"action": req.Action})
 }
 
 // Summary handlers

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -233,6 +233,7 @@ func NewRouter(ctx context.Context, s *store.SQLiteStore, hub *Hub, agentMgr *ag
 		r.Post("/{convId}/fast-mode", h.SetConversationFastMode)
 		r.Post("/{convId}/max-thinking-tokens", h.SetConversationMaxThinkingTokens)
 		r.Post("/{convId}/approve-plan", h.ApprovePlan)
+		r.Post("/{convId}/approve-tool", h.ApproveTool)
 		r.Post("/{convId}/answer-question", h.AnswerConversationQuestion)
 		r.Post("/{convId}/answer-sprint-phase", h.AnswerSprintPhaseProposal)
 		r.Post("/{convId}/resume-agent", h.ResumeAgent)

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -36,6 +36,7 @@ import { useChatInputAttachments } from './useChatInputAttachments';
 import { useChatInputKeyboardShortcuts } from './useChatInputKeyboardShortcuts';
 import { ChatInputPillSuggestions } from './ChatInputPillSuggestions';
 import { ChatInputPlanApproval } from './ChatInputPlanApproval';
+import { ToolApprovalBanner } from './ToolApprovalBanner';
 import { ChatInputToolbar } from './ChatInputToolbar';
 
 // Flat file type for mention items
@@ -143,6 +144,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const [planModeEnabled, setPlanModeEnabled] = useState(defaultPlanMode);
   const defaultFastMode = useSettingsStore((s) => s.defaultFastMode);
   const [fastModeEnabled, setFastModeEnabled] = useState(defaultFastMode);
+  const defaultPermissionMode = useSettingsStore((s) => s.defaultPermissionMode);
+  const setDefaultPermissionMode = useSettingsStore((s) => s.setDefaultPermissionMode);
+  const [permissionMode, setPermissionMode] = useState(defaultPermissionMode);
   const sendWithEnter = useSettingsStore((s) => s.sendWithEnter);
   const suggestionsEnabled = useSettingsStore((s) => s.suggestionsEnabled);
   const autoSubmitPill = useSettingsStore((s) => s.autoSubmitPillSuggestion);
@@ -360,6 +364,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
   // Check if there's a pending plan approval request
   const pendingPlanApproval = streamingInput.pendingPlanApproval;
+
+  // Check if there's a pending tool approval request
+  const pendingToolApproval = streamingInput.pendingToolApproval;
 
   // Derive compose button mode from streaming + text + queue state
   const hasText = message.trim().length > 0;
@@ -728,6 +735,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           message: trimmedContent,
           model: selectedModel.id,
           planMode: planModeEnabled ? true : undefined,
+          // TODO: permissionMode is only set on creation — changing the setting mid-session
+          // won't affect existing conversations (unlike model/fastMode which have set_* messages).
+          permissionMode: permissionMode !== 'bypassPermissions' ? permissionMode : undefined,
           fastMode: fastModeEnabled ? true : undefined,
           maxThinkingTokens: thinkingParams.maxThinkingTokens,
           effort: thinkingParams.effort,
@@ -935,6 +945,11 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         />
       )}
 
+      {/* Tool Approval Banner */}
+      {pendingToolApproval && selectedConversationId && !pendingPlanApproval && (
+        <ToolApprovalBanner conversationId={selectedConversationId} />
+      )}
+
       <div className={cn(
         'relative',
         pendingPlanApproval && 'plan-approval-border'
@@ -1084,6 +1099,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             defaultLevel: defaultThinkingLevel,
             setLevel: setThinkingLevel,
             setDefault: setDefaultThinkingLevel,
+          }}
+          permissionMode={{
+            mode: permissionMode,
+            defaultMode: defaultPermissionMode,
+            setMode: setPermissionMode,
+            setDefault: setDefaultPermissionMode,
           }}
           planModeEnabled={planModeEnabled}
           onPlanModeToggle={handlePlanModeToggle}

--- a/src/components/conversation/ChatInputToolbar.tsx
+++ b/src/components/conversation/ChatInputToolbar.tsx
@@ -22,6 +22,7 @@ import {
   Check,
   Star,
   Sparkles,
+  Shield,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
@@ -63,9 +64,26 @@ export interface ActionButtonProps {
   onStop: () => void;
 }
 
+export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk';
+
+export interface PermissionModeProps {
+  mode: PermissionMode;
+  defaultMode: PermissionMode;
+  setMode: (mode: PermissionMode) => void;
+  setDefault: (mode: PermissionMode) => void;
+}
+
+const PERMISSION_MODE_OPTIONS: { id: PermissionMode; label: string; description: string; color: string }[] = [
+  { id: 'bypassPermissions', label: 'Full access', description: 'All tools auto-approved', color: 'text-green-500' },
+  { id: 'acceptEdits', label: 'Accept edits', description: 'File edits auto-approved, Bash prompts', color: 'text-blue-500' },
+  { id: 'default', label: 'Ask for approval', description: 'Approve each tool individually', color: 'text-yellow-500' },
+  { id: 'dontAsk', label: 'Read-only', description: 'Only read tools, all others denied', color: 'text-orange-500' },
+];
+
 interface ChatInputToolbarProps {
   model: ModelProps;
   thinking: ThinkingProps;
+  permissionMode: PermissionModeProps;
   planModeEnabled: boolean;
   onPlanModeToggle: () => void;
   fastModeEnabled: boolean;
@@ -81,6 +99,7 @@ interface ChatInputToolbarProps {
 export function ChatInputToolbar({
   model,
   thinking,
+  permissionMode,
   planModeEnabled,
   onPlanModeToggle,
   fastModeEnabled,
@@ -92,6 +111,8 @@ export function ChatInputToolbar({
   action,
   showInfo,
 }: ChatInputToolbarProps) {
+  const currentPermOption = PERMISSION_MODE_OPTIONS.find((o) => o.id === permissionMode.mode) ?? PERMISSION_MODE_OPTIONS[0];
+  const isPermModified = permissionMode.mode !== permissionMode.defaultMode;
   return (
     <div className="flex items-center gap-1 px-2 pb-2">
       {/* Model Selector */}
@@ -280,6 +301,81 @@ export function ChatInputToolbar({
         <BookOpen className="h-4 w-4" />
         {planModeEnabled && <span className="text-xs font-medium">Plan</span>}
       </Button>
+
+      {/* Permission Mode Dropdown */}
+      {permissionMode.mode !== 'bypassPermissions' && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn(
+                'h-7 gap-1.5 px-2 text-xs',
+                isPermModified && 'bg-amber-500/10 hover:bg-amber-500/20',
+                currentPermOption.color,
+              )}
+              title={`Permissions: ${currentPermOption.label}`}
+              aria-label={`Permissions: ${currentPermOption.label}`}
+            >
+              <Shield className="h-4 w-4" />
+              <span className="font-medium">{currentPermOption.label}</span>
+              <ChevronDown className="h-3 w-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-64">
+            <DropdownMenuLabel className="text-2xs font-normal text-muted-foreground uppercase tracking-wider">
+              Permission Mode
+            </DropdownMenuLabel>
+            {PERMISSION_MODE_OPTIONS.map((option) => {
+              const isSelected = option.id === permissionMode.mode;
+              const isDefault = option.id === permissionMode.defaultMode;
+              return (
+                <DropdownMenuItem
+                  key={option.id}
+                  onClick={() => permissionMode.setMode(option.id)}
+                  className="group flex-col items-start gap-0 py-2"
+                >
+                  <div className="flex w-full items-center gap-1.5">
+                    <span className={cn('font-medium', option.color)}>{option.label}</span>
+                    <span className="ml-auto flex shrink-0 items-center gap-1">
+                      {isSelected && <Check className="h-3.5 w-3.5" />}
+                      {isDefault ? (
+                        <Star className="h-3 w-3 fill-current text-amber-500" />
+                      ) : (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              aria-label={`Set ${option.label} as default permission mode`}
+                              className="flex items-center justify-center rounded p-0.5 text-muted-foreground/50 opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                              onPointerDown={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                permissionMode.setDefault(option.id);
+                                showInfo(`${option.label} set as default permission mode`);
+                              }}
+                            >
+                              <Star className="h-3 w-3" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="right" sideOffset={8}>Set as default</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </span>
+                  </div>
+                  <span className="text-xs text-muted-foreground leading-tight">
+                    {option.description}
+                  </span>
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
 
       {/* Spacer */}
       <div className="flex-1" />

--- a/src/components/conversation/ToolApprovalBanner.tsx
+++ b/src/components/conversation/ToolApprovalBanner.tsx
@@ -1,0 +1,262 @@
+import { useCallback, useEffect, useState, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Shield, ShieldAlert, Terminal, FileEdit, Globe, Wrench } from 'lucide-react';
+import { useAppStore } from '@/stores/appStore';
+import { approveTool } from '@/lib/api/conversations';
+
+const TIMEOUT_MS = 60_000; // 60 seconds
+
+function getToolIcon(toolName: string) {
+  switch (toolName) {
+    case 'Bash':
+      return <Terminal className="h-4 w-4" />;
+    case 'Write':
+    case 'Edit':
+    case 'NotebookEdit':
+      return <FileEdit className="h-4 w-4" />;
+    case 'WebFetch':
+      return <Globe className="h-4 w-4" />;
+    default:
+      return <Wrench className="h-4 w-4" />;
+  }
+}
+
+function getToolSummary(toolName: string, toolInput: Record<string, unknown>): string {
+  switch (toolName) {
+    case 'Bash':
+      return (toolInput.command as string) || 'shell command';
+    case 'Write':
+    case 'Edit':
+      return (toolInput.file_path as string) || 'file modification';
+    case 'Read':
+      return (toolInput.file_path as string) || 'file read';
+    case 'WebFetch':
+      return (toolInput.url as string) || 'web request';
+    default:
+      return toolName;
+  }
+}
+
+function ToolInputPreview({ toolName, toolInput }: { toolName: string; toolInput: Record<string, unknown> }) {
+  if (toolName === 'Bash') {
+    return (
+      <pre className="mt-1.5 p-2 rounded bg-muted text-xs font-mono overflow-x-auto max-h-24 whitespace-pre-wrap break-all">
+        {(toolInput.command as string) || ''}
+      </pre>
+    );
+  }
+
+  if (toolName === 'Write' || toolName === 'Edit') {
+    return (
+      <div className="mt-1.5 text-xs text-muted-foreground">
+        <span className="font-mono">{(toolInput.file_path as string) || ''}</span>
+        {typeof toolInput.old_string === 'string' && (
+          <pre className="mt-1 p-2 rounded bg-muted font-mono overflow-x-auto max-h-20 whitespace-pre-wrap break-all">
+            {`- ${(toolInput.old_string as string).slice(0, 200)}\n+ ${((toolInput.new_string as string) || '').slice(0, 200)}`}
+          </pre>
+        )}
+        {typeof toolInput.content === 'string' && !toolInput.old_string && (
+          <pre className="mt-1 p-2 rounded bg-muted font-mono overflow-x-auto max-h-20 whitespace-pre-wrap break-all">
+            {(toolInput.content as string).slice(0, 500)}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  if (toolName === 'WebFetch') {
+    return (
+      <div className="mt-1.5 text-xs text-muted-foreground font-mono">
+        {(toolInput.url as string) || ''}
+      </div>
+    );
+  }
+
+  // Generic: show JSON
+  return (
+    <pre className="mt-1.5 p-2 rounded bg-muted text-xs font-mono overflow-x-auto max-h-24 whitespace-pre-wrap break-all">
+      {JSON.stringify(toolInput, null, 2).slice(0, 500)}
+    </pre>
+  );
+}
+
+interface ToolApprovalBannerProps {
+  conversationId: string;
+}
+
+export function ToolApprovalBanner({ conversationId }: ToolApprovalBannerProps) {
+  const streamingState = useAppStore((s) => s.streamingState[conversationId]);
+  const clearPendingToolApproval = useAppStore((s) => s.clearPendingToolApproval);
+  const pending = streamingState?.pendingToolApproval;
+
+  const [error, setError] = useState<string | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const autoDeniedRef = useRef(false);
+
+  // Reset guards when a new request arrives
+  useEffect(() => {
+    autoDeniedRef.current = false;
+    setSubmitting(false);
+  }, [pending?.requestId]);
+
+  // Progress bar timer
+  useEffect(() => {
+    if (!pending) {
+      setElapsed(0);
+      return;
+    }
+    const startTime = pending.timestamp;
+    timerRef.current = setInterval(() => {
+      const now = Date.now();
+      setElapsed(now - startTime);
+    }, 200);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [pending]);
+
+  // Auto-deny on timeout (guarded to prevent retry loop on API failure)
+  useEffect(() => {
+    if (!pending || elapsed < TIMEOUT_MS || autoDeniedRef.current) return;
+    autoDeniedRef.current = true;
+    handleAction('deny_once');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elapsed, pending]);
+
+  const handleAction = useCallback(async (action: 'allow_once' | 'allow_session' | 'allow_always' | 'deny_once' | 'deny_always') => {
+    if (!pending || submitting) return;
+    setSubmitting(true);
+    try {
+      setError(null);
+      await approveTool(conversationId, pending.requestId, action, pending.specifier);
+      clearPendingToolApproval(conversationId);
+    } catch (err) {
+      setSubmitting(false);
+      setError(err instanceof Error ? err.message : 'Failed to send tool approval');
+    }
+  }, [conversationId, pending, clearPendingToolApproval, submitting]);
+
+  // Keyboard shortcuts — only active when no editable element is focused.
+  // Uses closest('[data-slate-editor]') to detect the Plate rich-text editor
+  // in addition to standard INPUT/TEXTAREA/contentEditable checks.
+  useEffect(() => {
+    if (!pending) return;
+
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isEditable = target.tagName === 'INPUT'
+        || target.tagName === 'TEXTAREA'
+        || target.isContentEditable
+        || target.closest?.('[data-slate-editor]') != null;
+
+      if (isEditable) {
+        // Only handle Escape in editable areas
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          handleAction('deny_once');
+        }
+        return;
+      }
+
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleAction('allow_always'); // Allow for entire session
+      } else if (e.key === 'Enter' && e.shiftKey) {
+        e.preventDefault();
+        handleAction('allow_once');
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        handleAction('deny_once');
+      }
+    };
+
+    window.addEventListener('keydown', handler, { capture: true });
+    return () => window.removeEventListener('keydown', handler, { capture: true });
+  }, [pending, handleAction]);
+
+  if (!pending) return null;
+
+  const progressPct = Math.min(100, (elapsed / TIMEOUT_MS) * 100);
+
+  return (
+    <div className="space-y-1.5 mb-2">
+      {/* Timeout progress bar */}
+      <div className="h-0.5 bg-muted rounded-full overflow-hidden">
+        <div
+          className="h-full bg-orange-500 transition-all duration-200"
+          style={{ width: `${100 - progressPct}%` }}
+        />
+      </div>
+
+      {/* Tool info */}
+      <div className="flex items-start gap-2 text-sm">
+        <div className="flex items-center gap-1.5 text-orange-500 mt-0.5">
+          <ShieldAlert className="h-4 w-4" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 font-medium">
+            {getToolIcon(pending.toolName)}
+            <span>{pending.toolName}</span>
+            <span className="text-muted-foreground font-normal truncate">
+              {getToolSummary(pending.toolName, pending.toolInput)}
+            </span>
+          </div>
+          <ToolInputPreview toolName={pending.toolName} toolInput={pending.toolInput} />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs text-destructive hover:text-destructive"
+            disabled={submitting}
+            onClick={() => handleAction('deny_once')}
+          >
+            Deny
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs text-destructive hover:text-destructive"
+            disabled={submitting}
+            onClick={() => handleAction('deny_always')}
+          >
+            Deny Session
+          </Button>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs"
+            disabled={submitting}
+            onClick={() => handleAction('allow_once')}
+          >
+            Allow Once
+            <kbd className="ml-1 px-1 py-0.5 rounded bg-muted text-2xs font-mono">⇧↵</kbd>
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="h-7 text-xs font-semibold bg-foreground text-background hover:bg-foreground/80"
+            disabled={submitting}
+            onClick={() => handleAction('allow_always')}
+          >
+            <Shield className="h-3.5 w-3.5 mr-1" />
+            Allow Session
+            <kbd className="ml-1 px-1 py-0.5 rounded bg-background/20 text-background text-2xs font-mono">⌘↵</kbd>
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-xs text-destructive">{error}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/sections/AdvancedSettings.tsx
+++ b/src/components/settings/sections/AdvancedSettings.tsx
@@ -17,6 +17,13 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { SettingsRow } from '../shared/SettingsRow';
 import { SettingsGroup } from '../shared/SettingsGroup';
 
@@ -149,6 +156,19 @@ export function AdvancedSettings() {
       </SettingsGroup>
 
       <SettingsGroup label="Security">
+        <SettingsRow
+          settingId="defaultPermissionMode"
+          title="Default permission mode"
+          description="Controls how the agent requests permission to use tools. Applies to new conversations."
+          isModified={useSettingsStore((s) => s.defaultPermissionMode) !== SETTINGS_DEFAULTS.defaultPermissionMode}
+          onReset={() => useSettingsStore.getState().setDefaultPermissionMode(SETTINGS_DEFAULTS.defaultPermissionMode)}
+        >
+          <PermissionModeSelect
+            value={useSettingsStore((s) => s.defaultPermissionMode)}
+            onChange={useSettingsStore.getState().setDefaultPermissionMode}
+          />
+        </SettingsRow>
+
         <SettingsRow
           settingId="neverLoadDotMcp"
           title="Block workspace MCP configs"
@@ -490,5 +510,37 @@ function EnvSection() {
         </Button>
       </div>
     </SettingsRow>
+  );
+}
+
+const PERMISSION_MODES = [
+  { id: 'bypassPermissions' as const, label: 'Full access', description: 'All tools auto-approved' },
+  { id: 'acceptEdits' as const, label: 'Accept edits', description: 'File edits auto-approved, Bash requires approval' },
+  { id: 'default' as const, label: 'Ask for approval', description: 'Approve each tool call individually' },
+  { id: 'dontAsk' as const, label: 'Read-only', description: 'Only read tools allowed, all others denied' },
+];
+
+function PermissionModeSelect({
+  value,
+  onChange,
+}: {
+  value: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk';
+  onChange: (value: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk') => void;
+}) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-[180px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {PERMISSION_MODES.map((mode) => (
+          <SelectItem key={mode.id} value={mode.id}>
+            <div className="flex flex-col">
+              <span>{mode.label}</span>
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }

--- a/src/components/settings/settingsRegistry.ts
+++ b/src/components/settings/settingsRegistry.ts
@@ -386,6 +386,14 @@ export const SETTINGS_REGISTRY: SettingMeta[] = [
 
   // ── Advanced: Security ──
   {
+    id: 'defaultPermissionMode',
+    title: 'Default permission mode',
+    description: 'Controls how the agent requests permission to use tools',
+    keywords: ['permission', 'mode', 'security', 'approval', 'tool', 'sandbox', 'bypass', 'default'],
+    category: 'advanced',
+    categoryLabel: 'Advanced',
+  },
+  {
     id: 'neverLoadDotMcp',
     title: 'Block workspace MCP configs',
     description: 'Never auto-load .mcp.json from workspace repositories. Prevents repo-provided MCP servers from running commands.',

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -496,6 +496,21 @@ export function useWebSocket(enabled: boolean = true) {
         }
         break;
 
+      case 'tool_approval_request':
+        // Non-bypass permission mode: a tool needs user approval
+        if (event?.requestId && event?.toolName) {
+          store.setPendingToolApproval(
+            conversationId,
+            event.requestId as string,
+            event.toolName as string,
+            (event.toolInput as Record<string, unknown>) || {},
+            event.specifier as string | undefined,
+          );
+          notifyBackgroundSession(conversationId);
+          notifyDesktop(conversationId, 'Tool approval needed', `${event.toolName} requires permission`);
+        }
+        break;
+
       case 'plan_mode_auto_exited':
         store.setPlanModeActive(conversationId, false);
         markPlanModeExited(conversationId);

--- a/src/lib/api/conversations.ts
+++ b/src/lib/api/conversations.ts
@@ -205,6 +205,7 @@ export async function createConversation(
     message?: string;
     model?: string;
     planMode?: boolean;
+    permissionMode?: string;
     fastMode?: boolean;
     maxThinkingTokens?: number;
     effort?: string;
@@ -394,6 +395,24 @@ export async function approvePlan(convId: string, requestId: string, approved: b
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ requestId, approved, ...(reason && { reason }) }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(text || `HTTP ${res.status}`, res.status, text);
+  }
+}
+
+// Approve or deny a pending tool execution request
+export async function approveTool(
+  convId: string,
+  requestId: string,
+  action: 'allow_once' | 'allow_session' | 'allow_always' | 'deny_once' | 'deny_always',
+  specifier?: string,
+): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/approve-tool`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ requestId, action, ...(specifier && { specifier }) }),
   });
   if (!res.ok) {
     const text = await res.text();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -354,6 +354,10 @@ export interface AgentEvent {
   };
   fastModeState?: 'off' | 'cooldown' | 'on';
 
+  // Tool approval fields
+  toolInput?: Record<string, unknown>;
+  specifier?: string;
+
   // Extended result fields
   durationMs?: number;
   durationApiMs?: number;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -187,6 +187,7 @@ const DEFAULT_STREAMING: StreamingState = {
   isThinking: false,
   planModeActive: false,
   pendingPlanApproval: null,
+  pendingToolApproval: null,
   startTime: undefined,
 };
 
@@ -253,6 +254,7 @@ interface StreamingState {
   startTime?: number; // When streaming started (for elapsed time)
   planModeActive: boolean; // Whether plan mode is active for this conversation
   pendingPlanApproval: { requestId: string; planContent?: string } | null; // Pending ExitPlanMode approval request
+  pendingToolApproval: { requestId: string; toolName: string; toolInput: Record<string, unknown>; specifier?: string; timestamp: number } | null; // Pending tool approval request
   approvedPlanContent?: string; // Plan content to persist after approval
   approvedPlanTimestamp?: number; // When the plan was approved (for timeline ordering)
   recovery?: { attempt: number; maxAttempts: number }; // Agent crash recovery in progress
@@ -492,6 +494,8 @@ interface AppState {
   setPlanModeActive: (conversationId: string, active: boolean) => void;
   setPendingPlanApproval: (conversationId: string, requestId: string, planContent?: string) => void;
   clearPendingPlanApproval: (conversationId: string) => void;
+  setPendingToolApproval: (conversationId: string, requestId: string, toolName: string, toolInput: Record<string, unknown>, specifier?: string) => void;
+  clearPendingToolApproval: (conversationId: string) => void;
   setApprovedPlanContent: (conversationId: string, content: string) => void;
   clearApprovedPlanContent: (conversationId: string) => void;
   addActiveTool: (conversationId: string, tool: ActiveTool, opts?: { skipTimeout?: boolean }) => void;
@@ -1674,6 +1678,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       thinking: null,
       isThinking: false,
       pendingPlanApproval: null,
+      pendingToolApproval: null,
       startTime: undefined,
       recovery: undefined,
     }),
@@ -1724,6 +1729,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       thinking: null,
       isThinking: false,
       pendingPlanApproval: null,
+      pendingToolApproval: null,
       startTime: undefined,
       compactBoundary: undefined,
     }),
@@ -1775,6 +1781,16 @@ updateFileTabContent: (id, content) => set((state) => ({
   clearPendingPlanApproval: (conversationId) => set((state) => ({
     streamingState: updateStreamingConv(state.streamingState, conversationId, {
       pendingPlanApproval: null,
+    }),
+  })),
+  setPendingToolApproval: (conversationId: string, requestId: string, toolName: string, toolInput: Record<string, unknown>, specifier?: string) => set((state) => ({
+    streamingState: updateStreamingConv(state.streamingState, conversationId, {
+      pendingToolApproval: { requestId, toolName, toolInput, specifier, timestamp: Date.now() },
+    }),
+  })),
+  clearPendingToolApproval: (conversationId: string) => set((state) => ({
+    streamingState: updateStreamingConv(state.streamingState, conversationId, {
+      pendingToolApproval: null,
     }),
   })),
   setApprovedPlanContent: (conversationId, content) => set((state) => ({
@@ -2080,6 +2096,7 @@ updateFileTabContent: (id, content) => set((state) => ({
         startTime: keepStreaming ? Date.now() : undefined,
         planModeActive: streaming?.planModeActive || false,
         pendingPlanApproval: null,
+        pendingToolApproval: null,
         approvedPlanContent: undefined,
         approvedPlanTimestamp: undefined,
       };

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -153,7 +153,7 @@ export const useSessionActivityState = (sessionId: string): SessionActivityState
 
           const convId = c.id;
           if (state.pendingUserQuestion[convId]) return 'awaiting_input';
-          if (state.streamingState[convId]?.pendingPlanApproval) {
+          if (state.streamingState[convId]?.pendingPlanApproval || state.streamingState[convId]?.pendingToolApproval) {
             highestState = 'awaiting_approval';
           } else if (state.streamingState[convId]?.isStreaming && highestState === 'idle') {
             highestState = 'working';
@@ -186,7 +186,7 @@ export const useActiveSessions = <T extends { id: string }>(sessions: T[]): T[] 
               if (c.status !== 'active') continue;
               const convId = c.id;
               if (state.pendingUserQuestion[convId]) { activity = 'awaiting_input'; break; }
-              if (state.streamingState[convId]?.pendingPlanApproval) {
+              if (state.streamingState[convId]?.pendingPlanApproval || state.streamingState[convId]?.pendingToolApproval) {
                 activity = 'awaiting_approval';
               } else if (state.streamingState[convId]?.isStreaming && activity === 'idle') {
                 activity = 'working';
@@ -344,6 +344,7 @@ export const useStreamingChatInput = (conversationId: string | null) =>
       return {
         isStreaming: st?.isStreaming ?? false,
         pendingPlanApproval: st?.pendingPlanApproval ?? null,
+        pendingToolApproval: st?.pendingToolApproval ?? null,
         planModeActive: st?.planModeActive ?? false,
       };
     })

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -99,6 +99,7 @@ export const SETTINGS_DEFAULTS = {
   archiveOnMerge: false,
   // Security
   neverLoadDotMcp: false,
+  defaultPermissionMode: 'bypassPermissions' as const,
   // Account
   strictPrivacy: false,
   // Sidebar
@@ -140,6 +141,7 @@ interface SettingsState {
   archiveOnMerge: boolean;
   // Security settings
   neverLoadDotMcp: boolean;
+  defaultPermissionMode: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk';
   // Account settings
   strictPrivacy: boolean;
   // UI state
@@ -215,6 +217,7 @@ interface SettingsState {
   setDeleteBranchOnArchive: (value: boolean) => void;
   setArchiveOnMerge: (value: boolean) => void;
   setNeverLoadDotMcp: (value: boolean) => void;
+  setDefaultPermissionMode: (value: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk') => void;
   setStrictPrivacy: (value: boolean) => void;
   setZenMode: (value: boolean) => void;
   setSidebarBottomPanelMinimized: (value: boolean) => void;
@@ -313,6 +316,8 @@ export const useSettingsStore = create<SettingsState>()(
       setBranchPrefixCustom: (value) => set({ branchPrefixCustom: value }),
       setDeleteBranchOnArchive: (value) => set({ deleteBranchOnArchive: value }),
       setArchiveOnMerge: (value) => set({ archiveOnMerge: value }),
+      setDefaultPermissionMode: (value: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk') =>
+        set({ defaultPermissionMode: value }),
       setNeverLoadDotMcp: (value) => {
         set({ neverLoadDotMcp: value });
         // Sync to backend so agent manager respects the global kill switch


### PR DESCRIPTION
## Summary

Implements a full tool approval flow so users can control which tools the agent is allowed to execute, matching Claude Code's permission model with security hardening.

- **New permission modes**: `default` (prompt each tool), `acceptEdits` (auto-allow file edits, prompt for Bash/MCP), `dontAsk` (read-only, deny all writes), `bypassPermissions` (existing behavior, unchanged)
- **Backend**: new `/approve-tool` endpoint with action whitelist validation, server-side `permissionMode` validation (rejects invalid values with 400)
- **Agent-runner**: `canUseTool` callback with session-scoped approvals, persistent rule evaluation (deny→ask→allow order), user prompting via `tool_approval_request` events, fail-closed on invalid permission mode
- **Frontend**: `ToolApprovalBanner` with timeout progress bar, keyboard shortcuts (`⇧↵` allow once, `⌘↵` allow session), double-click guard, settings UI in Advanced > Security
- **Security hardening**: iterative glob matcher (ReDoS-immune), `WebSearch` blocked in `dontAsk` mode, `PermissionRulesFile` path validation, fail-closed defaults

## Security review findings addressed

| Issue | Fix |
|-------|-----|
| No server-side validation of `permissionMode` | Whitelist validation in Go handler |
| Invalid mode falls back to `bypassPermissions` | Changed to fail-closed (`"default"`) |
| `WebSearch` bypasses `dontAsk` mode | Moved to `NETWORK_TOOLS` set, blocked in `dontAsk` |
| `PermissionRulesFile` path not validated | Added `filepath.Clean` + `filepath.IsAbs` guard |
| Bare `Enter` approves tools globally | Changed to `⇧↵` (once) / `⌘↵` (session) |
| `allow_always` label misleading (session-only) | Renamed to "Allow Session" / "Deny Session" |
| ReDoS in `wildcardMatch` | Replaced with iterative two-pointer algorithm |
| No double-click protection | Added `submitting` state + disabled buttons |

## Test plan

- [ ] Start a conversation with `default` permission mode — verify tool approval banner appears for Write/Edit/Bash
- [ ] Approve with "Allow Once" — tool executes, next call re-prompts
- [ ] Approve with "Allow Session" — subsequent calls auto-allowed
- [ ] Deny — tool is denied, agent receives denial message
- [ ] `acceptEdits` mode — file edits auto-approved, Bash prompts
- [ ] `dontAsk` mode — only Read/Glob/Grep work, everything else denied (including WebSearch)
- [ ] `bypassPermissions` mode — existing behavior unchanged
- [ ] Verify keyboard shortcuts work: `⇧↵`, `⌘↵`, `Esc`
- [ ] Verify timeout auto-denies after 60 seconds
- [ ] Settings: change default permission mode, verify persists across conversations
- [ ] Send invalid `permissionMode` via API — verify 400 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)