### PR TITLE
fix: clear stale PR data on branch switch and improve base session UX

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -138,18 +138,26 @@ func (w *PRWatcher) UnwatchSession(sessionID string) {
 	}
 }
 
-// UpdateSessionBranch updates the branch for a watched session (e.g., after branch rename)
+// UpdateSessionBranch updates the branch for a watched session (e.g., after branch switch)
 // and invalidates the PR cache for the affected repo so the next poll fetches fresh data.
+// Clears stale PR data so the watcher doesn't carry over PR info from the old branch.
 func (w *PRWatcher) UpdateSessionBranch(sessionID, newBranch string) {
 	var repoPath string
 
 	w.mu.Lock()
 	if entry, exists := w.sessions[sessionID]; exists {
 		entry.Branch = newBranch
+		// Clear stale PR data from the old branch
+		entry.PRStatus = models.PRStatusNone
+		entry.PRNumber = 0
+		entry.PRUrl = ""
+		entry.PRTitle = ""
+		entry.CheckStatus = ""
+		entry.Mergeable = nil
 		// Reset last checked to trigger re-check
 		entry.LastChecked = time.Time{}
 		repoPath = entry.RepoPath
-		logger.PRWatcher.Infof("Updated branch for session %s: %s", sessionID, newBranch)
+		logger.PRWatcher.Infof("Updated branch for session %s: %s (cleared stale PR data)", sessionID, newBranch)
 	}
 	w.mu.Unlock()
 

--- a/backend/server/base_session_handlers.go
+++ b/backend/server/base_session_handlers.go
@@ -166,9 +166,16 @@ func (h *Handlers) SwitchSessionBranch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update session branch in DB
+	// Update session branch in DB and clear stale PR fields
 	if err := h.store.UpdateSession(ctx, sessionID, func(s *models.Session) {
 		s.Branch = req.Branch
+		s.PRStatus = models.PRStatusNone
+		s.PRNumber = 0
+		s.PRUrl = ""
+		s.PRTitle = ""
+		s.CheckStatus = models.CheckStatusNone
+		s.HasCheckFailures = false
+		s.HasMergeConflict = false
 	}); err != nil {
 		writeDBError(w, err)
 		return
@@ -180,6 +187,11 @@ func (h *Handlers) SwitchSessionBranch(w http.ResponseWriter, r *http.Request) {
 		h.snapshotCache.Invalidate(sessionID)
 	}
 
+	// Update PR watcher to poll the new branch (clears stale PR data)
+	if h.prWatcher != nil {
+		h.prWatcher.UpdateSessionBranch(sessionID, req.Branch)
+	}
+
 	// Broadcast branch change via WebSocket
 	if h.hub != nil {
 		h.hub.Broadcast(Event{
@@ -188,6 +200,21 @@ func (h *Handlers) SwitchSessionBranch(w http.ResponseWriter, r *http.Request) {
 				"sessionId": sessionID,
 				"reason":    "branch_switched",
 				"branch":    req.Branch,
+			},
+		})
+	}
+
+	// Broadcast PR clearing so the frontend removes the badge immediately
+	if h.hub != nil {
+		h.hub.Broadcast(Event{
+			Type:      "session_pr_update",
+			SessionID: sessionID,
+			Payload: map[string]interface{}{
+				"prStatus":    models.PRStatusNone,
+				"prNumber":    0,
+				"prUrl":       "",
+				"prTitle":     "",
+				"checkStatus": models.CheckStatusNone,
 			},
 		})
 	}

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -487,13 +487,13 @@ export function SessionToolbarContent() {
           </span>
           <span className="flex items-center gap-1.5 shrink-0">
             {selectedSession.sessionType === 'base' ? (
-              <FolderGit2 className="h-4 w-4 text-amber-500" />
+              <FolderGit2 className="h-4 w-4 text-blue-500" />
             ) : (
               <GitBranch className="h-4 w-4 text-purple-400" />
             )}
             <span className="text-base font-semibold truncate">{selectedSession.branch || selectedSession.name}</span>
             {selectedSession.sessionType === 'base' && (
-              <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-500 font-medium">Base</span>
+              <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500 font-medium">Base</span>
             )}
           </span>
         </span>
@@ -502,17 +502,21 @@ export function SessionToolbarContent() {
         titlePosition: 'left' as const,
         title: (
           <div className="flex items-center gap-1.5">
-            <TaskStatusSelector
-              value={selectedSession.taskStatus}
-              onChange={handleTaskStatusChange}
-              size="sm"
-            />
-            <SprintPhaseBar
-              phase={selectedSession.sprintPhase}
-              onChange={handleSprintPhaseChange}
-              disabled={isAgentWorking}
-              onOpenToolbar={toggleSprintToolbar}
-            />
+            {selectedSession.sessionType !== 'base' && (
+              <>
+                <TaskStatusSelector
+                  value={selectedSession.taskStatus}
+                  onChange={handleTaskStatusChange}
+                  size="sm"
+                />
+                <SprintPhaseBar
+                  phase={selectedSession.sprintPhase}
+                  onChange={handleSprintPhaseChange}
+                  disabled={isAgentWorking}
+                  onOpenToolbar={toggleSprintToolbar}
+                />
+              </>
+            )}
             {selectedSession.prStatus && selectedSession.prStatus !== 'none' && selectedSession.prNumber && selectedWorkspaceId && (
               <PRHoverCard
                 workspaceId={selectedWorkspaceId}

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -177,7 +177,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
   };
 
   // Sidebar grouping/sorting
-  const { groups: sidebarGroups, flatSessions } = useSidebarSessions({
+  const { groups: sidebarGroups, flatSessions, pinnedSessions } = useSidebarSessions({
     sessions,
     workspaces,
     groupBy: sidebarGroupBy,
@@ -728,10 +728,40 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                 </div>
               ) : (
                 <>
+                  {/* Pinned: Base sessions always render at the top */}
+                  {pinnedSessions.map((session) => {
+                    const ws = workspaces.find((w) => w.id === session.workspaceId);
+                    return (
+                      <ErrorBoundary
+                        key={session.id}
+                        section="SessionRow"
+                        fallback={<CardErrorFallback message="Error loading session" />}
+                      >
+                        <SessionRow
+                          session={session}
+                          contentView={contentView}
+                          selectedSessionId={selectedSessionId}
+                          onSelectSession={(id, e) => handleSelectSession(session.workspaceId, id, e)}
+                          onArchiveSession={handleArchiveSession}
+                          onTaskStatusChange={handleTaskStatusChange}
+                          onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
+                          onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
+                          formatTimeAgo={formatTimeAgo}
+                          showProjectIndicator={sidebarGroupBy === 'none'}
+                          workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
+                          workspaceName={ws?.name}
+                        />
+                      </ErrorBoundary>
+                    );
+                  })}
+                  {pinnedSessions.length > 0 && (flatSessions.length > 0 || sidebarGroups.length > 0) && (
+                    <div className="mx-2 my-1 border-t border-border/40" />
+                  )}
+
                   {/* Mode: None — flat session list */}
                   {sidebarGroupBy === 'none' && (
                     <>
-                      {flatSessions.length === 0 ? (
+                      {flatSessions.length === 0 && pinnedSessions.length === 0 ? (
                         <div className="py-2 px-2 text-sm text-muted-foreground/70">
                           No sessions found
                         </div>
@@ -768,7 +798,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                   {/* Mode: Status — status group headers with sessions */}
                   {sidebarGroupBy === 'status' && (
                     <>
-                      {sidebarGroups.length === 0 ? (
+                      {sidebarGroups.length === 0 && pinnedSessions.length === 0 ? (
                         <div className="py-2 px-2 text-sm text-muted-foreground/70">
                           No sessions found
                         </div>
@@ -1461,6 +1491,10 @@ function SessionRow({
                         <ClipboardCheck className="w-3.5 h-3.5 text-blue-500" />
                       </div>
                     </div>
+                  ) : session.sessionType === 'base' ? (
+                    <div className="w-4 shrink-0 flex items-center justify-center">
+                      <FolderGit2 className="w-3.5 h-3.5 text-blue-500" />
+                    </div>
                   ) : (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
@@ -1489,9 +1523,6 @@ function SessionRow({
                   )}
                   {/* Branch name container - grows and truncates */}
                   <div className="flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
-                    {session.sessionType === 'base' && (
-                      <FolderGit2 className="w-3.5 h-3.5 shrink-0 text-amber-500" />
-                    )}
                     <span className={cn(
                       "text-base truncate flex-1 w-0",
                       isSessionSelected ? "text-foreground font-normal" : "text-foreground/60 font-normal",
@@ -1584,27 +1615,31 @@ function SessionRow({
         </HoverCard>
       </ContextMenuTrigger>
       <ContextMenuContent>
-        <ContextMenuSub>
-          <ContextMenuSubTrigger>
-            <TaskStatusIcon status={session.taskStatus} className="h-4 w-4" />
-            Status
-          </ContextMenuSubTrigger>
-          <ContextMenuSubContent className="w-44">
-            {TASK_STATUS_OPTIONS.map((option) => (
-              <ContextMenuItem
-                key={option.value}
-                onClick={() => onTaskStatusChange(session.id, option.value)}
-              >
-                <TaskStatusIcon status={option.value} className="h-4 w-4" />
-                <span className="flex-1">{option.label}</span>
-                {option.value === session.taskStatus && (
-                  <Check className="h-3.5 w-3.5 text-muted-foreground" />
-                )}
-              </ContextMenuItem>
-            ))}
-          </ContextMenuSubContent>
-        </ContextMenuSub>
-        <ContextMenuSeparator />
+        {session.sessionType !== 'base' && (
+          <>
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>
+                <TaskStatusIcon status={session.taskStatus} className="h-4 w-4" />
+                Status
+              </ContextMenuSubTrigger>
+              <ContextMenuSubContent className="w-44">
+                {TASK_STATUS_OPTIONS.map((option) => (
+                  <ContextMenuItem
+                    key={option.value}
+                    onClick={() => onTaskStatusChange(session.id, option.value)}
+                  >
+                    <TaskStatusIcon status={option.value} className="h-4 w-4" />
+                    <span className="flex-1">{option.label}</span>
+                    {option.value === session.taskStatus && (
+                      <Check className="h-3.5 w-3.5 text-muted-foreground" />
+                    )}
+                  </ContextMenuItem>
+                ))}
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+            <ContextMenuSeparator />
+          </>
+        )}
         {onOpenBranches && (
           <ContextMenuItem onClick={() => onOpenBranches()}>
             <GitBranch className="h-4 w-4" />

--- a/src/components/shared/SessionHoverCard.tsx
+++ b/src/components/shared/SessionHoverCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { GitBranch, GitPullRequest } from 'lucide-react';
+import { FolderGit2, GitBranch, GitPullRequest } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 import { getTaskStatusOption, getPRStatusInfo } from '@/lib/session-fields';
@@ -29,17 +29,28 @@ export function SessionHoverCardBody({
     <>
       {/* Header: branch icon + name */}
       <div className="flex items-center gap-1.5 px-3 pt-2.5 pb-1">
-        <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        {session.sessionType === 'base' ? (
+          <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+        ) : (
+          <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
         <span className="text-sm font-medium text-foreground truncate">
           {session.branch || session.name}
         </span>
+        {session.sessionType === 'base' && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500 font-medium shrink-0">Base</span>
+        )}
       </div>
 
       {/* Meta row: status + time */}
       <div className="flex items-center gap-1.5 px-3 pb-2 text-xs text-muted-foreground">
-        <TaskStatusIcon status={session.taskStatus} className="h-3 w-3 shrink-0" />
-        <span className="shrink-0">{statusOption.label}</span>
-        <span className="text-muted-foreground/50">&middot;</span>
+        {session.sessionType !== 'base' && (
+          <>
+            <TaskStatusIcon status={session.taskStatus} className="h-3 w-3 shrink-0" />
+            <span className="shrink-0">{statusOption.label}</span>
+            <span className="text-muted-foreground/50">&middot;</span>
+          </>
+        )}
         <span className="shrink-0">
           {formatTimeAgo(
             lastAgentCompletedAt !== undefined && lastAgentCompletedAt > new Date(session.updatedAt).getTime()

--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -39,11 +39,6 @@ const DEFAULT_COLLAPSED_STATUSES = new Set<SessionTaskStatus>(['done', 'cancelle
 
 function sortSessions(sessions: WorktreeSession[], sortBy: SidebarSortBy): WorktreeSession[] {
   return [...sessions].sort((a, b) => {
-    // Base sessions always sort first, regardless of sort mode
-    const aBase = a.sessionType === 'base' ? 0 : 1;
-    const bBase = b.sessionType === 'base' ? 0 : 1;
-    if (aBase !== bBase) return aBase - bBase;
-
     switch (sortBy) {
       case 'recent':
         return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
@@ -142,27 +137,33 @@ export function useSidebarSessions({
   filters,
   workspaceColors,
   getWorkspaceColor: getDefaultColor,
-}: UseSidebarSessionsOptions): { groups: SidebarGroup[]; flatSessions: WorktreeSession[] } {
+}: UseSidebarSessionsOptions): { groups: SidebarGroup[]; flatSessions: WorktreeSession[]; pinnedSessions: WorktreeSession[] } {
   return useMemo(() => {
     const filtered = filterSessions(sessions, filters);
+
+    // Separate base sessions — they are always pinned at the top, outside groups
+    const pinnedSessions = filtered.filter((s) => s.sessionType === 'base');
+    const regularSessions = filtered.filter((s) => s.sessionType !== 'base');
 
     if (groupBy === 'none') {
       return {
         groups: [],
-        flatSessions: sortSessions(filtered, sortBy),
+        flatSessions: sortSessions(regularSessions, sortBy),
+        pinnedSessions,
       };
     }
 
     if (groupBy === 'status') {
       return {
-        groups: buildStatusGroups(filtered, sortBy),
+        groups: buildStatusGroups(regularSessions, sortBy),
         flatSessions: [],
+        pinnedSessions,
       };
     }
 
-    // Pre-group sessions by workspace for O(w+n) instead of O(w×n)
+    // Pre-group regular sessions by workspace for O(w+n) instead of O(w×n)
     const byWorkspace = new Map<string, WorktreeSession[]>();
-    for (const s of filtered) {
+    for (const s of regularSessions) {
       const list = byWorkspace.get(s.workspaceId);
       if (list) list.push(s);
       else byWorkspace.set(s.workspaceId, [s]);
@@ -185,7 +186,7 @@ export function useSidebarSessions({
           sessions: sortSessions(wsSessions, sortBy),
         });
       }
-      return { groups, flatSessions: [] };
+      return { groups, flatSessions: [], pinnedSessions };
     }
 
     // project-status
@@ -208,10 +209,10 @@ export function useSidebarSessions({
           subGroups,
         });
       }
-      return { groups, flatSessions: [] };
+      return { groups, flatSessions: [], pinnedSessions };
     }
 
-    return { groups: [], flatSessions: [] };
+    return { groups: [], flatSessions: [], pinnedSessions };
   }, [sessions, workspaces, groupBy, sortBy, filters, workspaceColors, getDefaultColor]);
 }
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1280,6 +1280,16 @@ export function useWebSocket(enabled: boolean = true) {
               updates.taskStatus = payload.taskStatus as import('@/lib/types').SessionTaskStatus;
             }
 
+            // When PR is cleared (e.g., branch switch), ensure all PR fields are reset
+            if (updates.prStatus === 'none') {
+              updates.prNumber = 0;
+              updates.prUrl = '';
+              updates.prTitle = '';
+              updates.checkStatus = 'none';
+              updates.hasCheckFailures = false;
+              updates.hasMergeConflict = false;
+            }
+
             const prevPrStatus = getStore().sessions.find(
               (s: { id: string }) => s.id === data.sessionId
             )?.prStatus;


### PR DESCRIPTION
## Summary

- **Fix stale PR badges on branch switch**: When switching branches on a base session, PR fields (status, number, URL, title, check status) are now cleared in the DB, PR watcher, and via a WebSocket broadcast so the frontend removes the badge immediately
- **Pin base sessions at top of sidebar**: Base sessions are separated from regular sessions and always rendered first, with a thin divider between them
- **Consistent base session UX**: Blue `FolderGit2` icon everywhere (replaces amber), task status selector and sprint phase bar hidden for base sessions, context menu status submenu hidden

## Changes

### Backend (`backend/`)
- `pr_watcher.go`: `UpdateSessionBranch` now clears all stale PR fields (status, number, URL, title, check status, mergeable) before polling the new branch
- `base_session_handlers.go`: `SwitchSessionBranch` clears PR fields in DB, notifies the PR watcher, and broadcasts a `session_pr_update` event with reset values

### Frontend (`src/`)
- `useSidebarSessions.ts`: Returns `pinnedSessions` (base sessions) separately from `flatSessions`/`groups`; removes base-session-first sort hack
- `WorkspaceSidebar.tsx`: Renders pinned sessions above mode-specific content with a divider; fixes "No sessions found" showing when only base sessions exist
- `SessionToolbarContent.tsx`: Hides task status selector and sprint phase bar for base sessions; updates icon color to blue
- `SessionHoverCard.tsx`: Shows `FolderGit2` icon + "Base" badge for base sessions; hides task status in meta row
- `useWebSocket.ts`: Unconditionally resets all PR fields when `prStatus === 'none'` (defensive against partial payloads)

## Test plan

- [ ] Switch branches on a base session that has an open PR → PR badge should disappear immediately
- [ ] Switch to a branch that has a PR → PR badge should appear after next poll cycle
- [ ] Verify base sessions appear pinned at the top of the sidebar in all groupBy modes (none, status, project, project-status)
- [ ] Verify "No sessions found" does NOT appear when only base sessions exist
- [ ] Verify thin divider appears between pinned base sessions and regular sessions
- [ ] Verify base session context menu has no "Status" submenu
- [ ] Verify base session toolbar has no task status selector or sprint phase bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)