### PR TITLE
feat: move base session git status to hover popover

### DIFF
--- a/src/components/navigation/BaseSessionCard.tsx
+++ b/src/components/navigation/BaseSessionCard.tsx
@@ -56,33 +56,6 @@ export function BaseSessionCard({
     true,
   );
 
-  // Build status chips
-  const statusChips: { text: string; color: string }[] = [];
-  if (gitStatus) {
-    if (gitStatus.workingDirectory.hasChanges) {
-      const count = gitStatus.workingDirectory.totalUncommitted;
-      statusChips.push({
-        text: `${count} uncommitted`,
-        color: 'text-amber-500',
-      });
-    } else {
-      statusChips.push({ text: 'Clean', color: 'text-text-success' });
-    }
-
-    if (gitStatus.sync.aheadBy > 0) {
-      statusChips.push({
-        text: `${gitStatus.sync.aheadBy}\u2191`,
-        color: 'text-muted-foreground',
-      });
-    }
-    if (gitStatus.sync.behindBy > 0) {
-      statusChips.push({
-        text: `${gitStatus.sync.behindBy}\u2193`,
-        color: 'text-muted-foreground',
-      });
-    }
-  }
-
   // Activity icon overlay
   const activityIcon =
     activityState === 'working' ? (
@@ -134,31 +107,6 @@ export function BaseSessionCard({
                 </span>
               </div>
 
-              {/* Row 2: Git status chips */}
-              <div className="flex items-center gap-1 pl-[22px] text-xs text-muted-foreground">
-                {loading ? (
-                  <div className="w-24 h-3 rounded bg-muted animate-pulse" />
-                ) : (
-                  <>
-                    {statusChips.map((chip, i) => (
-                      <span key={i} className="flex items-center gap-1">
-                        {i > 0 && <span className="text-muted-foreground/40">&middot;</span>}
-                        <span className={chip.color}>{chip.text}</span>
-                      </span>
-                    ))}
-                    {statusChips.length > 0 && (
-                      <span className="text-muted-foreground/40">&middot;</span>
-                    )}
-                    <span className="shrink-0">
-                      {formatTimeAgo(
-                        lastAgentCompletedAt !== undefined && lastAgentCompletedAt > new Date(session.updatedAt).getTime()
-                          ? new Date(lastAgentCompletedAt).toISOString()
-                          : session.updatedAt
-                      )}
-                    </span>
-                  </>
-                )}
-              </div>
             </div>
           </HoverCardTrigger>
           <HoverCardContent side="right" align="start" sideOffset={8} className="w-72 p-0">
@@ -166,6 +114,7 @@ export function BaseSessionCard({
               session={session}
               formatTimeAgo={formatTimeAgo}
               lastAgentCompletedAt={lastAgentCompletedAt}
+              gitStatus={{ data: gitStatus, loading }}
               onCreatePR={() => {
                 setHoverOpen(false);
                 onSelectSession(session.id);

--- a/src/components/shared/SessionHoverCard.tsx
+++ b/src/components/shared/SessionHoverCard.tsx
@@ -6,12 +6,14 @@ import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 import { getTaskStatusOption, getPRStatusInfo } from '@/lib/session-fields';
 import { PRNumberBadge } from '@/components/shared/PRNumberBadge';
 import type { WorktreeSession } from '@/lib/types';
+import type { GitStatusDTO } from '@/lib/api';
 
 interface SessionHoverCardBodyProps {
   session: WorktreeSession;
   formatTimeAgo: (date: string) => string;
   lastAgentCompletedAt?: number;
   onCreatePR?: () => void;
+  gitStatus?: { data: GitStatusDTO | null; loading: boolean };
 }
 
 export function SessionHoverCardBody({
@@ -19,6 +21,7 @@ export function SessionHoverCardBody({
   formatTimeAgo,
   lastAgentCompletedAt,
   onCreatePR,
+  gitStatus,
 }: SessionHoverCardBodyProps) {
   const hasStats = session.stats && (session.stats.additions > 0 || session.stats.deletions > 0);
   const hasPR = session.prStatus && session.prStatus !== 'none';
@@ -43,8 +46,35 @@ export function SessionHoverCardBody({
       </div>
 
       {/* Meta row: status + time */}
-      <div className="flex items-center gap-1.5 px-3 pb-2 text-xs text-muted-foreground">
-        {session.sessionType !== 'base' && (
+      <div className="flex items-center gap-1.5 px-3 pb-2 text-xs text-muted-foreground flex-wrap">
+        {session.sessionType === 'base' ? (
+          <>
+            {gitStatus?.loading ? (
+              <div className="w-20 h-3 rounded bg-muted animate-pulse" />
+            ) : gitStatus?.data ? (
+              <>
+                {gitStatus.data.workingDirectory.hasChanges ? (
+                  <span className="text-amber-500">{gitStatus.data.workingDirectory.totalUncommitted} uncommitted</span>
+                ) : (
+                  <span className="text-text-success">Clean</span>
+                )}
+                {gitStatus.data.sync.aheadBy > 0 && (
+                  <>
+                    <span className="text-muted-foreground/40">&middot;</span>
+                    <span>{gitStatus.data.sync.aheadBy}&uarr;</span>
+                  </>
+                )}
+                {gitStatus.data.sync.behindBy > 0 && (
+                  <>
+                    <span className="text-muted-foreground/40">&middot;</span>
+                    <span>{gitStatus.data.sync.behindBy}&darr;</span>
+                  </>
+                )}
+                <span className="text-muted-foreground/40">&middot;</span>
+              </>
+            ) : null}
+          </>
+        ) : (
           <>
             <TaskStatusIcon status={session.taskStatus} className="h-3 w-3 shrink-0" />
             <span className="shrink-0">{statusOption.label}</span>


### PR DESCRIPTION
## Summary
- Remove the second row (git status chips) from the BaseSessionCard sidebar cell for a more compact layout
- Display git status info (clean/uncommitted, ahead/behind) in the hover popover instead
- Pass `gitStatus` data from the existing hook through to `SessionHoverCardBody`

## Test plan
- [ ] Hover over base session card — popover shows git status chips (Clean/uncommitted, ahead/behind arrows, time ago)
- [ ] Base session card shows only one row (icon + branch name + "Base" badge)
- [ ] Non-base session hover cards are unchanged
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)