### PR TITLE
feat: remove timestamp from session cell, add sidebar meta toggle

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1407,6 +1407,7 @@ function SessionRow({
   const isSessionSelected = contentView.type === 'conversation' && selectedSessionId === session.id;
   const hasPR = session.prStatus && session.prStatus !== 'none';
   const hasStats = session.stats && (session.stats.additions > 0 || session.stats.deletions > 0);
+  const sidebarShowSessionMeta = useSettingsStore((s) => s.sidebarShowSessionMeta);
 
   // Derive activity state from streaming, pending questions, and plan approvals
   const sessionId = session.id;
@@ -1540,50 +1541,46 @@ function SessionRow({
                     </div>
                   </div>
                 </div>
-                {/* Second line: project indicator · priority · session name · PR info · status */}
-                <div className="flex items-center gap-1 mt-0.5 pl-1 text-sm text-muted-foreground">
-                  {/* Project indicator for non-project grouping modes */}
-                  {showProjectIndicator && workspaceColor && (
-                    <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: workspaceColor }} />
-                  )}
-                  {showProjectIndicator && workspaceName && (
-                    <span className="shrink-0 text-muted-foreground/70">{workspaceName}</span>
-                  )}
-                  {/* PR badge if applicable */}
-                  {hasPR && session.prNumber && (
-                    <>
-                      {showProjectIndicator && workspaceName && <span className="text-muted-foreground/50">·</span>}
-                      <PRNumberBadge
-                        prNumber={session.prNumber}
-                        prStatus={session.prStatus as 'open' | 'merged' | 'closed'}
-                        checkStatus={session.checkStatus}
-                        hasMergeConflict={session.hasMergeConflict}
-                        prUrl={session.prUrl}
-                        size="sm"
-                      />
-                    </>
-                  )}
-                  {hasPR && !session.prNumber && (
-                    <>
-                      {showProjectIndicator && workspaceName && <span className="text-muted-foreground/50">·</span>}
-                      <GitPullRequest className="h-3 w-3 shrink-0 text-nav-icon-prs" />
-                    </>
-                  )}
-                  {prStatusInfo && (
-                    <>
-                      <span className="text-muted-foreground/50">·</span>
-                      <span className={cn('shrink-0', prStatusInfo.color)}>
-                        {prStatusInfo.text}
-                      </span>
-                    </>
-                  )}
-                  {!hasPR && (
-                    <>
-                      {showProjectIndicator && workspaceName && <span className="text-muted-foreground/50">·</span>}
-                      <span className="shrink-0">{formatTimeAgo(session.updatedAt)}</span>
-                    </>
-                  )}
-                </div>
+                {/* Second line: project indicator · PR info · status (only when there's meaningful content) */}
+                {sidebarShowSessionMeta && (hasPR || (showProjectIndicator && workspaceName)) && (
+                  <div className="flex items-center gap-1 mt-0.5 pl-1 text-sm text-muted-foreground">
+                    {/* Project indicator for non-project grouping modes */}
+                    {showProjectIndicator && workspaceColor && (
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: workspaceColor }} />
+                    )}
+                    {showProjectIndicator && workspaceName && (
+                      <span className="shrink-0 text-muted-foreground/70">{workspaceName}</span>
+                    )}
+                    {/* PR badge if applicable */}
+                    {hasPR && session.prNumber && (
+                      <>
+                        {showProjectIndicator && workspaceName && <span className="text-muted-foreground/50">·</span>}
+                        <PRNumberBadge
+                          prNumber={session.prNumber}
+                          prStatus={session.prStatus as 'open' | 'merged' | 'closed'}
+                          checkStatus={session.checkStatus}
+                          hasMergeConflict={session.hasMergeConflict}
+                          prUrl={session.prUrl}
+                          size="sm"
+                        />
+                      </>
+                    )}
+                    {hasPR && !session.prNumber && (
+                      <>
+                        {showProjectIndicator && workspaceName && <span className="text-muted-foreground/50">·</span>}
+                        <GitPullRequest className="h-3 w-3 shrink-0 text-nav-icon-prs" />
+                      </>
+                    )}
+                    {prStatusInfo && (
+                      <>
+                        <span className="text-muted-foreground/50">·</span>
+                        <span className={cn('shrink-0', prStatusInfo.color)}>
+                          {prStatusInfo.text}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           </HoverCardTrigger>

--- a/src/components/settings/sections/AppearanceSettings.tsx
+++ b/src/components/settings/sections/AppearanceSettings.tsx
@@ -105,6 +105,8 @@ export function AppearanceSettings() {
   const setFontSize = useSettingsStore((s) => s.setFontSize);
   const zenMode = useSettingsStore((s) => s.zenMode);
   const setZenMode = useSettingsStore((s) => s.setZenMode);
+  const sidebarShowSessionMeta = useSettingsStore((s) => s.sidebarShowSessionMeta);
+  const setSidebarShowSessionMeta = useSettingsStore((s) => s.setSidebarShowSessionMeta);
   const showTokenUsage = useSettingsStore((s) => s.showTokenUsage);
   const setShowTokenUsage = useSettingsStore((s) => s.setShowTokenUsage);
   const showChatCost = useSettingsStore((s) => s.showChatCost);
@@ -171,6 +173,18 @@ export function AppearanceSettings() {
           onReset={() => setZenMode(SETTINGS_DEFAULTS.zenMode)}
         >
           <Switch checked={zenMode} onCheckedChange={setZenMode} aria-label="Zen mode" />
+        </SettingsRow>
+      </SettingsGroup>
+
+      <SettingsGroup label="Sidebar">
+        <SettingsRow
+          settingId="sidebarShowSessionMeta"
+          title="Show session status line"
+          description="Display PR status (Merged, Ready for Merge, etc.) below session names in the sidebar"
+          isModified={sidebarShowSessionMeta !== SETTINGS_DEFAULTS.sidebarShowSessionMeta}
+          onReset={() => setSidebarShowSessionMeta(SETTINGS_DEFAULTS.sidebarShowSessionMeta)}
+        >
+          <Switch checked={sidebarShowSessionMeta} onCheckedChange={setSidebarShowSessionMeta} aria-label="Show session status line" />
         </SettingsRow>
       </SettingsGroup>
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -108,6 +108,7 @@ export const SETTINGS_DEFAULTS = {
   // Sidebar
   sidebarGroupBy: 'project' as SidebarGroupBy,
   sidebarSortBy: 'recent' as SidebarSortBy,
+  sidebarShowSessionMeta: true,
   // Dictation
   dictationShortcut: 'cmd-shift-d' as DictationShortcutPreset,
   dictationCustomShortcut: '',
@@ -189,6 +190,7 @@ interface SettingsState {
   // Sidebar grouping/sorting
   sidebarGroupBy: SidebarGroupBy;
   sidebarSortBy: SidebarSortBy;
+  sidebarShowSessionMeta: boolean; // Whether to show the second line (PR status) in session cells
   collapsedSidebarGroups: string[]; // composite keys toggled from default, e.g. "status:done"
   workspaceOrder: string[]; // Persisted workspace display order (array of workspace IDs)
 
@@ -260,6 +262,7 @@ interface SettingsState {
   resetAllSettings: () => void;
   setSidebarGroupBy: (value: SidebarGroupBy) => void;
   setSidebarSortBy: (value: SidebarSortBy) => void;
+  setSidebarShowSessionMeta: (value: boolean) => void;
   toggleSidebarGroupCollapsed: (key: string) => void;
   ensureSidebarGroupExpanded: (key: string, defaultCollapsed: boolean) => void;
   setLastRepoDashboardWorkspaceId: (id: string | null) => void;
@@ -438,6 +441,7 @@ export const useSettingsStore = create<SettingsState>()(
       resetAllSettings: () => set({ ...SETTINGS_DEFAULTS }),
       setSidebarGroupBy: (value) => set({ sidebarGroupBy: value }),
       setSidebarSortBy: (value) => set({ sidebarSortBy: value }),
+      setSidebarShowSessionMeta: (value) => set({ sidebarShowSessionMeta: value }),
       setLastRepoDashboardWorkspaceId: (id) => set({ lastRepoDashboardWorkspaceId: id }),
       setWorkspaceOrder: (order) => set({ workspaceOrder: order }),
       toggleSidebarGroupCollapsed: (key) =>


### PR DESCRIPTION
## Summary

- Removes the always-visible timestamp from session rows in the sidebar (the second line previously showed `updatedAt` when there was no PR)
- The second line now only renders when there is meaningful content: a PR badge or a project workspace indicator
- Adds a **"Show session status line"** toggle in Appearance settings (`sidebarShowSessionMeta`) so users can hide the second line entirely

## How to test

1. Open the sidebar — session rows should no longer show a timestamp below the branch name
2. Sessions with open/merged PRs should still show the PR badge and status on the second line
3. In Appearance settings → Sidebar → toggle "Show session status line" off — the second line (PR badge + project indicator) should disappear for all sessions
4. Reset the toggle — it returns to the default (on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)