### PR TITLE
feat: add base session type for direct repo operations

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/chatml/chatml-backend/logger"
+	"github.com/chatml/chatml-backend/models"
 )
 
 // Git command timeout tiers — choose the appropriate tier at each call site.
@@ -1609,4 +1610,269 @@ func (rm *RepoManager) GetFileDiffUnified(ctx context.Context, repoPath, baseRef
 	}
 
 	return diff, nil
+}
+
+// ============================================================================
+// Base session operations: preflight checks, branch management, stash
+// ============================================================================
+
+// CheckPreflight inspects the repository for states that block base session usage.
+func (rm *RepoManager) CheckPreflight(ctx context.Context, repoPath string) (*models.PreflightStatus, error) {
+	status := &models.PreflightStatus{OK: true}
+
+	// Resolve git dir (handles both regular repos and worktrees)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--git-dir")
+	defer cancel()
+	gitDirOut, err := cmd.Output()
+	if err != nil {
+		status.OK = false
+		status.CorruptedIndex = true
+		status.ErrorMessage = "unable to resolve git directory"
+		return status, nil
+	}
+	gitDir := strings.TrimSpace(string(gitDirOut))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(repoPath, gitDir)
+	}
+
+	// Check for active rebase
+	if _, err := os.Stat(filepath.Join(gitDir, "rebase-merge")); err == nil {
+		status.OK = false
+		status.ActiveRebase = true
+	}
+	if _, err := os.Stat(filepath.Join(gitDir, "rebase-apply")); err == nil {
+		status.OK = false
+		status.ActiveRebase = true
+	}
+
+	// Check for active merge
+	if _, err := os.Stat(filepath.Join(gitDir, "MERGE_HEAD")); err == nil {
+		status.OK = false
+		status.ActiveMerge = true
+	}
+
+	// Check for active cherry-pick
+	if _, err := os.Stat(filepath.Join(gitDir, "CHERRY_PICK_HEAD")); err == nil {
+		status.OK = false
+		status.ActiveCherryPick = true
+	}
+
+	// Check for detached HEAD
+	cmd2, cancel2 := gitCmdWithContext(ctx, TimeoutFast, repoPath, "symbolic-ref", "HEAD")
+	defer cancel2()
+	if err := cmd2.Run(); err != nil {
+		status.OK = false
+		status.DetachedHead = true
+	}
+
+	// Check for corrupted index (git status fails)
+	cmd3, cancel3 := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "status", "--porcelain")
+	defer cancel3()
+	if err := cmd3.Run(); err != nil {
+		status.OK = false
+		status.CorruptedIndex = true
+	}
+
+	// Build error message
+	if !status.OK {
+		var issues []string
+		if status.ActiveRebase {
+			issues = append(issues, "a rebase is in progress")
+		}
+		if status.ActiveMerge {
+			issues = append(issues, "a merge is in progress")
+		}
+		if status.ActiveCherryPick {
+			issues = append(issues, "a cherry-pick is in progress")
+		}
+		if status.DetachedHead {
+			issues = append(issues, "HEAD is detached")
+		}
+		if status.CorruptedIndex {
+			issues = append(issues, "git index may be corrupted")
+		}
+		status.ErrorMessage = "Repository is in an unusual state: " + strings.Join(issues, "; ")
+	}
+
+	return status, nil
+}
+
+// CreateBranch creates a new branch at the given start point.
+func (rm *RepoManager) CreateBranch(ctx context.Context, repoPath, name, startPoint string) error {
+	if err := ValidateGitRef(name); err != nil {
+		return fmt.Errorf("invalid branch name: %w", err)
+	}
+	args := []string{"branch", name}
+	if startPoint != "" {
+		if err := ValidateGitRef(startPoint); err != nil {
+			return fmt.Errorf("invalid start point: %w", err)
+		}
+		args = append(args, startPoint)
+	}
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, args...)
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git branch failed: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// SwitchBranch switches the working tree to the given branch.
+// Returns an error with dirty file details if the working tree has uncommitted changes.
+func (rm *RepoManager) SwitchBranch(ctx context.Context, repoPath, branchName string) error {
+	if err := ValidateGitRef(branchName); err != nil {
+		return fmt.Errorf("invalid branch name: %w", err)
+	}
+
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "switch", branchName)
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		outStr := strings.TrimSpace(string(out))
+		// Detect dirty working tree
+		if strings.Contains(outStr, "uncommitted changes") || strings.Contains(outStr, "local changes") {
+			return &DirtyWorkingTreeError{Message: outStr}
+		}
+		return fmt.Errorf("git switch failed: %s", outStr)
+	}
+	return nil
+}
+
+// DirtyWorkingTreeError indicates that a branch switch was blocked by uncommitted changes.
+type DirtyWorkingTreeError struct {
+	Message string
+}
+
+func (e *DirtyWorkingTreeError) Error() string {
+	return e.Message
+}
+
+// ListStashes returns all stash entries for the repository.
+func (rm *RepoManager) ListStashes(ctx context.Context, repoPath string) ([]models.StashEntry, error) {
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "stash", "list", "--format=%gd\t%gs")
+	defer cancel()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git stash list: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return []models.StashEntry{}, nil
+	}
+
+	var entries []models.StashEntry
+	for _, line := range strings.Split(raw, "\n") {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		// parts[0] = "stash@{0}", parts[1] = message
+		idxStr := strings.TrimPrefix(parts[0], "stash@{")
+		idxStr = strings.TrimSuffix(idxStr, "}")
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil {
+			continue // skip malformed lines rather than silently using 0
+		}
+
+		// Extract branch from message if present (format: "WIP on branch: ..." or "On branch: ...")
+		msg := parts[1]
+		branch := ""
+		if colonIdx := strings.Index(msg, ":"); colonIdx != -1 {
+			prefix := msg[:colonIdx]
+			if spaceIdx := strings.LastIndex(prefix, " "); spaceIdx != -1 {
+				branch = prefix[spaceIdx+1:]
+			}
+		}
+
+		entries = append(entries, models.StashEntry{
+			Index:   idx,
+			Branch:  branch,
+			Message: msg,
+		})
+	}
+	return entries, nil
+}
+
+// CreateStash creates a new stash with an optional message.
+func (rm *RepoManager) CreateStash(ctx context.Context, repoPath, message string, includeUntracked bool) error {
+	args := []string{"stash", "push"}
+	if message != "" {
+		args = append(args, "-m", message)
+	}
+	if includeUntracked {
+		args = append(args, "--include-untracked")
+	}
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, args...)
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git stash push: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ApplyStash applies a stash entry without removing it.
+func (rm *RepoManager) ApplyStash(ctx context.Context, repoPath string, index int) error {
+	ref := fmt.Sprintf("stash@{%d}", index)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "stash", "apply", ref)
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git stash apply: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// PopStash applies and removes a stash entry.
+func (rm *RepoManager) PopStash(ctx context.Context, repoPath string, index int) error {
+	ref := fmt.Sprintf("stash@{%d}", index)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutHeavy, repoPath, "stash", "pop", ref)
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git stash pop: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// DropStash removes a stash entry without applying it.
+func (rm *RepoManager) DropStash(ctx context.Context, repoPath string, index int) error {
+	ref := fmt.Sprintf("stash@{%d}", index)
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "stash", "drop", ref)
+	defer cancel()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git stash drop: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// GetDirtyFiles returns a list of files with uncommitted changes (staged or unstaged).
+func (rm *RepoManager) GetDirtyFiles(ctx context.Context, repoPath string) ([]string, error) {
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "status", "--porcelain")
+	defer cancel()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git status: %w", err)
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+	var files []string
+	for _, line := range strings.Split(raw, "\n") {
+		if len(line) > 3 {
+			name := strings.TrimSpace(line[3:])
+			// For renames/copies, porcelain v1 format is "old -> new"; use the destination.
+			if arrowIdx := strings.Index(name, " -> "); arrowIdx != -1 {
+				name = name[arrowIdx+4:]
+			}
+			if name != "" {
+				files = append(files, name)
+			}
+		}
+	}
+	return files, nil
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/chatml/chatml-backend/appdir"
 	"github.com/chatml/chatml-backend/agent"
+	"github.com/chatml/chatml-backend/appdir"
 	"github.com/chatml/chatml-backend/branch"
 	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/github"
@@ -25,6 +25,8 @@ import (
 	"github.com/chatml/chatml-backend/scripts"
 	"github.com/chatml/chatml-backend/server"
 	"github.com/chatml/chatml-backend/store"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -509,6 +511,101 @@ func main() {
 	// become available (env var, keychain, credentials file, cached SDK token).
 	router, routerCleanup := server.NewRouter(ctx, s, hub, agentMgr, ghClient, linearClient, branchWatcher, prWatcher, prCache, issueCache, statsCache, diffCache, snapshotCache, nil, scriptRunner)
 	defer routerCleanup()
+
+	// Backfill base sessions for existing workspaces that don't have one yet.
+	// This handles upgrades from versions that didn't auto-create base sessions.
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Main.Errorf("PANIC in base session backfill: %v\n%s", r, debug.Stack())
+			}
+		}()
+
+		repos, err := s.ListRepos(ctx)
+		if err != nil {
+			logger.Main.Warnf("Base session backfill: failed to list repos: %v", err)
+			return
+		}
+
+		for _, repo := range repos {
+			// Check if workspace already has a base session
+			existing, err := s.GetBaseSessionForWorkspace(ctx, repo.ID)
+			if err != nil {
+				logger.Main.Warnf("Base session backfill: failed to check workspace %s: %v", repo.ID, err)
+				continue
+			}
+			if existing != nil {
+				continue // already has one
+			}
+
+			// Verify the repo path still exists on disk
+			if _, statErr := os.Stat(repo.Path); os.IsNotExist(statErr) {
+				continue
+			}
+
+			branch, _ := repoManager.GetCurrentBranch(ctx, repo.Path)
+			now := time.Now()
+			sess := &models.Session{
+				ID:           uuid.New().String(),
+				WorkspaceID:  repo.ID,
+				Name:         repo.Name,
+				Branch:       branch,
+				WorktreePath: repo.Path,
+				SessionType:  models.SessionTypeBase,
+				Status:       "idle",
+				PRStatus:     "none",
+				Priority:     models.PriorityNone,
+				TaskStatus:   models.TaskStatusInProgress,
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			}
+			if err := s.AddSession(ctx, sess); err != nil {
+				logger.Main.Warnf("Base session backfill: failed to create session for workspace %s: %v", repo.ID, err)
+				continue
+			}
+
+			convID := uuid.New().String()[:8]
+			conv := &models.Conversation{
+				ID:          convID,
+				SessionID:   sess.ID,
+				Type:        models.ConversationTypeTask,
+				Name:        "Untitled",
+				Status:      models.ConversationStatusIdle,
+				Messages:    []models.Message{},
+				ToolSummary: []models.ToolAction{},
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}
+			if err := s.AddConversation(ctx, conv); err != nil {
+				logger.Main.Warnf("Base session backfill: failed to create conversation for workspace %s: %v", repo.ID, err)
+				continue
+			}
+
+			setupMsg := models.Message{
+				ID:   uuid.New().String()[:8],
+				Role: "system",
+				SetupInfo: &models.SetupInfo{
+					SessionName:  sess.Name,
+					BranchName:   branch,
+					OriginBranch: branch,
+				},
+				Timestamp: now,
+			}
+			if err := s.AddMessageToConversation(ctx, convID, setupMsg); err != nil {
+				logger.Main.Warnf("Base session backfill: failed to create setup message for workspace %s: %v", repo.ID, err)
+				continue
+			}
+
+			// Start branch watching for the backfilled session
+			if branchWatcher != nil {
+				if watchErr := branchWatcher.WatchSession(sess.ID, repo.Path, branch); watchErr != nil {
+					logger.Main.Warnf("Base session backfill: failed to watch session %s: %v", sess.ID, watchErr)
+				}
+			}
+
+			logger.Main.Infof("Backfilled base session for workspace %q (%s)", repo.Name, repo.ID)
+		}
+	}()
 
 	// Pre-warm session stats cache in background so the first getDashboardData
 	// returns stats from cache instead of computing them on-the-fly.

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -20,6 +20,7 @@ type Session struct {
 	Name             string        `json:"name"`
 	Branch           string        `json:"branch"`
 	WorktreePath     string        `json:"worktreePath"`
+	SessionType      string        `json:"sessionType"`              // "worktree" or "base"
 	BaseCommitSHA    string        `json:"baseCommitSha,omitempty"`    // Commit SHA the session was created from
 	TargetBranch     string        `json:"targetBranch,omitempty"`    // Per-session target branch override (e.g. "origin/develop")
 	Task             string        `json:"task,omitempty"`
@@ -263,6 +264,17 @@ const (
 	ConversationStatusIdle      = "idle"
 	ConversationStatusCompleted = "completed"
 )
+
+// SessionType constants
+const (
+	SessionTypeWorktree = "worktree"
+	SessionTypeBase     = "base"
+)
+
+// IsBaseSession returns true if this session operates directly on the repo checkout.
+func (s *Session) IsBaseSession() bool {
+	return s.SessionType == SessionTypeBase
+}
 
 // SessionStatus constants
 const (
@@ -516,6 +528,24 @@ type BranchSyncResult struct {
 	NewBaseSha    string   `json:"newBaseSha,omitempty"`
 	ConflictFiles []string `json:"conflictFiles,omitempty"`
 	ErrorMessage  string   `json:"errorMessage,omitempty"`
+}
+
+// PreflightStatus reports git state issues that block base session usage.
+type PreflightStatus struct {
+	OK               bool   `json:"ok"`
+	ActiveRebase     bool   `json:"activeRebase,omitempty"`
+	ActiveMerge      bool   `json:"activeMerge,omitempty"`
+	ActiveCherryPick bool   `json:"activeCherryPick,omitempty"`
+	DetachedHead     bool   `json:"detachedHead,omitempty"`
+	CorruptedIndex   bool   `json:"corruptedIndex,omitempty"`
+	ErrorMessage     string `json:"errorMessage,omitempty"`
+}
+
+// StashEntry represents a single git stash entry.
+type StashEntry struct {
+	Index   int    `json:"index"`
+	Branch  string `json:"branch"`
+	Message string `json:"message"`
 }
 
 // Checkpoint represents a file state snapshot created by the Claude Agent SDK at message boundaries.

--- a/backend/server/base_session_handlers.go
+++ b/backend/server/base_session_handlers.go
@@ -1,0 +1,343 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/chatml/chatml-backend/git"
+	"github.com/chatml/chatml-backend/logger"
+	"github.com/chatml/chatml-backend/models"
+	"github.com/go-chi/chi/v5"
+)
+
+// ============================================================================
+// Base session handlers: preflight, branch management, stash
+// ============================================================================
+
+// getBaseSession is a helper that loads a session and validates it is a base session.
+func (h *Handlers) getBaseSession(w http.ResponseWriter, r *http.Request) (string, string, bool) {
+	ctx := r.Context()
+	sessionID := chi.URLParam(r, "sessionId")
+	workspaceID := chi.URLParam(r, "id")
+
+	sess, err := h.store.GetSession(ctx, sessionID)
+	if err != nil {
+		writeDBError(w, err)
+		return "", "", false
+	}
+	if sess == nil || sess.WorkspaceID != workspaceID {
+		writeNotFound(w, "session")
+		return "", "", false
+	}
+	if !sess.IsBaseSession() {
+		writeValidationError(w, "this endpoint is only available for base sessions")
+		return "", "", false
+	}
+	return workspaceID, sess.WorktreePath, true
+}
+
+// PreflightCheck runs safety checks on the repository for a base session.
+// GET /api/repos/{id}/sessions/{sessionId}/preflight
+func (h *Handlers) PreflightCheck(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	status, err := h.repoManager.CheckPreflight(ctx, repoPath)
+	if err != nil {
+		writeInternalError(w, "preflight check failed", err)
+		return
+	}
+	writeJSON(w, status)
+}
+
+// GetCurrentBranch returns the current branch of a base session's repo.
+// GET /api/repos/{id}/sessions/{sessionId}/current-branch
+func (h *Handlers) GetCurrentSessionBranch(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sessionID := chi.URLParam(r, "sessionId")
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	branch, err := h.repoManager.GetCurrentBranch(ctx, repoPath)
+	if err != nil {
+		writeInternalError(w, "failed to get current branch", err)
+		return
+	}
+
+	// Update DB if branch changed
+	if err := h.store.UpdateSession(ctx, sessionID, func(s *models.Session) {
+		s.Branch = branch
+	}); err != nil {
+		logger.Handlers.Warnf("Failed to update branch in DB for session %s: %v", sessionID, err)
+	}
+
+	writeJSON(w, map[string]string{"branch": branch})
+}
+
+// CreateSessionBranch creates a new branch in the base session's repo.
+// POST /api/repos/{id}/sessions/{sessionId}/branches/create
+func (h *Handlers) CreateSessionBranch(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Name       string `json:"name"`
+		StartPoint string `json:"startPoint,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeValidationError(w, "branch name is required")
+		return
+	}
+
+	if err := h.repoManager.CreateBranch(ctx, repoPath, req.Name, req.StartPoint); err != nil {
+		writeInternalError(w, "failed to create branch", err)
+		return
+	}
+
+	writeJSON(w, map[string]string{"branch": req.Name})
+}
+
+// SwitchSessionBranch switches the base session's repo to a different branch.
+// POST /api/repos/{id}/sessions/{sessionId}/branches/switch
+func (h *Handlers) SwitchSessionBranch(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sessionID := chi.URLParam(r, "sessionId")
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Branch string `json:"branch"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+	if req.Branch == "" {
+		writeValidationError(w, "branch name is required")
+		return
+	}
+
+	// Check for dirty working tree before switching
+	dirtyFiles, err := h.repoManager.GetDirtyFiles(ctx, repoPath)
+	if err != nil {
+		writeInternalError(w, "failed to check working tree status", err)
+		return
+	}
+	if len(dirtyFiles) > 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":      "working tree has uncommitted changes",
+			"dirtyFiles": dirtyFiles,
+		})
+		return
+	}
+
+	// Switch branch
+	if err := h.repoManager.SwitchBranch(ctx, repoPath, req.Branch); err != nil {
+		if _, ok := err.(*git.DirtyWorkingTreeError); ok {
+			// Race: files became dirty between the pre-flight check and git switch.
+			// Re-fetch dirty files so the response shape matches the pre-flight path.
+			raceFiles, _ := h.repoManager.GetDirtyFiles(ctx, repoPath)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":      "working tree has uncommitted changes",
+				"dirtyFiles": raceFiles,
+			})
+			return
+		}
+		writeInternalError(w, "failed to switch branch", err)
+		return
+	}
+
+	// Update session branch in DB
+	if err := h.store.UpdateSession(ctx, sessionID, func(s *models.Session) {
+		s.Branch = req.Branch
+	}); err != nil {
+		writeDBError(w, err)
+		return
+	}
+
+	// Invalidate caches so the new branch is reflected immediately
+	h.baseBranchCache.Delete(sessionID)
+	if h.snapshotCache != nil {
+		h.snapshotCache.Invalidate(sessionID)
+	}
+
+	// Broadcast branch change via WebSocket
+	if h.hub != nil {
+		h.hub.Broadcast(Event{
+			Type: "session_updated",
+			Payload: map[string]interface{}{
+				"sessionId": sessionID,
+				"reason":    "branch_switched",
+				"branch":    req.Branch,
+			},
+		})
+	}
+
+	writeJSON(w, map[string]string{"branch": req.Branch})
+}
+
+// DeleteSessionBranch deletes a local branch from the base session's repo.
+// DELETE /api/repos/{id}/sessions/{sessionId}/branches/{name}
+func (h *Handlers) DeleteSessionBranch(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	branchName := chi.URLParam(r, "branchName")
+	if branchName == "" {
+		writeValidationError(w, "branch name is required")
+		return
+	}
+
+	// The existing DeleteLocalBranch in cleanup.go already checks protected branches
+	if err := h.repoManager.DeleteLocalBranch(ctx, repoPath, branchName); err != nil {
+		writeInternalError(w, "failed to delete branch", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ============================================================================
+// Stash handlers
+// ============================================================================
+
+// ListStashes returns all stash entries for the base session's repo.
+// GET /api/repos/{id}/sessions/{sessionId}/stashes
+func (h *Handlers) ListStashes(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	entries, err := h.repoManager.ListStashes(ctx, repoPath)
+	if err != nil {
+		writeInternalError(w, "failed to list stashes", err)
+		return
+	}
+	writeJSON(w, entries)
+}
+
+// CreateStash creates a new stash in the base session's repo.
+// POST /api/repos/{id}/sessions/{sessionId}/stashes
+func (h *Handlers) CreateStash(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Message          string `json:"message,omitempty"`
+		IncludeUntracked bool   `json:"includeUntracked,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, "invalid request body")
+		return
+	}
+
+	if err := h.repoManager.CreateStash(ctx, repoPath, req.Message, req.IncludeUntracked); err != nil {
+		writeInternalError(w, "failed to create stash", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+// parseStashIndex extracts and validates the stash index from the URL.
+func parseStashIndex(w http.ResponseWriter, r *http.Request) (int, bool) {
+	index, err := strconv.Atoi(chi.URLParam(r, "index"))
+	if err != nil || index < 0 {
+		writeValidationError(w, "invalid stash index")
+		return 0, false
+	}
+	return index, true
+}
+
+// ApplyStash applies a stash entry without removing it.
+// POST /api/repos/{id}/sessions/{sessionId}/stashes/{index}/apply
+func (h *Handlers) ApplyStash(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	index, ok := parseStashIndex(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.repoManager.ApplyStash(ctx, repoPath, index); err != nil {
+		writeInternalError(w, "failed to apply stash", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// PopStash applies and removes a stash entry.
+// POST /api/repos/{id}/sessions/{sessionId}/stashes/{index}/pop
+func (h *Handlers) PopStash(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	index, ok := parseStashIndex(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.repoManager.PopStash(ctx, repoPath, index); err != nil {
+		writeInternalError(w, "failed to pop stash", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DropStash removes a stash entry without applying it.
+// DELETE /api/repos/{id}/sessions/{sessionId}/stashes/{index}
+func (h *Handlers) DropStash(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, repoPath, ok := h.getBaseSession(w, r)
+	if !ok {
+		return
+	}
+
+	index, ok := parseStashIndex(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.repoManager.DropStash(ctx, repoPath, index); err != nil {
+		writeInternalError(w, "failed to drop stash", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -530,6 +530,12 @@ func (c *DirListingCache) Stats() (total int, expired int) {
 	return total, expired
 }
 
+// baseBranchCacheEntry holds a cached branch name with expiry.
+type baseBranchCacheEntry struct {
+	branch    string
+	expiresAt time.Time
+}
+
 type Handlers struct {
 	store            *store.SQLiteStore
 	repoManager      *git.RepoManager
@@ -540,6 +546,7 @@ type Handlers struct {
 	fileSizeConfig   FileSizeConfig
 	dirCache         *DirListingCache
 	branchCache      *BranchCache
+	baseBranchCache  sync.Map // sessionID → *baseBranchCacheEntry (2s TTL)
 	branchWatcher    *branch.Watcher
 	prWatcher        *branch.PRWatcher
 	hub              *Hub // For broadcasting WebSocket events
@@ -718,6 +725,29 @@ func (h *Handlers) getSessionAndWorkspace(ctx context.Context, sessionID string)
 	workingPath = session.WorktreePath
 	if workingPath == "" {
 		workingPath = session.WorkspacePath
+	}
+
+	// For base sessions, dynamically read the current branch from git.
+	// The DB branch field may be stale if the user switched branches externally.
+	// Use a short TTL cache to avoid spawning a git subprocess on every call.
+	if session.IsBaseSession() {
+		const baseBranchTTL = 2 * time.Second
+		usedCache := false
+		if cached, ok := h.baseBranchCache.Load(session.ID); ok {
+			if entry := cached.(*baseBranchCacheEntry); time.Now().Before(entry.expiresAt) {
+				session.Branch = entry.branch
+				usedCache = true
+			}
+		}
+		if !usedCache {
+			if currentBranch, brErr := h.repoManager.GetCurrentBranch(ctx, workingPath); brErr == nil && currentBranch != "" {
+				session.Branch = currentBranch
+				h.baseBranchCache.Store(session.ID, &baseBranchCacheEntry{
+					branch:    currentBranch,
+					expiresAt: time.Now().Add(baseBranchTTL),
+				})
+			}
+		}
 	}
 
 	// Compute the merge-base between the target branch and HEAD.

--- a/backend/server/repo_handlers.go
+++ b/backend/server/repo_handlers.go
@@ -58,6 +58,11 @@ func (h *Handlers) AddRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Auto-create base session for the new workspace
+	if _, err := h.initBaseSession(ctx, repo.ID, repo.Name, branch, repo.Path); err != nil {
+		logger.Handlers.Warnf("Failed to auto-create base session for workspace %s: %v", repo.ID, err)
+	}
+
 	writeJSON(w, repo)
 }
 

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -184,6 +184,17 @@ func NewRouter(ctx context.Context, s *store.SQLiteStore, hub *Hub, agentMgr *ag
 		// Commit status endpoints
 		r.Post("/{id}/sessions/{sessionId}/status", h.PostCommitStatus)
 		r.Get("/{id}/sessions/{sessionId}/statuses", h.ListCommitStatuses)
+		// Base session endpoints (preflight, branch management, stash)
+		r.Get("/{id}/sessions/{sessionId}/preflight", h.PreflightCheck)
+		r.Get("/{id}/sessions/{sessionId}/current-branch", h.GetCurrentSessionBranch)
+		r.Post("/{id}/sessions/{sessionId}/branches/create", h.CreateSessionBranch)
+		r.Post("/{id}/sessions/{sessionId}/branches/switch", h.SwitchSessionBranch)
+		r.Delete("/{id}/sessions/{sessionId}/branches/{branchName}", h.DeleteSessionBranch)
+		r.Get("/{id}/sessions/{sessionId}/stashes", h.ListStashes)
+		r.Post("/{id}/sessions/{sessionId}/stashes", h.CreateStash)
+		r.Post("/{id}/sessions/{sessionId}/stashes/{index}/apply", h.ApplyStash)
+		r.Post("/{id}/sessions/{sessionId}/stashes/{index}/pop", h.PopStash)
+		r.Delete("/{id}/sessions/{sessionId}/stashes/{index}", h.DropStash)
 		r.Get("/{id}/agents", h.ListAgents)
 		r.With(agentRateLimiter).Post("/{id}/agents", h.SpawnAgent)
 		// File tabs

--- a/backend/server/session_handlers.go
+++ b/backend/server/session_handlers.go
@@ -152,6 +152,73 @@ type CreateSessionRequest struct {
 	CheckoutExisting bool `json:"checkoutExisting,omitempty"`
 	// SystemMessage is optional custom content for the initial system message (e.g. PR context)
 	SystemMessage string `json:"systemMessage,omitempty"`
+	// SessionType is "worktree" (default) or "base" — base sessions operate on the repo directly
+	SessionType string `json:"sessionType,omitempty"`
+}
+
+// initBaseSession creates a base session with its initial conversation and setup message,
+// then starts the branch watcher. Returns the created session or an error.
+func (h *Handlers) initBaseSession(ctx context.Context, workspaceID, name, branch, repoPath string) (*models.Session, error) {
+	now := time.Now()
+	sess := &models.Session{
+		ID:           uuid.New().String(),
+		WorkspaceID:  workspaceID,
+		Name:         name,
+		Branch:       branch,
+		WorktreePath: repoPath,
+		SessionType:  models.SessionTypeBase,
+		Status:       "idle",
+		PRStatus:     "none",
+		Priority:     models.PriorityNone,
+		TaskStatus:   models.TaskStatusInProgress,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	if err := h.store.AddSession(ctx, sess); err != nil {
+		return nil, fmt.Errorf("add session: %w", err)
+	}
+
+	// Create initial conversation
+	convID := uuid.New().String()[:8]
+	conv := &models.Conversation{
+		ID:          convID,
+		SessionID:   sess.ID,
+		Type:        models.ConversationTypeTask,
+		Name:        "Untitled",
+		Status:      models.ConversationStatusIdle,
+		Messages:    []models.Message{},
+		ToolSummary: []models.ToolAction{},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := h.store.AddConversation(ctx, conv); err != nil {
+		return nil, fmt.Errorf("add conversation: %w", err)
+	}
+
+	// System message
+	setupMsg := models.Message{
+		ID:   uuid.New().String()[:8],
+		Role: "system",
+		SetupInfo: &models.SetupInfo{
+			SessionName:  sess.Name,
+			BranchName:   branch,
+			OriginBranch: branch,
+		},
+		Timestamp: now,
+	}
+	if err := h.store.AddMessageToConversation(ctx, convID, setupMsg); err != nil {
+		return nil, fmt.Errorf("add setup message: %w", err)
+	}
+
+	// Watch for branch changes
+	if h.branchWatcher != nil {
+		if err := h.branchWatcher.WatchSession(sess.ID, repoPath, branch); err != nil {
+			logger.Handlers.Warnf("Failed to start branch watching for base session %s: %v", sess.ID, err)
+		}
+	}
+
+	return sess, nil
 }
 
 // resolveRepoBranchPrefix returns the branch prefix based on repo-level settings.
@@ -216,6 +283,38 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
+	// ─── Base session fast path ───
+	// Base sessions operate directly on the repo checkout: no worktree, no branch creation.
+	if req.SessionType == models.SessionTypeBase {
+		// Enforce one base session per workspace
+		existing, err := h.store.GetBaseSessionForWorkspace(ctx, workspaceID)
+		if err != nil {
+			writeDBError(w, err)
+			return
+		}
+		if existing != nil {
+			writeConflict(w, "workspace already has a base session")
+			return
+		}
+
+		branch, _ := h.repoManager.GetCurrentBranch(ctx, repo.Path)
+		sessionName := req.Name
+		if sessionName == "" {
+			sessionName = repo.Name
+		}
+
+		sess, err := h.initBaseSession(ctx, workspaceID, sessionName, branch, repo.Path)
+		if err != nil {
+			writeInternalError(w, "failed to create base session", err)
+			return
+		}
+
+		writeJSON(w, sess)
+		return
+	}
+
+	// ─── Worktree session path (existing logic) ───
 
 	// Generate session ID
 	sessionID := uuid.New().String()
@@ -590,6 +689,12 @@ func (h *Handlers) UpdateSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Block archiving of base sessions
+	if req.Archived != nil && *req.Archived && session.IsBaseSession() {
+		writeValidationError(w, "base sessions cannot be archived")
+		return
+	}
+
 	// If archiving, check if session has any messages. Delete blank sessions instead.
 	if req.Archived != nil && *req.Archived {
 		hasMessages, msgErr := h.store.SessionHasMessages(ctx, id)
@@ -847,6 +952,12 @@ func (h *Handlers) DeleteSession(w http.ResponseWriter, r *http.Request) {
 	sess, err := h.store.GetSession(ctx, sessionID)
 	if err != nil {
 		writeDBError(w, err)
+		return
+	}
+
+	// Block deletion of base sessions
+	if sess != nil && sess.IsBaseSession() {
+		writeValidationError(w, "base sessions cannot be deleted")
 		return
 	}
 

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -135,12 +135,14 @@ func (s *SQLiteStore) initSchema() error {
 		auto_named INTEGER NOT NULL DEFAULT 0,
 		check_status TEXT NOT NULL DEFAULT 'none',
 		sprint_phase TEXT NOT NULL DEFAULT '',
+		session_type TEXT NOT NULL DEFAULT 'worktree',
 		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		FOREIGN KEY (workspace_id) REFERENCES repos(id) ON DELETE CASCADE
 	);
 	CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id ON sessions(workspace_id);
 	CREATE INDEX IF NOT EXISTS idx_sessions_workspace_name ON sessions(workspace_id, name);
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_base_per_workspace ON sessions(workspace_id) WHERE session_type = 'base';
 
 	-- Agents (legacy, still actively used by agent/manager.go)
 	CREATE TABLE IF NOT EXISTS agents (
@@ -332,6 +334,10 @@ func (s *SQLiteStore) runMigrations() error {
 	_, _ = s.db.Exec(`ALTER TABLE review_comments ADD COLUMN resolution_type TEXT DEFAULT ''`)
 	// Add sprint_phase column to sessions (ignore error if already exists)
 	_, _ = s.db.Exec(`ALTER TABLE sessions ADD COLUMN sprint_phase TEXT NOT NULL DEFAULT ''`)
+	// Add session_type column for base session support (ignore error if already exists)
+	_, _ = s.db.Exec(`ALTER TABLE sessions ADD COLUMN session_type TEXT NOT NULL DEFAULT 'worktree'`)
+	// Unique index: one base session per workspace
+	_, _ = s.db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_base_per_workspace ON sessions(workspace_id) WHERE session_type = 'base'`)
 	return nil
 }
 
@@ -504,13 +510,18 @@ func (s *SQLiteStore) AddSession(ctx context.Context, session *models.Session) e
 			statsDeletions = session.Stats.Deletions
 		}
 
+		sessionType := session.SessionType
+		if sessionType == "" {
+			sessionType = models.SessionTypeWorktree
+		}
+
 		_, err := s.db.ExecContext(ctx, `
 			INSERT INTO sessions (id, workspace_id, name, branch, worktree_path, base_commit_sha, target_branch,
 				task, status, agent_id, pr_status, pr_url, pr_number, pr_title, has_merge_conflict,
 				has_check_failures, check_status, stats_additions, stats_deletions, pinned, archived,
 				priority, task_status, archive_summary, archive_summary_status, auto_named, sprint_phase,
-				created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				session_type, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			session.ID, session.WorkspaceID, session.Name, session.Branch,
 			session.WorktreePath, session.BaseCommitSHA, nullString(session.TargetBranch),
 			session.Task, session.Status, session.AgentID,
@@ -521,7 +532,7 @@ func (s *SQLiteStore) AddSession(ctx context.Context, session *models.Session) e
 			session.Priority, session.TaskStatus,
 			session.ArchiveSummary, session.ArchiveSummaryStatus,
 			boolToInt(session.AutoNamed), session.SprintPhase,
-			session.CreatedAt, session.UpdatedAt)
+			sessionType, session.CreatedAt, session.UpdatedAt)
 		return err
 	})
 }
@@ -536,7 +547,8 @@ func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Sessio
 			task, status, agent_id,
 			pr_status, pr_url, pr_number, pr_title, has_merge_conflict, has_check_failures, check_status,
 			stats_additions, stats_deletions, pinned, archived, priority, task_status,
-			archive_summary, archive_summary_status, auto_named, sprint_phase, created_at, updated_at
+			archive_summary, archive_summary_status, auto_named, sprint_phase, session_type,
+			created_at, updated_at
 		FROM sessions WHERE id = ?`, id).Scan(
 		&session.ID, &session.WorkspaceID, &session.Name, &session.Branch,
 		&session.WorktreePath, &session.BaseCommitSHA, &targetBranch,
@@ -545,7 +557,7 @@ func (s *SQLiteStore) GetSession(ctx context.Context, id string) (*models.Sessio
 		&hasMergeConflict, &hasCheckFailures, &session.CheckStatus, &statsAdditions, &statsDeletions,
 		&pinned, &archived, &session.Priority, &session.TaskStatus,
 		&session.ArchiveSummary, &session.ArchiveSummaryStatus,
-		&autoNamed, &session.SprintPhase,
+		&autoNamed, &session.SprintPhase, &session.SessionType,
 		&session.CreatedAt, &session.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -587,7 +599,7 @@ func (s *SQLiteStore) GetSessionWithWorkspace(ctx context.Context, id string) (*
 			s.target_branch, s.task, s.status, s.agent_id, s.pr_status, s.pr_url, s.pr_number, s.pr_title,
 			s.has_merge_conflict, s.has_check_failures, s.check_status, s.stats_additions, s.stats_deletions,
 			s.pinned, s.archived, s.priority, s.task_status, s.archive_summary, s.archive_summary_status,
-			s.auto_named, s.sprint_phase, s.created_at, s.updated_at,
+			s.auto_named, s.sprint_phase, s.session_type, s.created_at, s.updated_at,
 			r.path, r.branch, r.remote
 		FROM sessions s
 		JOIN repos r ON s.workspace_id = r.id
@@ -598,7 +610,7 @@ func (s *SQLiteStore) GetSessionWithWorkspace(ctx context.Context, id string) (*
 		&result.PRStatus, &result.PRUrl, &result.PRNumber, &result.PRTitle,
 		&hasMergeConflict, &hasCheckFailures, &result.CheckStatus, &statsAdditions, &statsDeletions,
 		&pinned, &archived, &result.Priority, &result.TaskStatus, &result.ArchiveSummary, &result.ArchiveSummaryStatus,
-		&autoNamed, &result.SprintPhase, &result.CreatedAt, &result.UpdatedAt,
+		&autoNamed, &result.SprintPhase, &result.SessionType, &result.CreatedAt, &result.UpdatedAt,
 		&result.WorkspacePath, &result.WorkspaceBranch, &result.WorkspaceRemote)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -633,7 +645,8 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, workspaceID string, incl
 		task, status, agent_id,
 		pr_status, pr_url, pr_number, pr_title, has_merge_conflict, has_check_failures, check_status,
 		stats_additions, stats_deletions, pinned, archived, priority, task_status,
-		archive_summary, archive_summary_status, auto_named, sprint_phase, created_at, updated_at
+		archive_summary, archive_summary_status, auto_named, sprint_phase, session_type,
+		created_at, updated_at
 		FROM sessions WHERE workspace_id = ?`
 	if !includeArchived {
 		query += " AND archived = 0"
@@ -659,7 +672,7 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, workspaceID string, incl
 			&hasMergeConflict, &hasCheckFailures, &session.CheckStatus, &statsAdditions, &statsDeletions,
 			&pinned, &archived, &session.Priority, &session.TaskStatus,
 			&session.ArchiveSummary, &session.ArchiveSummaryStatus,
-			&autoNamed, &session.SprintPhase,
+			&autoNamed, &session.SprintPhase, &session.SessionType,
 			&session.CreatedAt, &session.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("ListSessions scan: %w", err)
 		}
@@ -697,7 +710,8 @@ func (s *SQLiteStore) ListAllSessions(ctx context.Context, includeArchived bool)
 		task, status, agent_id,
 		pr_status, pr_url, pr_number, pr_title, has_merge_conflict, has_check_failures, check_status,
 		stats_additions, stats_deletions, pinned, archived, priority, task_status,
-		archive_summary, archive_summary_status, auto_named, sprint_phase, created_at, updated_at
+		archive_summary, archive_summary_status, auto_named, sprint_phase, session_type,
+		created_at, updated_at
 		FROM sessions`
 	if !includeArchived {
 		query += " WHERE archived = 0"
@@ -723,7 +737,7 @@ func (s *SQLiteStore) ListAllSessions(ctx context.Context, includeArchived bool)
 			&hasMergeConflict, &hasCheckFailures, &session.CheckStatus, &statsAdditions, &statsDeletions,
 			&pinned, &archived, &session.Priority, &session.TaskStatus,
 			&session.ArchiveSummary, &session.ArchiveSummaryStatus,
-			&autoNamed, &session.SprintPhase,
+			&autoNamed, &session.SprintPhase, &session.SessionType,
 			&session.CreatedAt, &session.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("ListAllSessions scan: %w", err)
 		}
@@ -783,7 +797,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, updates func
 				pr_number = ?, pr_title = ?, has_merge_conflict = ?, has_check_failures = ?, check_status = ?,
 				stats_additions = ?, stats_deletions = ?, pinned = ?, archived = ?,
 				priority = ?, task_status = ?, archive_summary = ?, archive_summary_status = ?,
-				auto_named = ?, sprint_phase = ?, updated_at = ?
+				auto_named = ?, sprint_phase = ?, session_type = ?, updated_at = ?
 			WHERE id = ?`,
 			session.Name, session.Branch, session.WorktreePath, session.BaseCommitSHA,
 			nullString(session.TargetBranch),
@@ -793,7 +807,7 @@ func (s *SQLiteStore) UpdateSession(ctx context.Context, id string, updates func
 			statsAdditions, statsDeletions, boolToInt(session.Pinned), boolToInt(session.Archived),
 			session.Priority, session.TaskStatus,
 			session.ArchiveSummary, session.ArchiveSummaryStatus,
-			boolToInt(session.AutoNamed), session.SprintPhase,
+			boolToInt(session.AutoNamed), session.SprintPhase, session.SessionType,
 			session.UpdatedAt, id)
 		return err
 	})
@@ -809,7 +823,8 @@ func (s *SQLiteStore) getSessionNoLock(ctx context.Context, id string) (*models.
 			task, status, agent_id,
 			pr_status, pr_url, pr_number, pr_title, has_merge_conflict, has_check_failures, check_status,
 			stats_additions, stats_deletions, pinned, archived, priority, task_status,
-			archive_summary, archive_summary_status, auto_named, sprint_phase, created_at, updated_at
+			archive_summary, archive_summary_status, auto_named, sprint_phase, session_type,
+			created_at, updated_at
 		FROM sessions WHERE id = ?`, id).Scan(
 		&session.ID, &session.WorkspaceID, &session.Name, &session.Branch,
 		&session.WorktreePath, &session.BaseCommitSHA, &targetBranch,
@@ -818,7 +833,7 @@ func (s *SQLiteStore) getSessionNoLock(ctx context.Context, id string) (*models.
 		&hasMergeConflict, &hasCheckFailures, &session.CheckStatus, &statsAdditions, &statsDeletions,
 		&pinned, &archived, &session.Priority, &session.TaskStatus,
 		&session.ArchiveSummary, &session.ArchiveSummaryStatus,
-		&autoNamed, &session.SprintPhase,
+		&autoNamed, &session.SprintPhase, &session.SessionType,
 		&session.CreatedAt, &session.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -866,6 +881,57 @@ func (s *SQLiteStore) SessionExistsByName(ctx context.Context, workspaceID, name
 		return false, fmt.Errorf("SessionExistsByName: %w", err)
 	}
 	return exists, nil
+}
+
+// GetBaseSessionForWorkspace returns the base session for a workspace, or nil if none exists.
+func (s *SQLiteStore) GetBaseSessionForWorkspace(ctx context.Context, workspaceID string) (*models.Session, error) {
+	var session models.Session
+	var hasMergeConflict, hasCheckFailures, statsAdditions, statsDeletions, pinned, archived, autoNamed int
+	var agentID, targetBranch sql.NullString
+
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, workspace_id, name, branch, worktree_path, base_commit_sha, target_branch,
+			task, status, agent_id,
+			pr_status, pr_url, pr_number, pr_title, has_merge_conflict, has_check_failures, check_status,
+			stats_additions, stats_deletions, pinned, archived, priority, task_status,
+			archive_summary, archive_summary_status, auto_named, sprint_phase, session_type,
+			created_at, updated_at
+		FROM sessions WHERE workspace_id = ? AND session_type = 'base'`, workspaceID).Scan(
+		&session.ID, &session.WorkspaceID, &session.Name, &session.Branch,
+		&session.WorktreePath, &session.BaseCommitSHA, &targetBranch,
+		&session.Task, &session.Status, &agentID,
+		&session.PRStatus, &session.PRUrl, &session.PRNumber, &session.PRTitle,
+		&hasMergeConflict, &hasCheckFailures, &session.CheckStatus, &statsAdditions, &statsDeletions,
+		&pinned, &archived, &session.Priority, &session.TaskStatus,
+		&session.ArchiveSummary, &session.ArchiveSummaryStatus,
+		&autoNamed, &session.SprintPhase, &session.SessionType,
+		&session.CreatedAt, &session.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("GetBaseSessionForWorkspace: %w", err)
+	}
+
+	session.HasMergeConflict = intToBool(hasMergeConflict)
+	session.HasCheckFailures = intToBool(hasCheckFailures)
+	session.Pinned = intToBool(pinned)
+	session.Archived = intToBool(archived)
+	session.AutoNamed = intToBool(autoNamed)
+	if agentID.Valid {
+		session.AgentID = agentID.String
+	}
+	if targetBranch.Valid {
+		session.TargetBranch = targetBranch.String
+	}
+	if statsAdditions > 0 || statsDeletions > 0 {
+		session.Stats = &models.SessionStats{
+			Additions: statsAdditions,
+			Deletions: statsDeletions,
+		}
+	}
+
+	return &session, nil
 }
 
 // ============================================================================

--- a/src/components/dialogs/AddWorkspaceModal.tsx
+++ b/src/components/dialogs/AddWorkspaceModal.tsx
@@ -5,7 +5,7 @@ import { useAppStore } from '@/stores/appStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix } from '@/stores/settingsStore';
 import { navigate } from '@/lib/navigation';
-import { addRepo, createSession as createSessionApi, listConversations as listConversationsApi, mapSessionDTO } from '@/lib/api';
+import { addRepo, createSession as createSessionApi, listSessions as listSessionsApi, listConversations as listConversationsApi, mapSessionDTO } from '@/lib/api';
 import type { SetupInfo } from '@/lib/types';
 import {
   Dialog,
@@ -67,7 +67,11 @@ export function AddWorkspaceModal({ isOpen, onClose }: AddWorkspaceModalProps) {
       };
       addWorkspace(workspace);
 
-      // Auto-create first session for the new workspace (backend generates city-based name)
+      // Fetch the auto-created base session (created by backend during AddRepo)
+      const existingSessions = await listSessionsApi(workspace.id);
+      existingSessions.forEach((s) => addSession(mapSessionDTO(s)));
+
+      // Auto-create first worktree session for the new workspace
       const branchPrefix = workspace.branchPrefix
         ? getWorkspaceBranchPrefix(workspace)
         : getBranchPrefix();

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -43,6 +43,7 @@ import {
   Gauge,
   Boxes,
   ExternalLink,
+  FolderGit2,
 } from 'lucide-react';
 import { resolveWorkspaceColor } from '@/lib/workspace-colors';
 import { updateSession as apiUpdateSession } from '@/lib/api';
@@ -485,8 +486,15 @@ export function SessionToolbarContent() {
             <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
           </span>
           <span className="flex items-center gap-1.5 shrink-0">
-            <GitBranch className="h-4 w-4 text-purple-400" />
+            {selectedSession.sessionType === 'base' ? (
+              <FolderGit2 className="h-4 w-4 text-amber-500" />
+            ) : (
+              <GitBranch className="h-4 w-4 text-purple-400" />
+            )}
             <span className="text-base font-semibold truncate">{selectedSession.branch || selectedSession.name}</span>
+            {selectedSession.sessionType === 'base' && (
+              <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-500 font-medium">Base</span>
+            )}
           </span>
         </span>
       ),

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -81,6 +81,7 @@ import {
   MessageCircleQuestion,
   ClipboardCheck,
   Link,
+  FolderGit2,
 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
@@ -1488,6 +1489,9 @@ function SessionRow({
                   )}
                   {/* Branch name container - grows and truncates */}
                   <div className="flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
+                    {session.sessionType === 'base' && (
+                      <FolderGit2 className="w-3.5 h-3.5 shrink-0 text-amber-500" />
+                    )}
                     <span className={cn(
                       "text-base truncate flex-1 w-0",
                       isSessionSelected ? "text-foreground font-normal" : "text-foreground/60 font-normal",
@@ -1505,18 +1509,20 @@ function SessionRow({
                         <span className="text-text-error ml-1">-{session.stats!.deletions}</span>
                       </span>
                     )}
-                    {/* Archive action - visible on hover */}
-                    <div className="hidden group-hover:flex items-center gap-1">
-                      <button
-                        className="p-0.5 rounded hover:bg-muted text-muted-foreground/60 hover:text-muted-foreground"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onArchiveSession(session.id);
-                        }}
-                      >
-                        <Archive className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
+                    {/* Archive action - visible on hover (hidden for base sessions) */}
+                    {session.sessionType !== 'base' && (
+                      <div className="hidden group-hover:flex items-center gap-1">
+                        <button
+                          className="p-0.5 rounded hover:bg-muted text-muted-foreground/60 hover:text-muted-foreground"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onArchiveSession(session.id);
+                          }}
+                        >
+                          <Archive className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    )}
                   </div>
                 </div>
                 {/* Second line: project indicator · PR info · status (only when there's meaningful content) */}
@@ -1611,11 +1617,13 @@ function SessionRow({
             Pull Requests
           </ContextMenuItem>
         )}
-        {(onOpenBranches || onOpenPRs) && <ContextMenuSeparator />}
-        <ContextMenuItem onClick={() => onArchiveSession(session.id)} variant="destructive">
-          <Archive className="h-4 w-4" />
-          Archive
-        </ContextMenuItem>
+        {(onOpenBranches || onOpenPRs) && session.sessionType !== 'base' && <ContextMenuSeparator />}
+        {session.sessionType !== 'base' && (
+          <ContextMenuItem onClick={() => onArchiveSession(session.id)} variant="destructive">
+            <Archive className="h-4 w-4" />
+            Archive
+          </ContextMenuItem>
+        )}
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -39,6 +39,11 @@ const DEFAULT_COLLAPSED_STATUSES = new Set<SessionTaskStatus>(['done', 'cancelle
 
 function sortSessions(sessions: WorktreeSession[], sortBy: SidebarSortBy): WorktreeSession[] {
   return [...sessions].sort((a, b) => {
+    // Base sessions always sort first, regardless of sort mode
+    const aBase = a.sessionType === 'base' ? 0 : 1;
+    const bBase = b.sessionType === 'base' ? 0 : 1;
+    if (aBase !== bBase) return aBase - bBase;
+
     switch (sortBy) {
       case 'recent':
         return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();

--- a/src/lib/api/sessions.ts
+++ b/src/lib/api/sessions.ts
@@ -23,6 +23,7 @@ export interface SessionDTO {
   hasCheckFailures?: boolean;
   checkStatus?: 'none' | 'pending' | 'success' | 'failure';
   targetBranch?: string;
+  sessionType?: 'worktree' | 'base';
   sprintPhase?: string | null;
   pinned?: boolean;
   archived?: boolean;
@@ -53,6 +54,7 @@ export function mapSessionDTO(session: SessionDTO): import('@/lib/types').Worktr
     hasCheckFailures: session.hasCheckFailures,
     checkStatus: session.checkStatus as import('@/lib/types').WorktreeSession['checkStatus'],
     targetBranch: session.targetBranch,
+    sessionType: session.sessionType,
     sprintPhase: (session.sprintPhase || null) as import('@/lib/types').SprintPhase | null,
     pinned: session.pinned,
     archived: session.archived,
@@ -81,7 +83,7 @@ export async function listAllSessions(includeArchived?: boolean): Promise<Sessio
 
 export async function createSession(
   workspaceId: string,
-  data: { name?: string; branch?: string; branchPrefix?: string; worktreePath?: string; task?: string; checkoutExisting?: boolean; systemMessage?: string } = {}
+  data: { name?: string; branch?: string; branchPrefix?: string; worktreePath?: string; task?: string; checkoutExisting?: boolean; systemMessage?: string; sessionType?: 'worktree' | 'base' } = {}
 ): Promise<SessionDTO> {
   const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions`, {
     method: 'POST',
@@ -111,6 +113,99 @@ export async function deleteSession(workspaceId: string, sessionId: string): Pro
     method: 'DELETE',
   });
   await handleVoidResponse(res, 'Failed to delete session');
+}
+
+// ============================================================================
+// Base session API functions
+// ============================================================================
+
+export interface PreflightStatus {
+  ok: boolean;
+  activeRebase?: boolean;
+  activeMerge?: boolean;
+  activeCherryPick?: boolean;
+  detachedHead?: boolean;
+  corruptedIndex?: boolean;
+  errorMessage?: string;
+}
+
+export interface StashEntry {
+  index: number;
+  branch: string;
+  message: string;
+}
+
+export async function preflightCheck(workspaceId: string, sessionId: string): Promise<PreflightStatus> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/preflight`);
+  return handleResponse<PreflightStatus>(res);
+}
+
+export async function getCurrentBranch(workspaceId: string, sessionId: string): Promise<{ branch: string }> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/current-branch`);
+  return handleResponse<{ branch: string }>(res);
+}
+
+export async function createBranch(workspaceId: string, sessionId: string, name: string, startPoint?: string): Promise<{ branch: string }> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/branches/create`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, startPoint }),
+  });
+  return handleResponse<{ branch: string }>(res);
+}
+
+export async function switchBranch(workspaceId: string, sessionId: string, branch: string): Promise<{ branch: string }> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/branches/switch`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ branch }),
+  });
+  return handleResponse<{ branch: string }>(res);
+}
+
+export async function deleteBranch(workspaceId: string, sessionId: string, branchName: string): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/branches/${encodeURIComponent(branchName)}`, {
+    method: 'DELETE',
+  });
+  await handleVoidResponse(res, 'Failed to delete branch');
+}
+
+export async function listStashes(workspaceId: string, sessionId: string): Promise<StashEntry[]> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/stashes`);
+  return handleResponse<StashEntry[]>(res);
+}
+
+export async function createStash(workspaceId: string, sessionId: string, message?: string, includeUntracked?: boolean): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/stashes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message, includeUntracked }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(text || `HTTP ${res.status}`, res.status, text);
+  }
+}
+
+export async function applyStash(workspaceId: string, sessionId: string, index: number): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/stashes/${index}/apply`, {
+    method: 'POST',
+  });
+  await handleVoidResponse(res, 'Failed to apply stash');
+}
+
+export async function popStash(workspaceId: string, sessionId: string, index: number): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/stashes/${index}/pop`, {
+    method: 'POST',
+  });
+  await handleVoidResponse(res, 'Failed to pop stash');
+}
+
+export async function dropStash(workspaceId: string, sessionId: string, index: number): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/repos/${workspaceId}/sessions/${sessionId}/stashes/${index}`, {
+    method: 'DELETE',
+  });
+  await handleVoidResponse(res, 'Failed to drop stash');
 }
 
 export async function sendSessionMessage(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,7 @@ export interface WorktreeSession {
   hasCheckFailures?: boolean;
   checkStatus?: 'none' | 'pending' | 'success' | 'failure';
   targetBranch?: string; // Per-session target branch override (e.g. "origin/develop")
+  sessionType?: 'worktree' | 'base'; // "base" = operates on repo directly, no worktree
   sprintPhase?: SprintPhase | null; // Current sprint workflow phase (null = no sprint active)
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

- Introduces a **base session** type that operates directly on the repo checkout (no worktree). Each workspace gets exactly one, enforced by a unique partial DB index.
- Full backend support: preflight checks, branch create/switch/delete, stash CRUD, workspace ownership validation, TTL-cached branch lookups, and a shared `initBaseSession` helper.
- Frontend shows base sessions with a distinct icon/badge, sorts them first, and hides archive/delete actions.
- **Startup migration** backfills base sessions for existing workspaces so upgrades work seamlessly.

## Test plan

- [ ] Add a new workspace → verify base session appears automatically alongside the first worktree session
- [ ] Restart backend with existing workspaces → verify base sessions are backfilled (check logs for "Backfilled base session")
- [ ] Verify base session shows FolderGit2 icon and "Base" badge in toolbar
- [ ] Verify archive/delete are hidden in sidebar context menu for base sessions
- [ ] Verify base session always sorts first regardless of sort mode
- [ ] Test branch switch API: `POST /api/repos/{id}/sessions/{sid}/branches/switch` with dirty working tree → expect 409 with `dirtyFiles`
- [ ] Test cross-workspace access: use a session ID from workspace A against workspace B's URL → expect 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)