### PR TITLE
fix: improve dictation toggle robustness and shortcut hint memoization

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -274,6 +274,10 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const dictationShortcutDef = useMemo(() => {
     return parseDictationShortcut(dictationShortcutPref, dictationCustomShortcut);
   }, [dictationShortcutPref, dictationCustomShortcut]);
+  const dictationShortcutHint = useMemo(
+    () => formatShortcutHint(dictationShortcutDef),
+    [dictationShortcutDef]
+  );
   useCustomShortcut(dictationShortcutDef, toggleDictation, { enabled: dictationAvailable });
 
   // Session-scoped streaming state — prevents cross-session plan/state leakage
@@ -1019,7 +1023,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       )}
 
       {/* Dictation waveform visualizer */}
-      <DictationWaveform audioLevel={audioLevel} isActive={isDictating} />
+      <DictationWaveform audioLevel={audioLevel} isActive={isDictating} shortcutHint={dictationShortcutHint} />
 
       <div className={cn(
         'relative',
@@ -1205,7 +1209,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             isDictating,
             isAvailable: dictationAvailable,
             onToggle: toggleDictation,
-            shortcutHint: formatShortcutHint(dictationShortcutDef),
+            shortcutHint: dictationShortcutHint,
           }}
         />
       </div>

--- a/src/components/conversation/DictationWaveform.tsx
+++ b/src/components/conversation/DictationWaveform.tsx
@@ -3,7 +3,6 @@
 import { useMemo } from 'react';
 import { Mic } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { isMacOS } from '@/lib/platform';
 
 const BAR_COUNT = 24;
 
@@ -25,9 +24,10 @@ function barMultiplier(index: number, level: number): number {
 interface DictationWaveformProps {
   audioLevel: number;
   isActive: boolean;
+  shortcutHint?: string;
 }
 
-export function DictationWaveform({ audioLevel, isActive }: DictationWaveformProps) {
+export function DictationWaveform({ audioLevel, isActive, shortcutHint }: DictationWaveformProps) {
   // Derive multipliers deterministically from audioLevel (no setState needed)
   const barMultipliers = useMemo(
     () => Array.from({ length: BAR_COUNT }, (_, i) => barMultiplier(i, audioLevel)),
@@ -35,8 +35,6 @@ export function DictationWaveform({ audioLevel, isActive }: DictationWaveformPro
   );
 
   if (!isActive) return null;
-
-  const shortcutHint = isMacOS() ? '\u2318+Shift+D' : 'Ctrl+Shift+D';
 
   return (
     <div
@@ -81,9 +79,11 @@ export function DictationWaveform({ audioLevel, isActive }: DictationWaveformPro
         <span className="text-xs font-medium text-orange-600 dark:text-orange-400">
           Listening...
         </span>
-        <span className="text-[10px] text-muted-foreground">
-          {shortcutHint} to stop
-        </span>
+        {shortcutHint && (
+          <span className="text-[10px] text-muted-foreground">
+            {shortcutHint} to stop
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/hooks/useDictation.ts
+++ b/src/hooks/useDictation.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { safeInvoke, safeListen } from '@/lib/tauri';
 import { isMacOS } from '@/lib/platform';
 
@@ -38,18 +39,22 @@ interface UseDictationReturn {
 }
 
 export function useDictation(options: UseDictationOptions): UseDictationReturn {
-  const [isDictating, setIsDictating] = useState(false);
+  const [isDictating, setIsDictatingState] = useState(false);
   const [isAvailable, setIsAvailable] = useState(false);
   const [audioLevel, setAudioLevel] = useState(0);
   const optionsRef = useRef(options);
   const isDictatingRef = useRef(false);
+  const togglingRef = useRef(false);
 
   useEffect(() => {
     optionsRef.current = options;
   });
-  useEffect(() => {
-    isDictatingRef.current = isDictating;
-  });
+
+  // Synchronously update both ref and state to avoid stale closures
+  const setDictating = useCallback((value: boolean) => {
+    isDictatingRef.current = value;
+    setIsDictatingState(value);
+  }, []);
 
   // Check availability on mount (isAvailable starts as false, so non-macOS needs no setState)
   useEffect(() => {
@@ -77,12 +82,12 @@ export function useDictation(options: UseDictationOptions): UseDictationReturn {
         setAudioLevel(payload.level);
       }),
       safeListen<DictationError>('dictation-error', (payload) => {
-        setIsDictating(false);
+        setDictating(false);
         setAudioLevel(0);
         optionsRef.current.onError?.(payload.message);
       }),
       safeListen<void>('dictation-ended', () => {
-        setIsDictating(false);
+        setDictating(false);
         setAudioLevel(0);
         optionsRef.current.onEnd?.();
       }),
@@ -91,7 +96,7 @@ export function useDictation(options: UseDictationOptions): UseDictationReturn {
     return () => {
       promises.forEach((p) => p.then((unlisten) => unlisten()));
     };
-  }, [isAvailable]);
+  }, [isAvailable, setDictating]);
 
   // Stop dictation on unmount if active
   useEffect(() => {
@@ -103,32 +108,56 @@ export function useDictation(options: UseDictationOptions): UseDictationReturn {
   }, []);
 
   const toggle = useCallback(async () => {
-    if (!isAvailable) return;
+    if (!isAvailable || togglingRef.current) return;
+    togglingRef.current = true;
 
-    if (isDictating) {
-      await safeInvoke('stop_dictation');
-      setIsDictating(false);
-      setAudioLevel(0);
-    } else {
-      const result = await safeInvoke('start_dictation');
-      if (result !== null) {
-        // start_dictation returns Ok(()) on success, error string on failure
-        setIsDictating(true);
+    try {
+      if (isDictatingRef.current) {
+        // Use raw invoke (not safeInvoke) so stop errors are visible and don't silently desync UI
+        try {
+          await invoke('stop_dictation');
+        } catch (e: unknown) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          optionsRef.current.onError?.(`Failed to stop dictation: ${errMsg}`);
+          return;
+        }
+        setDictating(false);
+        setAudioLevel(0);
       } else {
-        // safeInvoke returns null on error (already logged)
-        // Re-check permissions in case they were denied
-        const status = await safeInvoke<DictationPermissionStatus>(
-          'check_dictation_permissions'
-        );
-        if (status === 'denied' || status === 'restricted') {
-          setIsAvailable(false);
-          optionsRef.current.onError?.(
-            'Speech recognition permission denied. Enable it in System Settings > Privacy & Security.'
-          );
+        try {
+          // Use raw invoke (not safeInvoke) so we can inspect the error for "already active" desync recovery
+          await invoke('start_dictation');
+          setDictating(true);
+        } catch (e: unknown) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          // Rust backend emits "already active" when dictation is running but frontend state was out of sync
+          if (errMsg.includes('already active')) {
+            // Backend thinks dictation is active but frontend didn't know — stop it (resilient toggle)
+            try {
+              await invoke('stop_dictation');
+            } catch {
+              // Best-effort recovery — if stop also fails, just reset UI state
+            }
+            setDictating(false);
+            setAudioLevel(0);
+          } else {
+            // Permission or other error — re-check permissions
+            const status = await safeInvoke<DictationPermissionStatus>(
+              'check_dictation_permissions'
+            );
+            if (status === 'denied' || status === 'restricted') {
+              setIsAvailable(false);
+              optionsRef.current.onError?.(
+                'Speech recognition permission denied. Enable it in System Settings > Privacy & Security.'
+              );
+            }
+          }
         }
       }
+    } finally {
+      togglingRef.current = false;
     }
-  }, [isAvailable, isDictating]);
+  }, [isAvailable, setDictating]);
 
   return { isDictating, toggle, isAvailable, audioLevel };
 }


### PR DESCRIPTION
## Summary

- **Stop-dictation error handling**: `stop_dictation` now uses raw `invoke` (not `safeInvoke`) so failures are surfaced to the user via `onError` instead of silently resetting the UI while the backend stays active.
- **"Already active" recovery**: The recovery `stop_dictation` call is wrapped in its own try/catch to prevent unhandled promise rejections if the backend is in a bad state.
- **Code clarity**: Added inline comments explaining why raw `invoke` is used over `safeInvoke` in the toggle function, and documenting the exact Rust error string the frontend matches on.
- **Memoization**: `dictationShortcutHint` is now memoized in `ChatInput` alongside `dictationShortcutDef`, avoiding two redundant `formatShortcutHint` calls per render.

## Test plan

- [ ] Start dictation → toggle off → confirm waveform disappears and backend stops
- [ ] Start dictation → simulate `stop_dictation` failure → confirm error message is shown and waveform stays visible (UI not desynced)
- [ ] Toggle rapidly → confirm `togglingRef` guard prevents race, only one operation runs at a time
- [ ] Change dictation shortcut in Settings → confirm waveform hint updates to match new shortcut