### PR TITLE
fix: sort model dropdowns as Opus → Sonnet → Haiku

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -25,7 +25,7 @@ import { LinearIssuePicker } from './LinearIssuePicker';
 import { WorkspacePicker } from './WorkspacePicker';
 import type { LinearIssueDTO } from '@/lib/api';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
-import { MODELS as SHARED_MODELS, type ModelEntry, toShortDisplayName, isNewModel, isDefaultRecommended, deduplicateById, deduplicateByName } from '@/lib/models';
+import { MODELS as SHARED_MODELS, type ModelEntry, toShortDisplayName, isNewModel, isDefaultRecommended, deduplicateById, deduplicateByName, sortModelEntries } from '@/lib/models';
 import type { MentionItem } from '@/components/ui/mention-node';
 import { trackEvent } from '@/lib/telemetry';
 import { listSessionFiles, type FileNodeDTO } from '@/lib/api';
@@ -135,7 +135,7 @@ function buildModelList(dynamic: ReturnType<typeof useAppStore.getState>['suppor
   // Also deduplicate by display name — SDK may report dated variants
   // (e.g. claude-sonnet-4-6 and claude-sonnet-4-6-20260301) that resolve
   // to the same friendly name.
-  return deduplicateByName(entries);
+  return sortModelEntries(deduplicateByName(entries));
 }
 
 

--- a/src/components/settings/sections/AIModelSettings.tsx
+++ b/src/components/settings/sections/AIModelSettings.tsx
@@ -13,7 +13,7 @@ import {
 import { Eye, EyeOff } from 'lucide-react';
 import { useSettingsStore, SETTINGS_DEFAULTS } from '@/stores/settingsStore';
 import { useAppStore } from '@/stores/appStore';
-import { MODELS as SHARED_MODELS, toShortDisplayName, isDefaultRecommended, deduplicateById, deduplicateByName } from '@/lib/models';
+import { MODELS as SHARED_MODELS, toShortDisplayName, isDefaultRecommended, deduplicateById, deduplicateByName, sortModelEntries } from '@/lib/models';
 import type { ThinkingLevel } from '@/lib/thinkingLevels';
 import { getAnthropicApiKey, setAnthropicApiKey } from '@/lib/api';
 import { useToast } from '@/components/ui/toast';
@@ -43,7 +43,7 @@ export function AIModelSettings() {
     const entries = dynamicModels
       .filter((m) => !isDefaultRecommended(m.displayName))
       .map((m) => ({ id: m.value, name: toShortDisplayName(m.value, m.displayName) }));
-    return deduplicateByName(deduplicateById(entries));
+    return sortModelEntries(deduplicateByName(deduplicateById(entries)));
   }, [dynamicModels]);
 
   return (

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -89,6 +89,24 @@ export function deduplicateByName<T extends { name: string }>(entries: T[]): T[]
   });
 }
 
+/** Tier rank for sorting: Opus=0, Sonnet=1, Haiku=2, unknown=3 */
+function modelTierRank(id: string): number {
+  const lower = id.toLowerCase();
+  if (lower.includes('opus')) return 0;
+  if (lower.includes('sonnet')) return 1;
+  if (lower.includes('haiku')) return 2;
+  return 3;
+}
+
+/** Sort model entries by tier (Opus → Sonnet → Haiku), then by ID for stability. */
+export function sortModelEntries<T extends { id: string }>(entries: T[]): T[] {
+  return [...entries].sort((a, b) => {
+    const rankDiff = modelTierRank(a.id) - modelTierRank(b.id);
+    if (rankDiff !== 0) return rankDiff;
+    return a.id.localeCompare(b.id);
+  });
+}
+
 /** SDK model entry as reported by the agent. */
 interface SdkModelEntry {
   value: string;


### PR DESCRIPTION
## What

Model dropdowns in the Composer toolbar and Settings page were showing models in SDK-reported order (Sonnet before Opus) instead of the canonical tier order.

## Changes

- Added `sortModelEntries()` utility in `src/lib/models.ts` that ranks models by tier (Opus=0, Sonnet=1, Haiku=2, unknown=3) with stable secondary sort by ID
- Applied sorting in `ChatInput.tsx` `buildModelList()` after deduplication
- Applied sorting in `AIModelSettings.tsx` `modelOptions` useMemo after deduplication

The static fallback `MODELS` array was already in the correct order; this only affects the dynamic SDK-reported model list.

## How to test

1. Open the Composer toolbar model dropdown — should show Opus → Sonnet → Haiku
2. Open Settings → AI & Models — both "Default Model" and "Review Model" dropdowns should show Opus → Sonnet → Haiku

🤖 Generated with [Claude Code](https://claude.com/claude-code)