### PR TITLE
fix: centralize backend URL resolution with port-file discovery for external MCP

### DIFF
--- a/agent-runner/src/mcp/server.ts
+++ b/agent-runner/src/mcp/server.ts
@@ -7,15 +7,7 @@ import { createCommentTools } from "./tools/comments.js";
 import { createPRTools } from "./tools/pr.js";
 import { createScriptTools } from "./tools/scripts.js";
 import { createSprintTools } from "./tools/sprint.js";
-
-const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://127.0.0.1:9876";
-const AUTH_TOKEN = process.env.CHATML_AUTH_TOKEN || "";
-
-function buildHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (AUTH_TOKEN) headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
-  return headers;
-}
+import { buildHeaders, BACKEND_URL } from "./tools/fetch-utils.js";
 
 function sessionApiUrl(context: WorkspaceContext, path: string): string {
   return `${BACKEND_URL}/api/repos/${context.workspaceId}/sessions/${context.sessionId}${path}`;

--- a/agent-runner/src/mcp/tools/comments.ts
+++ b/agent-runner/src/mcp/tools/comments.ts
@@ -2,19 +2,7 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { WorkspaceContext } from "../context.js";
-import { fetchWithRetry, formatFetchError } from "./fetch-utils.js";
-
-// Backend URL from environment. This matches the default port used by the Go backend.
-// TODO: Consider adding backendUrl to WorkspaceContext for consistency with other tools
-const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://127.0.0.1:9876";
-const AUTH_TOKEN = process.env.CHATML_AUTH_TOKEN || "";
-
-function buildHeaders(json = false): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (json) headers["Content-Type"] = "application/json";
-  if (AUTH_TOKEN) headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
-  return headers;
-}
+import { fetchWithRetry, formatFetchError, buildHeaders, BACKEND_URL } from "./fetch-utils.js";
 
 export function createCommentTools(context: WorkspaceContext) {
   return [

--- a/agent-runner/src/mcp/tools/fetch-utils.ts
+++ b/agent-runner/src/mcp/tools/fetch-utils.ts
@@ -4,9 +4,56 @@
 // Retries only on TypeError (network-level failures like ECONNREFUSED),
 // never on HTTP error responses (4xx, 5xx).
 
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
 const RETRY_DELAYS_MS = [500, 1000, 2000];
 
 const AUTH_TOKEN = process.env.CHATML_AUTH_TOKEN || "";
+
+// Resolve the ChatML app data directory, mirroring appdir.go's platform logic.
+// Can be overridden via CHATML_DATA_DIR (used by dev builds).
+function getAppDataDir(): string {
+  if (process.env.CHATML_DATA_DIR) return process.env.CHATML_DATA_DIR;
+  const home = homedir();
+  switch (process.platform) {
+    case "darwin":
+      return join(home, "Library", "Application Support", "ChatML");
+    case "win32": {
+      const localAppData = process.env.LOCALAPPDATA;
+      return localAppData
+        ? join(localAppData, "ChatML")
+        : join(home, "AppData", "Local", "ChatML");
+    }
+    default:
+      return process.env.XDG_DATA_HOME
+        ? join(process.env.XDG_DATA_HOME, "ChatML")
+        : join(home, ".local", "share", "ChatML");
+  }
+}
+
+// Determine the backend URL. Priority:
+//   1. CHATML_BACKEND_URL env var (set when spawned by ChatML internally)
+//   2. Port file written by the backend at startup (enables external MCP usage)
+//   3. Default port 9876 fallback
+function resolveBackendUrl(): string {
+  if (process.env.CHATML_BACKEND_URL) return process.env.CHATML_BACKEND_URL;
+  try {
+    const portFile = join(getAppDataDir(), "state", "backend.port");
+    const portNum = parseInt(readFileSync(portFile, "utf8").trim(), 10);
+    if (portNum >= 1 && portNum <= 65535) return `http://127.0.0.1:${portNum}`;
+  } catch {
+    // File not found or unreadable — fall through to default
+  }
+  return "http://127.0.0.1:9876";
+}
+
+// Resolved once at module load time. For internal usage (CHATML_BACKEND_URL set by the
+// spawning process) this is always correct. For external MCP usage, the backend must be
+// running before the MCP client starts; if the backend later restarts on a different port,
+// the MCP client must also restart to pick up the new port from the port file.
+export const BACKEND_URL = resolveBackendUrl();
 
 /** Build standard headers for backend requests (auth + optional JSON content-type). */
 export function buildHeaders(json = false): Record<string, string> {

--- a/agent-runner/src/mcp/tools/pr.ts
+++ b/agent-runner/src/mcp/tools/pr.ts
@@ -2,20 +2,10 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { WorkspaceContext } from "../context.js";
-import { fetchWithRetry, formatFetchError } from "./fetch-utils.js";
-
-const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://127.0.0.1:9876";
-const AUTH_TOKEN = process.env.CHATML_AUTH_TOKEN || "";
+import { fetchWithRetry, formatFetchError, buildHeaders, BACKEND_URL } from "./fetch-utils.js";
 
 // Matches GitHub PR URLs: https://github.com/owner/repo/pull/123
 const PR_URL_PATTERN = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/;
-
-function buildHeaders(json = false): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (json) headers["Content-Type"] = "application/json";
-  if (AUTH_TOKEN) headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
-  return headers;
-}
 
 export function createPRTools(context: WorkspaceContext) {
   return [

--- a/agent-runner/src/mcp/tools/sprint.ts
+++ b/agent-runner/src/mcp/tools/sprint.ts
@@ -2,9 +2,7 @@
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { WorkspaceContext } from "../context.js";
-import { fetchWithRetry, formatFetchError, buildHeaders } from "./fetch-utils.js";
-
-const BACKEND_URL = process.env.CHATML_BACKEND_URL || "http://127.0.0.1:9876";
+import { fetchWithRetry, formatFetchError, buildHeaders, BACKEND_URL } from "./fetch-utils.js";
 
 // Sprint phase definitions — keep in sync with:
 //   backend/models/types.go (ValidSprintPhases)

--- a/backend/main.go
+++ b/backend/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime/debug"
 	"strconv"
 	"syscall"
@@ -104,6 +105,19 @@ func main() {
 		logger.Main.Fatalf("Failed to initialize store: %v", err)
 	}
 	defer s.Close()
+
+	// Write the actual port to a well-known file so external tools (e.g., Claude Code MCP)
+	// can discover the backend without requiring CHATML_BACKEND_URL to be set.
+	// Written here — after all Fatalf-capable initialization — so the file is only
+	// created when the backend is actually going to start serving requests.
+	// defer os.Remove runs on clean exit (SIGINT/SIGTERM); hard crashes leave the
+	// file behind, but the next successful startup overwrites it.
+	portFile := filepath.Join(appdir.StateDir(), "backend.port")
+	if err := os.WriteFile(portFile, []byte(strconv.Itoa(actualPort)), 0644); err != nil {
+		logger.Main.Warnf("Failed to write port file: %v", err)
+	} else {
+		defer os.Remove(portFile)
+	}
 
 	hub := server.NewHub()
 	wm := git.NewWorktreeManager()


### PR DESCRIPTION
## Summary

- **Centralizes** the duplicated `BACKEND_URL` / `buildHeaders` definitions that were independently copy-pasted across `server.ts`, `comments.ts`, `pr.ts`, and `sprint.ts` into `fetch-utils.ts`
- **Adds port-file discovery** so Claude Code MCP servers running outside the ChatML process (without `CHATML_BACKEND_URL`) can find the backend automatically without hardcoding port 9876

## How it works

**Backend (`main.go`):** After all fatal-capable initialization completes, writes the actual bound port to `{StateDir}/state/backend.port`. Defers removal on clean shutdown. Writing it late ensures the file only exists when the server is genuinely ready to serve.

**MCP client (`fetch-utils.ts`):** `resolveBackendUrl()` uses a three-tier priority:
1. `CHATML_BACKEND_URL` env var — set when spawned internally by ChatML (unchanged behavior)
2. Port file at `{AppDataDir}/state/backend.port` — new; enables external MCP usage
3. Default `http://127.0.0.1:9876` — unchanged fallback

Port file content is validated to be a valid TCP port (1–65535) before use. `BACKEND_URL` is resolved once at module load; if the backend restarts on a different port, the MCP client must also restart (documented in a comment).

## Test plan

- [ ] Normal startup: verify `backend.port` file is created in `{StateDir}/state/` and removed on clean exit (Ctrl+C)
- [ ] External MCP: start backend, then start a Claude Code MCP session without `CHATML_BACKEND_URL` set — tools should connect successfully
- [ ] Non-default port: set `PORT=9877`, verify `backend.port` contains `9877` and MCP tools use it
- [ ] Corrupted port file: write `999999` to `backend.port`, verify MCP falls through to default 9876
- [ ] Internal spawn: verify `CHATML_BACKEND_URL` still takes priority over the port file

🤖 Generated with [Claude Code](https://claude.com/claude-code)