### PR TITLE
fix: nest base sessions under their workspace in grouped sidebar modes

### DIFF
--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -141,7 +141,8 @@ export function useSidebarSessions({
   return useMemo(() => {
     const filtered = filterSessions(sessions, filters);
 
-    // Separate base sessions — they are always pinned at the top, outside groups
+    // In flat/status modes, pin base sessions at the top.
+    // In project/project-status modes, nest them under their workspace.
     const pinnedSessions = filtered.filter((s) => s.sessionType === 'base');
     const regularSessions = filtered.filter((s) => s.sessionType !== 'base');
 
@@ -161,9 +162,9 @@ export function useSidebarSessions({
       };
     }
 
-    // Pre-group regular sessions by workspace for O(w+n) instead of O(w×n)
+    // For project-based grouping, include ALL sessions (base + regular) under their workspace
     const byWorkspace = new Map<string, WorktreeSession[]>();
-    for (const s of regularSessions) {
+    for (const s of filtered) {
       const list = byWorkspace.get(s.workspaceId);
       if (list) list.push(s);
       else byWorkspace.set(s.workspaceId, [s]);
@@ -186,7 +187,7 @@ export function useSidebarSessions({
           sessions: sortSessions(wsSessions, sortBy),
         });
       }
-      return { groups, flatSessions: [], pinnedSessions };
+      return { groups, flatSessions: [], pinnedSessions: [] };
     }
 
     // project-status
@@ -209,10 +210,10 @@ export function useSidebarSessions({
           subGroups,
         });
       }
-      return { groups, flatSessions: [], pinnedSessions };
+      return { groups, flatSessions: [], pinnedSessions: [] };
     }
 
-    return { groups: [], flatSessions: [], pinnedSessions };
+    return { groups: [], flatSessions: [], pinnedSessions: [] };
   }, [sessions, workspaces, groupBy, sortBy, filters, workspaceColors, getDefaultColor]);
 }
 


### PR DESCRIPTION
## Summary
- Base sessions (`sessionType === 'base'`) were rendered as orphan items at the top of the SESSIONS sidebar instead of being nested under their parent workspace node
- Fixed `useSidebarSessions` to include base sessions in workspace grouping for `project` and `project-status` modes, while preserving the pinned-at-top behavior for `none` and `status` modes

## Test plan
- [ ] Open sidebar with base sessions present across multiple workspaces
- [ ] Switch to **project** grouping → base sessions should appear under their workspace node
- [ ] Switch to **project-status** grouping → base sessions should appear under workspace > status group
- [ ] Switch to **none** / **status** grouping → base sessions should still pin at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)