### PR TITLE
fix: prevent message pane z-index from blocking input area clicks

### DIFF
--- a/src/components/conversation/CachedConversationPane.tsx
+++ b/src/components/conversation/CachedConversationPane.tsx
@@ -115,7 +115,7 @@ export function CachedConversationPane({
       isActive ? 'z-10' : 'invisible pointer-events-none z-0'
     )}>
       {/* Message panes — one per cached conversation, visibility-toggled */}
-      <div className="relative flex-1 min-h-0">
+      <div className="relative flex-1 min-h-0 overflow-hidden">
         {/* Session home state when no conversation is selected and no conversations exist */}
         {!conversationId && !hasConversations && (
           <div className="h-full overflow-auto">
@@ -136,7 +136,7 @@ export function CachedConversationPane({
       </div>
 
       {/* Chat Input */}
-      <div className="shrink-0 relative">
+      <div className="shrink-0 relative z-10">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- The first checkbox in AskUserQuestion multi-select was sometimes unclickable while items below worked fine
- Root cause: `ConversationMessagePane` (`z-10`, `absolute inset-0`) could overlap the input area wrapper (no z-index) due to subpixel rounding in flex layouts — the message pane's stacking context won over the input area at the boundary
- Fix: add `overflow-hidden` to the message area wrapper to clip overflow, and `z-10` to the input wrapper as defense-in-depth

## Test plan
- [ ] Trigger AskUserQuestion with `multiSelect: true` and 3+ options — verify first checkbox is clickable
- [ ] Verify fade overlay at bottom of message list still renders
- [ ] Verify scroll-to-bottom button still works
- [ ] Verify ConversationMarkers minimap (top-right) still shows and popover works
- [ ] Test with different viewport heights

🤖 Generated with [Claude Code](https://claude.com/claude-code)