### PR TITLE
fix: always show permission mode shield and auto-approve chatml tools

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1870,6 +1870,11 @@ const canUseTool: CanUseTool = async (toolName, toolInput, _options) => {
     return { behavior: "allow", updatedInput: toolInput };
   }
 
+  // First-party ChatML MCP tools are always auto-approved
+  if (toolName.startsWith("mcp__chatml__")) {
+    return { behavior: "allow", updatedInput: toolInput };
+  }
+
   // Network tools (e.g., WebSearch) are auto-allowed except in dontAsk mode
   // where they could exfiltrate codebase context via search queries.
   if (NETWORK_TOOLS.has(toolName) && currentPermissionMode !== "dontAsk") {

--- a/src/components/conversation/ChatInputToolbar.tsx
+++ b/src/components/conversation/ChatInputToolbar.tsx
@@ -313,8 +313,7 @@ export function ChatInputToolbar({
       </Button>
 
       {/* Permission Mode Dropdown */}
-      {permissionMode.mode !== 'bypassPermissions' && (
-        <DropdownMenu>
+      <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
@@ -385,7 +384,6 @@ export function ChatInputToolbar({
             })}
           </DropdownMenuContent>
         </DropdownMenu>
-      )}
 
       {/* Spacer */}
       <div className="flex-1" />


### PR DESCRIPTION
## What

Two fixes to the tool permission system:

1. **Shield button always visible** — removed the `bypassPermissions` condition that hid the permission mode dropdown entirely when in Full Access mode, making it impossible to switch away without going to Settings.

2. **Auto-approve `mcp__chatml__*` tools** — first-party ChatML MCP tools (sprint phase, session status, workspace diff, etc.) now bypass the approval prompt, same as `Read`/`Glob` and other built-in tools.

## Why

- Selecting "Full Access" from the shield dropdown caused it to disappear with no way to switch back mid-conversation
- `mcp__chatml__` tools are part of the product itself and should never require user approval

## How to test

1. Start a conversation in any non-bypass permission mode — shield should be visible
2. Switch to "Full Access" — shield stays visible and dropdown still works
3. In default permission mode, trigger any `mcp__chatml__*` tool (e.g. sprint phase update) — no approval banner should appear
4. Trigger a non-chatml MCP tool — approval banner should still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)