### PR TITLE
feat: add dedicated sprint phases toolbar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,7 @@ import { registerSession, getSessionDirName, openFolderDialog } from '@/lib/taur
 import { trackEvent } from '@/lib/telemetry';
 import { useBranchCacheStore } from '@/stores/branchCacheStore';
 import { useRecentlyClosedStore } from '@/stores/recentlyClosedStore';
+import { useUIStore } from '@/stores/uiStore';
 import { captureClosedConversation, useRestoreConversation } from '@/hooks/useRecentlyClosed';
 import { useShortcut } from '@/hooks/useShortcut';
 import type { SetupInfo } from '@/lib/types';
@@ -52,6 +53,7 @@ import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { StreamingWarningHandler } from '@/components/shared/StreamingWarningHandler';
 import { ConnectionStatusHandler } from '@/components/shared/ConnectionStatusHandler';
 import { ConnectionBanner } from '@/components/shared/ConnectionBanner';
+import { SprintPhaseToolbar } from '@/components/shared/SprintPhaseToolbar';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { HEALTH_CHECK_MAX_RETRIES, HEALTH_CHECK_INITIAL_DELAY_MS } from '@/lib/constants';
 
@@ -168,6 +170,8 @@ export default function Home() {
   const selectPreviousTab = useAppStore((s) => s.selectPreviousTab);
   const confirmCloseActiveTab = useSettingsStore((s) => s.confirmCloseActiveTab);
   const contentView = useSettingsStore((s) => s.contentView);
+  const sprintToolbarOpen = useUIStore((s) => s.sprintToolbarOpen);
+  const setSprintToolbarOpen = useUIStore((s) => s.setSprintToolbarOpen);
 
   const { error: showError } = useToast();
   const { showWizard, showGuidedTour, completeWizard, completeTour, skipAll } = useOnboarding();
@@ -609,6 +613,9 @@ export default function Home() {
                 !layout.leftSidebarCollapsed && !layout.zenMode && "border-l rounded-tl-lg"
               )}>
               <ContentActionBar />
+              {sprintToolbarOpen && selectedSessionId && (
+                <SprintPhaseToolbar onClose={() => setSprintToolbarOpen(false)} />
+              )}
               <ConnectionBanner onReconnect={reconnect} onManualSidecarRestart={manualRestart} />
 
               {/* Content Area */}

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -66,6 +66,7 @@ import { TargetBranchSelector } from '@/components/shared/TargetBranchSelector';
 import { useInstalledApps } from '@/hooks/useInstalledApps';
 import type { InstalledApp } from '@/hooks/useInstalledApps';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { useUIStore } from '@/stores/uiStore';
 import { getAppById, getAppName, CATEGORY_LABELS } from '@/lib/openApps';
 import type { AppCategory } from '@/lib/openApps';
 import { getAppIcon } from '@/components/icons/AppIcons';
@@ -130,6 +131,8 @@ export function SessionToolbarContent() {
   const { installedApps } = useInstalledApps();
   const defaultOpenApp = useSettingsStore((s) => s.defaultOpenApp);
   const workspaceColors = useSettingsStore((s) => s.workspaceColors);
+  const toggleSprintToolbar = useUIStore((s) => s.toggleSprintToolbar);
+  const setSprintToolbarOpen = useUIStore((s) => s.setSprintToolbarOpen);
   const { requestArchive, dialogProps: archiveDialogProps } = useArchiveSession({
     onSuccess: () => showSuccess('Session archived'),
     onError: () => showError('Failed to archive session'),
@@ -219,6 +222,11 @@ export function SessionToolbarContent() {
       showError('Failed to send message to agent');
     });
   }, [selectedConversationId, showWarning, showError, addMessage, updateConversation, setStreaming, isAgentWorking]);
+
+  // Close sprint toolbar when session changes
+  useEffect(() => {
+    setSprintToolbarOpen(false);
+  }, [selectedSessionId, setSprintToolbarOpen]);
 
   // Listen for git-create-pr events from menu handler and command palette
   useEffect(() => {
@@ -403,8 +411,17 @@ export function SessionToolbarContent() {
     apiUpdateSession(selectedWorkspaceId, selectedSession.id, apiPayload).catch(() => {
       storeUpdateSession(selectedSession.id, { sprintPhase: prevPhase, taskStatus: prevStatus });
       showError('Failed to update sprint phase');
+      // Reopen toolbar if deactivation failed and sprint reverted to active
+      if (!value && prevPhase) setSprintToolbarOpen(true);
     });
-  }, [selectedSession, selectedWorkspaceId, storeUpdateSession, showError]);
+
+    // Open toolbar when sprint is first activated; close it when deactivated
+    if (!value) {
+      setSprintToolbarOpen(false);
+    } else if (!prevPhase) {
+      setSprintToolbarOpen(true);
+    }
+  }, [selectedSession, selectedWorkspaceId, storeUpdateSession, showError, setSprintToolbarOpen]);
 
   // Listen for toggle-sprint events from slash command
   useAppEventListener('toggle-sprint', () => {
@@ -461,6 +478,7 @@ export function SessionToolbarContent() {
               phase={selectedSession.sprintPhase}
               onChange={handleSprintPhaseChange}
               disabled={isAgentWorking}
+              onOpenToolbar={toggleSprintToolbar}
             />
             {selectedSession.prStatus && selectedSession.prStatus !== 'none' && selectedSession.prNumber && selectedWorkspaceId && (
               <PRHoverCard

--- a/src/components/shared/SprintPhaseBar.tsx
+++ b/src/components/shared/SprintPhaseBar.tsx
@@ -1,33 +1,21 @@
 'use client';
 
-import { useCallback } from 'react';
 import { SPRINT_PHASE_OPTIONS } from '@/lib/session-fields';
-import { SPRINT_PHASES } from '@/lib/types';
 import type { SprintPhase } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
-import { Play, X } from 'lucide-react';
+import { Play } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface SprintPhaseBarProps {
   phase: SprintPhase | null | undefined;
   onChange: (phase: SprintPhase | null) => void;
   disabled?: boolean;
+  /** Called when Sprint button is clicked while inactive — opens the sprint toolbar */
+  onOpenToolbar?: () => void;
 }
 
-export function SprintPhaseBar({ phase, onChange, disabled }: SprintPhaseBarProps) {
-  const currentIndex = phase ? SPRINT_PHASES.indexOf(phase) : -1;
-
-  const handlePhaseClick = useCallback((clickedPhase: SprintPhase) => {
-    if (disabled) return;
-    // Clicking the active phase deactivates sprint
-    if (clickedPhase === phase) {
-      onChange(null);
-    } else {
-      onChange(clickedPhase);
-    }
-  }, [phase, onChange, disabled]);
-
+export function SprintPhaseBar({ phase, onChange, disabled, onOpenToolbar }: SprintPhaseBarProps) {
   // No sprint active — show compact start button
   if (!phase) {
     return (
@@ -37,7 +25,7 @@ export function SprintPhaseBar({ phase, onChange, disabled }: SprintPhaseBarProp
             variant="ghost"
             size="sm"
             className="h-6 px-2 gap-1 text-xs text-muted-foreground hover:text-foreground"
-            onClick={() => onChange('think')}
+            onClick={() => onOpenToolbar ? onOpenToolbar() : onChange('think')}
             disabled={disabled}
           >
             <Play className="h-3 w-3" />
@@ -49,55 +37,29 @@ export function SprintPhaseBar({ phase, onChange, disabled }: SprintPhaseBarProp
     );
   }
 
-  return (
-    <div className="flex items-center gap-0.5">
-      {SPRINT_PHASE_OPTIONS.map((opt, idx) => {
-        const isActive = opt.value === phase;
-        const isCompleted = idx < currentIndex;
-        const Icon = opt.icon;
+  // Sprint active — show compact pill indicator (full bar is in SprintPhaseToolbar below)
+  const activeOpt = SPRINT_PHASE_OPTIONS.find((o) => o.value === phase);
+  if (!activeOpt) return null;
+  const Icon = activeOpt.icon;
 
-        return (
-          <Tooltip key={opt.value}>
-            <TooltipTrigger asChild>
-              <button
-                className={cn(
-                  'flex items-center gap-1 h-6 px-1.5 rounded-sm text-xs font-medium transition-colors',
-                  isActive && opt.activeClass,
-                  isCompleted && 'text-muted-foreground/60',
-                  !isActive && !isCompleted && 'text-muted-foreground/40 hover:text-muted-foreground/70',
-                  disabled && 'pointer-events-none opacity-50',
-                )}
-                onClick={() => handlePhaseClick(opt.value)}
-                disabled={disabled}
-                aria-label={opt.label}
-                aria-pressed={isActive}
-              >
-                <Icon className={cn('h-3 w-3', isActive && opt.color)} />
-                <span className={cn(
-                  'hidden @[500px]:inline',
-                  isActive && 'inline', // Always show label for active phase
-                )}>
-                  {opt.label}
-                </span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{opt.description}</TooltipContent>
-          </Tooltip>
-        );
-      })}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            className="flex items-center h-6 px-1 text-muted-foreground/40 hover:text-muted-foreground/70 transition-colors"
-            onClick={() => onChange(null)}
-            disabled={disabled}
-            aria-label="Exit sprint"
-          >
-            <X className="h-3 w-3" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Exit sprint</TooltipContent>
-      </Tooltip>
-    </div>
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          className={cn(
+            'flex items-center gap-1 h-6 px-2 rounded-sm text-xs font-medium transition-colors',
+            activeOpt.activeClass,
+            disabled && 'pointer-events-none opacity-50',
+          )}
+          onClick={() => onOpenToolbar ? onOpenToolbar() : onChange(null)}
+          disabled={disabled}
+          aria-label={`Sprint: ${activeOpt.label} — click to open sprint toolbar`}
+        >
+          <Icon className={cn('h-3 w-3', activeOpt.color)} />
+          {activeOpt.label}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Sprint: {activeOpt.label} — click to manage sprint</TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/shared/SprintPhaseToolbar.tsx
+++ b/src/components/shared/SprintPhaseToolbar.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useWorkspaceSelection, useSessionActivityState } from '@/stores/selectors';
+import { dispatchAppEvent } from '@/lib/custom-events';
+import { SPRINT_PHASE_OPTIONS } from '@/lib/session-fields';
+import { SPRINT_PHASES } from '@/lib/types';
+import type { SprintPhase } from '@/lib/types';
+import { cn } from '@/lib/utils';
+import { Check, ChevronRight, X } from 'lucide-react';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+
+interface SprintPhaseToolbarProps {
+  onClose: () => void;
+}
+
+export function SprintPhaseToolbar({ onClose }: SprintPhaseToolbarProps) {
+  const { selectedSessionId, sessions } = useWorkspaceSelection();
+  const selectedSession = sessions.find((s) => s.id === selectedSessionId);
+  const isAgentWorking = useSessionActivityState(selectedSessionId ?? '') === 'working';
+
+  const phase = selectedSession?.sprintPhase;
+  const currentIndex = phase ? SPRINT_PHASES.indexOf(phase) : -1;
+
+  // Delegate phase changes to SessionToolbarContent via the existing event bus,
+  // ensuring PHASE_TO_STATUS sync happens in one place.
+  const handleChange = (value: SprintPhase | null) => {
+    dispatchAppEvent('sprint-phase-advance', { phase: value });
+    if (!value) onClose();
+  };
+
+  if (!selectedSession) return null;
+
+  return (
+    <div className="shrink-0 border-b border-border/60 bg-background animate-in slide-in-from-top-1 fade-in duration-150">
+      <div className="flex items-center h-9 px-3 gap-2">
+        {/* Left: Sprint label */}
+        <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50 shrink-0 select-none">
+          Sprint
+        </span>
+
+        <div className="w-px h-4 bg-border/60 shrink-0" />
+
+        {/* Center: Phase stepper */}
+        <div className="flex-1 flex items-center justify-center">
+          {SPRINT_PHASE_OPTIONS.map((opt, idx) => {
+            const isActive = opt.value === phase;
+            const isCompleted = idx < currentIndex;
+            const Icon = opt.icon;
+            const isLast = idx === SPRINT_PHASE_OPTIONS.length - 1;
+
+            return (
+              <div key={opt.value} className="flex items-center">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => handleChange(isActive ? null : opt.value)}
+                      disabled={isAgentWorking}
+                      aria-label={opt.label}
+                      aria-pressed={isActive}
+                      className={cn(
+                        'flex items-center gap-1.5 h-7 px-2.5 rounded-md text-xs font-medium transition-all',
+                        isActive && [opt.activeClass, 'shadow-sm'],
+                        isCompleted && 'text-muted-foreground/50 hover:text-muted-foreground/80 hover:bg-accent/50',
+                        !isActive && !isCompleted && 'text-muted-foreground/30 hover:text-muted-foreground/70 hover:bg-accent/50',
+                        isAgentWorking && 'pointer-events-none opacity-50',
+                      )}
+                    >
+                      {isCompleted
+                        ? <Check className="h-3 w-3 shrink-0" />
+                        : <Icon className={cn('h-3 w-3 shrink-0', isActive && opt.color)} />
+                      }
+                      <span className={cn('hidden sm:inline', isActive && 'inline')}>
+                        {opt.label}
+                      </span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{opt.description}</TooltipContent>
+                </Tooltip>
+                {!isLast && (
+                  <ChevronRight className="h-3 w-3 text-muted-foreground/20 shrink-0 mx-0.5" />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="w-px h-4 bg-border/60 shrink-0" />
+
+        {/* Right: Close */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onClose}
+              className="flex items-center justify-center h-6 w-6 rounded-sm text-muted-foreground/40 hover:text-muted-foreground/80 hover:bg-accent transition-colors shrink-0"
+              aria-label="Close sprint toolbar"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Close</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -40,6 +40,9 @@ interface UIState {
   // Per-tab cached rich titles (ReactNode) for the tab strip
   tabTitles: Record<string, ReactNode>;
 
+  // Sprint phase toolbar visibility
+  sprintToolbarOpen: boolean;
+
   // Actions
   setToolbarBackground: (toolbar: ToolbarId, className: string) => void;
   setAllToolbarBackgrounds: (className: string) => void;
@@ -47,6 +50,8 @@ interface UIState {
   setToolbarConfig: (config: ToolbarConfig | null) => void;
   setTabTitle: (tabId: string, title: ReactNode) => void;
   removeTabTitle: (tabId: string) => void;
+  setSprintToolbarOpen: (open: boolean) => void;
+  toggleSprintToolbar: () => void;
 }
 
 const defaultBackgrounds: ToolbarBackgrounds = {
@@ -59,6 +64,7 @@ export const useUIStore = create<UIState>()((set) => ({
   toolbarBackgrounds: { ...defaultBackgrounds },
   toolbarConfig: null,
   tabTitles: {},
+  sprintToolbarOpen: false,
 
   setToolbarBackground: (toolbar, className) =>
     set((state) => ({
@@ -95,4 +101,7 @@ export const useUIStore = create<UIState>()((set) => ({
       const { [tabId]: _removed, ...rest } = state.tabTitles;
       return { tabTitles: rest };
     }),
+
+  setSprintToolbarOpen: (open) => set({ sprintToolbarOpen: open }),
+  toggleSprintToolbar: () => set((s) => ({ sprintToolbarOpen: !s.sprintToolbarOpen })),
 }));


### PR DESCRIPTION
## What

Adds a collapsible `SprintPhaseToolbar` — a full phase stepper that slides in below the content action bar when the user enters or interacts with a sprint. Replaces the previous inline phase buttons in `SprintPhaseBar` with a cleaner two-piece design: a compact pill indicator in the toolbar strip + a dedicated expandable toolbar for phase navigation.

## Changes

### New: `SprintPhaseToolbar`
- Full phase stepper with chevron separators and checkmarks for completed steps
- Slides in with a subtle animation below `ContentActionBar`
- Dispatches `sprint-phase-advance` events so all phase-change logic (including `PHASE_TO_STATUS` sync) stays centralised in `SessionToolbarContent`
- X button closes the toolbar without exiting sprint

### Updated: `SprintPhaseBar`
- **Inactive state**: clicking "Sprint" opens the toolbar (via `onOpenToolbar` prop) instead of immediately activating sprint
- **Active state**: pill now toggles the toolbar open/closed rather than directly exiting sprint — fixes a dead-end where the toolbar couldn't be reopened once dismissed
- Added null guard on `activeOpt` (was a non-null assertion that would crash on unknown DB phase values)

### Updated: `uiStore`
- `sprintToolbarOpen` state with `setSprintToolbarOpen` / `toggleSprintToolbar` actions

### Updated: `SessionToolbarContent`
- Toolbar auto-opens when sprint is first activated (including via `/sprint` slash command)
- Toolbar closes when sprint is deactivated; reopens if the deactivation API call fails and the phase reverts
- Toolbar resets to closed on session change
- `setSprintToolbarOpen` extracted as a stable Zustand selector (was using `getState()` inside callbacks, missing from deps)

## How to test

1. Open a session → click **Sprint** button → toolbar should slide in with all phases
2. Click a phase in the toolbar → phase updates, task status syncs
3. Click X on toolbar → toolbar closes, sprint pill remains in the bottom toolbar
4. Click the sprint pill → toolbar reopens
5. Click the active phase in the toolbar → sprint exits, toolbar closes, pill disappears
6. Run `/sprint` slash command → sprint activates and toolbar opens automatically
7. Switch sessions → toolbar closes