### PR TITLE
fix: prevent speech recognition teardown from clearing dictated text

### DIFF
--- a/src-tauri/src/speech.rs
+++ b/src-tauri/src/speech.rs
@@ -252,6 +252,14 @@ mod platform {
             // Create recognition task with result handler
             let result_block =
                 block2::RcBlock::new(move |result: *mut AnyObject, error: *mut AnyObject| {
+                    // Suppress ALL callbacks during intentional teardown. Setting
+                    // stopped=true before endAudio/cancel means:
+                    //   - Genuine final-word results from endAudio are lost (acceptable).
+                    //   - Phantom empty transcripts from cancel are suppressed (the fix).
+                    if stopped_for_result.load(Ordering::Acquire) {
+                        return;
+                    }
+
                     if !result.is_null() {
                         let transcription: *mut AnyObject = msg_send![result, bestTranscription];
                         if !transcription.is_null() {
@@ -272,12 +280,6 @@ mod platform {
                     }
 
                     if !error.is_null() {
-                        // Suppress errors triggered by intentional stop — cancelling
-                        // the recognition task causes Apple's API to fire an error callback.
-                        if stopped_for_result.load(Ordering::Acquire) {
-                            return;
-                        }
-
                         let desc: *mut AnyObject = msg_send![error, localizedDescription];
                         let msg = if !desc.is_null() {
                             nsstring_to_string(desc)

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -249,12 +249,19 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
   // Speech-to-text dictation
   const preDictationTextRef = useRef('');
+  // Flag set only around setText calls from onTranscript so the resulting
+  // editor onChange (which fires with "" during reset) is ignored, while
+  // manual keystrokes during dictation still sync message state normally.
+  const settingFromTranscriptRef = useRef(false);
   const { isDictating, toggle: toggleDictation, isAvailable: dictationAvailable, audioLevel } = useDictation({
     onTranscript: (text, isFinal) => {
+      if (!text) return; // Ignore empty transcripts (e.g., phantom callback during teardown)
       const prefix = preDictationTextRef.current;
       const combined = prefix ? `${prefix} ${text}` : text;
+      settingFromTranscriptRef.current = true;
       plateInputRef.current?.setText(combined);
       setMessage(combined);
+      settingFromTranscriptRef.current = false;
     },
     onError: (msg) => showError(msg),
   });
@@ -1064,15 +1071,20 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             />
           </svg>
         )}
-        {/* Gradient border for streaming state (static for performance) */}
-        {isStreaming && !pendingPlanApproval && (
+        {/* Gradient border for streaming state (static for performance) — hidden when dictating */}
+        {isStreaming && !pendingPlanApproval && !isDictating && (
           <div className="absolute -inset-[1px] rounded-lg bg-gradient-to-r from-brand/60 via-purple-500/80 to-brand/60 opacity-70" />
+        )}
+        {/* Blue border for active dictation (takes priority over streaming) */}
+        {isDictating && (
+          <div className="absolute -inset-[1px] rounded-lg bg-blue-500/50 opacity-70" />
         )}
       <div className={cn(
         'relative rounded-lg border border-border bg-card dark:bg-input',
-        isStreaming && !pendingPlanApproval && 'border-transparent',
+        isStreaming && !pendingPlanApproval && !isDictating && 'border-transparent',
         pendingPlanApproval && 'border-transparent',
         planModeEnabled && !isStreaming && 'border-transparent',
+        isDictating && 'border-transparent',
         isDragOver && 'ring-2 ring-primary ring-offset-2 border-primary'
       )}>
         {/* Drag overlay - drop zone */}
@@ -1146,7 +1158,12 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             slashCommands={slashCommands}
             onSlashCommandExecute={handleSlashCommandExecute}
             onInput={(text) => {
-              setMessage(text);
+              // Skip the onChange fired by editor.tf.reset() inside setText —
+              // it emits "" before queueMicrotask re-inserts the transcript.
+              // Manual keystrokes during dictation still sync normally.
+              if (!settingFromTranscriptRef.current) {
+                setMessage(text);
+              }
               if (text.trim() && selectedConversationId && useAppStore.getState().inputSuggestions[selectedConversationId]) {
                 clearInputSuggestion(selectedConversationId);
               }


### PR DESCRIPTION
## Summary

- **Backend (speech.rs)**: Move the `stopped` flag guard to the top of the recognition result closure so *all* callbacks (both transcript results and errors) are suppressed during intentional teardown. Previously only errors were guarded, allowing Apple's phantom empty-transcript callback after `cancel` to slip through and wipe the editor.
- **Frontend (ChatInput.tsx)**: Replace the broad `isDictatingRef` guard in `onInput` with a narrow `settingFromTranscriptRef` flag that's only active during `setText` calls from `onTranscript`. This blocks the synthetic `onChange("")` from `editor.tf.reset()` while still allowing manual keystrokes and input-suggestion clearing to work during dictation.
- **UI**: Add blue border overlay for active dictation state, with explicit priority over the streaming gradient overlay.

## Test plan

- [ ] Start dictation, speak a sentence, stop dictation — text should persist in the editor
- [ ] Start dictation while a previous message is streaming — blue border should show (not gradient)
- [ ] Type manually while dictation is active — typed text should appear and message state should stay in sync
- [ ] Verify ghost-text suggestions dismiss when dictating into a field that has one
- [ ] Stop dictation rapidly after starting — no empty transcript should clear the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)