### PR TITLE
feat: add faint blue background to base session card

### DIFF
--- a/src/components/navigation/BaseSessionCard.tsx
+++ b/src/components/navigation/BaseSessionCard.tsx
@@ -108,8 +108,8 @@ export function BaseSessionCard({
               className={cn(
                 'group relative flex flex-col gap-1 rounded-lg border px-2.5 py-2 my-0.5 cursor-pointer transition-colors',
                 isSessionSelected
-                  ? 'bg-surface-2 border-border/60 hover:bg-surface-3'
-                  : 'bg-surface-0 border-border/40 hover:bg-surface-1',
+                  ? 'bg-blue-500/10 border-blue-500/20 hover:bg-blue-500/15'
+                  : 'bg-blue-500/[0.04] border-blue-500/10 hover:bg-blue-500/[0.07]',
               )}
               onClick={(e) => onSelectSession(session.id, e)}
             >


### PR DESCRIPTION
## Summary
- Adds a subtle blue background tint to the base session card so it visually stands out from worktree sessions in the sidebar
- Unselected state uses ~4% blue opacity, hover ~7%, selected ~10% — complementing the existing blue "Base" badge

## Test plan
- [ ] Open sidebar with a workspace containing a base session
- [ ] Verify the base session card has a faint blue background distinguishing it from worktree sessions
- [ ] Hover and select the card to confirm the blue intensifies appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)