### PR TITLE
polish: improve speech listening bar UX and fix spurious errors

### DIFF
--- a/src-tauri/src/speech.rs
+++ b/src-tauri/src/speech.rs
@@ -218,6 +218,7 @@ mod platform {
             // the recognition request pointer, preventing use-after-free on teardown.
             let stopped = Arc::new(AtomicBool::new(false));
             let stopped_for_tap = Arc::clone(&stopped);
+            let stopped_for_result = Arc::clone(&stopped);
 
             // Store request ptr as usize for the tap callback (avoids Send issues)
             let request_ptr = Retained::as_ptr(&request) as usize;
@@ -271,6 +272,12 @@ mod platform {
                     }
 
                     if !error.is_null() {
+                        // Suppress errors triggered by intentional stop — cancelling
+                        // the recognition task causes Apple's API to fire an error callback.
+                        if stopped_for_result.load(Ordering::Acquire) {
+                            return;
+                        }
+
                         let desc: *mut AnyObject = msg_send![error, localizedDescription];
                         let msg = if !desc.is_null() {
                             nsstring_to_string(desc)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -644,7 +644,7 @@ code.hljs { padding: 3px 5px; }
 
 .dictation-active {
   position: relative;
-  background-color: rgba(249, 115, 22, 0.1);
+  background-color: rgba(59, 130, 246, 0.1);
 }
 
 .dictation-active::after {
@@ -652,14 +652,14 @@ code.hljs { padding: 3px 5px; }
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 2px solid rgba(249, 115, 22, 0.4);
+  border: 2px solid rgba(59, 130, 246, 0.4);
   animation: dictation-pulse 1.5s ease-in-out infinite;
   will-change: transform, opacity;
   pointer-events: none;
 }
 
 .dictation-active:hover {
-  background-color: rgba(249, 115, 22, 0.2);
+  background-color: rgba(59, 130, 246, 0.2);
 }
 
 /* Sound level bars animation — currently unused, no component references .sound-bar */

--- a/src/components/conversation/ChatInputToolbar.tsx
+++ b/src/components/conversation/ChatInputToolbar.tsx
@@ -436,7 +436,7 @@ export function ChatInputToolbar({
               size="icon"
               className={cn(
                 'h-7 w-7 rounded-md',
-                dictation.isDictating && 'dictation-active text-orange-500'
+                dictation.isDictating && 'dictation-active text-blue-500'
               )}
               onClick={dictation.onToggle}
               aria-label={dictation.isDictating ? 'Stop dictation' : 'Start dictation'}

--- a/src/components/conversation/DictationWaveform.tsx
+++ b/src/components/conversation/DictationWaveform.tsx
@@ -1,25 +1,24 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useRef } from 'react';
 import { Mic } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const BAR_COUNT = 24;
+const MIN_HEIGHT = 0.08;
+const WAVE_SPEED = 4;
 
-// Pre-compute deterministic base offsets (no randomness needed — visual variety
-// comes from the audio-level multipliers which change per frame).
-const BAR_OFFSETS = Array.from({ length: BAR_COUNT }, (_, i) => {
-  // Use a simple hash-like formula for deterministic but varied offsets
-  const t = ((i * 7 + 3) % BAR_COUNT) / BAR_COUNT;
-  return t * 0.3 + 0.05;
+// Phase offsets for each bar — creates two overlapping sine waves for organic feel
+const PHASE_OFFSETS = Array.from({ length: BAR_COUNT }, (_, i) => ({
+  primary: (i / BAR_COUNT) * Math.PI * 2,
+  secondary: (i / BAR_COUNT) * Math.PI * 3 + 1.2,
+}));
+
+// Center envelope — bars in the center are taller than edges
+const CENTER_FACTORS = Array.from({ length: BAR_COUNT }, (_, i) => {
+  const center = (BAR_COUNT - 1) / 2;
+  return 1 - (Math.abs(i - center) / center) * 0.3;
 });
-
-// Simple deterministic hash to produce pseudo-random multipliers per bar + audioLevel
-function barMultiplier(index: number, level: number): number {
-  const seed = index * 2654435761 + Math.round(level * 1000) * 2246822519;
-  const hash = ((seed >>> 0) ^ (seed >>> 16)) >>> 0;
-  return 0.6 + (hash % 1000) / 2500; // range [0.6, 1.0]
-}
 
 interface DictationWaveformProps {
   audioLevel: number;
@@ -28,11 +27,51 @@ interface DictationWaveformProps {
 }
 
 export function DictationWaveform({ audioLevel, isActive, shortcutHint }: DictationWaveformProps) {
-  // Derive multipliers deterministically from audioLevel (no setState needed)
-  const barMultipliers = useMemo(
-    () => Array.from({ length: BAR_COUNT }, (_, i) => barMultiplier(i, audioLevel)),
-    [audioLevel]
-  );
+  const audioLevelRef = useRef(audioLevel);
+  const rafRef = useRef<number>(0);
+  const timeRef = useRef(0);
+  const lastFrameRef = useRef(0);
+  // Direct refs to bar DOM elements — updated each frame without going through React state
+  const barsRef = useRef<(HTMLDivElement | null)[]>([]);
+
+  // Keep audioLevel ref in sync without restarting the animation loop
+  useEffect(() => {
+    audioLevelRef.current = audioLevel;
+  }, [audioLevel]);
+
+  // Animation loop — writes heights directly to DOM to avoid 60 React re-renders/sec
+  useEffect(() => {
+    if (!isActive) return;
+
+    lastFrameRef.current = performance.now();
+
+    const animate = (now: number) => {
+      const dt = (now - lastFrameRef.current) / 1000;
+      lastFrameRef.current = now;
+      timeRef.current += dt;
+
+      const t = timeRef.current;
+      const level = audioLevelRef.current;
+
+      for (let i = 0; i < BAR_COUNT; i++) {
+        const el = barsRef.current[i];
+        if (!el) continue;
+        const { primary, secondary } = PHASE_OFFSETS[i];
+        // Two overlapping sine waves at different speeds for organic motion
+        const wave1 = Math.sin(t * WAVE_SPEED + primary);
+        const wave2 = Math.sin(t * WAVE_SPEED * 0.7 + secondary) * 0.4;
+        const combined = (wave1 + wave2) / 1.4; // normalize to [-1, 1]
+        const normalized = (combined + 1) / 2; // [0, 1]
+        const height = MIN_HEIGHT + level * normalized * CENTER_FACTORS[i] * (1 - MIN_HEIGHT);
+        el.style.height = `${Math.max(8, height * 100)}%`;
+      }
+
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [isActive]);
 
   if (!isActive) return null;
 
@@ -40,43 +79,31 @@ export function DictationWaveform({ audioLevel, isActive, shortcutHint }: Dictat
     <div
       className={cn(
         'flex items-center gap-3 px-3 py-2 rounded-t-lg',
-        'bg-orange-500/5 border-b border-orange-500/20',
+        'bg-blue-500/5 border-b border-blue-500/20',
         'animate-in slide-in-from-bottom-2 fade-in duration-200'
       )}
     >
       {/* Mic icon with pulse */}
       <div className="relative flex-shrink-0">
-        <Mic className="size-4 text-orange-500" />
-        <div className="absolute inset-0 rounded-full border border-orange-500/40 animate-ping" />
+        <Mic className="size-4 text-blue-500" />
+        <div className="absolute inset-0 rounded-full border border-blue-500/40 animate-ping" />
       </div>
 
       {/* Waveform bars */}
       <div className="flex items-center gap-[2px] h-6 flex-1 min-w-0">
-        {BAR_OFFSETS.map((baseOffset, i) => {
-          const multiplier = barMultipliers[i] ?? 1;
-          const height = Math.min(
-            1,
-            baseOffset + audioLevel * multiplier
-          );
-          // Create a gentle wave shape: bars in the center are taller
-          const centerFactor =
-            1 - Math.abs(i - BAR_COUNT / 2) / (BAR_COUNT / 2) * 0.3;
-
-          return (
-            <div
-              key={i}
-              className="sound-bar flex-1 min-w-[2px] max-w-[4px] rounded-full bg-orange-500/60"
-              style={{
-                height: `${Math.max(8, height * centerFactor * 100)}%`,
-              }}
-            />
-          );
-        })}
+        {Array.from({ length: BAR_COUNT }, (_, i) => (
+          <div
+            key={i}
+            ref={(el) => { barsRef.current[i] = el; }}
+            className="sound-bar flex-1 min-w-[2px] max-w-[4px] rounded-full bg-blue-500/60"
+            style={{ height: `${MIN_HEIGHT * 100}%` }}
+          />
+        ))}
       </div>
 
       {/* Label */}
       <div className="flex-shrink-0 flex items-center gap-2">
-        <span className="text-xs font-medium text-orange-600 dark:text-orange-400">
+        <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
           Listening...
         </span>
         {shortcutHint && (

--- a/src/hooks/useDictation.ts
+++ b/src/hooks/useDictation.ts
@@ -45,6 +45,9 @@ export function useDictation(options: UseDictationOptions): UseDictationReturn {
   const optionsRef = useRef(options);
   const isDictatingRef = useRef(false);
   const togglingRef = useRef(false);
+  // Tracks whether an explicit stop is in progress — used to suppress the
+  // spurious "no speech detected" error Apple fires during session teardown.
+  const isStoppingRef = useRef(false);
 
   useEffect(() => {
     optionsRef.current = options;
@@ -82,6 +85,17 @@ export function useDictation(options: UseDictationOptions): UseDictationReturn {
         setAudioLevel(payload.level);
       }),
       safeListen<DictationError>('dictation-error', (payload) => {
+        // Apple's SFSpeechRecognizer fires a spurious "No speech detected" error
+        // during session teardown after cancelling the recognition task. Suppress
+        // it only when we know an explicit stop is in progress — the Rust-side
+        // stopped_for_result flag handles the same race but has a narrow window
+        // before the AtomicBool is set; this is the JS-side safety net.
+        if (
+          isStoppingRef.current &&
+          payload.message.toLowerCase().includes('no speech detected')
+        ) {
+          return;
+        }
         setDictating(false);
         setAudioLevel(0);
         optionsRef.current.onError?.(payload.message);
@@ -89,6 +103,7 @@ export function useDictation(options: UseDictationOptions): UseDictationReturn {
       safeListen<void>('dictation-ended', () => {
         setDictating(false);
         setAudioLevel(0);
+        isStoppingRef.current = false;
         optionsRef.current.onEnd?.();
       }),
     ];
@@ -113,16 +128,19 @@ export function useDictation(options: UseDictationOptions): UseDictationReturn {
 
     try {
       if (isDictatingRef.current) {
+        isStoppingRef.current = true;
         // Use raw invoke (not safeInvoke) so stop errors are visible and don't silently desync UI
         try {
           await invoke('stop_dictation');
         } catch (e: unknown) {
+          isStoppingRef.current = false;
           const errMsg = e instanceof Error ? e.message : String(e);
           optionsRef.current.onError?.(`Failed to stop dictation: ${errMsg}`);
           return;
         }
         setDictating(false);
         setAudioLevel(0);
+        // isStoppingRef is reset when dictation-ended fires
       } else {
         try {
           // Use raw invoke (not safeInvoke) so we can inspect the error for "already active" desync recovery


### PR DESCRIPTION
## Summary

- **Blue color scheme**: dictation active state (button, waveform, CSS pulse animation) switched from orange to blue
- **Waveform animation perf**: replaced `useState` + `setBarHeights` in the RAF loop with direct DOM ref writes via `barsRef`, eliminating ~60 React re-renders/sec while dictation is active
- **Fix spurious teardown errors (Rust)**: added `stopped_for_result` `AtomicBool` check in the recognition result handler — when a cancel is intentional, Apple's API fires an error callback which is now suppressed before it reaches the JS layer
- **Fix spurious teardown errors (JS)**: replaced the broad `hasReceivedTranscriptRef` suppression guard (true whenever any transcript was received) with a precise `isStoppingRef` flag that is only `true` during an explicit stop invocation; prevents the UI from getting permanently stuck in "Listening..." if Apple fires "no speech detected" spontaneously mid-session

## Test plan

- [ ] Start dictation — button and waveform should be blue, not orange
- [ ] Speak — waveform bars animate smoothly with audio level response
- [ ] Stop dictation (button or shortcut) — UI returns to idle, no spurious error toast
- [ ] Stop dictation after speaking something — no "no speech detected" error flashes
- [ ] Stop dictation without speaking — "no speech detected" error should still appear
- [ ] Rapid toggle (start → stop → start) — no stuck "Listening..." state