### PR TITLE
fix: move session_type index to migrations to fix existing DB startup

### DIFF
--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -142,7 +142,6 @@ func (s *SQLiteStore) initSchema() error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id ON sessions(workspace_id);
 	CREATE INDEX IF NOT EXISTS idx_sessions_workspace_name ON sessions(workspace_id, name);
-	CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_base_per_workspace ON sessions(workspace_id) WHERE session_type = 'base';
 
 	-- Agents (legacy, still actively used by agent/manager.go)
 	CREATE TABLE IF NOT EXISTS agents (


### PR DESCRIPTION
## Summary
- Removes duplicate `CREATE UNIQUE INDEX idx_sessions_base_per_workspace` from the schema string
- The index was already created in `runMigrations()` after the `session_type` column is added via `ALTER TABLE`
- For existing databases, `CREATE TABLE IF NOT EXISTS` is a no-op, so the index creation in the schema string fails with "no such column: session_type" before migrations ever run, causing a FATAL startup crash

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go build ./...` — builds clean
- [ ] Run `make dev` with existing database — backend starts without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)