### PR TITLE
feat: handle SDK 0.2.72+ event types with elicitation, prompt suggestions, and tool summaries

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -492,6 +492,7 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 	// Pending interaction state for snapshot recovery after app restart
 	var pendingPlanApprovalSnapshot *PendingPlanApprovalSnapshot
 	var pendingUserQuestionSnapshot *PendingUserQuestionSnapshot
+	var pendingElicitationSnapshot *PendingElicitationSnapshot
 
 	// Per-turn accumulation for message persistence (Phase 3)
 	var completedTools []models.ToolUsageRecord
@@ -587,6 +588,7 @@ func (m *Manager) handleConversationOutput(convID string, proc *Process) {
 			SubAgents:           subAgents,
 			PendingPlanApproval: pendingPlanApprovalSnapshot,
 			PendingUserQuestion: pendingUserQuestionSnapshot,
+			PendingElicitation:  pendingElicitationSnapshot,
 		}
 		data, err := json.Marshal(snapshot)
 		if err != nil {
@@ -1036,6 +1038,59 @@ outer:
 					}
 				}
 
+			// ── SDK 0.2.72+ event types ──────────────────────────────────
+
+			case EventTypeElicitationRequest:
+				// MCP server is requesting user input — track for snapshot recovery
+				pendingElicitationSnapshot = &PendingElicitationSnapshot{
+					ElicitationID: event.ElicitationID,
+					McpServerName: event.McpServerName,
+					Timestamp:     time.Now().UnixMilli(),
+				}
+				markSnapshotDirty()
+
+			case EventTypeElicitationResult:
+				// Elicitation answered — clear pending state
+				pendingElicitationSnapshot = nil
+				markSnapshotDirty()
+
+			case EventTypeElicitationComplete:
+				// Elicitation flow finished — clear pending state
+				pendingElicitationSnapshot = nil
+				markSnapshotDirty()
+
+			case EventTypePromptSuggestion:
+				// AI-generated next-prompt suggestion — forwarded to frontend only
+
+			case EventTypeToolUseSummary:
+				// AI-generated summary of preceding tool work — forwarded to frontend only
+
+			case EventTypeHookStarted, EventTypeHookProgress:
+				// Hook execution lifecycle — informational, no snapshot state
+
+			case EventTypeWorktreeCreated:
+				logger.Manager.Infof("[%s] Worktree created: %s", convID, event.WorktreePath)
+
+			case EventTypeWorktreeRemoved:
+				logger.Manager.Infof("[%s] Worktree removed: %s", convID, event.WorktreePath)
+
+			case EventTypeInstructionsLoaded:
+				logger.Manager.Debugf("[%s] Instructions loaded from %s (reason: %s)", convID, event.FilePath, event.LoadReason)
+
+			case EventTypeMcpServersUpdated:
+				// Dynamic MCP server configuration changed at runtime — informational
+
+			case EventTypeSupportedAgents, EventTypeInitializationResult:
+				// Informational — no state tracking needed
+
+			// ── SDK 0.2.76+ event types ──────────────────────────────────
+
+			case EventTypeSessionForked:
+				logger.Manager.Infof("[%s] Session forked", convID)
+
+			case EventTypeMessageCancelled:
+				logger.Manager.Debugf("[%s] Message cancelled", convID)
+
 			case EventTypeTurnComplete, EventTypeComplete, EventTypeResult:
 				// Atomically clear the active turn flag and take any deferred
 				// user message. Store BEFORE the assistant message so the DB
@@ -1205,6 +1260,7 @@ outer:
 				isThinking = false
 				pendingPlanApprovalSnapshot = nil
 				pendingUserQuestionSnapshot = nil
+				pendingElicitationSnapshot = nil
 				thinkingBlocks = nil
 				currentThinkingText = ""
 				thinkingBlockStart = nil

--- a/backend/agent/parser.go
+++ b/backend/agent/parser.go
@@ -200,7 +200,7 @@ type AgentEvent struct {
 	McpServerName   string                 `json:"mcpServerName,omitempty"`
 	ElicitationMode string                 `json:"elicitationMode,omitempty"`
 	URL             string                 `json:"url,omitempty"`
-	ElicitationId   string                 `json:"elicitationId,omitempty"`
+	ElicitationID   string                 `json:"elicitationId,omitempty"`
 	RequestedSchema map[string]interface{} `json:"requestedSchema,omitempty"`
 	Action          string                 `json:"action,omitempty"`
 
@@ -446,6 +446,7 @@ type StreamingSnapshot struct {
 	// Pending interaction state — persisted so the frontend can recover after app restart.
 	PendingPlanApproval *PendingPlanApprovalSnapshot `json:"pendingPlanApproval,omitempty"`
 	PendingUserQuestion *PendingUserQuestionSnapshot `json:"pendingUserQuestion,omitempty"`
+	PendingElicitation  *PendingElicitationSnapshot  `json:"pendingElicitation,omitempty"`
 }
 
 // PendingPlanApprovalSnapshot captures a pending ExitPlanMode approval request.
@@ -453,6 +454,13 @@ type PendingPlanApprovalSnapshot struct {
 	RequestID   string `json:"requestId"`
 	PlanContent string `json:"planContent,omitempty"`
 	Timestamp   int64  `json:"timestamp"` // Unix milliseconds
+}
+
+// PendingElicitationSnapshot captures a pending MCP elicitation request.
+type PendingElicitationSnapshot struct {
+	ElicitationID string `json:"elicitationId"`
+	McpServerName string `json:"mcpServerName"`
+	Timestamp     int64  `json:"timestamp"` // Unix milliseconds
 }
 
 // PendingUserQuestionSnapshot captures a pending AskUserQuestion request.

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -288,6 +288,9 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const inputSuggestion = useAppStore(
     (s) => selectedConversationId ? s.inputSuggestions[selectedConversationId] : undefined
   );
+  const promptSuggestions = useAppStore(
+    (s) => selectedConversationId ? s.promptSuggestions[selectedConversationId] : undefined
+  );
 
   // File mentions for Plate editor
   const [mentionItems, setMentionItems] = useState<MentionItem[]>([]);
@@ -690,6 +693,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
   const handlePillClick = useCallback((pill: SuggestionPill) => {
     if (selectedConversationId) {
       clearInputSuggestion(selectedConversationId);
+      useAppStore.getState().clearPromptSuggestions(selectedConversationId);
     }
     if (autoSubmitPill) {
       sendMessage(pill.value);
@@ -1013,9 +1017,17 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
 
   return (
     <div className="pt-1 px-3 pb-3">
-      {/* Pill Suggestions */}
+      {/* Pill Suggestions (input suggestions take priority, prompt suggestions as fallback) */}
       {suggestionsEnabled && inputSuggestion?.pills && inputSuggestion.pills.length > 0 && !isStreaming && !pendingPlanApproval && !isSuggestionStale && (
         <ChatInputPillSuggestions pills={inputSuggestion.pills} onPillClick={handlePillClick} />
+      )}
+      {/* Prompt suggestions intentionally skip the isSuggestionStale age check —
+          they represent "what to ask next" and stay relevant until the next turn clears them. */}
+      {suggestionsEnabled && (!inputSuggestion?.pills || inputSuggestion.pills.length === 0) && promptSuggestions && promptSuggestions.length > 0 && !isStreaming && !pendingPlanApproval && (
+        <ChatInputPillSuggestions
+          pills={promptSuggestions.map((s) => ({ label: s.length > 60 ? s.slice(0, 57) + '...' : s, value: s }))}
+          onPillClick={handlePillClick}
+        />
       )}
 
       {/* Plan Approval Bar */}

--- a/src/components/conversation/InterruptedBanner.tsx
+++ b/src/components/conversation/InterruptedBanner.tsx
@@ -53,6 +53,13 @@ export function InterruptedBanner({ conversationId }: InterruptedBannerProps) {
           {interrupted.hadPendingQuestion && (
             <span className="text-muted-foreground"> The AI was waiting for your answer.</span>
           )}
+          {interrupted.hadPendingElicitation && (
+            <span className="text-muted-foreground">
+              {interrupted.elicitationMcpServer
+                ? ` ${interrupted.elicitationMcpServer} was requesting input.`
+                : ' An MCP server was requesting input.'}
+            </span>
+          )}
         </div>
         <Button
           variant="outline"

--- a/src/components/conversation/ToolUsageBlock.tsx
+++ b/src/components/conversation/ToolUsageBlock.tsx
@@ -98,7 +98,6 @@ function calculateEditStats(params?: Record<string, unknown>): { additions: numb
 }
 
 export const ToolUsageBlock = memo(function ToolUsageBlock({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   id,
   tool,
   params,
@@ -139,6 +138,15 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
       }
     }
   }, [compacted, isActive, conversationId, messageId]);
+  // Tool use summary: show AI-generated summary for the last tool in a summary group
+  const toolUseSummary = useAppStore((s) => {
+    if (!conversationId) return undefined;
+    const summaries = s.toolUseSummaries[conversationId];
+    if (!summaries) return undefined;
+    // Find a summary where this tool is the LAST in the group (avoids repetition)
+    return summaries.find((su) => su.toolUseIds[su.toolUseIds.length - 1] === id)?.summary;
+  });
+
   const mcpInfo = useMemo(() => parseMcpToolName(tool), [tool]);
 
   const ToolIcon = useMemo((): LucideIcon => {
@@ -360,6 +368,7 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
   const showExpandable = hasDetails || hasOutput;
 
   return (
+    <>
     <Collapsible open={isOpen} onOpenChange={handleOpenChange}>
       <CollapsibleTrigger
         className={cn(
@@ -660,6 +669,12 @@ export const ToolUsageBlock = memo(function ToolUsageBlock({
         </CollapsibleContent>
       )}
     </Collapsible>
+    {toolUseSummary && (
+      <div className="ml-6 mt-0.5 text-2xs text-text-3 italic leading-relaxed">
+        {toolUseSummary}
+      </div>
+    )}
+    </>
   );
 });
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -74,6 +74,7 @@ export function useWebSocket(enabled: boolean = true) {
         s.setThinking(convId, false);
         s.appendStreamingText(convId, text);
         s.clearInputSuggestion(convId);
+        s.clearPromptSuggestions(convId);
       },
       // onFlushThinking: simple append
       (convId, text) => {
@@ -175,6 +176,8 @@ export function useWebSocket(enabled: boolean = true) {
         store.clearInterruptedState(conversationId);
         // Clear stale input suggestions from the previous turn
         store.clearInputSuggestion(conversationId);
+        store.clearPromptSuggestions(conversationId);
+        store.clearToolUseSummaries(conversationId);
         // Capture budget/thinking configuration from init event (per-conversation)
         if (event?.budgetConfig) {
           const config = event.budgetConfig;
@@ -906,6 +909,54 @@ export function useWebSocket(enabled: boolean = true) {
         }
         break;
 
+      // ── SDK 0.2.72+ event types ──────────────────────────────────
+
+      case 'prompt_suggestion':
+        if (event?.suggestion && typeof event.suggestion === 'string') {
+          store.addPromptSuggestion(conversationId, event.suggestion);
+        }
+        break;
+
+      case 'tool_use_summary':
+        if (event?.summary && event?.precedingToolUseIds) {
+          store.addToolUseSummary(conversationId, {
+            summary: event.summary as string,
+            toolUseIds: event.precedingToolUseIds as string[],
+          });
+        }
+        break;
+
+      case 'rate_limit':
+        if (event?.rateLimitInfo) {
+          window.dispatchEvent(new CustomEvent('agent-notification', {
+            detail: { title: 'Rate limited', message: 'API rate limit reached, requests will be delayed', type: 'warning', conversationId },
+          }));
+        }
+        break;
+
+      case 'elicitation_request':
+        if (event?.mcpServerName) {
+          window.dispatchEvent(new CustomEvent('agent-notification', {
+            detail: { title: 'MCP Input', message: `${event.mcpServerName as string} is requesting input...`, type: 'info', conversationId },
+          }));
+        }
+        break;
+
+      case 'elicitation_result':
+      case 'elicitation_complete':
+      case 'hook_started':
+      case 'hook_progress':
+      case 'worktree_created':
+      case 'worktree_removed':
+      case 'instructions_loaded':
+      case 'supported_agents':
+      case 'mcp_servers_updated':
+      case 'initialization_result':
+      case 'session_forked':
+      case 'message_cancelled':
+        // Informational events — no frontend state changes needed
+        break;
+
     }
   // getStore is a stable reference (useAppStore.getState), no deps needed
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1025,6 +1076,8 @@ export function useWebSocket(enabled: boolean = true) {
           agentSessionId: item.agentSessionId,
           hadPendingPlan: !!item.snapshot?.pendingPlanApproval,
           hadPendingQuestion: !!item.snapshot?.pendingUserQuestion,
+          hadPendingElicitation: !!item.snapshot?.pendingElicitation,
+          elicitationMcpServer: item.snapshot?.pendingElicitation?.mcpServerName,
           snapshot: item.snapshot,
         });
         // Inject the snapshot's text as a visible assistant message so the user

--- a/src/hooks/useWebSocketHelpers.ts
+++ b/src/hooks/useWebSocketHelpers.ts
@@ -132,6 +132,12 @@ export const BATCHABLE_EVENTS = new Set([
   'permission_mode_changed', 'plan_approval_request', 'plan_mode_auto_exited',
   'streaming_warning', 'summary_updated', 'checkpoint_created', 'files_rewound',
   'ghost_text',
+  // SDK 0.2.72+ informational events
+  'prompt_suggestion', 'tool_use_summary', 'rate_limit',
+  'elicitation_request', 'elicitation_result', 'elicitation_complete',
+  'hook_started', 'hook_progress', 'worktree_created', 'worktree_removed',
+  'instructions_loaded', 'supported_agents', 'mcp_servers_updated',
+  'initialization_result', 'session_forked', 'message_cancelled',
 ]);
 
 // Content event types that should be suppressed during reconciliation.

--- a/src/lib/api/conversations.ts
+++ b/src/lib/api/conversations.ts
@@ -320,6 +320,7 @@ export interface StreamingSnapshotDTO {
   subAgents?: SnapshotSubAgent[];
   pendingPlanApproval?: { requestId: string; planContent?: string; timestamp: number } | null;
   pendingUserQuestion?: { requestId: string; questions: import('@/lib/types').UserQuestion[]; timestamp: number } | null;
+  pendingElicitation?: { elicitationId: string; mcpServerName: string; timestamp: number } | null;
 }
 
 export async function getStreamingSnapshot(convId: string): Promise<StreamingSnapshotDTO | null> {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -267,6 +267,8 @@ export interface InterruptedInfo {
   agentSessionId: string;
   hadPendingPlan: boolean;
   hadPendingQuestion: boolean;
+  hadPendingElicitation: boolean;
+  elicitationMcpServer?: string; // MCP server name if elicitation was pending
   snapshot: StreamingSnapshotDTO | null;
   resuming?: boolean; // true while resume is in progress
 }
@@ -357,6 +359,12 @@ interface AppState {
   // Input suggestions from Haiku (keyed by conversationId)
   inputSuggestions: { [conversationId: string]: InputSuggestion };
 
+  // SDK prompt suggestions (keyed by conversationId, array of suggestion strings)
+  promptSuggestions: { [conversationId: string]: string[] };
+
+  // Tool use summaries from SDK (keyed by conversationId)
+  toolUseSummaries: { [conversationId: string]: Array<{ summary: string; toolUseIds: string[] }> };
+
   // Conversation summaries (keyed by conversationId)
   summaries: { [conversationId: string]: Summary };
 
@@ -430,6 +438,14 @@ interface AppState {
   // Input suggestion actions
   setInputSuggestion: (conversationId: string, suggestion: InputSuggestion) => void;
   clearInputSuggestion: (conversationId: string) => void;
+
+  // SDK prompt suggestion actions
+  addPromptSuggestion: (conversationId: string, suggestion: string) => void;
+  clearPromptSuggestions: (conversationId: string) => void;
+
+  // Tool use summary actions
+  addToolUseSummary: (conversationId: string, summary: { summary: string; toolUseIds: string[] }) => void;
+  clearToolUseSummaries: (conversationId: string) => void;
 
   // Message actions
   addMessage: (message: Message) => void;
@@ -683,6 +699,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   pendingSprintPhaseProposal: {},
   interruptedState: {},
   inputSuggestions: {},
+  promptSuggestions: {},
+  toolUseSummaries: {},
   summaries: {},
   lastFileChange: null,
   messagePagination: {},
@@ -1282,6 +1300,32 @@ export const useAppStore = create<AppState>((set, get) => ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [conversationId]: _removed, ...rest } = state.inputSuggestions;
     return { inputSuggestions: rest };
+  }),
+
+  // SDK prompt suggestion actions
+  addPromptSuggestion: (conversationId, suggestion) => set((state) => {
+    const existing = state.promptSuggestions[conversationId] ?? [];
+    // Deduplicate and cap at 3
+    if (existing.includes(suggestion)) return state;
+    const updated = [...existing, suggestion].slice(-3);
+    return { promptSuggestions: { ...state.promptSuggestions, [conversationId]: updated } };
+  }),
+  clearPromptSuggestions: (conversationId) => set((state) => {
+    if (!state.promptSuggestions[conversationId]) return state;
+    const { [conversationId]: _removed, ...rest } = state.promptSuggestions;
+    return { promptSuggestions: rest };
+  }),
+
+  // Tool use summary actions
+  addToolUseSummary: (conversationId, summary) => set((state) => {
+    const existing = state.toolUseSummaries[conversationId] ?? [];
+    const updated = [...existing, summary].slice(-20);
+    return { toolUseSummaries: { ...state.toolUseSummaries, [conversationId]: updated } };
+  }),
+  clearToolUseSummaries: (conversationId) => set((state) => {
+    if (!state.toolUseSummaries[conversationId]) return state;
+    const { [conversationId]: _removed, ...rest } = state.toolUseSummaries;
+    return { toolUseSummaries: rest };
   }),
 
   // Message actions


### PR DESCRIPTION
## Summary

- **Elicitation lifecycle**: Track MCP elicitation requests in the streaming snapshot for crash recovery, surface pending state in the `InterruptedBanner`
- **Prompt suggestions**: Store SDK-emitted prompt suggestions and display them as fallback pill suggestions in `ChatInput` when no Haiku-generated suggestions exist (capped at 3, deduplicated)
- **Tool use summaries**: Store SDK-emitted tool summaries and render them below the last tool in each summary group in `ToolUsageBlock`
- **New event routing**: Handle `rate_limit`, `hook_started/progress`, `worktree_created/removed`, `instructions_loaded`, `mcp_servers_updated`, `session_forked`, `message_cancelled`, and `initialization_result` across backend and frontend
- **Review fixes**: Remove spurious `markSnapshotDirty()` calls on non-state-changing events, fix Go naming (`ElicitationId` → `ElicitationID`), add clarifying comment for prompt suggestion staleness behavior

### Files changed

| File | Change |
|------|--------|
| `backend/agent/parser.go` | Add `PendingElicitationSnapshot` struct, fix `ElicitationID` naming |
| `backend/agent/manager.go` | Handle 15 new event types, track elicitation snapshot state |
| `src/stores/appStore.ts` | Add `promptSuggestions` and `toolUseSummaries` state + actions, extend `InterruptedInfo` |
| `src/hooks/useWebSocket.ts` | Route new events, clear suggestions on turn start, wire elicitation recovery |
| `src/hooks/useWebSocketHelpers.ts` | Register new events as batchable |
| `src/components/conversation/ChatInput.tsx` | Render prompt suggestion pills as fallback |
| `src/components/conversation/ToolUsageBlock.tsx` | Render tool use summaries below tool blocks |
| `src/components/conversation/InterruptedBanner.tsx` | Show elicitation context in interrupted banner |
| `src/lib/api/conversations.ts` | Extend `StreamingSnapshotDTO` with `pendingElicitation` |

## Test plan

- [ ] Verify Go backend compiles: `cd backend && go build ./...`
- [ ] Verify frontend compiles: `npm run build`
- [ ] Test prompt suggestions appear as pills after agent turn completes with suggestions
- [ ] Test tool use summaries render below the last tool in a group
- [ ] Test rate limit notification appears when rate_limit event fires
- [ ] Test elicitation_request notification shows MCP server name
- [ ] Test interrupted banner shows elicitation context after crash during pending elicitation
- [ ] Test prompt suggestions clear on new turn start
- [ ] Test unknown/informational events don't cause unnecessary snapshot writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)