### PR TITLE
fix: preserve dictated text across speech segments after pause

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -262,6 +262,11 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
       plateInputRef.current?.setText(combined);
       setMessage(combined);
       settingFromTranscriptRef.current = false;
+      // When a segment finalizes (pause detected), accumulate the combined text
+      // so the next speech segment appends to it instead of replacing it.
+      if (isFinal) {
+        preDictationTextRef.current = combined;
+      }
     },
     onError: (msg) => showError(msg),
   });


### PR DESCRIPTION
## Summary
- Fixes speech dictation dropping previously spoken text when the user pauses and continues speaking
- When `SFSpeechRecognizer` finalizes a segment (on pause), updates `preDictationTextRef` with the accumulated text so subsequent segments append correctly

## Root Cause
`preDictationTextRef` was only set once when dictation started. After a pause, Apple's speech recognizer finalizes the current segment and starts a new one whose transcript only contains the new speech. Since `preDictationTextRef` still pointed to the original pre-dictation text, the new segment's text replaced everything instead of appending.

## Test plan
- [ ] Start dictation, speak a phrase, pause for 3-5 seconds, then continue speaking
- [ ] Verify the new speech appends to the previous text (not replaces it)
- [ ] Verify text typed before starting dictation is preserved throughout
- [ ] Verify single continuous speech (no pause) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)