### PR TITLE
feat: redesign model selector UI with descriptions and canonical catalog

### DIFF
--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -25,7 +25,7 @@ import { LinearIssuePicker } from './LinearIssuePicker';
 import { WorkspacePicker } from './WorkspacePicker';
 import type { LinearIssueDTO } from '@/lib/api';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
-import { MODELS as SHARED_MODELS, type ModelEntry, toShortDisplayName, isNewModel, isDefaultRecommended, deduplicateById, deduplicateByName, sortModelEntries } from '@/lib/models';
+import { MODELS as SHARED_MODELS, type ModelEntry, toShortDisplayName, getModelDescription, isDefaultRecommended, deduplicateById, deduplicateByName, sortModelEntries } from '@/lib/models';
 import type { MentionItem } from '@/components/ui/mention-node';
 import { trackEvent } from '@/lib/telemetry';
 import { playSound } from '@/lib/sounds';
@@ -109,6 +109,7 @@ function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = ''): FlatFil
 const STATIC_MODELS: ModelEntry[] = SHARED_MODELS.map((m) => ({
   id: m.id,
   name: m.name,
+  description: m.description,
   icon: Sparkles,
   supportsThinking: m.supportsThinking,
   supportsEffort: m.supportsEffort,
@@ -125,12 +126,12 @@ function buildModelList(dynamic: ReturnType<typeof useAppStore.getState>['suppor
       .map((m) => ({
         id: m.value,
         name: toShortDisplayName(m.value, m.displayName),
+        description: getModelDescription(m.value),
         icon: Sparkles,
         supportsThinking: m.supportsAdaptiveThinking ?? true,
         supportsEffort: m.supportsEffort ?? false,
         supportedEffortLevels: m.supportedEffortLevels,
         supportsFastMode: m.supportsFastMode,
-        isNew: isNewModel(m.value),
       }))
   );
   // Also deduplicate by display name — SDK may report dated variants

--- a/src/components/conversation/ChatInputToolbar.tsx
+++ b/src/components/conversation/ChatInputToolbar.tsx
@@ -144,19 +144,18 @@ export function ChatInputToolbar({
             return (
               <DropdownMenuItem
                 key={m.id}
-                className="group flex items-center gap-2 pr-1.5"
+                className="group flex items-start gap-2 pr-1.5 py-2"
                 onClick={() => model.setSelected(m)}
               >
-                <span className="flex flex-1 items-center gap-1.5 min-w-0">
-                  <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
-                  <span className="truncate">{m.name}</span>
-                  {m.isNew && (
-                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted font-medium leading-none">
-                      NEW
+                <span className="flex flex-1 flex-col min-w-0">
+                  <span className="truncate font-medium">{m.name}</span>
+                  {m.description && (
+                    <span className="text-xs text-muted-foreground leading-tight">
+                      {m.description}
                     </span>
                   )}
                 </span>
-                <span className="ml-auto flex shrink-0 items-center gap-1">
+                <span className="mt-0.5 flex shrink-0 items-center gap-1">
                   {isSelected && <Check className="h-3.5 w-3.5" />}
                   {isDefault ? (
                     <Star className="h-3 w-3 fill-current text-amber-500" />

--- a/src/components/settings/sections/AIModelSettings.tsx
+++ b/src/components/settings/sections/AIModelSettings.tsx
@@ -13,7 +13,7 @@ import {
 import { Eye, EyeOff } from 'lucide-react';
 import { useSettingsStore, SETTINGS_DEFAULTS } from '@/stores/settingsStore';
 import { useAppStore } from '@/stores/appStore';
-import { MODELS as SHARED_MODELS, toShortDisplayName, isDefaultRecommended, deduplicateById, deduplicateByName, sortModelEntries } from '@/lib/models';
+import { MODELS as SHARED_MODELS, toShortDisplayName, getModelDescription, isDefaultRecommended, deduplicateById, deduplicateByName, sortModelEntries } from '@/lib/models';
 import type { ThinkingLevel } from '@/lib/thinkingLevels';
 import { getAnthropicApiKey, setAnthropicApiKey } from '@/lib/api';
 import { useToast } from '@/components/ui/toast';
@@ -38,11 +38,11 @@ export function AIModelSettings() {
   const dynamicModels = useAppStore((s) => s.supportedModels);
   const modelOptions = useMemo(() => {
     if (dynamicModels.length === 0) {
-      return SHARED_MODELS.map((m) => ({ id: m.id, name: m.name }));
+      return SHARED_MODELS.map((m) => ({ id: m.id, name: m.name, description: m.description }));
     }
     const entries = dynamicModels
       .filter((m) => !isDefaultRecommended(m.displayName))
-      .map((m) => ({ id: m.value, name: toShortDisplayName(m.value, m.displayName) }));
+      .map((m) => ({ id: m.value, name: toShortDisplayName(m.value, m.displayName), description: getModelDescription(m.value) }));
     return sortModelEntries(deduplicateByName(deduplicateById(entries)));
   }, [dynamicModels]);
 
@@ -59,12 +59,19 @@ export function AIModelSettings() {
           onReset={() => setDefaultModel(SETTINGS_DEFAULTS.defaultModel)}
         >
           <Select value={defaultModel} onValueChange={setDefaultModel}>
-            <SelectTrigger className="w-52" aria-label="Default model">
+            <SelectTrigger className="w-64" aria-label="Default model">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {modelOptions.map((m) => (
-                <SelectItem key={m.id} value={m.id}>{m.name}</SelectItem>
+                <SelectItem key={m.id} value={m.id} textValue={m.name}>
+                  <div className="flex flex-col">
+                    <span>{m.name}</span>
+                    {m.description && (
+                      <span className="text-xs text-muted-foreground">{m.description}</span>
+                    )}
+                  </div>
+                </SelectItem>
               ))}
             </SelectContent>
           </Select>
@@ -78,12 +85,19 @@ export function AIModelSettings() {
           onReset={() => setReviewModel(SETTINGS_DEFAULTS.reviewModel)}
         >
           <Select value={reviewModel} onValueChange={setReviewModel}>
-            <SelectTrigger className="w-52" aria-label="Review model">
+            <SelectTrigger className="w-64" aria-label="Review model">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {modelOptions.map((m) => (
-                <SelectItem key={m.id} value={m.id}>{m.name}</SelectItem>
+                <SelectItem key={m.id} value={m.id} textValue={m.name}>
+                  <div className="flex flex-col">
+                    <span>{m.name}</span>
+                    {m.description && (
+                      <span className="text-xs text-muted-foreground">{m.description}</span>
+                    )}
+                  </div>
+                </SelectItem>
               ))}
             </SelectContent>
           </Select>

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -9,11 +9,11 @@ vi.mock('@/stores/appStore', () => ({
   },
 }));
 
-const { getModelDisplayName, getModelInfo, buildTurnConfigLabel, MODELS, toShortDisplayName, isNewModel, isDefaultRecommended } = await import('../models');
+const { getModelDisplayName, getModelInfo, getModelDescription, buildTurnConfigLabel, MODELS, toShortDisplayName, isDefaultRecommended } = await import('../models');
 
 describe('getModelDisplayName', () => {
   it('returns short display name for known static models', () => {
-    expect(getModelDisplayName('claude-opus-4-6')).toBe('Opus 4.6');
+    expect(getModelDisplayName('claude-opus-4-6')).toBe('Opus 4.6 (1M context)');
     expect(getModelDisplayName('claude-sonnet-4-6')).toBe('Sonnet 4.6');
     expect(getModelDisplayName('claude-haiku-4-5-20251001')).toBe('Haiku 4.5');
   });
@@ -55,14 +55,14 @@ describe('getModelDisplayName', () => {
 });
 
 describe('toShortDisplayName', () => {
-  it('returns short name for known models', () => {
-    expect(toShortDisplayName('claude-opus-4-6', 'Claude Opus 4.6')).toBe('Opus 4.6');
+  it('returns canonical name for known models', () => {
+    expect(toShortDisplayName('claude-opus-4-6', 'Claude Opus 4.6')).toBe('Opus 4.6 (1M context)');
     expect(toShortDisplayName('claude-sonnet-4-6', 'Claude Sonnet 4.6')).toBe('Sonnet 4.6');
     expect(toShortDisplayName('claude-haiku-4-5-20251001', 'Claude Haiku 4.5')).toBe('Haiku 4.5');
   });
 
-  it('appends 1M for extended context models', () => {
-    expect(toShortDisplayName('claude-opus-4-6[1m]', 'Claude Opus 4.6 1M')).toBe('Opus 4.6 1M');
+  it('returns same canonical name for extended context variant', () => {
+    expect(toShortDisplayName('claude-opus-4-6[1m]', 'Claude Opus 4.6 1M')).toBe('Opus 4.6 (1M context)');
   });
 
   it('handles dated model variants', () => {
@@ -78,14 +78,19 @@ describe('toShortDisplayName', () => {
   });
 });
 
-describe('isNewModel', () => {
-  it('returns true for models in NEW_MODEL_IDS', () => {
-    expect(isNewModel('claude-opus-4-6[1m]')).toBe(true);
+describe('getModelDescription', () => {
+  it('returns description for known models', () => {
+    expect(getModelDescription('claude-opus-4-6')).toBe('Most capable for ambitious work');
+    expect(getModelDescription('claude-sonnet-4-6')).toBe('Most efficient for everyday tasks');
+    expect(getModelDescription('claude-haiku-4-5-20251001')).toBe('Fastest for quick answers');
   });
 
-  it('returns false for regular models', () => {
-    expect(isNewModel('claude-opus-4-6')).toBe(false);
-    expect(isNewModel('claude-sonnet-4-6')).toBe(false);
+  it('returns same description for extended context variant', () => {
+    expect(getModelDescription('claude-opus-4-6[1m]')).toBe('Most capable for ambitious work');
+  });
+
+  it('returns undefined for unknown models', () => {
+    expect(getModelDescription('custom-model')).toBeUndefined();
   });
 });
 
@@ -117,7 +122,8 @@ describe('getModelInfo', () => {
     const opus = getModelInfo('claude-opus-4-6');
     expect(opus).toBeDefined();
     expect(opus!.id).toBe('claude-opus-4-6');
-    expect(opus!.name).toBe('Opus 4.6');
+    expect(opus!.name).toBe('Opus 4.6 (1M context)');
+    expect(opus!.description).toBe('Most capable for ambitious work');
     expect(opus!.supportsThinking).toBe(true);
     expect(opus!.supportsEffort).toBe(true);
   });
@@ -188,7 +194,7 @@ describe('buildTurnConfigLabel', () => {
   });
 
   it('returns model display name only', () => {
-    expect(buildTurnConfigLabel({ model: 'claude-opus-4-6' })).toBe('Opus 4.6');
+    expect(buildTurnConfigLabel({ model: 'claude-opus-4-6' })).toBe('Opus 4.6 (1M context)');
   });
 
   it('returns effort only', () => {
@@ -206,7 +212,7 @@ describe('buildTurnConfigLabel', () => {
 
   it('combines all three parts', () => {
     const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', effort: 'high', permissionMode: 'plan' });
-    expect(label).toBe('Opus 4.6 \u00b7 high effort \u00b7 plan mode');
+    expect(label).toBe('Opus 4.6 (1M context) \u00b7 high effort \u00b7 plan mode');
   });
 
   it('handles Bedrock ARN in label', () => {
@@ -227,7 +233,7 @@ describe('buildTurnConfigLabel', () => {
 
   it('shows fast label when fastModeState is on', () => {
     const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', fastModeState: 'on' });
-    expect(label).toBe('Opus 4.6 \u00b7 fast');
+    expect(label).toBe('Opus 4.6 (1M context) \u00b7 fast');
   });
 
   it('shows cooldown label when fastModeState is cooldown', () => {
@@ -237,6 +243,6 @@ describe('buildTurnConfigLabel', () => {
 
   it('omits fast label when fastModeState is off', () => {
     const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', fastModeState: 'off' });
-    expect(label).toBe('Opus 4.6');
+    expect(label).toBe('Opus 4.6 (1M context)');
   });
 });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -2,48 +2,52 @@ import React from 'react';
 import { useAppStore } from '@/stores/appStore';
 
 // ---------------------------------------------------------------------------
-// Short name mapping
+// Canonical model catalog — single source of truth for display names & descriptions
 // ---------------------------------------------------------------------------
 
-/** Map known base model IDs → short display names (no "Claude" prefix). */
-const SHORT_NAME_MAP: Record<string, string> = {
-  'claude-opus-4-6': 'Opus 4.6',
-  'claude-sonnet-4-6': 'Sonnet 4.6',
-  'claude-haiku-4-5-20251001': 'Haiku 4.5',
-  'claude-haiku-4-5': 'Haiku 4.5',
+interface ModelCatalogEntry {
+  displayName: string;
+  description: string;
+}
+
+/** Canonical display names and descriptions, keyed by base model ID. */
+const MODEL_CATALOG: Record<string, ModelCatalogEntry> = {
+  'claude-opus-4-6':   { displayName: 'Opus 4.6 (1M context)', description: 'Most capable for ambitious work' },
+  'claude-sonnet-4-6': { displayName: 'Sonnet 4.6',            description: 'Most efficient for everyday tasks' },
+  'claude-haiku-4-5':  { displayName: 'Haiku 4.5',             description: 'Fastest for quick answers' },
 };
 
-/** Models that should show a "NEW" badge in the selector. */
-const NEW_MODEL_IDS = new Set(['claude-opus-4-6[1m]']);
+/**
+ * Normalize an SDK model value to a base ID for catalog lookup.
+ * Strips `[1m]` suffix and trailing date `-20YYMMDD`.
+ */
+function toBaseId(sdkValue: string): string {
+  return sdkValue.replace(/\[1m\]$/, '').replace(/-20\d{6}$/, '');
+}
+
+/** Look up the catalog entry for an SDK model value. */
+function catalogLookup(sdkValue: string): ModelCatalogEntry | undefined {
+  return MODEL_CATALOG[toBaseId(sdkValue)];
+}
+
+// ---------------------------------------------------------------------------
+// Display name & description helpers
+// ---------------------------------------------------------------------------
 
 /**
  * Convert an SDK model value + displayName to a short display name.
- *
- * Examples:
- *   ("claude-opus-4-6", "Claude Opus 4.6")        → "Opus 4.6"
- *   ("claude-opus-4-6[1m]", "Claude Opus 4.6 1M") → "Opus 4.6 1M"
- *   ("claude-sonnet-4-6-20260301", "Sonnet 4.6")   → "Sonnet 4.6"
- *   ("custom-model", "My Custom Model")             → "My Custom Model"
+ * Uses the canonical catalog first, falls back to stripping "Claude " prefix.
  */
 export function toShortDisplayName(sdkValue: string, sdkDisplayName: string): string {
-  const has1M = sdkValue.includes('[1m]');
-  // Strip [1m] suffix and any trailing date (e.g. -20260301) to find the base ID
-  const baseId = sdkValue.replace(/\[1m\]$/, '').replace(/-20\d{6}$/, '');
-
-  let name = SHORT_NAME_MAP[baseId];
-  if (!name) {
-    // Fallback: strip "Claude " prefix from SDK display name
-    name = sdkDisplayName.replace(/^Claude\s+/i, '');
-  }
-  if (has1M && !name.includes('1M')) {
-    name += ' 1M';
-  }
-  return name;
+  const entry = catalogLookup(sdkValue);
+  if (entry) return entry.displayName;
+  // Fallback for unknown models: strip "Claude " prefix
+  return sdkDisplayName.replace(/^Claude\s+/i, '');
 }
 
-/** Check whether a model should show the "NEW" badge. */
-export function isNewModel(sdkValue: string): boolean {
-  return NEW_MODEL_IDS.has(sdkValue);
+/** Get the canonical description for a model, or undefined for unknown models. */
+export function getModelDescription(sdkValue: string): string | undefined {
+  return catalogLookup(sdkValue)?.description;
 }
 
 /** Check whether an SDK entry is the "Default (recommended)" pseudo-model. */
@@ -55,10 +59,14 @@ export function isDefaultRecommended(sdkDisplayName: string): boolean {
 // Static fallback models (used before SDK connects)
 // ---------------------------------------------------------------------------
 
+// Note: Haiku uses a dated id ('claude-haiku-4-5-20251001') that differs from
+// its catalog key ('claude-haiku-4-5'). This is intentional — the SDK reports
+// the dated variant and stored user settings reference it. catalogLookup via
+// toBaseId handles the mapping transparently.
 export const MODELS = [
-  { id: 'claude-opus-4-6', name: 'Opus 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
-  { id: 'claude-sonnet-4-6', name: 'Sonnet 4.6', provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
-  { id: 'claude-haiku-4-5-20251001', name: 'Haiku 4.5', provider: 'claude', supportsThinking: true, supportsEffort: false, supportsFastMode: false },
+  { id: 'claude-opus-4-6', name: MODEL_CATALOG['claude-opus-4-6'].displayName, description: MODEL_CATALOG['claude-opus-4-6'].description, provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
+  { id: 'claude-sonnet-4-6', name: MODEL_CATALOG['claude-sonnet-4-6'].displayName, description: MODEL_CATALOG['claude-sonnet-4-6'].description, provider: 'claude', supportsThinking: true, supportsEffort: true, supportsFastMode: true },
+  { id: 'claude-haiku-4-5-20251001', name: MODEL_CATALOG['claude-haiku-4-5'].displayName, description: MODEL_CATALOG['claude-haiku-4-5'].description, provider: 'claude', supportsThinking: true, supportsEffort: false, supportsFastMode: false },
 ] as const;
 
 export type ModelId = (typeof MODELS)[number]['id'];
@@ -141,17 +149,18 @@ export function buildDeduplicatedModelIds(dynamic: SdkModelEntry[]): string[] {
 export interface ModelEntry {
   id: string;
   name: string;
+  description?: string;
   icon: React.ComponentType<{ className?: string }>;
   supportsThinking: boolean;
   supportsEffort: boolean;
   supportedEffortLevels?: ('low' | 'medium' | 'high' | 'max')[];
   supportsFastMode?: boolean;
-  isNew?: boolean;
 }
 
 export interface DynamicModelInfo {
   id: string;
   name: string;
+  description?: string;
   provider: string;
   supportsThinking: boolean;
   supportsEffort: boolean;
@@ -174,6 +183,7 @@ export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
     return {
       id: sdkModel.value,
       name: toShortDisplayName(sdkModel.value, sdkModel.displayName),
+      description: getModelDescription(sdkModel.value),
       provider: 'claude',
       supportsThinking: sdkModel.supportsAdaptiveThinking ?? true,
       supportsEffort: sdkModel.supportsEffort ?? false,
@@ -188,6 +198,7 @@ export function getModelInfo(modelId: string): DynamicModelInfo | undefined {
     return {
       id: staticModel.id,
       name: staticModel.name,
+      description: staticModel.description,
       provider: staticModel.provider,
       supportsThinking: staticModel.supportsThinking,
       supportsEffort: staticModel.supportsEffort,


### PR DESCRIPTION
## Summary

- Introduces `MODEL_CATALOG` as a single source of truth for model display names and descriptions, replacing the old `SHORT_NAME_MAP` + `NEW_MODEL_IDS` pattern
- Model selectors (toolbar dropdown + settings page) now show a two-line layout with name and description (e.g. "Most capable for ambitious work")
- Static `MODELS` array derives name/description from the catalog to prevent drift between sources
- Adds `textValue` prop to Radix `SelectItem` in settings to prevent description text from leaking into the closed trigger
- Removes `isNewModel` / `NEW` badge in favor of always-visible descriptions

## Changed files

- `src/lib/models.ts` — New `MODEL_CATALOG`, `toBaseId`, `catalogLookup`, `getModelDescription`; `MODELS` derives from catalog
- `src/components/conversation/ChatInput.tsx` — Passes `description` through to `ModelEntry`
- `src/components/conversation/ChatInputToolbar.tsx` — Two-line model dropdown layout, removed redundant wrapper span
- `src/components/settings/sections/AIModelSettings.tsx` — Two-line select items with `textValue` fix, wider triggers
- `src/lib/__tests__/models.test.ts` — Updated for new canonical names and added `getModelDescription` tests

## Test plan

- [ ] Verify model selector dropdown in chat toolbar shows name + description for each model
- [ ] Verify settings page model selects show name + description in dropdown, but only name in the closed trigger
- [ ] Verify Opus shows "Opus 4.6 (1M context)" everywhere (including turn config labels)
- [ ] Verify unknown/Bedrock models still display correctly with no description

🤖 Generated with [Claude Code](https://claude.com/claude-code)