### PR TITLE
feat: show last agent completion timestamp in session hover card

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1413,6 +1413,7 @@ function SessionRow({
   const sessionId = session.id;
   const activityState = useSessionActivityState(sessionId);
   const isSessionUnread = useIsSessionUnread(sessionId);
+  const lastAgentCompletedAt = useAppStore((s) => s.lastTurnCompletedAt[sessionId]);
 
   // Determine PR status display
   const getPRStatusInfo = () => {
@@ -1588,6 +1589,7 @@ function SessionRow({
             <SessionHoverCardBody
               session={session}
               formatTimeAgo={formatTimeAgo}
+              lastAgentCompletedAt={lastAgentCompletedAt}
               onCreatePR={() => {
                 setHoverOpen(false);
                 onSelectSession(session.id);

--- a/src/components/shared/SessionHoverCard.tsx
+++ b/src/components/shared/SessionHoverCard.tsx
@@ -10,12 +10,14 @@ import type { WorktreeSession } from '@/lib/types';
 interface SessionHoverCardBodyProps {
   session: WorktreeSession;
   formatTimeAgo: (date: string) => string;
+  lastAgentCompletedAt?: number;
   onCreatePR?: () => void;
 }
 
 export function SessionHoverCardBody({
   session,
   formatTimeAgo,
+  lastAgentCompletedAt,
   onCreatePR,
 }: SessionHoverCardBodyProps) {
   const hasStats = session.stats && (session.stats.additions > 0 || session.stats.deletions > 0);
@@ -37,7 +39,13 @@ export function SessionHoverCardBody({
         <TaskStatusIcon status={session.taskStatus} className="h-3 w-3 shrink-0" />
         <span className="shrink-0">{statusOption.label}</span>
         <span className="text-muted-foreground/50">&middot;</span>
-        <span className="shrink-0">{formatTimeAgo(session.updatedAt)}</span>
+        <span className="shrink-0">
+          {formatTimeAgo(
+            lastAgentCompletedAt !== undefined && lastAgentCompletedAt > new Date(session.updatedAt).getTime()
+              ? new Date(lastAgentCompletedAt).toISOString()
+              : session.updatedAt
+          )}
+        </span>
       </div>
 
       {/* PR row */}


### PR DESCRIPTION
## What

Shows the last agent turn completion timestamp in the session hover card meta row, using the in-memory `lastTurnCompletedAt` store value when available.

## Why

The existing `session.updatedAt` comes from the backend and may lag behind real-time agent activity. Showing the in-session completion timestamp gives a more accurate "just completed" signal in the hover card.

## How it works

- `SessionRow` reads `lastTurnCompletedAt[sessionId]` from the app store and passes it to `SessionHoverCardBody` as `lastAgentCompletedAt`
- The hover card displays whichever timestamp is more recent — `lastAgentCompletedAt` or `session.updatedAt` — so backend events (PR status changes, branch syncs) that bump `updatedAt` after the agent turn are still reflected correctly
- Falls back to `session.updatedAt` on page reload (in-memory store resets)

## Testing

1. Start an agent session and let it complete a turn
2. Hover over the session row in the sidebar — the meta row should show a fresh "just now" / recent timestamp
3. Verify the fallback: reload the page, hover again — should show `session.updatedAt` instead