### PR TITLE
feat: redesign Home page with polished UI and better visual hierarchy

### DIFF
--- a/src/components/shared/EmptyView.tsx
+++ b/src/components/shared/EmptyView.tsx
@@ -48,6 +48,13 @@ export function EmptyView({
   const hasWorkspace = !!selectedWorkspaceId;
   const modKey = isMacOS() ? '⌘' : 'Ctrl+';
 
+  const greeting = useMemo(() => {
+    const hour = new Date().getHours();
+    if (hour < 12) return 'Good morning';
+    if (hour < 17) return 'Good afternoon';
+    return 'Good evening';
+  }, []);
+
   return (
     <FullContentLayout
       title="Home"
@@ -56,38 +63,34 @@ export function EmptyView({
       showLeftSidebar={showLeftSidebar}
     >
       <div className="h-full overflow-y-auto bg-content-background">
-        <div className="max-w-2xl mx-auto px-6 pt-14 pb-16 stagger-children">
-          {/* Mascot + Brand Hero */}
-          <div className="flex flex-col items-center text-center mb-10">
-            {/* Mascot with ambient glow */}
-            <div className="relative mb-6">
-              <div className="absolute inset-0 rounded-full bg-brand/15 blur-[40px] pointer-events-none" />
-              <div className="relative w-20 h-20 rounded-full ring-[2.5px] ring-brand/40 ring-offset-[3px] ring-offset-background overflow-hidden shadow-xl shadow-brand/15">
+        <div className="max-w-xl mx-auto px-6 pt-8 pb-16 stagger-children">
+          {/* Compact Hero */}
+          <div className="flex items-center gap-3 mb-8">
+            <div className="relative shrink-0">
+              <div className="absolute inset-0 rounded-full bg-brand/10 blur-xl pointer-events-none" />
+              <div className="relative w-10 h-10 rounded-full ring-1 ring-border/50 overflow-hidden">
                 <Image
                   src="/mascot.png"
                   alt="ChatML mascot"
-                  width={80}
-                  height={80}
+                  width={40}
+                  height={40}
                   className="w-full h-full object-cover"
                   priority
                 />
               </div>
             </div>
-
-            {/* Brand wordmark */}
-            <h1 className="font-mono font-bold text-2xl tracking-[-0.05em] mb-2">
-              <span className="text-foreground/60">chat</span>
-              <span className="text-brand">ml</span>
-            </h1>
-
-            {/* Contextual subtitle */}
-            <p className="text-sm text-muted-foreground">
-              What would you like to work on?
-            </p>
+            <div>
+              <h1 className="text-base font-semibold text-foreground">
+                {greeting}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                What would you like to work on?
+              </p>
+            </div>
           </div>
 
           {/* Hero Action Grid */}
-          <div className="mb-10">
+          <div className="mb-6">
             <QuickActions
               onOpenProject={onOpenProject}
               onCloneFromUrl={onCloneFromUrl}
@@ -98,7 +101,7 @@ export function EmptyView({
           </div>
 
           {/* Live Activity Strip */}
-          <div className="mb-10">
+          <div className="mb-6">
             <LiveActivityStrip
               sessions={nonArchivedSessions}
               workspaces={workspaces}
@@ -107,7 +110,7 @@ export function EmptyView({
           </div>
 
           {/* Recent Sessions */}
-          <div className="mb-10">
+          <div className="mb-8">
             <RecentSessions
               sessions={recentSessions}
               workspaces={workspaces}
@@ -116,12 +119,8 @@ export function EmptyView({
           </div>
 
           {/* Cmd+K hint */}
-          <p className="text-center text-xs text-muted-foreground/60 pt-4">
-            Press{' '}
-            <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-mono text-xs">
-              {modKey}K
-            </kbd>{' '}
-            for commands
+          <p className="text-center text-[11px] text-muted-foreground/40 pt-2">
+            {modKey}K for commands
           </p>
         </div>
       </div>

--- a/src/components/shared/smart-launcher/LiveActivityCard.tsx
+++ b/src/components/shared/smart-launcher/LiveActivityCard.tsx
@@ -44,7 +44,7 @@ export function LiveActivityCard({ session, workspace, workspaceColors }: LiveAc
   return (
     <button
       onClick={handleClick}
-      className="w-[200px] shrink-0 snap-start rounded-xl border border-border/50 bg-card/50 px-4 py-3 hover:border-border hover:bg-card transition-all duration-200 cursor-pointer text-left"
+      className="w-[190px] shrink-0 snap-start rounded-lg border border-border/40 bg-card/60 px-3.5 py-2.5 hover:border-border/70 hover:bg-card transition-all duration-150 cursor-pointer text-left"
     >
       {/* Row 1: workspace dot + session name */}
       <div className="flex items-center gap-2 mb-2">

--- a/src/components/shared/smart-launcher/LiveActivityStrip.tsx
+++ b/src/components/shared/smart-launcher/LiveActivityStrip.tsx
@@ -22,17 +22,18 @@ export function LiveActivityStrip({ sessions, workspaces, workspaceColors }: Liv
   if (activeSessions.length === 0) return null;
 
   return (
-    <div>
+    <div className="rounded-xl bg-surface-1/50 border border-border/30 p-4">
       {/* Section header with live dot */}
       <div className="flex items-center gap-2 mb-3">
-        <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
+        <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
         <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Active Now
         </h2>
+        <span className="text-xs text-muted-foreground/50">{activeSessions.length}</span>
       </div>
 
       {/* Horizontal scroll container */}
-      <div className="flex gap-3 overflow-x-auto scrollbar-none snap-x snap-mandatory pb-1">
+      <div className="flex gap-2.5 overflow-x-auto scrollbar-none snap-x snap-mandatory pb-0.5">
         {activeSessions.map((session) => (
           <LiveActivityCard
             key={session.id}

--- a/src/components/shared/smart-launcher/QuickActions.tsx
+++ b/src/components/shared/smart-launcher/QuickActions.tsx
@@ -15,30 +15,30 @@ const ACTION_CARDS = [
   {
     icon: Plus,
     label: 'New session',
+    description: 'Start coding with AI',
     key: 'new-session',
     requiresWorkspace: true,
-    bgClass: 'bg-brand/10 dark:bg-brand/15',
     iconClass: 'text-brand',
   },
   {
     icon: FolderOpen,
     label: 'Open project',
+    description: 'From local folder',
     key: 'open',
-    bgClass: 'bg-emerald-500/10 dark:bg-emerald-500/15',
     iconClass: 'text-emerald-600 dark:text-emerald-400',
   },
   {
     icon: Globe,
     label: 'Clone repo',
+    description: 'From GitHub URL',
     key: 'clone',
-    bgClass: 'bg-blue-500/10 dark:bg-blue-500/15',
     iconClass: 'text-blue-600 dark:text-blue-400',
   },
   {
     icon: GitBranch,
     label: 'From PR',
+    description: 'Review a pull request',
     key: 'from-pr',
-    bgClass: 'bg-purple-500/10 dark:bg-purple-500/15',
     iconClass: 'text-purple-600 dark:text-purple-400',
   },
 ] as const;
@@ -68,8 +68,8 @@ export function QuickActions({
   };
 
   return (
-    <div className="grid grid-cols-4 gap-4">
-      {ACTION_CARDS.map(({ icon: Icon, label, key, bgClass, iconClass, ...rest }) => {
+    <div className="grid grid-cols-2 gap-2.5">
+      {ACTION_CARDS.map(({ icon: Icon, label, description, key, iconClass, ...rest }) => {
         const disabled = 'requiresWorkspace' in rest && rest.requiresWorkspace && !hasWorkspace;
         return (
           <button
@@ -77,33 +77,31 @@ export function QuickActions({
             onClick={() => !disabled && handleCardClick(key)}
             disabled={disabled}
             className={cn(
-              'group flex flex-col items-center gap-3 py-4 px-2 rounded-2xl transition-all duration-200',
+              'group flex items-center gap-3 rounded-xl border px-3.5 py-3 text-left transition-all duration-150',
+              'border-border/40 bg-card/40',
               disabled
                 ? 'opacity-40 cursor-not-allowed'
-                : 'cursor-pointer hover:bg-muted/50'
+                : 'cursor-pointer hover:bg-card/80 hover:border-border/70 hover:shadow-sm active:scale-[0.98]'
             )}
             {...(key === 'open' ? { 'data-tour-target': 'add-workspace' } : {})}
           >
-            {/* Icon container */}
-            <div
-              className={cn(
-                'w-16 h-16 rounded-2xl flex items-center justify-center transition-all duration-200',
-                bgClass,
-                !disabled && 'group-hover:scale-[1.08] group-active:scale-[0.95]'
-              )}
-            >
-              <Icon className={cn('size-8', iconClass)} />
+            <div className={cn(
+              'size-9 rounded-lg bg-muted/50 flex items-center justify-center shrink-0 transition-colors',
+              !disabled && 'group-hover:bg-muted/80'
+            )}>
+              <Icon className={cn('size-5', iconClass)} />
             </div>
-
-            {/* Label */}
-            <span
-              className={cn(
-                'text-sm font-medium text-muted-foreground transition-colors duration-200',
+            <div className="min-w-0">
+              <div className={cn(
+                'text-sm font-medium text-foreground/90 transition-colors',
                 !disabled && 'group-hover:text-foreground'
-              )}
-            >
-              {label}
-            </span>
+              )}>
+                {label}
+              </div>
+              <div className="text-xs text-muted-foreground truncate">
+                {description}
+              </div>
+            </div>
           </button>
         );
       })}

--- a/src/components/shared/smart-launcher/RecentSessionItem.tsx
+++ b/src/components/shared/smart-launcher/RecentSessionItem.tsx
@@ -31,7 +31,7 @@ export function RecentSessionItem({ session, workspace, workspaceColors }: Recen
   return (
     <button
       onClick={handleClick}
-      className="w-full rounded-xl border border-transparent px-4 py-3 hover:bg-card/60 hover:border-border/50 transition-all duration-150 text-left cursor-pointer"
+      className="w-full rounded-lg px-3 py-2.5 hover:bg-muted/40 transition-colors duration-100 text-left cursor-pointer"
     >
       {/* Row 1: primary info */}
       <div className="flex items-center gap-2.5">
@@ -79,7 +79,7 @@ export function RecentSessionItem({ session, workspace, workspaceColors }: Recen
 
       {/* Row 2: secondary info */}
       {hasSecondRow && (
-        <div className="flex items-center gap-3 mt-1.5 ml-5 text-xs text-muted-foreground">
+        <div className="flex items-center gap-3 mt-1.5 ml-[18px] text-xs text-muted-foreground">
           {/* Workspace name */}
           {workspace && (
             <span className="truncate max-w-[120px]">{workspace.name}</span>

--- a/src/components/shared/smart-launcher/RecentSessions.tsx
+++ b/src/components/shared/smart-launcher/RecentSessions.tsx
@@ -14,14 +14,14 @@ export function RecentSessions({ sessions, workspaces, workspaceColors }: Recent
 
   return (
     <div>
-      <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-        Recent Sessions
+      <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+        Recent
       </h2>
 
       {sessions.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No sessions yet</p>
+        <p className="text-sm text-muted-foreground py-4 text-center">No sessions yet</p>
       ) : (
-        <div className="flex flex-col gap-1">
+        <div className="divide-y divide-border/30">
           {sessions.map((session) => (
             <RecentSessionItem
               key={session.id}


### PR DESCRIPTION
## Summary
- **Compact hero**: Replaced oversized mascot + wordmark stack with inline 40px mascot and time-of-day greeting
- **2×2 glass action cards**: Horizontal icon+text layout with descriptions, subtle borders and glass-like backgrounds, press feedback
- **Elevated active sessions**: Wrapped in bordered container with count badge for visual distinction
- **Refined recent sessions**: Divider-separated list with tighter rows, snappier hover transitions
- **Tighter layout**: Narrowed to `max-w-xl`, reduced top padding, varied section spacing for visual rhythm

## Test plan
- [ ] Navigate to Home (no session selected) — verify new layout renders
- [ ] Check both light and dark mode appearance
- [ ] Verify all 4 quick actions work (New session, Open project, Clone repo, From PR)
- [ ] Verify "New session" disabled state when no workspace selected
- [ ] Click active session cards → navigates correctly
- [ ] Click recent session rows → navigates correctly
- [ ] Verify stagger animation plays on page load
- [ ] No horizontal overflow or layout issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)