### PR TITLE
feat: add sessionType to SetupInfo for base vs worktree session cards

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -280,6 +280,7 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 				SessionName:  session.Name,
 				BranchName:   session.Branch,
 				OriginBranch: originBranch,
+				SessionType:  session.SessionType,
 			},
 			Timestamp: now,
 		}

--- a/backend/main.go
+++ b/backend/main.go
@@ -588,6 +588,7 @@ func main() {
 					SessionName:  sess.Name,
 					BranchName:   branch,
 					OriginBranch: branch,
+					SessionType:  models.SessionTypeBase,
 				},
 				Timestamp: now,
 			}

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -130,12 +130,13 @@ type MessagePage struct {
 	OldestPosition int       `json:"oldestPosition,omitempty"`
 }
 
-// SetupInfo contains information about the worktree setup for system messages
+// SetupInfo contains information about the session setup for system messages
 type SetupInfo struct {
 	SessionName  string `json:"sessionName"`
 	BranchName   string `json:"branchName"`
 	OriginBranch string `json:"originBranch"`
 	FileCount    int    `json:"fileCount,omitempty"`
+	SessionType  string `json:"sessionType,omitempty"`
 }
 
 // RunStats contains detailed statistics from an agent run

--- a/backend/models/types_test.go
+++ b/backend/models/types_test.go
@@ -279,6 +279,7 @@ func TestMessage_JSONSerialization(t *testing.T) {
 				BranchName:   "feature/test",
 				OriginBranch: "main",
 				FileCount:    42,
+				SessionType:  SessionTypeWorktree,
 			},
 			Timestamp: now,
 		}
@@ -295,6 +296,7 @@ func TestMessage_JSONSerialization(t *testing.T) {
 		require.Equal(t, "feature/test", decoded.SetupInfo.BranchName)
 		require.Equal(t, "main", decoded.SetupInfo.OriginBranch)
 		require.Equal(t, 42, decoded.SetupInfo.FileCount)
+		require.Equal(t, SessionTypeWorktree, decoded.SetupInfo.SessionType)
 	})
 
 	t.Run("message with run summary", func(t *testing.T) {
@@ -564,6 +566,7 @@ func TestSetupInfo_JSONSerialization(t *testing.T) {
 		BranchName:   "feature/awesome",
 		OriginBranch: "main",
 		FileCount:    256,
+		SessionType:  SessionTypeWorktree,
 	}
 
 	data, err := json.Marshal(info)
@@ -577,6 +580,7 @@ func TestSetupInfo_JSONSerialization(t *testing.T) {
 	require.Equal(t, info.BranchName, decoded.BranchName)
 	require.Equal(t, info.OriginBranch, decoded.OriginBranch)
 	require.Equal(t, info.FileCount, decoded.FileCount)
+	require.Equal(t, info.SessionType, decoded.SessionType)
 }
 
 func TestSetupInfo_JSONSerialization_OmitEmpty(t *testing.T) {
@@ -596,6 +600,9 @@ func TestSetupInfo_JSONSerialization_OmitEmpty(t *testing.T) {
 
 	_, hasFileCount := rawMap["fileCount"]
 	require.False(t, hasFileCount, "fileCount should be omitted when zero")
+
+	_, hasSessionType := rawMap["sessionType"]
+	require.False(t, hasSessionType, "sessionType should be omitted when empty")
 }
 
 func TestToolAction_JSONSerialization(t *testing.T) {

--- a/backend/server/session_handlers.go
+++ b/backend/server/session_handlers.go
@@ -204,6 +204,7 @@ func (h *Handlers) initBaseSession(ctx context.Context, workspaceID, name, branc
 			SessionName:  sess.Name,
 			BranchName:   branch,
 			OriginBranch: branch,
+			SessionType:  models.SessionTypeBase,
 		},
 		Timestamp: now,
 	}
@@ -566,6 +567,7 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 			SessionName:  sess.Name,
 			BranchName:   sess.Branch,
 			OriginBranch: originBranch,
+			SessionType:  models.SessionTypeWorktree,
 		},
 		Timestamp: now,
 	}

--- a/backend/store/sqlite_test.go
+++ b/backend/store/sqlite_test.go
@@ -1266,6 +1266,7 @@ func TestAddMessageToConversation_WithSetupInfo(t *testing.T) {
 			BranchName:   "feature/test",
 			OriginBranch: "main",
 			FileCount:    42,
+			SessionType:  models.SessionTypeBase,
 		},
 	}
 
@@ -1280,6 +1281,7 @@ func TestAddMessageToConversation_WithSetupInfo(t *testing.T) {
 	assert.Equal(t, "feature/test", page.Messages[0].SetupInfo.BranchName)
 	assert.Equal(t, "main", page.Messages[0].SetupInfo.OriginBranch)
 	assert.Equal(t, 42, page.Messages[0].SetupInfo.FileCount)
+	assert.Equal(t, models.SessionTypeBase, page.Messages[0].SetupInfo.SessionType)
 }
 
 func TestAddMessageToConversation_WithRunSummary(t *testing.T) {
@@ -2017,6 +2019,7 @@ func TestGetConversationMessages_WithSetupInfo(t *testing.T) {
 			BranchName:   "feature/test",
 			OriginBranch: "main",
 			FileCount:    42,
+			SessionType:  models.SessionTypeWorktree,
 		},
 		Timestamp: time.Now(),
 	}
@@ -2030,6 +2033,7 @@ func TestGetConversationMessages_WithSetupInfo(t *testing.T) {
 	assert.Equal(t, "feature/test", page.Messages[0].SetupInfo.BranchName)
 	assert.Equal(t, "main", page.Messages[0].SetupInfo.OriginBranch)
 	assert.Equal(t, 42, page.Messages[0].SetupInfo.FileCount)
+	assert.Equal(t, models.SessionTypeWorktree, page.Messages[0].SetupInfo.SessionType)
 }
 
 func TestGetConversationMessages_WithRunSummary(t *testing.T) {

--- a/src/components/shared/SystemInfoCard.tsx
+++ b/src/components/shared/SystemInfoCard.tsx
@@ -1,14 +1,8 @@
 'use client';
 
-import { GitBranch, FolderGit2 } from 'lucide-react';
+import { GitBranch, FolderGit2, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
-
-export interface SetupInfo {
-  sessionName: string;
-  branchName: string;
-  originBranch: string;
-  fileCount?: number;
-}
+import type { SetupInfo } from '@/lib/types';
 
 interface SystemInfoCardProps {
   setupInfo: SetupInfo;
@@ -16,28 +10,57 @@ interface SystemInfoCardProps {
 }
 
 export function SystemInfoCard({ setupInfo, className }: SystemInfoCardProps) {
-  const { sessionName, branchName, originBranch, fileCount } = setupInfo;
+  const { sessionName, branchName, originBranch, fileCount, sessionType } = setupInfo;
+  // sessionType is omitempty on the backend — legacy messages lack this field
+  // and correctly fall through to the worktree rendering path
+  const isBase = sessionType === 'base';
 
   return (
     <div
       className={cn(
-        'rounded-lg border border-purple-400/20 bg-purple-500/10 dark:border-purple-400/20 dark:bg-purple-500/10 px-3 py-2 text-base',
+        'rounded-lg border px-3 py-2 text-base',
+        isBase
+          ? 'border-blue-400/20 bg-blue-500/10'
+          : 'border-purple-400/20 bg-purple-500/10',
         className
       )}
     >
       <p className="text-muted-foreground mb-3">
-        You are in a new git worktree of your codebase called{' '}
-        <span className="font-medium text-foreground">{sessionName}</span>
+        {isBase ? (
+          <>
+            This is the base session for your repository{' '}
+            <span className="font-medium text-foreground">{sessionName}</span>
+          </>
+        ) : (
+          <>
+            You are in a new git worktree of your codebase called{' '}
+            <span className="font-medium text-foreground">{sessionName}</span>
+          </>
+        )}
       </p>
       <div className="space-y-1.5 text-base text-muted-foreground">
         <div className="flex items-center gap-2">
           <GitBranch className="w-3.5 h-3.5 shrink-0" />
-          <span>
-            Branched <span className="font-medium text-foreground">{branchName}</span> from{' '}
-            <span className="font-medium text-foreground">{originBranch}</span>
-          </span>
+          {isBase ? (
+            <span>
+              Currently on <span className="font-medium text-foreground">{branchName}</span>
+            </span>
+          ) : (
+            <span>
+              Branched <span className="font-medium text-foreground">{branchName}</span> from{' '}
+              <span className="font-medium text-foreground">{originBranch}</span>
+            </span>
+          )}
         </div>
-        {fileCount !== undefined && (
+        {isBase && (
+          <div className="flex items-center gap-2 text-amber-600 dark:text-amber-500">
+            <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+            <span>
+              Changes are made directly to your repository. Use a worktree session for development.
+            </span>
+          </div>
+        )}
+        {!isBase && fileCount !== undefined && (
           <div className="flex items-center gap-2">
             <FolderGit2 className="w-3.5 h-3.5 shrink-0" />
             <span>

--- a/src/lib/api/conversations.ts
+++ b/src/lib/api/conversations.ts
@@ -28,6 +28,7 @@ export interface SetupInfoDTO {
   branchName: string;
   originBranch: string;
   fileCount?: number;
+  sessionType?: 'worktree' | 'base';
 }
 
 export interface RunStatsDTO {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -218,6 +218,7 @@ export interface SetupInfo {
   branchName: string;
   originBranch: string;
   fileCount?: number;
+  sessionType?: 'worktree' | 'base';
 }
 
 // Attachment = File attached to a message


### PR DESCRIPTION
## Summary

- Adds `sessionType` field (`"base"` | `"worktree"`) to `SetupInfo` across backend and frontend
- All three backend setup message creation paths now populate `SessionType` from the session model
- `SystemInfoCard` renders distinct UI: blue card with warning banner for base sessions, purple card with branch info for worktree sessions
- Removes duplicate `SetupInfo` type from component, imports from `@/lib/types`
- Adds test coverage for `sessionType` omitempty serialization and store round-trip persistence

## Test plan

- [x] `go test ./models/` — SetupInfo serialization + omitempty tests pass
- [x] `go test ./store/` — round-trip tests with SessionType for both base and worktree
- [ ] Manual: create a base session → verify blue card with warning banner
- [ ] Manual: create a worktree session → verify purple card with branch info
- [ ] Manual: verify legacy sessions (without sessionType) still render as worktree cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)