### PR TITLE
fix: harden permission mode runtime changes with validation and rollback

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -180,9 +180,23 @@ let prePlanPermissionMode: PermissionMode = "bypassPermissions";
     }
   }
   currentPermissionMode = initialPermissionMode;
-  // If the agent starts in plan mode, the pre-plan fallback should be
-  // bypassPermissions so that ExitPlanMode restores to the correct non-plan mode.
-  prePlanPermissionMode = initialPermissionMode === "plan" ? "bypassPermissions" : initialPermissionMode;
+  // If the agent starts in plan mode, determine what permission mode to restore to
+  // after ExitPlanMode. The --pre-plan-permission-mode arg lets the caller specify
+  // the intended post-plan mode (e.g., "default" when the user has Ask for Approval
+  // enabled alongside Plan mode). Without this arg, fall back to "bypassPermissions".
+  if (initialPermissionMode === "plan") {
+    const prePlanArg = getArg("--pre-plan-permission-mode");
+    if (prePlanArg && (validPermissionModes as readonly string[]).includes(prePlanArg) && prePlanArg !== "plan") {
+      prePlanPermissionMode = prePlanArg as PermissionMode;
+    } else {
+      if (prePlanArg) {
+        console.error(`Invalid --pre-plan-permission-mode value: "${prePlanArg}". Falling back to "bypassPermissions".`);
+      }
+      prePlanPermissionMode = "bypassPermissions";
+    }
+  } else {
+    prePlanPermissionMode = initialPermissionMode;
+  }
 }
 
 // Task 6: Settings Sources Configuration

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1971,6 +1971,39 @@ func (m *Manager) SetConversationPlanMode(convID string, enabled bool) error {
 	return proc.SetPermissionMode(mode)
 }
 
+// SetConversationPermissionMode sets the permission mode for a running conversation.
+// Valid modes: "default", "acceptEdits", "bypassPermissions", "dontAsk".
+func (m *Manager) SetConversationPermissionMode(convID string, mode string) error {
+	validModes := map[string]bool{
+		"default": true, "acceptEdits": true,
+		"bypassPermissions": true, "dontAsk": true,
+	}
+	if !validModes[mode] {
+		return fmt.Errorf("invalid permission mode: %q", mode)
+	}
+
+	m.mu.RLock()
+	proc, ok := m.convProcesses[convID]
+	m.mu.RUnlock()
+
+	if !ok {
+		// Process fully cleaned up — mode will be applied on next start.
+		return nil
+	}
+
+	if proc.IsPlanModeActive() {
+		return fmt.Errorf("cannot change permission mode while in plan mode")
+	}
+
+	if proc.IsStopped() || !proc.IsRunning() {
+		// Process idle — persist in options so restart picks it up.
+		proc.SetOptionsPermissionMode(mode)
+		return nil
+	}
+
+	return proc.SetPermissionMode(mode)
+}
+
 // SetConversationFastMode toggles fast output mode for a running conversation
 func (m *Manager) SetConversationFastMode(convID string, enabled bool) error {
 	m.mu.RLock()

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -233,6 +233,12 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	}
 	if opts.PlanMode {
 		args = append(args, "--permission-mode", "plan")
+		// When the user also specified a non-bypass permission mode, pass it as the
+		// post-plan restore target so the agent knows what to revert to after ExitPlanMode.
+		// Without this, prePlanPermissionMode always falls back to "bypassPermissions".
+		if opts.PermissionMode != "" && opts.PermissionMode != "bypassPermissions" {
+			args = append(args, "--pre-plan-permission-mode", opts.PermissionMode)
+		}
 	} else if opts.PermissionMode != "" && opts.PermissionMode != "bypassPermissions" {
 		// Non-default permission mode (e.g., "default", "acceptEdits", "dontAsk")
 		args = append(args, "--permission-mode", opts.PermissionMode)
@@ -1020,6 +1026,13 @@ func (p *Process) SetOptionsPlanMode(enabled bool) {
 	defer p.mu.Unlock()
 	p.opts.PlanMode = enabled
 	p.planModeActive = enabled
+}
+
+// SetOptionsPermissionMode updates the permission mode in process options so it survives restart.
+func (p *Process) SetOptionsPermissionMode(mode string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.opts.PermissionMode = mode
 }
 
 // TakePendingUserMessage returns and clears the pending user message.

--- a/backend/server/conversation_handlers.go
+++ b/backend/server/conversation_handlers.go
@@ -21,6 +21,15 @@ import (
 
 // Conversation handlers
 
+// isValidPermissionMode reports whether mode is one of the allowed non-plan permission modes.
+func isValidPermissionMode(mode string) bool {
+	switch mode {
+	case "default", "acceptEdits", "bypassPermissions", "dontAsk":
+		return true
+	}
+	return false
+}
+
 func (h *Handlers) ListConversations(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	sessionID := chi.URLParam(r, "sessionId")
@@ -191,15 +200,9 @@ func (h *Handlers) CreateConversation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate permissionMode if provided
-	if req.PermissionMode != "" {
-		validPermissionModes := map[string]bool{
-			"default": true, "acceptEdits": true,
-			"bypassPermissions": true, "dontAsk": true,
-		}
-		if !validPermissionModes[req.PermissionMode] {
-			writeValidationError(w, "permissionMode must be one of: default, acceptEdits, bypassPermissions, dontAsk")
-			return
-		}
+	if req.PermissionMode != "" && !isValidPermissionMode(req.PermissionMode) {
+		writeValidationError(w, "permissionMode must be one of: default, acceptEdits, bypassPermissions, dontAsk")
+		return
 	}
 
 	// Build options for starting the conversation
@@ -661,6 +664,42 @@ func (h *Handlers) SetConversationPlanMode(w http.ResponseWriter, r *http.Reques
 	}
 
 	writeJSON(w, map[string]bool{"enabled": req.Enabled})
+}
+
+type SetPermissionModeRequest struct {
+	Mode string `json:"mode"`
+}
+
+func (h *Handlers) SetConversationPermissionMode(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	convID := chi.URLParam(r, "convId")
+	conv, err := h.store.GetConversationMeta(ctx, convID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if conv == nil {
+		writeNotFound(w, "conversation")
+		return
+	}
+
+	var req SetPermissionModeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	if !isValidPermissionMode(req.Mode) {
+		writeValidationError(w, "mode must be one of: default, acceptEdits, bypassPermissions, dontAsk")
+		return
+	}
+
+	if err := h.agentManager.SetConversationPermissionMode(convID, req.Mode); err != nil {
+		writeInternalError(w, "failed to set permission mode", err)
+		return
+	}
+
+	writeJSON(w, map[string]string{"mode": req.Mode})
 }
 
 type SetFastModeRequest struct {

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -230,6 +230,7 @@ func NewRouter(ctx context.Context, s *store.SQLiteStore, hub *Hub, agentMgr *ag
 		r.Get("/{convId}/drop-stats", h.GetConversationDropStats)
 		r.Post("/{convId}/rewind", h.RewindConversation)
 		r.Post("/{convId}/plan-mode", h.SetConversationPlanMode)
+		r.Post("/{convId}/permission-mode", h.SetConversationPermissionMode)
 		r.Post("/{convId}/fast-mode", h.SetConversationFastMode)
 		r.Post("/{convId}/max-thinking-tokens", h.SetConversationMaxThinkingTokens)
 		r.Post("/{convId}/approve-plan", h.ApprovePlan)

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useAppStore } from '@/stores/appStore';
-import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, setConversationFastMode, approvePlan } from '@/lib/api';
+import { createConversation, sendConversationMessage, stopConversation, setConversationPlanMode, setConversationFastMode, setConversationPermissionMode, approvePlan } from '@/lib/api';
 import { markPlanModeExited } from '@/hooks/useWebSocket';
 import { dispatchAppEvent, useAppEventListener } from '@/lib/custom-events';
 import { useShortcut, useCustomShortcut } from '@/hooks/useShortcut';
@@ -37,7 +37,7 @@ import { useChatInputKeyboardShortcuts } from './useChatInputKeyboardShortcuts';
 import { ChatInputPillSuggestions } from './ChatInputPillSuggestions';
 import { ChatInputPlanApproval } from './ChatInputPlanApproval';
 import { ToolApprovalBanner } from './ToolApprovalBanner';
-import { ChatInputToolbar } from './ChatInputToolbar';
+import { ChatInputToolbar, type PermissionMode } from './ChatInputToolbar';
 import { DictationWaveform } from './DictationWaveform';
 import { useDictation } from '@/hooks/useDictation';
 
@@ -586,6 +586,21 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
     }
   }, [fastModeEnabled, selectedConversationId]);
 
+  const handlePermissionModeChange = useCallback(async (mode: PermissionMode) => {
+    const previousMode = permissionMode;
+    setPermissionMode(mode);
+
+    if (selectedConversationId) {
+      try {
+        await setConversationPermissionMode(selectedConversationId, mode);
+      } catch (err) {
+        // Rollback optimistic update — the live process rejected the change (e.g. plan mode active).
+        setPermissionMode(previousMode);
+        console.debug('setConversationPermissionMode failed (will apply on next message):', err);
+      }
+    }
+  }, [permissionMode, selectedConversationId]);
+
   // Handle plan approval
   const handleApprovePlan = useCallback(async () => {
     if (!selectedConversationId || !pendingPlanApproval) return;
@@ -807,8 +822,6 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           message: trimmedContent,
           model: selectedModel.id,
           planMode: planModeEnabled ? true : undefined,
-          // TODO: permissionMode is only set on creation — changing the setting mid-session
-          // won't affect existing conversations (unlike model/fastMode which have set_* messages).
           permissionMode: permissionMode !== 'bypassPermissions' ? permissionMode : undefined,
           fastMode: fastModeEnabled ? true : undefined,
           maxThinkingTokens: thinkingParams.maxThinkingTokens,
@@ -1178,7 +1191,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
           permissionMode={{
             mode: permissionMode,
             defaultMode: defaultPermissionMode,
-            setMode: setPermissionMode,
+            setMode: handlePermissionModeChange,
             setDefault: setDefaultPermissionMode,
           }}
           planModeEnabled={planModeEnabled}

--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -8,6 +8,7 @@ import {
   setWorkspacesBasePath,
   createConversation,
   setConversationPlanMode,
+  setConversationPermissionMode,
   approvePlan,
   resolvePR,
 } from '../api';
@@ -316,6 +317,57 @@ describe('Plan Mode API', () => {
       );
 
       await expect(setConversationPlanMode('conv-1', true)).rejects.toThrow();
+    });
+  });
+
+  describe('setConversationPermissionMode', () => {
+    it('sets a valid permission mode', async () => {
+      let receivedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/permission-mode`, async ({ request }) => {
+          receivedBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({ mode: receivedBody.mode });
+        })
+      );
+
+      await expect(setConversationPermissionMode('conv-1', 'default')).resolves.toBeUndefined();
+      expect(receivedBody).toEqual({ mode: 'default' });
+    });
+
+    it('sends the mode in request body', async () => {
+      let receivedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/permission-mode`, async ({ request }) => {
+          receivedBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json({ mode: receivedBody.mode });
+        })
+      );
+
+      await setConversationPermissionMode('conv-1', 'acceptEdits');
+      expect(receivedBody.mode).toBe('acceptEdits');
+    });
+
+    it('rejects when conversation not found (404)', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/permission-mode`, () => {
+          return HttpResponse.json({ error: 'conversation not found' }, { status: 404 });
+        })
+      );
+
+      await expect(setConversationPermissionMode('nonexistent', 'default')).rejects.toThrow();
+    });
+
+    it('rejects on server error (500)', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/permission-mode`, () => {
+          return HttpResponse.json(
+            { error: 'failed to set permission mode' },
+            { status: 500 }
+          );
+        })
+      );
+
+      await expect(setConversationPermissionMode('conv-1', 'default')).rejects.toThrow();
     });
   });
 

--- a/src/lib/api/conversations.ts
+++ b/src/lib/api/conversations.ts
@@ -402,6 +402,22 @@ export async function approvePlan(convId: string, requestId: string, approved: b
   }
 }
 
+// Set permission mode for a running conversation
+export async function setConversationPermissionMode(
+  convId: string,
+  mode: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk',
+): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/permission-mode`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mode }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(text || `HTTP ${res.status}`, res.status, text);
+  }
+}
+
 // Approve or deny a pending tool execution request
 export async function approveTool(
   convId: string,


### PR DESCRIPTION
## Summary

- **Validation defense-in-depth**: `SetConversationPermissionMode` in `manager.go` now validates the mode string before persisting or forwarding it, preventing invalid modes from reaching the agent runner via direct internal calls that bypass the HTTP layer
- **Plan-mode desync fix**: Blocks permission-mode changes while the process is actively in plan mode (would have silently set `planModeActive = false` via `proc.SetPermissionMode`)
- **UI rollback on API failure**: `handlePermissionModeChange` now captures `previousMode` and restores it if the API call fails, keeping UI state in sync with the live agent
- **Shared validation helper**: Extracted `isValidPermissionMode()` in `conversation_handlers.go` to replace duplicated inline maps in `CreateConversation` and `SetConversationPermissionMode` handlers
- **Type safety**: `setConversationPermissionMode` `mode` param typed as the `PermissionMode` union instead of `string`
- **Test coverage**: 4 tests added for `setConversationPermissionMode` (success, body shape, 404, 500) — mirrors existing `setConversationPlanMode` coverage
- **Error visibility**: `--pre-plan-permission-mode` CLI arg now logs `console.error` for invalid values, matching `--permission-mode` behaviour

## Test plan

- [ ] Change permission mode on a running conversation — verify it applies immediately
- [ ] Try to change permission mode while plan mode is active — verify the dropdown reverts (rollback)
- [ ] Verify `npm run test` passes for `src/lib/__tests__/api.test.ts`
- [ ] Verify `cd backend && go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)