### PR TITLE
fix: harden agent instructions against cross-worktree writes and main branch commits

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -3213,6 +3213,7 @@ Do NOT use `+"`"+`mcp__chatml__start_linear_issue`+"`"+` — it creates git bran
 		session.WorktreePath,
 		session.WorktreePath,
 		session.WorktreePath,
+		session.WorktreePath,
 		targetBranchShort,
 		targetBranchShort,
 	)


### PR DESCRIPTION
## Summary

- **NEVER commit on `main`/`master`**: adds an explicit rule requiring the agent to check `git branch --show-current` before every commit and stop with an explanation if it detects a protected branch
- **Strict worktree boundary**: expands the single-line "stay in worktree directory" instruction into a multi-point rule that names the session worktree as the *only* valid path for all file operations — explicitly prohibiting writes to other sessions' worktree directories and absolute paths pointing outside

## Why

A session agent wrote changes into the wrong worktree path (another session's directory). The previous instruction only said "do not `cd` outside", which was too vague to prevent file writes via absolute paths.

## Test plan

- [ ] Start a new session and verify the system prompt contains both new rules (visible in agent logs or via `mcp__chatml__get_session_status`)
- [ ] Confirm `go build ./...` in `backend/` passes (already verified locally)