### PR TITLE
fix: prevent detached HEAD from corrupting session branch names

### DIFF
--- a/backend/branch/watcher.go
+++ b/backend/branch/watcher.go
@@ -90,16 +90,41 @@ func (w *Watcher) WatchSession(sessionID, worktreePath, currentBranch string) er
 		return fmt.Errorf("failed to watch gitdir %s: %w", gitDir, err)
 	}
 
+	// If the stored branch looks like a stale detached-HEAD artifact,
+	// re-read the actual branch from HEAD. This self-heals sessions that
+	// had their branch corrupted by a transient detached state (e.g., rebase).
+	initialBranch := currentBranch
+	if strings.Contains(currentBranch, "(detached)") || currentBranch == "HEAD" {
+		if actual, err := readCurrentBranch(headPath); err == nil && actual != "" {
+			initialBranch = actual
+		}
+	}
+
 	w.sessions[sessionID] = &WatchEntry{
 		SessionID:    sessionID,
 		WorktreePath: worktreePath,
 		GitDir:       gitDir,
 		HeadPath:     headPath,
 		IndexPath:    filepath.Join(gitDir, "index"),
-		LastBranch:   currentBranch,
+		LastBranch:   initialBranch,
 	}
 
 	logger.BranchWatcher.Infof("Started watching session %s at %s", sessionID, headPath)
+
+	// Emit a correction event if we healed a stale detached branch
+	if initialBranch != currentBranch && initialBranch != "" {
+		onChange := w.onChange
+		w.mu.Unlock()
+		if onChange != nil {
+			onChange(BranchChangeEvent{
+				SessionID: sessionID,
+				OldBranch: currentBranch,
+				NewBranch: initialBranch,
+			})
+		}
+		w.mu.Lock()
+	}
+
 	return nil
 }
 
@@ -287,10 +312,8 @@ func readCurrentBranch(headPath string) (string, error) {
 		return strings.TrimPrefix(content, "ref: refs/heads/"), nil
 	}
 
-	// Detached HEAD state - return the commit SHA (first 8 chars)
-	if len(content) >= 8 {
-		return content[:8] + " (detached)", nil
-	}
-
-	return content, nil
+	// Detached HEAD state — return empty string so the watcher skips
+	// the event. Transient detached states (e.g., during rebase) should
+	// not overwrite the session's branch name.
+	return "", nil
 }

--- a/backend/branch/watcher_test.go
+++ b/backend/branch/watcher_test.go
@@ -132,9 +132,9 @@ func TestReadCurrentBranch_DetachedHead(t *testing.T) {
 		t.Fatalf("readCurrentBranch failed: %v", err)
 	}
 
-	expected := "abc123de (detached)"
-	if branch != expected {
-		t.Errorf("readCurrentBranch = %q, want %q", branch, expected)
+	// Detached HEAD should return empty string so watcher skips the event
+	if branch != "" {
+		t.Errorf("readCurrentBranch = %q, want empty string for detached HEAD", branch)
 	}
 }
 
@@ -483,7 +483,8 @@ func TestReadCurrentBranch_ShortSHA(t *testing.T) {
 
 	branch, err := readCurrentBranch(headPath)
 	require.NoError(t, err)
-	require.Equal(t, "abc123", branch)
+	// Short SHA is still a detached HEAD — should return empty string
+	require.Equal(t, "", branch)
 }
 
 func TestReadCurrentBranch_FileNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary
- Branch watcher no longer persists transient detached HEAD states (e.g., during rebase) as the session's branch name
- `readCurrentBranch` returns empty string for detached HEAD, causing the watcher to skip the event
- `WatchSession` self-heals stale `(detached)` branch names on startup by re-reading actual HEAD and emitting a correction event

## Test plan
- [ ] Trigger a rebase on a worktree session — verify branch name does not change to `sha (detached)`
- [ ] Restart the app with a session that has a stale `(detached)` branch — verify it self-heals to the correct branch
- [ ] Run `go test ./branch/...` — all tests pass

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)