### PR TITLE
feat: polish SystemInfoCard design

### DIFF
--- a/src/components/shared/SystemInfoCard.tsx
+++ b/src/components/shared/SystemInfoCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { GitBranch, FolderGit2, AlertTriangle } from 'lucide-react';
+import { GitBranch, GitFork, FolderGit2, AlertTriangle, Server } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
 import type { SetupInfo } from '@/lib/types';
 
 interface SystemInfoCardProps {
@@ -15,32 +16,60 @@ export function SystemInfoCard({ setupInfo, className }: SystemInfoCardProps) {
   // and correctly fall through to the worktree rendering path
   const isBase = sessionType === 'base';
 
+  const Icon = isBase ? Server : GitFork;
+
   return (
     <div
       className={cn(
-        'rounded-lg border px-3 py-2 text-base',
+        'rounded-xl border px-4 py-3.5 text-base',
         isBase
-          ? 'border-blue-400/20 bg-blue-500/10'
-          : 'border-purple-400/20 bg-purple-500/10',
+          ? 'border-blue-400/30 bg-blue-500/8'
+          : 'border-purple-400/30 bg-purple-500/8',
         className
       )}
     >
-      <p className="text-muted-foreground mb-3">
-        {isBase ? (
-          <>
-            This is the base session for your repository{' '}
-            <span className="font-medium text-foreground">{sessionName}</span>
-          </>
-        ) : (
-          <>
-            You are in a new git worktree of your codebase called{' '}
-            <span className="font-medium text-foreground">{sessionName}</span>
-          </>
-        )}
-      </p>
-      <div className="space-y-1.5 text-base text-muted-foreground">
+      {/* Header */}
+      <div className="flex items-center gap-2.5">
+        <div
+          className={cn(
+            'flex items-center justify-center rounded-lg p-1.5',
+            isBase ? 'bg-blue-500/15' : 'bg-purple-500/15'
+          )}
+        >
+          <Icon
+            className={cn(
+              'w-4 h-4',
+              isBase ? 'text-blue-600 dark:text-blue-400' : 'text-purple-600 dark:text-purple-400'
+            )}
+          />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-foreground truncate">{sessionName}</span>
+            <Badge
+              className={cn(
+                'text-2xs uppercase tracking-wide',
+                isBase
+                  ? 'border-blue-400/30 bg-blue-500/15 text-blue-700 dark:text-blue-300'
+                  : 'border-purple-400/30 bg-purple-500/15 text-purple-700 dark:text-purple-300'
+              )}
+            >
+              {isBase ? 'Base' : 'Worktree'}
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {isBase ? 'Base session for your repository' : 'Git worktree session'}
+          </p>
+        </div>
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-border/50 my-2.5" />
+
+      {/* Info rows */}
+      <div className="space-y-1.5 text-sm text-muted-foreground">
         <div className="flex items-center gap-2">
-          <GitBranch className="w-3.5 h-3.5 shrink-0" />
+          <GitBranch className="w-4 h-4 shrink-0" />
           {isBase ? (
             <span>
               Currently on <span className="font-medium text-foreground">{branchName}</span>
@@ -52,17 +81,9 @@ export function SystemInfoCard({ setupInfo, className }: SystemInfoCardProps) {
             </span>
           )}
         </div>
-        {isBase && (
-          <div className="flex items-center gap-2 text-amber-600 dark:text-amber-500">
-            <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
-            <span>
-              Changes are made directly to your repository. Use a worktree session for development.
-            </span>
-          </div>
-        )}
         {!isBase && fileCount !== undefined && (
           <div className="flex items-center gap-2">
-            <FolderGit2 className="w-3.5 h-3.5 shrink-0" />
+            <FolderGit2 className="w-4 h-4 shrink-0" />
             <span>
               Created <span className="font-medium text-foreground">{sessionName}</span> with{' '}
               <span className="font-medium text-foreground">{fileCount.toLocaleString()}</span> files
@@ -70,6 +91,16 @@ export function SystemInfoCard({ setupInfo, className }: SystemInfoCardProps) {
           </div>
         )}
       </div>
+
+      {/* Warning block (base only) */}
+      {isBase && (
+        <div className="flex items-center gap-2 mt-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          <span>
+            Changes are made directly to your repository. Use a worktree session for development.
+          </span>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Redesigned SystemInfoCard with a structured header featuring type-specific icons (Server for base, GitFork for worktree) and a colored Base/Worktree badge
- Added a visual divider between header and info rows
- Moved the base session warning into a styled amber block at the bottom for better visual hierarchy

## Test plan
- [ ] Verify base session card renders with Server icon, "Base" badge, and amber warning
- [ ] Verify worktree session card renders with GitFork icon, "Worktree" badge, and file count
- [ ] Check dark mode rendering for both card variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)