### PR TITLE
release: v0.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatml",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@10.30.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "chatml"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "argon2",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chatml"
-version = "0.1.16"
+version = "0.1.17"
 description = "ChatML"
 authors = ["you"]
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "chatml",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "identifier": "com.chatml.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## What's Changed

### Features
- redesign welcome screen with centered layout and review fixes (#1110)
- move base session git status from card to hover popover (#1107) (#1107)
- polish quick actions grid with styled icon cards (#1106)
- add faint blue background to base session card for visual distinction (#1105)
- replace base session row with info card showing git status (#1104)
- polish SystemInfoCard with icon header, badge, and styled warning (#1103)
- add clear PR/issue linking with suppression and multi-entry-point UI (#1102)
- add sessionType to SetupInfo for base vs worktree session cards (#1099)
- unify sessions list and polish Home page layout (#1097)
- live HTML preview for code blocks (#1094)
- redesign Home page with polished UI and better visual hierarchy (#1091) (#1092)
- add base session type for direct repo operations (#1091)
- handle SDK 0.2.72+ event types with elicitation, prompt suggestions, and tool summaries (#1090)
- show last agent completion timestamp in session hover card (#1082)
- improve popover PR title prominence and deduplicate PR status logic (#1081)
- remove timestamp from session cell, add sidebar meta toggle (#1077)
- show PR title with badge in session hover card popover (#1074)
- add dedicated sprint phases toolbar (#1070)
- add OS-specific speech-to-text dictation (#1067)
- add tool approval system for non-bypass permission modes (#1066)
- cloud relay for mobile remote control (#1061)
- add hover card to session rows in workspace sidebar (#1059)
- integrate gstack skill packs and sprint phase workflow (#1057)

### Fixes
- restore conversation pane content after tab close and visibility toggle (#1114)
- auto-restart speech recognition on pause to preserve text (#1113)
- use effective permission mode in plan mode for tool approval (#1112)
- preserve dictated text across speech segments after pause (#1111)
- prevent detached HEAD from corrupting session branch names (#1108)
- hoist base session above status groups in sidebar hierarchy (#1101)
- remove colored labels from permission mode dropdown (#1100)
- nest base sessions under their workspace in grouped sidebar modes (#1098)
- clear stale PR data on branch switch and improve base session UX (#1095)
- move session_type index to migrations to fix existing DB startup (#1093)
- prevent message pane z-index from blocking input area clicks (#1089)
- prevent speech recognition teardown from clearing dictated text (#1088)
- prevent tool approval UI from disappearing prematurely (#1087)
- centralize backend URL resolution with port-file discovery for external MCP (#1086)
- sort model dropdowns as Opus → Sonnet → Haiku (#1085)
- harden CI failure detection robustness (#1080)
- harden agent instructions against cross-worktree writes and main branch commits (#1079)
- harden permission mode runtime changes with validation and rollback (#1076)
- accept absolute paths in session file content API (#1075)
- guard editor focus and document focusEditor override in slash command
- resolve OAuth login failure and editor stability issues (#1072)
- always show permission mode shield and auto-approve chatml tools (#1071)
- improve dictation toggle robustness and shortcut hint (#1069)
- use chatml-dev:// OAuth redirect URI in dev builds (#1068)
- remove AUTO_MODEL_ID, deduplicate models, and fix context meter (#1065)
- clean up orphaned mermaid error elements from DOM (#1062)
- remove redundant "Clean Up Branches" button from Branches dashboard (#1060)
- always show scroll-to-bottom pill when scrolled away from bottom (#1058)
- route CMD+V paste to PTY when terminal is focused (#1056)

### Other
- revise CLAUDE.md for clarity and completeness (#1109)
- optimize git command hot paths with cached file I/O (#1096)
- consolidate session git calls into single /snapshot endpoint (#1084)
- improve speech listening bar UX and fix spurious errors (#1083)
- cache app icons and PATH resolution in AppState (#1078)
- add unit tests for lib utilities and zustand stores (#1064)