### PR TITLE
feat: show PR title with badge in session hover card popover

### DIFF
--- a/src/components/shared/SessionHoverCard.tsx
+++ b/src/components/shared/SessionHoverCard.tsx
@@ -4,6 +4,7 @@ import { GitBranch, GitPullRequest } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 import { getTaskStatusOption } from '@/lib/session-fields';
+import { PRNumberBadge } from '@/components/shared/PRNumberBadge';
 import type { WorktreeSession } from '@/lib/types';
 
 interface SessionHoverCardBodyProps {
@@ -38,6 +39,20 @@ export function SessionHoverCardBody({
         <span className="text-muted-foreground/50">&middot;</span>
         <span className="shrink-0">{formatTimeAgo(session.updatedAt)}</span>
       </div>
+
+      {/* PR row */}
+      {hasPR && session.prNumber && session.prTitle && (
+        <div className="border-t border-border/50 px-3 py-2 flex items-center gap-2 min-w-0">
+          <PRNumberBadge
+            prNumber={session.prNumber}
+            prStatus={session.prStatus as 'open' | 'merged' | 'closed'}
+            checkStatus={session.checkStatus}
+            hasMergeConflict={session.hasMergeConflict}
+            prUrl={session.prUrl}
+          />
+          <span className="text-xs text-muted-foreground truncate">{session.prTitle}</span>
+        </div>
+      )}
 
       {/* Description */}
       {session.task && (


### PR DESCRIPTION
## Summary

- When a session has an associated PR, the hover card popover now shows the PR title preceded by the `PRNumberBadge` component
- The PR row appears between the status/time meta row and the task description
- Only renders when `prNumber`, `prStatus`, and `prTitle` are all present

## Test plan

- [ ] Hover over a session card that has a PR → popover should show the PR badge + title
- [ ] Hover over a session without a PR → no PR row appears
- [ ] PR badge reflects correct status styling (open/merged/closed/pending/conflict/failure)
- [ ] PR title truncates cleanly on long titles
- [ ] Clicking the PR badge opens the PR URL in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)