### PR TITLE
fix: hoist base session above status groups in sidebar

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -845,6 +845,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                             <SortableWorkspaceItem
                               key={ws.id}
                               workspace={ws}
+                              baseSessions={group.baseSessions}
                               sessions={group.sessions}
                               isExpanded={isWorkspaceExpanded(ws.id)}
                               selectedSessionId={selectedSessionId}
@@ -1148,6 +1149,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
 
 interface SortableWorkspaceItemProps {
   workspace: Workspace;
+  baseSessions?: WorktreeSession[];
   sessions: WorktreeSession[];
   isExpanded: boolean;
   selectedSessionId: string | null;
@@ -1168,6 +1170,7 @@ interface SortableWorkspaceItemProps {
 
 function SortableWorkspaceItem({
   workspace,
+  baseSessions,
   sessions,
   isExpanded,
   selectedSessionId,
@@ -1341,8 +1344,31 @@ function SortableWorkspaceItem({
         {/* Sessions */}
         <CollapsibleContent>
           <div className="ml-3 overflow-hidden">
-            {/* Sessions */}
-            {sessions.length === 0 ? (
+            {/* Base sessions first */}
+            {baseSessions?.map((session) => (
+              <ErrorBoundary
+                key={session.id}
+                section="SessionRow"
+                fallback={<CardErrorFallback message="Error loading session" />}
+              >
+                <SessionRow
+                  session={session}
+                  contentView={contentView}
+                  selectedSessionId={selectedSessionId}
+                  onSelectSession={onSelectSession}
+                  onArchiveSession={onArchiveSession}
+                  onTaskStatusChange={onTaskStatusChange}
+                  onOpenBranches={onOpenBranches}
+                  onOpenPRs={onOpenPRs}
+                  formatTimeAgo={formatTimeAgo}
+                />
+              </ErrorBoundary>
+            ))}
+            {baseSessions && baseSessions.length > 0 && sessions.length > 0 && (
+              <div className="my-1 mx-2 border-t border-border/40" />
+            )}
+            {/* Worktree sessions */}
+            {sessions.length === 0 && (!baseSessions || baseSessions.length === 0) ? (
               <div className="py-2 px-2 text-sm text-muted-foreground/70">
                 No active sessions
               </div>
@@ -1931,12 +1957,37 @@ function SortableProjectStatusItem({
 
             <CollapsibleContent>
               <div className="ml-3 overflow-hidden">
-                {(!group.subGroups || group.subGroups.length === 0) ? (
+                {/* Base sessions first */}
+                {group.baseSessions?.map((session) => (
+                  <ErrorBoundary
+                    key={session.id}
+                    section="SessionRow"
+                    fallback={<CardErrorFallback message="Error loading session" />}
+                  >
+                    <SessionRow
+                      session={session}
+                      contentView={contentView}
+                      selectedSessionId={selectedSessionId}
+                      onSelectSession={onSelectSession}
+                      onArchiveSession={onArchiveSession}
+                      onTaskStatusChange={onTaskStatusChange}
+                      onOpenBranches={onOpenBranches}
+                      onOpenPRs={onOpenPRs}
+                      formatTimeAgo={formatTimeAgo}
+                    />
+                  </ErrorBoundary>
+                ))}
+                {group.baseSessions && group.baseSessions.length > 0 &&
+                  group.subGroups && group.subGroups.length > 0 && (
+                  <div className="my-1 mx-2 border-t border-border/40" />
+                )}
+                {(!group.subGroups || group.subGroups.length === 0) &&
+                 (!group.baseSessions || group.baseSessions.length === 0) ? (
                   <div className="py-2 px-2 text-sm text-muted-foreground/70">
                     No active sessions
                   </div>
                 ) : (
-                  group.subGroups.map((subGroup) => (
+                  group.subGroups?.map((subGroup) => (
                     <Collapsible
                       key={subGroup.key}
                       open={isSubGroupExpanded(subGroup.key, subGroup.defaultCollapsed)}

--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -12,6 +12,7 @@ export interface SidebarGroup {
   workspaceId?: string;
   statusValue?: SessionTaskStatus;
   color?: string;
+  baseSessions?: WorktreeSession[];
   sessions: WorktreeSession[];
   subGroups?: SidebarGroup[];
 }
@@ -176,6 +177,8 @@ export function useSidebarSessions({
         const wsSessions = byWorkspace.get(ws.id) ?? [];
         if (wsSessions.length === 0 && filters.searchTerm) continue;
         const color = workspaceColors[ws.id] || getDefaultColor(ws.id);
+        const base = wsSessions.filter(s => s.sessionType === 'base');
+        const regular = wsSessions.filter(s => s.sessionType !== 'base');
         groups.push({
           key: `project:${ws.id}`,
           label: ws.name,
@@ -184,7 +187,8 @@ export function useSidebarSessions({
           defaultCollapsed: false,
           workspaceId: ws.id,
           color,
-          sessions: sortSessions(wsSessions, sortBy),
+          baseSessions: base,
+          sessions: sortSessions(regular, sortBy),
         });
       }
       return { groups, flatSessions: [], pinnedSessions: [] };
@@ -197,7 +201,9 @@ export function useSidebarSessions({
         const wsSessions = byWorkspace.get(ws.id) ?? [];
         if (wsSessions.length === 0 && filters.searchTerm) continue;
         const color = workspaceColors[ws.id] || getDefaultColor(ws.id);
-        const subGroups = buildStatusGroups(wsSessions, sortBy, `project:${ws.id}`);
+        const base = wsSessions.filter(s => s.sessionType === 'base');
+        const regular = wsSessions.filter(s => s.sessionType !== 'base');
+        const subGroups = buildStatusGroups(regular, sortBy, `project:${ws.id}`);
         groups.push({
           key: `project:${ws.id}`,
           label: ws.name,
@@ -206,6 +212,7 @@ export function useSidebarSessions({
           defaultCollapsed: false,
           workspaceId: ws.id,
           color,
+          baseSessions: base,
           sessions: [], // sessions are in subGroups
           subGroups,
         });


### PR DESCRIPTION
## Summary
- Base sessions (e.g., "main") now render as the first child immediately below the workspace name in both `project` and `project-status` grouping modes
- Added `baseSessions` field to `SidebarGroup` to separate base sessions from regular worktree sessions at the data layer
- A subtle separator divides the base session from status groups/worktree sessions below

## Test plan
- [ ] Open sidebar in `project-status` mode — base session appears right below workspace name, above status groups
- [ ] Switch to `project` mode — base session appears first, then worktree sessions
- [ ] Verify `status` and `none` modes still pin base sessions at top (unchanged)
- [ ] Collapse/expand workspace — base session stays inside the collapsible
- [ ] Workspace with no base session renders normally without extra spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)