### PR TITLE
fix: accept absolute paths in session file content API

### DIFF
--- a/backend/server/file_handlers.go
+++ b/backend/server/file_handlers.go
@@ -415,6 +415,17 @@ func (h *Handlers) GetSessionFileContent(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// If an absolute path was sent, strip the worktree prefix to make it relative
+	if filepath.IsAbs(filePath) {
+		prefix := session.WorktreePath
+		if !strings.HasSuffix(prefix, "/") {
+			prefix += "/"
+		}
+		if strings.HasPrefix(filePath, prefix) {
+			filePath = filePath[len(prefix):]
+		}
+	}
+
 	// Validate and clean the path to prevent directory traversal attacks
 	cleanPath, err := validatePath(session.WorktreePath, filePath)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Clicking on Edit tool file paths in the conversation area was returning a 400 "invalid path" error
- Root cause: when `worktreePath` is not yet loaded on the frontend, `toRelativePath()` falls through and sends the raw absolute path to the backend
- The backend's `validatePath()` unconditionally rejected absolute paths

## What changed

In `GetSessionFileContent` (`backend/server/file_handlers.go`), before validation, the handler now checks if the incoming path is absolute. If it starts with the session's `worktreePath`, the prefix is stripped to produce a valid relative path. Paths outside the worktree are still rejected by `validatePath`.

## How to test

1. Open a session that has Edit tool calls in its conversation history
2. Click a file path badge in any tool usage block
3. File should open without errors (previously showed 400 in browser console)
4. Verify that a path pointing outside the worktree still returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)