### PR TITLE
feat: replace base session row with info card showing git status

### DIFF
--- a/src/components/navigation/BaseSessionCard.tsx
+++ b/src/components/navigation/BaseSessionCard.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  FolderGit2,
+  GitBranch,
+  GitPullRequest,
+  MessageCircleQuestion,
+  ClipboardCheck,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
+import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
+import { SessionHoverCardBody } from '@/components/shared/SessionHoverCard';
+import { useSessionActivityState, useIsSessionUnread } from '@/stores/selectors';
+import { useAppStore } from '@/stores/appStore';
+import { useBaseSessionGitStatus } from '@/hooks/useBaseSessionGitStatus';
+import { dispatchAppEvent } from '@/lib/custom-events';
+import type { WorktreeSession } from '@/lib/types';
+import type { ContentView } from '@/stores/settingsStore';
+
+interface BaseSessionCardProps {
+  session: WorktreeSession;
+  contentView: ContentView;
+  selectedSessionId: string | null;
+  onSelectSession: (sessionId: string, event?: React.MouseEvent) => void;
+  onOpenBranches?: (event?: React.MouseEvent) => void;
+  onOpenPRs?: (event?: React.MouseEvent) => void;
+  formatTimeAgo: (date: string) => string;
+}
+
+export function BaseSessionCard({
+  session,
+  contentView,
+  selectedSessionId,
+  onSelectSession,
+  onOpenBranches,
+  onOpenPRs,
+  formatTimeAgo,
+}: BaseSessionCardProps) {
+  const isSessionSelected = contentView.type === 'conversation' && selectedSessionId === session.id;
+  const sessionId = session.id;
+  const activityState = useSessionActivityState(sessionId);
+  const isSessionUnread = useIsSessionUnread(sessionId);
+  const lastAgentCompletedAt = useAppStore((s) => s.lastTurnCompletedAt[sessionId]);
+  const [hoverOpen, setHoverOpen] = useState(false);
+
+  const { gitStatus, loading } = useBaseSessionGitStatus(
+    session.workspaceId,
+    sessionId,
+    true,
+  );
+
+  // Build status chips
+  const statusChips: { text: string; color: string }[] = [];
+  if (gitStatus) {
+    if (gitStatus.workingDirectory.hasChanges) {
+      const count = gitStatus.workingDirectory.totalUncommitted;
+      statusChips.push({
+        text: `${count} uncommitted`,
+        color: 'text-amber-500',
+      });
+    } else {
+      statusChips.push({ text: 'Clean', color: 'text-text-success' });
+    }
+
+    if (gitStatus.sync.aheadBy > 0) {
+      statusChips.push({
+        text: `${gitStatus.sync.aheadBy}\u2191`,
+        color: 'text-muted-foreground',
+      });
+    }
+    if (gitStatus.sync.behindBy > 0) {
+      statusChips.push({
+        text: `${gitStatus.sync.behindBy}\u2193`,
+        color: 'text-muted-foreground',
+      });
+    }
+  }
+
+  // Activity icon overlay
+  const activityIcon =
+    activityState === 'working' ? (
+      <div className="session-active-indicator">
+        <div className="bar" />
+        <div className="bar" />
+        <div className="bar" />
+      </div>
+    ) : activityState === 'awaiting_input' ? (
+      <MessageCircleQuestion className="w-3.5 h-3.5 text-purple-500" />
+    ) : activityState === 'awaiting_approval' ? (
+      <ClipboardCheck className="w-3.5 h-3.5 text-blue-500" />
+    ) : (
+      <FolderGit2 className="w-4 h-4 text-blue-500" />
+    );
+
+  return (
+    <ContextMenu onOpenChange={(open) => { if (open) setHoverOpen(false); }}>
+      <ContextMenuTrigger asChild>
+        <HoverCard openDelay={500} closeDelay={100} open={hoverOpen} onOpenChange={setHoverOpen}>
+          <HoverCardTrigger asChild>
+            <div
+              className={cn(
+                'group relative flex flex-col gap-1 rounded-lg border px-2.5 py-2 my-0.5 cursor-pointer transition-colors',
+                isSessionSelected
+                  ? 'bg-surface-2 border-border/60 hover:bg-surface-3'
+                  : 'bg-surface-0 border-border/40 hover:bg-surface-1',
+              )}
+              onClick={(e) => onSelectSession(session.id, e)}
+            >
+              {/* Unread indicator */}
+              {isSessionUnread && !isSessionSelected && (
+                <div className="absolute left-0.5 top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full bg-brand" />
+              )}
+
+              {/* Row 1: Icon + branch name + Base badge */}
+              <div className="flex items-center gap-1.5">
+                <div className="w-4 shrink-0 flex items-center justify-center">
+                  {activityIcon}
+                </div>
+                <span className={cn(
+                  'text-base truncate flex-1 min-w-0',
+                  isSessionSelected ? 'text-foreground font-medium' : 'text-foreground/80 font-medium',
+                )}>
+                  {session.branch || session.name}
+                </span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500 font-medium shrink-0">
+                  Base
+                </span>
+              </div>
+
+              {/* Row 2: Git status chips */}
+              <div className="flex items-center gap-1 pl-[22px] text-xs text-muted-foreground">
+                {loading ? (
+                  <div className="w-24 h-3 rounded bg-muted animate-pulse" />
+                ) : (
+                  <>
+                    {statusChips.map((chip, i) => (
+                      <span key={i} className="flex items-center gap-1">
+                        {i > 0 && <span className="text-muted-foreground/40">&middot;</span>}
+                        <span className={chip.color}>{chip.text}</span>
+                      </span>
+                    ))}
+                    {statusChips.length > 0 && (
+                      <span className="text-muted-foreground/40">&middot;</span>
+                    )}
+                    <span className="shrink-0">
+                      {formatTimeAgo(
+                        lastAgentCompletedAt !== undefined && lastAgentCompletedAt > new Date(session.updatedAt).getTime()
+                          ? new Date(lastAgentCompletedAt).toISOString()
+                          : session.updatedAt
+                      )}
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+          </HoverCardTrigger>
+          <HoverCardContent side="right" align="start" sideOffset={8} className="w-72 p-0">
+            <SessionHoverCardBody
+              session={session}
+              formatTimeAgo={formatTimeAgo}
+              lastAgentCompletedAt={lastAgentCompletedAt}
+              onCreatePR={() => {
+                setHoverOpen(false);
+                onSelectSession(session.id);
+                requestAnimationFrame(() => dispatchAppEvent('git-create-pr'));
+              }}
+            />
+          </HoverCardContent>
+        </HoverCard>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {onOpenBranches && (
+          <ContextMenuItem onClick={() => onOpenBranches()}>
+            <GitBranch className="h-4 w-4" />
+            Branches
+          </ContextMenuItem>
+        )}
+        {onOpenPRs && (
+          <ContextMenuItem onClick={() => onOpenPRs()}>
+            <GitPullRequest className="h-4 w-4" />
+            Pull Requests
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -112,6 +112,7 @@ import { CardErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
 import { SessionHoverCardBody } from '@/components/shared/SessionHoverCard';
 import { dispatchAppEvent } from '@/lib/custom-events';
+import { BaseSessionCard } from '@/components/navigation/BaseSessionCard';
 
 interface WorkspaceSidebarProps {
   onOpenProject: () => void;
@@ -729,33 +730,25 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
               ) : (
                 <>
                   {/* Pinned: Base sessions always render at the top */}
-                  {pinnedSessions.map((session) => {
-                    const ws = workspaces.find((w) => w.id === session.workspaceId);
-                    return (
-                      <ErrorBoundary
-                        key={session.id}
-                        section="SessionRow"
-                        fallback={<CardErrorFallback message="Error loading session" />}
-                      >
-                        <SessionRow
-                          session={session}
-                          contentView={contentView}
-                          selectedSessionId={selectedSessionId}
-                          onSelectSession={(id, e) => handleSelectSession(session.workspaceId, id, e)}
-                          onArchiveSession={handleArchiveSession}
-                          onTaskStatusChange={handleTaskStatusChange}
-                          onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
-                          onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
-                          formatTimeAgo={formatTimeAgo}
-                          showProjectIndicator={sidebarGroupBy === 'none'}
-                          workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
-                          workspaceName={ws?.name}
-                        />
-                      </ErrorBoundary>
-                    );
-                  })}
+                  {pinnedSessions.map((session) => (
+                    <ErrorBoundary
+                      key={session.id}
+                      section="BaseSessionCard"
+                      fallback={<CardErrorFallback message="Error loading session" />}
+                    >
+                      <BaseSessionCard
+                        session={session}
+                        contentView={contentView}
+                        selectedSessionId={selectedSessionId}
+                        onSelectSession={(id, e) => handleSelectSession(session.workspaceId, id, e)}
+                        onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
+                        onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
+                        formatTimeAgo={formatTimeAgo}
+                      />
+                    </ErrorBoundary>
+                  ))}
                   {pinnedSessions.length > 0 && (flatSessions.length > 0 || sidebarGroups.length > 0) && (
-                    <div className="mx-2 my-1 border-t border-border/40" />
+                    <div className="mx-2 my-1.5 border-t border-border/40" />
                   )}
 
                   {/* Mode: None — flat session list */}
@@ -1348,16 +1341,14 @@ function SortableWorkspaceItem({
             {baseSessions?.map((session) => (
               <ErrorBoundary
                 key={session.id}
-                section="SessionRow"
+                section="BaseSessionCard"
                 fallback={<CardErrorFallback message="Error loading session" />}
               >
-                <SessionRow
+                <BaseSessionCard
                   session={session}
                   contentView={contentView}
                   selectedSessionId={selectedSessionId}
                   onSelectSession={onSelectSession}
-                  onArchiveSession={onArchiveSession}
-                  onTaskStatusChange={onTaskStatusChange}
                   onOpenBranches={onOpenBranches}
                   onOpenPRs={onOpenPRs}
                   formatTimeAgo={formatTimeAgo}
@@ -1365,7 +1356,7 @@ function SortableWorkspaceItem({
               </ErrorBoundary>
             ))}
             {baseSessions && baseSessions.length > 0 && sessions.length > 0 && (
-              <div className="my-1 mx-2 border-t border-border/40" />
+              <div className="my-1.5 mx-2 border-t border-border/40" />
             )}
             {/* Worktree sessions */}
             {sessions.length === 0 && (!baseSessions || baseSessions.length === 0) ? (
@@ -1961,16 +1952,14 @@ function SortableProjectStatusItem({
                 {group.baseSessions?.map((session) => (
                   <ErrorBoundary
                     key={session.id}
-                    section="SessionRow"
+                    section="BaseSessionCard"
                     fallback={<CardErrorFallback message="Error loading session" />}
                   >
-                    <SessionRow
+                    <BaseSessionCard
                       session={session}
                       contentView={contentView}
                       selectedSessionId={selectedSessionId}
                       onSelectSession={onSelectSession}
-                      onArchiveSession={onArchiveSession}
-                      onTaskStatusChange={onTaskStatusChange}
                       onOpenBranches={onOpenBranches}
                       onOpenPRs={onOpenPRs}
                       formatTimeAgo={formatTimeAgo}
@@ -1979,7 +1968,7 @@ function SortableProjectStatusItem({
                 ))}
                 {group.baseSessions && group.baseSessions.length > 0 &&
                   group.subGroups && group.subGroups.length > 0 && (
-                  <div className="my-1 mx-2 border-t border-border/40" />
+                  <div className="my-1.5 mx-2 border-t border-border/40" />
                 )}
                 {(!group.subGroups || group.subGroups.length === 0) &&
                  (!group.baseSessions || group.baseSessions.length === 0) ? (

--- a/src/hooks/useBaseSessionGitStatus.ts
+++ b/src/hooks/useBaseSessionGitStatus.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { getGitStatus, type GitStatusDTO, ApiError } from '@/lib/api';
+import { useAppStore } from '@/stores/appStore';
+import { GIT_STATUS_POLL_INTERVAL_MS } from '@/lib/constants';
+
+export interface UseBaseSessionGitStatusResult {
+  gitStatus: GitStatusDTO | null;
+  loading: boolean;
+}
+
+/**
+ * Lightweight git status hook for base session cards in the sidebar.
+ * Calls getGitStatus (not the full snapshot) and polls at 2x the normal interval.
+ */
+export function useBaseSessionGitStatus(
+  workspaceId: string | null,
+  sessionId: string | null,
+  active: boolean = true,
+): UseBaseSessionGitStatusResult {
+  const [gitStatus, setGitStatus] = useState<GitStatusDTO | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const lastFileChange = useAppStore((s) => s.lastFileChange);
+
+  const isMountedRef = useRef(false);
+  const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    if (!workspaceId || !sessionId) {
+      setGitStatus(null);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const status = await getGitStatus(workspaceId, sessionId);
+      if (isMountedRef.current) {
+        setGitStatus(status);
+        setLoading(false);
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        const isTransientNetwork = err instanceof ApiError && err.status === 0;
+        if (!isTransientNetwork) {
+          console.error('Failed to fetch base session git status:', err);
+        }
+        setLoading(false);
+      }
+    }
+  }, [workspaceId, sessionId]);
+
+  const debouncedRefetch = useCallback(() => {
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
+    }
+    debounceTimeoutRef.current = setTimeout(() => {
+      fetchStatus();
+    }, 500);
+  }, [fetchStatus]);
+
+  // Initial fetch
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    if (active) {
+      const id = setTimeout(() => fetchStatus(), 0);
+      return () => {
+        isMountedRef.current = false;
+        clearTimeout(id);
+        if (debounceTimeoutRef.current) {
+          clearTimeout(debounceTimeoutRef.current);
+        }
+      };
+    }
+
+    return () => {
+      isMountedRef.current = false;
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, [fetchStatus, active]);
+
+  // Periodic polling at 2x normal interval
+  useEffect(() => {
+    if (!active || !workspaceId || !sessionId) return;
+
+    const interval = setInterval(() => {
+      fetchStatus();
+    }, GIT_STATUS_POLL_INTERVAL_MS * 2);
+
+    return () => clearInterval(interval);
+  }, [active, workspaceId, sessionId, fetchStatus]);
+
+  // React to file change events
+  useEffect(() => {
+    if (!active || !workspaceId || !lastFileChange) return;
+    if (lastFileChange.workspaceId === workspaceId) {
+      debouncedRefetch();
+    }
+  }, [active, lastFileChange, workspaceId, debouncedRefetch]);
+
+  return { gitStatus, loading };
+}


### PR DESCRIPTION
## Summary
- Replace the plain base session row in the sidebar with a visually distinct info card
- Add `useBaseSessionGitStatus` hook that polls `getGitStatus()` every 60s and reacts to file change events
- Add `BaseSessionCard` component with card styling, "Base" badge, clean/dirty status, ahead/behind counts, and last activity time
- Swap `SessionRow` → `BaseSessionCard` at all 3 base-session render sites (pinned, project, project-status modes)

## Test plan
- [ ] Open sidebar with a workspace that has a base session — verify the card renders with branch name, "Base" badge, and git status
- [ ] Verify loading skeleton appears briefly then resolves to status chips
- [ ] Make a file change in the repo — verify status updates from "Clean" to "N uncommitted"
- [ ] Check all grouping modes (none/status, project, project-status) render the card correctly
- [ ] Hover over card — verify `SessionHoverCardBody` still appears
- [ ] Right-click — verify context menu shows Branches/PRs but NOT archive/status

🤖 Generated with [Claude Code](https://claude.com/claude-code)