### PR TITLE
perf: optimize git command hot paths with cached file I/O

### DIFF
--- a/backend/branch/watcher.go
+++ b/backend/branch/watcher.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/logger"
 	"github.com/fsnotify/fsnotify"
 )
@@ -64,7 +65,7 @@ func NewWatcher(onChange func(BranchChangeEvent)) (*Watcher, error) {
 // WatchSession starts watching a session's git HEAD file
 func (w *Watcher) WatchSession(sessionID, worktreePath, currentBranch string) error {
 	// Resolve gitdir from worktree's .git file
-	gitDir, err := resolveWorktreeGitDir(worktreePath)
+	gitDir, err := git.ResolveGitDir(worktreePath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve gitdir for %s: %w", worktreePath, err)
 	}
@@ -271,42 +272,6 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 			onBranchChangeNotify(evt.SessionID, evt.NewBranch)
 		}
 	}
-}
-
-// resolveWorktreeGitDir reads the worktree's .git file to find the actual gitdir
-func resolveWorktreeGitDir(worktreePath string) (string, error) {
-	gitFile := filepath.Join(worktreePath, ".git")
-
-	info, err := os.Stat(gitFile)
-	if err != nil {
-		return "", err
-	}
-
-	// If .git is a directory (not a worktree), the HEAD file is directly in it
-	if info.IsDir() {
-		return gitFile, nil
-	}
-
-	// .git is a file (worktree), read it to find the gitdir
-	data, err := os.ReadFile(gitFile)
-	if err != nil {
-		return "", err
-	}
-
-	content := strings.TrimSpace(string(data))
-	// Format: "gitdir: /path/to/main/repo/.git/worktrees/session-name"
-	if !strings.HasPrefix(content, "gitdir: ") {
-		return "", fmt.Errorf("unexpected .git file format: %s", content)
-	}
-
-	gitDir := strings.TrimPrefix(content, "gitdir: ")
-
-	// Handle relative paths
-	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(worktreePath, gitDir)
-	}
-
-	return filepath.Clean(gitDir), nil
 }
 
 // readCurrentBranch reads the branch name from a HEAD file

--- a/backend/branch/watcher_test.go
+++ b/backend/branch/watcher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chatml/chatml-backend/git"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,14 +32,14 @@ func TestResolveWorktreeGitDir_WorktreeFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Test resolveWorktreeGitDir
-	result, err := resolveWorktreeGitDir(worktreePath)
+	// Test git.ResolveGitDir
+	result, err := git.ResolveGitDir(worktreePath)
 	if err != nil {
-		t.Fatalf("resolveWorktreeGitDir failed: %v", err)
+		t.Fatalf("git.ResolveGitDir failed: %v", err)
 	}
 
 	if result != mainRepoGitDir {
-		t.Errorf("resolveWorktreeGitDir = %q, want %q", result, mainRepoGitDir)
+		t.Errorf("git.ResolveGitDir = %q, want %q", result, mainRepoGitDir)
 	}
 }
 
@@ -53,14 +54,14 @@ func TestResolveWorktreeGitDir_RegularRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Test resolveWorktreeGitDir
-	result, err := resolveWorktreeGitDir(repoPath)
+	// Test git.ResolveGitDir
+	result, err := git.ResolveGitDir(repoPath)
 	if err != nil {
-		t.Fatalf("resolveWorktreeGitDir failed: %v", err)
+		t.Fatalf("git.ResolveGitDir failed: %v", err)
 	}
 
 	if result != gitDir {
-		t.Errorf("resolveWorktreeGitDir = %q, want %q", result, gitDir)
+		t.Errorf("git.ResolveGitDir = %q, want %q", result, gitDir)
 	}
 }
 
@@ -85,15 +86,15 @@ func TestResolveWorktreeGitDir_RelativePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Test resolveWorktreeGitDir
-	result, err := resolveWorktreeGitDir(worktreePath)
+	// Test git.ResolveGitDir
+	result, err := git.ResolveGitDir(worktreePath)
 	if err != nil {
-		t.Fatalf("resolveWorktreeGitDir failed: %v", err)
+		t.Fatalf("git.ResolveGitDir failed: %v", err)
 	}
 
 	// Result should be absolute and cleaned
 	if result != mainRepoGitDir {
-		t.Errorf("resolveWorktreeGitDir = %q, want %q", result, mainRepoGitDir)
+		t.Errorf("git.ResolveGitDir = %q, want %q", result, mainRepoGitDir)
 	}
 }
 
@@ -457,7 +458,7 @@ func TestResolveWorktreeGitDir_InvalidFormat(t *testing.T) {
 	gitFile := filepath.Join(worktreePath, ".git")
 	require.NoError(t, os.WriteFile(gitFile, []byte("invalid format\n"), 0644))
 
-	_, err := resolveWorktreeGitDir(worktreePath)
+	_, err := git.ResolveGitDir(worktreePath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected .git file format")
 }
@@ -469,7 +470,7 @@ func TestResolveWorktreeGitDir_MissingGitFile(t *testing.T) {
 
 	// No .git file
 
-	_, err := resolveWorktreeGitDir(worktreePath)
+	_, err := git.ResolveGitDir(worktreePath)
 	require.Error(t, err)
 }
 

--- a/backend/git/fastread.go
+++ b/backend/git/fastread.go
@@ -1,0 +1,339 @@
+package git
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveGitDir resolves the .git directory for a repo or worktree path.
+// For regular repos, this returns repoPath/.git (a directory).
+// For worktrees, .git is a file containing "gitdir: <path>" — this returns the resolved path.
+func ResolveGitDir(repoPath string) (string, error) {
+	gitPath := filepath.Join(repoPath, ".git")
+
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Regular repo: .git is a directory
+	if info.IsDir() {
+		return gitPath, nil
+	}
+
+	// Worktree: .git is a file containing "gitdir: <path>"
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", err
+	}
+
+	content := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(content, "gitdir: ") {
+		return "", fmt.Errorf("unexpected .git file format: %s", content)
+	}
+
+	gitDir := strings.TrimPrefix(content, "gitdir: ")
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(repoPath, gitDir)
+	}
+
+	return filepath.Clean(gitDir), nil
+}
+
+// resolveCommonDir returns the "common" git directory that contains shared data
+// (config, packed-refs, refs/stash, etc). For regular repos this is the same as gitDir.
+// For worktrees, it reads the commondir file to find the main repo's .git directory.
+func resolveCommonDir(gitDir string) string {
+	commonDirFile := filepath.Join(gitDir, "commondir")
+	data, err := os.ReadFile(commonDirFile)
+	if err != nil {
+		// Not a worktree (or no commondir file) — gitDir is the common dir
+		return gitDir
+	}
+
+	rel := strings.TrimSpace(string(data))
+	if filepath.IsAbs(rel) {
+		return filepath.Clean(rel)
+	}
+	return filepath.Clean(filepath.Join(gitDir, rel))
+}
+
+// lookupPackedRef looks up a ref in the packed-refs file.
+// Returns the SHA if found, or an error if not found or on read failure.
+func lookupPackedRef(commonDir, refName string) (string, error) {
+	packedRefsPath := filepath.Join(commonDir, "packed-refs")
+	f, err := os.Open(packedRefsPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip comments and peeled refs (^sha lines)
+		if len(line) == 0 || line[0] == '#' || line[0] == '^' {
+			continue
+		}
+		// Format: "<sha> <refname>" — assumes SHA-1 (40 hex chars); SHA-256 repos are unsupported.
+		if len(line) > 41 && line[40] == ' ' {
+			if line[41:] == refName {
+				return line[:40], nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("ref %s not found in packed-refs", refName)
+}
+
+// readCurrentBranch reads the current branch name directly from .git/HEAD.
+// Returns the branch name (e.g., "main") or "HEAD" for detached HEAD state.
+func readCurrentBranch(repoPath string) (string, error) {
+	gitDir, err := ResolveGitDir(repoPath)
+	if err != nil {
+		return "", err
+	}
+	return readBranchFromGitDir(gitDir)
+}
+
+// readBranchFromGitDir reads the branch from a pre-resolved gitDir.
+func readBranchFromGitDir(gitDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return "", err
+	}
+
+	content := strings.TrimSpace(string(data))
+	if strings.HasPrefix(content, "ref: refs/heads/") {
+		return strings.TrimPrefix(content, "ref: refs/heads/"), nil
+	}
+
+	// Detached HEAD — return "HEAD" to match git rev-parse --abbrev-ref behavior
+	return "HEAD", nil
+}
+
+// readHeadSHA reads the HEAD commit SHA directly from .git files.
+// Resolves symbolic refs through loose ref files and packed-refs.
+func readHeadSHA(repoPath string) (string, error) {
+	gitDir, err := ResolveGitDir(repoPath)
+	if err != nil {
+		return "", err
+	}
+	return readHeadSHAFromGitDir(gitDir, nil)
+}
+
+// readHeadSHAFromGitDir reads the HEAD SHA from a pre-resolved gitDir.
+// If cache is non-nil, uses it for packed-refs lookup.
+func readHeadSHAFromGitDir(gitDir string, cache *GitCache) (string, error) {
+	data, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return "", err
+	}
+
+	content := strings.TrimSpace(string(data))
+
+	// Detached HEAD — content is the SHA directly
+	if !strings.HasPrefix(content, "ref: ") {
+		if len(content) >= 40 {
+			return content[:40], nil
+		}
+		return "", fmt.Errorf("unexpected HEAD content: %s", content)
+	}
+
+	// Symbolic ref — resolve it
+	refName := strings.TrimPrefix(content, "ref: ")
+	return resolveRefCached(gitDir, refName, cache)
+}
+
+// resolveRef resolves a ref name (e.g., "refs/heads/main") to its SHA.
+// Checks loose ref file first, then falls back to packed-refs.
+func resolveRef(gitDir, refName string) (string, error) {
+	return resolveRefCached(gitDir, refName, nil)
+}
+
+// resolveRefCached resolves a ref, using the cache for commonDir and packed-refs
+// lookups when non-nil.
+func resolveRefCached(gitDir, refName string, cache *GitCache) (string, error) {
+	var commonDir string
+	if cache != nil {
+		commonDir = cache.GetCommonDir(gitDir)
+	} else {
+		commonDir = resolveCommonDir(gitDir)
+	}
+
+	// Try loose ref file first (check both gitDir and commonDir for worktrees)
+	for _, dir := range []string{gitDir, commonDir} {
+		loosePath := filepath.Join(dir, refName)
+		data, err := os.ReadFile(loosePath)
+		if err == nil {
+			sha := strings.TrimSpace(string(data))
+			if len(sha) >= 40 {
+				return sha[:40], nil
+			}
+		}
+	}
+
+	// Fall back to packed-refs (cached when available)
+	if cache != nil {
+		return cache.LookupPackedRef(commonDir, refName)
+	}
+	return lookupPackedRef(commonDir, refName)
+}
+
+// readRemoteURL reads the URL for a named remote directly from .git/config.
+// Uses a minimal parser that only looks for [remote "<name>"] sections.
+func readRemoteURL(repoPath, remoteName string) (string, error) {
+	gitDir, err := ResolveGitDir(repoPath)
+	if err != nil {
+		return "", err
+	}
+
+	commonDir := resolveCommonDir(gitDir)
+	configPath := filepath.Join(commonDir, "config")
+
+	f, err := os.Open(configPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	targetSection := fmt.Sprintf(`[remote "%s"]`, remoteName)
+	inSection := false
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// New section header
+		if strings.HasPrefix(line, "[") {
+			inSection = (line == targetSection)
+			continue
+		}
+
+		if inSection && strings.HasPrefix(line, "url = ") {
+			return strings.TrimPrefix(line, "url = "), nil
+		}
+	}
+
+	return "", fmt.Errorf("remote %q not found in config", remoteName)
+}
+
+// readInProgressStatus checks for in-progress git operations by reading git internal files.
+// This replaces the subprocess call to git rev-parse --git-dir followed by file stats.
+func readInProgressStatus(repoPath string) (*InProgressStatus, error) {
+	gitDir, err := ResolveGitDir(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	return readInProgressFromGitDir(gitDir)
+}
+
+// readInProgressFromGitDir checks for in-progress git operations using a pre-resolved gitDir.
+func readInProgressFromGitDir(gitDir string) (*InProgressStatus, error) {
+	status := &InProgressStatus{Type: "none"}
+
+	// Check for rebase (interactive or otherwise)
+	rebaseMergeDir := filepath.Join(gitDir, "rebase-merge")
+	if _, err := os.Stat(rebaseMergeDir); err == nil {
+		status.Type = "rebase"
+		if msgnum, err := os.ReadFile(filepath.Join(rebaseMergeDir, "msgnum")); err == nil {
+			fmt.Sscanf(strings.TrimSpace(string(msgnum)), "%d", &status.Current)
+		}
+		if end, err := os.ReadFile(filepath.Join(rebaseMergeDir, "end")); err == nil {
+			fmt.Sscanf(strings.TrimSpace(string(end)), "%d", &status.Total)
+		}
+		return status, nil
+	}
+
+	rebaseApplyDir := filepath.Join(gitDir, "rebase-apply")
+	if _, err := os.Stat(rebaseApplyDir); err == nil {
+		status.Type = "rebase"
+		if next, err := os.ReadFile(filepath.Join(rebaseApplyDir, "next")); err == nil {
+			fmt.Sscanf(strings.TrimSpace(string(next)), "%d", &status.Current)
+		}
+		if last, err := os.ReadFile(filepath.Join(rebaseApplyDir, "last")); err == nil {
+			fmt.Sscanf(strings.TrimSpace(string(last)), "%d", &status.Total)
+		}
+		return status, nil
+	}
+
+	// Check for merge
+	if _, err := os.Stat(filepath.Join(gitDir, "MERGE_HEAD")); err == nil {
+		status.Type = "merge"
+		return status, nil
+	}
+
+	// Check for cherry-pick
+	if _, err := os.Stat(filepath.Join(gitDir, "CHERRY_PICK_HEAD")); err == nil {
+		status.Type = "cherry-pick"
+		return status, nil
+	}
+
+	// Check for revert
+	if _, err := os.Stat(filepath.Join(gitDir, "REVERT_HEAD")); err == nil {
+		status.Type = "revert"
+		return status, nil
+	}
+
+	return status, nil
+}
+
+// readUpstreamRef reads the upstream tracking ref for a branch from .git/config.
+// Returns the full remote ref (e.g., "origin/main") or an error if not configured.
+func readUpstreamRef(repoPath, branchName string) (string, error) {
+	gitDir, err := ResolveGitDir(repoPath)
+	if err != nil {
+		return "", err
+	}
+	return readUpstreamFromConfig(gitDir, branchName)
+}
+
+// readUpstreamFromConfig reads the upstream ref using a pre-resolved gitDir.
+func readUpstreamFromConfig(gitDir, branchName string) (string, error) {
+	commonDir := resolveCommonDir(gitDir)
+	configPath := filepath.Join(commonDir, "config")
+
+	f, err := os.Open(configPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	targetSection := fmt.Sprintf(`[branch "%s"]`, branchName)
+	inSection := false
+	var remote, merge string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "[") {
+			if inSection {
+				break // Passed our section
+			}
+			inSection = (line == targetSection)
+			continue
+		}
+
+		if !inSection {
+			continue
+		}
+
+		if strings.HasPrefix(line, "remote = ") {
+			remote = strings.TrimPrefix(line, "remote = ")
+		} else if strings.HasPrefix(line, "merge = ") {
+			merge = strings.TrimPrefix(line, "merge = ")
+		}
+	}
+
+	if remote == "" || merge == "" {
+		return "", fmt.Errorf("no upstream configured for branch %q", branchName)
+	}
+
+	// merge is typically "refs/heads/main" — convert to "origin/main"
+	branchRef := strings.TrimPrefix(merge, "refs/heads/")
+	return remote + "/" + branchRef, nil
+}

--- a/backend/git/fastread_test.go
+++ b/backend/git/fastread_test.go
@@ -1,0 +1,241 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveGitDir_RegularRepo(t *testing.T) {
+	dir := createTestGitRepo(t)
+
+	gitDir, err := ResolveGitDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, ".git"), gitDir)
+}
+
+func TestResolveGitDir_Worktree(t *testing.T) {
+	dir := createTestGitRepo(t)
+
+	// Create a worktree
+	worktreePath := t.TempDir()
+	runGit(t, dir, "worktree", "add", "-b", "test-wt", worktreePath, "main")
+
+	gitDir, err := ResolveGitDir(worktreePath)
+	require.NoError(t, err)
+	// Should point to the main repo's .git/worktrees/<name> directory
+	assert.Contains(t, gitDir, filepath.Join(dir, ".git", "worktrees"))
+}
+
+func TestResolveGitDir_NotARepo(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ResolveGitDir(dir)
+	assert.Error(t, err)
+}
+
+func TestResolveCommonDir_RegularRepo(t *testing.T) {
+	dir := createTestGitRepo(t)
+	gitDir := filepath.Join(dir, ".git")
+
+	commonDir := resolveCommonDir(gitDir)
+	assert.Equal(t, gitDir, commonDir)
+}
+
+func TestResolveCommonDir_Worktree(t *testing.T) {
+	dir := createTestGitRepo(t)
+	worktreePath := t.TempDir()
+	runGit(t, dir, "worktree", "add", "-b", "test-wt-common", worktreePath, "main")
+
+	gitDir, err := ResolveGitDir(worktreePath)
+	require.NoError(t, err)
+
+	commonDir := resolveCommonDir(gitDir)
+	// Common dir should be the main repo's .git directory
+	// Use EvalSymlinks to handle macOS /var -> /private/var symlink
+	expected, _ := filepath.EvalSymlinks(filepath.Join(dir, ".git"))
+	actual, _ := filepath.EvalSymlinks(commonDir)
+	assert.Equal(t, expected, actual)
+}
+
+func TestReadCurrentBranch(t *testing.T) {
+	dir := createTestGitRepo(t)
+
+	branch, err := readCurrentBranch(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "main", branch)
+}
+
+func TestReadCurrentBranch_FeatureBranch(t *testing.T) {
+	dir := createTestGitRepo(t)
+	runGit(t, dir, "checkout", "-b", "feature/my-feature")
+
+	branch, err := readCurrentBranch(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "feature/my-feature", branch)
+}
+
+func TestReadCurrentBranch_DetachedHead(t *testing.T) {
+	dir := createTestGitRepo(t)
+	sha := getCommitSHA(t, dir)
+	runGit(t, dir, "checkout", sha)
+
+	branch, err := readCurrentBranch(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "HEAD", branch)
+}
+
+func TestReadHeadSHA(t *testing.T) {
+	dir := createTestGitRepo(t)
+	expectedSHA := getCommitSHA(t, dir)
+
+	sha, err := readHeadSHA(dir)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, sha)
+}
+
+func TestReadHeadSHA_AfterCommit(t *testing.T) {
+	dir := createTestGitRepo(t)
+	createAndCommitFile(t, dir, "new.txt", "content", "new commit")
+	expectedSHA := getCommitSHA(t, dir)
+
+	sha, err := readHeadSHA(dir)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, sha)
+}
+
+func TestReadHeadSHA_DetachedHead(t *testing.T) {
+	dir := createTestGitRepo(t)
+	expectedSHA := getCommitSHA(t, dir)
+	runGit(t, dir, "checkout", expectedSHA)
+
+	sha, err := readHeadSHA(dir)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, sha)
+}
+
+func TestReadRemoteURL(t *testing.T) {
+	dir := createTestGitRepo(t)
+
+	url, err := readRemoteURL(dir, "origin")
+	require.NoError(t, err)
+	assert.NotEmpty(t, url)
+}
+
+func TestReadRemoteURL_NonExistentRemote(t *testing.T) {
+	dir := createTestGitRepo(t)
+
+	_, err := readRemoteURL(dir, "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestReadInProgressStatus_Clean(t *testing.T) {
+	dir := createTestGitRepo(t)
+
+	status, err := readInProgressStatus(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "none", status.Type)
+}
+
+func TestReadUpstreamRef(t *testing.T) {
+	dir := createTestGitRepo(t)
+
+	// main tracks origin/main (set up by createTestGitRepo)
+	upstream, err := readUpstreamRef(dir, "main")
+	require.NoError(t, err)
+	assert.Equal(t, "origin/main", upstream)
+}
+
+func TestReadUpstreamRef_NoUpstream(t *testing.T) {
+	dir := createTestGitRepo(t)
+	runGit(t, dir, "checkout", "-b", "local-only")
+
+	_, err := readUpstreamRef(dir, "local-only")
+	assert.Error(t, err)
+}
+
+func TestLookupPackedRef(t *testing.T) {
+	dir := createTestGitRepo(t)
+	expectedSHA := getCommitSHA(t, dir)
+
+	// Pack refs so they end up in packed-refs
+	runGit(t, dir, "pack-refs", "--all")
+
+	gitDir := filepath.Join(dir, ".git")
+	sha, err := lookupPackedRef(gitDir, "refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, sha)
+}
+
+func TestLookupPackedRef_NotFound(t *testing.T) {
+	dir := createTestGitRepo(t)
+	runGit(t, dir, "pack-refs", "--all")
+
+	gitDir := filepath.Join(dir, ".git")
+	_, err := lookupPackedRef(gitDir, "refs/heads/nonexistent")
+	assert.Error(t, err)
+}
+
+func TestReadHeadSHA_PackedRefs(t *testing.T) {
+	dir := createTestGitRepo(t)
+	expectedSHA := getCommitSHA(t, dir)
+
+	// Pack refs and remove loose ref file
+	runGit(t, dir, "pack-refs", "--all")
+
+	// Remove the loose ref file to force packed-refs lookup
+	looseRefPath := filepath.Join(dir, ".git", "refs", "heads", "main")
+	os.Remove(looseRefPath) // May already be gone after pack-refs --all on some git versions
+
+	sha, err := readHeadSHA(dir)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, sha)
+}
+
+func TestResolveRef_LooseRef(t *testing.T) {
+	dir := createTestGitRepo(t)
+	expectedSHA := getCommitSHA(t, dir)
+
+	gitDir := filepath.Join(dir, ".git")
+	sha, err := resolveRef(gitDir, "refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, sha)
+}
+
+func TestReadCurrentBranch_Worktree(t *testing.T) {
+	dir := createTestGitRepo(t)
+	worktreePath := t.TempDir()
+	runGit(t, dir, "worktree", "add", "-b", "wt-branch", worktreePath, "main")
+
+	branch, err := readCurrentBranch(worktreePath)
+	require.NoError(t, err)
+	assert.Equal(t, "wt-branch", branch)
+}
+
+func TestReadHeadSHA_Worktree(t *testing.T) {
+	dir := createTestGitRepo(t)
+	expectedSHA := getCommitSHA(t, dir)
+	worktreePath := t.TempDir()
+	runGit(t, dir, "worktree", "add", "-b", "wt-sha", worktreePath, "main")
+
+	sha, err := readHeadSHA(worktreePath)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, sha)
+}
+
+func TestReadRemoteURL_Worktree(t *testing.T) {
+	dir := createTestGitRepo(t)
+	worktreePath := t.TempDir()
+	runGit(t, dir, "worktree", "add", "-b", "wt-remote", worktreePath, "main")
+
+	url, err := readRemoteURL(worktreePath, "origin")
+	require.NoError(t, err)
+	assert.NotEmpty(t, url)
+
+	// Should match the main repo's remote URL
+	mainURL, err := readRemoteURL(dir, "origin")
+	require.NoError(t, err)
+	assert.Equal(t, mainURL, url)
+}

--- a/backend/git/gitcache.go
+++ b/backend/git/gitcache.go
@@ -1,0 +1,259 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// remoteURLTTL is how long cached remote URLs are valid.
+	// Remote URLs almost never change, so a long TTL is safe.
+	remoteURLTTL = 5 * time.Minute
+)
+
+// GitCache provides in-memory caching for git metadata that is expensive
+// to compute via subprocess but cheap to read from files. All methods are
+// safe for concurrent use.
+type GitCache struct {
+	mu sync.RWMutex
+
+	// gitDirs caches resolved git directory paths. These never change for the
+	// lifetime of a worktree, so entries are never invalidated.
+	gitDirs map[string]string // repoPath → gitDir
+
+	// commonDirs caches resolved common directory paths. Like gitDirs, these
+	// are immutable for a worktree's lifetime.
+	commonDirs map[string]string // gitDir → commonDir
+
+	// remoteURLs caches remote URLs with a TTL.
+	remoteURLs map[string]cachedString // "repoPath\x00remoteName" → URL
+
+	// packedRefs caches parsed packed-refs files, invalidated by mtime.
+	packedRefs map[string]*packedRefsEntry // commonDir → parsed refs
+
+	// upstreamRefs caches branch upstream tracking refs. These are set once
+	// (on first push) and never change for the branch's lifetime, so entries
+	// are never expired — only cleared on Invalidate.
+	upstreamRefs map[string]string // "repoPath\x00branch" → upstream (e.g., "origin/main")
+}
+
+type cachedString struct {
+	value     string
+	expiresAt time.Time
+}
+
+type packedRefsEntry struct {
+	mtime time.Time
+	refs  map[string]string // refName → SHA
+}
+
+// NewGitCache creates a new GitCache instance.
+func NewGitCache() *GitCache {
+	return &GitCache{
+		gitDirs:      make(map[string]string),
+		commonDirs:   make(map[string]string),
+		remoteURLs:   make(map[string]cachedString),
+		packedRefs:   make(map[string]*packedRefsEntry),
+		upstreamRefs: make(map[string]string),
+	}
+}
+
+// GetGitDir returns the cached git directory for a repo path, resolving it on first access.
+func (c *GitCache) GetGitDir(repoPath string) (string, error) {
+	c.mu.RLock()
+	if dir, ok := c.gitDirs[repoPath]; ok {
+		c.mu.RUnlock()
+		return dir, nil
+	}
+	c.mu.RUnlock()
+
+	dir, err := ResolveGitDir(repoPath)
+	if err != nil {
+		return "", err
+	}
+
+	c.mu.Lock()
+	c.gitDirs[repoPath] = dir
+	c.mu.Unlock()
+	return dir, nil
+}
+
+// GetCommonDir returns the cached common directory for a git directory.
+func (c *GitCache) GetCommonDir(gitDir string) string {
+	c.mu.RLock()
+	if dir, ok := c.commonDirs[gitDir]; ok {
+		c.mu.RUnlock()
+		return dir
+	}
+	c.mu.RUnlock()
+
+	dir := resolveCommonDir(gitDir)
+
+	c.mu.Lock()
+	c.commonDirs[gitDir] = dir
+	c.mu.Unlock()
+	return dir
+}
+
+// GetRemoteURL returns the cached remote URL, refreshing if expired.
+func (c *GitCache) GetRemoteURL(repoPath, remoteName string) (string, error) {
+	key := repoPath + "\x00" + remoteName
+
+	c.mu.RLock()
+	if cached, ok := c.remoteURLs[key]; ok && time.Now().Before(cached.expiresAt) {
+		c.mu.RUnlock()
+		return cached.value, nil
+	}
+	c.mu.RUnlock()
+
+	url, err := readRemoteURL(repoPath, remoteName)
+	if err != nil {
+		return "", err
+	}
+
+	c.mu.Lock()
+	c.remoteURLs[key] = cachedString{
+		value:     url,
+		expiresAt: time.Now().Add(remoteURLTTL),
+	}
+	c.mu.Unlock()
+	return url, nil
+}
+
+// GetUpstreamRef returns the cached upstream tracking ref for a branch.
+// Upstream refs are immutable for a branch's lifetime, so no TTL is needed.
+func (c *GitCache) GetUpstreamRef(repoPath, branch string) (string, error) {
+	key := repoPath + "\x00" + branch
+
+	c.mu.RLock()
+	if ref, ok := c.upstreamRefs[key]; ok {
+		c.mu.RUnlock()
+		return ref, nil
+	}
+	c.mu.RUnlock()
+
+	ref, err := readUpstreamRef(repoPath, branch)
+	if err != nil {
+		return "", err
+	}
+
+	c.mu.Lock()
+	c.upstreamRefs[key] = ref
+	c.mu.Unlock()
+	return ref, nil
+}
+
+// LookupPackedRef looks up a ref in the packed-refs file, using a cached parse
+// that is invalidated when the file's mtime changes.
+func (c *GitCache) LookupPackedRef(commonDir, refName string) (string, error) {
+	packedRefsPath := filepath.Join(commonDir, "packed-refs")
+	info, err := os.Stat(packedRefsPath)
+	if err != nil {
+		return "", err
+	}
+	mtime := info.ModTime()
+
+	c.mu.RLock()
+	if entry, ok := c.packedRefs[commonDir]; ok && entry.mtime.Equal(mtime) {
+		sha, found := entry.refs[refName]
+		c.mu.RUnlock()
+		if found {
+			return sha, nil
+		}
+		return "", fmt.Errorf("ref %s not found in packed-refs", refName)
+	}
+	c.mu.RUnlock()
+
+	// Parse the entire packed-refs file
+	refs, err := parsePackedRefs(packedRefsPath)
+	if err != nil {
+		return "", err
+	}
+
+	c.mu.Lock()
+	c.packedRefs[commonDir] = &packedRefsEntry{
+		mtime: mtime,
+		refs:  refs,
+	}
+	c.mu.Unlock()
+
+	if sha, ok := refs[refName]; ok {
+		return sha, nil
+	}
+	return "", fmt.Errorf("ref %s not found in packed-refs", refName)
+}
+
+// parsePackedRefs parses a packed-refs file into a map of refName → SHA.
+func parsePackedRefs(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	refs := make(map[string]string)
+	for _, line := range splitLines(string(data)) {
+		if len(line) == 0 || line[0] == '#' || line[0] == '^' {
+			continue
+		}
+		// Assumes SHA-1 (40 hex chars); SHA-256 repos are unsupported.
+		if len(line) > 41 && line[40] == ' ' {
+			refs[line[41:]] = line[:40]
+		}
+	}
+
+	return refs, nil
+}
+
+// splitLines splits a string by newlines, handling both \n and \r\n.
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			line := s[start:i]
+			if len(line) > 0 && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
+			lines = append(lines, line)
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+// Invalidate removes all cached data for a specific repo path.
+// Call this when a worktree is removed.
+func (c *GitCache) Invalidate(repoPath string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	gitDir := c.gitDirs[repoPath]
+	delete(c.gitDirs, repoPath)
+
+	if gitDir != "" {
+		commonDir := c.commonDirs[gitDir]
+		delete(c.commonDirs, gitDir)
+		if commonDir != "" {
+			delete(c.packedRefs, commonDir)
+		}
+	}
+
+	prefix := repoPath + "\x00"
+	for key := range c.remoteURLs {
+		if strings.HasPrefix(key, prefix) {
+			delete(c.remoteURLs, key)
+		}
+	}
+	for key := range c.upstreamRefs {
+		if strings.HasPrefix(key, prefix) {
+			delete(c.upstreamRefs, key)
+		}
+	}
+}

--- a/backend/git/gitcache_test.go
+++ b/backend/git/gitcache_test.go
@@ -1,0 +1,109 @@
+package git
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitCache_GetGitDir(t *testing.T) {
+	dir := createTestGitRepo(t)
+	cache := NewGitCache()
+
+	// First call should resolve and cache
+	gitDir, err := cache.GetGitDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, ".git"), gitDir)
+
+	// Second call should return cached value
+	gitDir2, err := cache.GetGitDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, gitDir, gitDir2)
+}
+
+func TestGitCache_GetGitDir_Worktree(t *testing.T) {
+	dir := createTestGitRepo(t)
+	worktreePath := t.TempDir()
+	runGit(t, dir, "worktree", "add", "-b", "cache-wt", worktreePath, "main")
+
+	cache := NewGitCache()
+
+	gitDir, err := cache.GetGitDir(worktreePath)
+	require.NoError(t, err)
+	assert.Contains(t, gitDir, filepath.Join(dir, ".git", "worktrees"))
+}
+
+func TestGitCache_GetCommonDir(t *testing.T) {
+	dir := createTestGitRepo(t)
+	cache := NewGitCache()
+
+	gitDir := filepath.Join(dir, ".git")
+	commonDir := cache.GetCommonDir(gitDir)
+	assert.Equal(t, gitDir, commonDir)
+
+	// Second call should return cached value
+	commonDir2 := cache.GetCommonDir(gitDir)
+	assert.Equal(t, commonDir, commonDir2)
+}
+
+func TestGitCache_GetRemoteURL(t *testing.T) {
+	dir := createTestGitRepo(t)
+	cache := NewGitCache()
+
+	url, err := cache.GetRemoteURL(dir, "origin")
+	require.NoError(t, err)
+	assert.NotEmpty(t, url)
+
+	// Second call should return cached value
+	url2, err := cache.GetRemoteURL(dir, "origin")
+	require.NoError(t, err)
+	assert.Equal(t, url, url2)
+}
+
+func TestGitCache_GetRemoteURL_NotFound(t *testing.T) {
+	dir := createTestGitRepo(t)
+	cache := NewGitCache()
+
+	_, err := cache.GetRemoteURL(dir, "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestGitCache_LookupPackedRef(t *testing.T) {
+	dir := createTestGitRepo(t)
+	expectedSHA := getCommitSHA(t, dir)
+	runGit(t, dir, "pack-refs", "--all")
+
+	cache := NewGitCache()
+	gitDir := filepath.Join(dir, ".git")
+
+	sha, err := cache.LookupPackedRef(gitDir, "refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, expectedSHA, sha)
+
+	// Second call should use cached packed-refs
+	sha2, err := cache.LookupPackedRef(gitDir, "refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, sha, sha2)
+}
+
+func TestGitCache_Invalidate(t *testing.T) {
+	dir := createTestGitRepo(t)
+	cache := NewGitCache()
+
+	// Populate cache
+	_, err := cache.GetGitDir(dir)
+	require.NoError(t, err)
+	_, err = cache.GetRemoteURL(dir, "origin")
+	require.NoError(t, err)
+
+	// Invalidate
+	cache.Invalidate(dir)
+
+	// gitDirs should be cleared
+	cache.mu.RLock()
+	_, cached := cache.gitDirs[dir]
+	cache.mu.RUnlock()
+	assert.False(t, cached)
+}

--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -58,10 +58,14 @@ func gitCmd(repoPath string, args ...string) (*exec.Cmd, context.CancelFunc) {
 	return gitCmdWithContext(context.Background(), TimeoutMedium, repoPath, args...)
 }
 
-type RepoManager struct{}
+type RepoManager struct {
+	cache *GitCache
+}
 
 func NewRepoManager() *RepoManager {
-	return &RepoManager{}
+	return &RepoManager{
+		cache: NewGitCache(),
+	}
 }
 
 // ValidateGitRef validates a git reference (branch, tag, commit SHA) to prevent command injection.
@@ -96,6 +100,13 @@ func (rm *RepoManager) ValidateRepo(path string) error {
 }
 
 func (rm *RepoManager) GetCurrentBranch(ctx context.Context, repoPath string) (string, error) {
+	// Fast path: resolve gitDir via cache, then read HEAD directly
+	if gitDir, err := rm.cache.GetGitDir(repoPath); err == nil {
+		if branch, err := readBranchFromGitDir(gitDir); err == nil {
+			return branch, nil
+		}
+	}
+	// Fallback to subprocess
 	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--abbrev-ref", "HEAD")
 	defer cancel()
 	out, err := cmd.Output()
@@ -766,11 +777,22 @@ func (rm *RepoManager) getSyncStatus(ctx context.Context, repoPath, baseBranch s
 		return status, fmt.Errorf("invalid base branch: %w", err)
 	}
 
-	// Check if remote tracking branch exists
-	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
-	remoteOut, _ := cmd.Output()
-	cancel()
-	remoteBranch := strings.TrimSpace(string(remoteOut))
+	// Check if remote tracking branch exists — resolve gitDir once, then use cached upstream
+	var remoteBranch string
+	if gitDir, err := rm.cache.GetGitDir(repoPath); err == nil {
+		if currentBranch, err := readBranchFromGitDir(gitDir); err == nil {
+			if upstream, err := rm.cache.GetUpstreamRef(repoPath, currentBranch); err == nil {
+				remoteBranch = upstream
+			}
+		}
+	}
+	if remoteBranch == "" {
+		// Fallback to subprocess
+		cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+		remoteOut, _ := cmd.Output()
+		cancel()
+		remoteBranch = strings.TrimSpace(string(remoteOut))
+	}
 	if remoteBranch != "" {
 		status.RemoteBranch = remoteBranch
 		status.HasRemote = true
@@ -778,7 +800,7 @@ func (rm *RepoManager) getSyncStatus(ctx context.Context, repoPath, baseBranch s
 
 	// Get ahead/behind compared to base branch (origin/main or similar)
 	remoteBase := "origin/" + baseBranch
-	cmd, cancel = gitCmdWithContext(ctx, TimeoutMedium, repoPath, "rev-list", "--left-right", "--count", remoteBase+"...HEAD")
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutMedium, repoPath, "rev-list", "--left-right", "--count", remoteBase+"...HEAD")
 	countOut, err := cmd.Output()
 	cancel()
 	if err != nil {
@@ -817,9 +839,16 @@ func (rm *RepoManager) getSyncStatus(ctx context.Context, repoPath, baseBranch s
 
 // getInProgressStatus checks for in-progress git operations
 func (rm *RepoManager) getInProgressStatus(ctx context.Context, repoPath string) (*InProgressStatus, error) {
+	// Fast path: resolve gitDir via cache, then check git internal files
+	if gitDir, err := rm.cache.GetGitDir(repoPath); err == nil {
+		if status, err := readInProgressFromGitDir(gitDir); err == nil {
+			return status, nil
+		}
+	}
+
+	// Fallback to subprocess for git-dir resolution
 	status := &InProgressStatus{Type: "none"}
 
-	// Get the git directory for this worktree
 	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--git-dir")
 	defer cancel()
 	gitDirOut, err := cmd.Output()
@@ -836,7 +865,6 @@ func (rm *RepoManager) getInProgressStatus(ctx context.Context, repoPath string)
 	rebaseApplyDir := filepath.Join(gitDir, "rebase-apply")
 	if _, err := os.Stat(rebaseMergeDir); err == nil {
 		status.Type = "rebase"
-		// Get progress
 		if msgnum, err := os.ReadFile(filepath.Join(rebaseMergeDir, "msgnum")); err == nil {
 			fmt.Sscanf(strings.TrimSpace(string(msgnum)), "%d", &status.Current)
 		}
@@ -847,7 +875,6 @@ func (rm *RepoManager) getInProgressStatus(ctx context.Context, repoPath string)
 	}
 	if _, err := os.Stat(rebaseApplyDir); err == nil {
 		status.Type = "rebase"
-		// Get progress from rebase-apply
 		if next, err := os.ReadFile(filepath.Join(rebaseApplyDir, "next")); err == nil {
 			fmt.Sscanf(strings.TrimSpace(string(next)), "%d", &status.Current)
 		}
@@ -857,19 +884,14 @@ func (rm *RepoManager) getInProgressStatus(ctx context.Context, repoPath string)
 		return status, nil
 	}
 
-	// Check for merge
 	if _, err := os.Stat(filepath.Join(gitDir, "MERGE_HEAD")); err == nil {
 		status.Type = "merge"
 		return status, nil
 	}
-
-	// Check for cherry-pick
 	if _, err := os.Stat(filepath.Join(gitDir, "CHERRY_PICK_HEAD")); err == nil {
 		status.Type = "cherry-pick"
 		return status, nil
 	}
-
-	// Check for revert
 	if _, err := os.Stat(filepath.Join(gitDir, "REVERT_HEAD")); err == nil {
 		status.Type = "revert"
 		return status, nil
@@ -1210,6 +1232,13 @@ func (rm *RepoManager) getAheadBehind(ctx context.Context, repoPath, branchName 
 
 // GetHeadSHA returns the SHA of the current HEAD commit
 func (rm *RepoManager) GetHeadSHA(ctx context.Context, repoPath string) (string, error) {
+	// Fast path: resolve gitDir via cache, then read HEAD and resolve ref (with cached packed-refs)
+	if gitDir, err := rm.cache.GetGitDir(repoPath); err == nil {
+		if sha, err := readHeadSHAFromGitDir(gitDir, rm.cache); err == nil {
+			return sha, nil
+		}
+	}
+	// Fallback to subprocess
 	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "HEAD")
 	defer cancel()
 	out, err := cmd.Output()
@@ -1221,14 +1250,24 @@ func (rm *RepoManager) GetHeadSHA(ctx context.Context, repoPath string) (string,
 
 // GetGitHubRemote extracts the GitHub owner and repo name from the origin remote URL
 func (rm *RepoManager) GetGitHubRemote(ctx context.Context, repoPath string) (owner, repo string, err error) {
-	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "remote", "get-url", "origin")
-	defer cancel()
-	out, err := cmd.Output()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get origin remote: %w", err)
+	// Fast path: read remote URL from .git/config (with cache)
+	var remoteURL string
+	if rm.cache != nil {
+		remoteURL, err = rm.cache.GetRemoteURL(repoPath, "origin")
+	} else {
+		remoteURL, err = readRemoteURL(repoPath, "origin")
 	}
 
-	remoteURL := strings.TrimSpace(string(out))
+	if err != nil {
+		// Fallback to subprocess
+		cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "remote", "get-url", "origin")
+		defer cancel()
+		out, fallbackErr := cmd.Output()
+		if fallbackErr != nil {
+			return "", "", fmt.Errorf("failed to get origin remote: %w", fallbackErr)
+		}
+		remoteURL = strings.TrimSpace(string(out))
+	}
 
 	// Parse various GitHub URL formats:
 	// - https://github.com/owner/repo.git


### PR DESCRIPTION
## Summary

- **Cached gitDir resolution**: All `RepoManager` fast paths now resolve gitDir once via `GitCache.GetGitDir` instead of calling `ResolveGitDir` (stat + readfile for worktrees) on every helper invocation. Eliminates 2-3 redundant syscalls per `getSyncStatus` call.
- **Cached upstream refs**: Added `GetUpstreamRef` to `GitCache` with no-expiry caching — upstream tracking refs are immutable for a branch's lifetime (set once at push). Eliminates repeated `.git/config` parsing on every status poll.
- **Cached packed-refs lookup**: Wired `resolveRef` to use `GitCache.LookupPackedRef` (mtime-invalidated map cache) instead of the uncached linear file scan. Activates the existing cache that was never connected.
- **Extracted gitDir-accepting helpers**: `readBranchFromGitDir`, `readHeadSHAFromGitDir`, `readInProgressFromGitDir`, `readUpstreamFromConfig`, `resolveRefCached` — allow callers to skip redundant gitDir resolution.
- **Consolidated `resolveWorktreeGitDir`**: Removed duplicate in `branch/watcher.go`, now uses shared `git.ResolveGitDir`.

## Impact

These are the hot paths called on every git status poll from the frontend (`GetStatus` → parallel goroutines for sync status, in-progress status, HEAD SHA, etc.). With many active sessions, the cumulative syscall and config-parse reduction is significant.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./git/...` — all pass (58s, includes worktree lifecycle tests)
- [x] `go test ./branch/...` — all pass (updated refs to `git.ResolveGitDir`)
- [ ] Manual: verify status polling works correctly with active worktree sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)