### PR TITLE
fix: sidebar sessions empty when project filter is selected

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -188,7 +188,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
   }, [sidebarProjectFilter, workspaces, setSidebarProjectFilter]);
 
   // Sidebar grouping/sorting
-  const { groups: sidebarGroups, flatSessions } = useSidebarSessions({
+  const { groups: sidebarGroups, flatSessions, effectiveGroupBy } = useSidebarSessions({
     sessions,
     workspaces,
     groupBy: sidebarGroupBy,
@@ -781,7 +781,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
               ) : (
                 <>
                   {/* Mode: None — flat session list */}
-                  {sidebarGroupBy === 'none' && (
+                  {effectiveGroupBy === 'none' && (
                     <>
                       {flatSessions.length === 0 ? (
                         <div className="py-2 px-2 text-sm text-muted-foreground/70">
@@ -818,7 +818,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                   )}
 
                   {/* Mode: Status — status group headers with sessions */}
-                  {sidebarGroupBy === 'status' && (
+                  {effectiveGroupBy === 'status' && (
                     <>
                       {sidebarGroups.length === 0 ? (
                         <div className="py-2 px-2 text-sm text-muted-foreground/70">
@@ -849,7 +849,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                   )}
 
                   {/* Mode: Project — workspace headers with sessions (with DnD) */}
-                  {sidebarGroupBy === 'project' && (
+                  {effectiveGroupBy === 'project' && (
                     <DndContext
                       sensors={sensors}
                       collisionDetection={closestCenter}
@@ -898,7 +898,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                   )}
 
                   {/* Mode: Project > Status — workspace headers with status sub-groups */}
-                  {sidebarGroupBy === 'project-status' && (
+                  {effectiveGroupBy === 'project-status' && (
                     <DndContext
                       sensors={sensors}
                       collisionDetection={closestCenter}

--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -147,7 +147,7 @@ export function useSidebarSessions({
   projectFilter,
   workspaceColors,
   getWorkspaceColor: getDefaultColor,
-}: UseSidebarSessionsOptions): { groups: SidebarGroup[]; flatSessions: WorktreeSession[] } {
+}: UseSidebarSessionsOptions): { groups: SidebarGroup[]; flatSessions: WorktreeSession[]; effectiveGroupBy: SidebarGroupBy } {
   return useMemo(() => {
     // When filtering to a single project, pre-filter sessions and downgrade groupBy
     const effectiveSessions = projectFilter
@@ -163,6 +163,7 @@ export function useSidebarSessions({
       return {
         groups: [],
         flatSessions: sortSessions(filtered, sortBy),
+        effectiveGroupBy,
       };
     }
 
@@ -170,6 +171,7 @@ export function useSidebarSessions({
       return {
         groups: buildStatusGroups(filtered, sortBy),
         flatSessions: [],
+        effectiveGroupBy,
       };
     }
 
@@ -201,7 +203,7 @@ export function useSidebarSessions({
           sessions: sortSessions(regular, sortBy),
         });
       }
-      return { groups, flatSessions: [] };
+      return { groups, flatSessions: [], effectiveGroupBy };
     }
 
     // project-status
@@ -227,10 +229,10 @@ export function useSidebarSessions({
           subGroups,
         });
       }
-      return { groups, flatSessions: [] };
+      return { groups, flatSessions: [], effectiveGroupBy };
     }
 
-    return { groups: [], flatSessions: [] };
+    return { groups: [], flatSessions: [], effectiveGroupBy };
   }, [sessions, workspaces, groupBy, sortBy, filters, projectFilter, workspaceColors, getDefaultColor]);
 }
 


### PR DESCRIPTION
## Summary
- Fixed sidebar showing no sessions when a specific project is selected from the filter dropdown
- Root cause: rendering conditionals used the raw `sidebarGroupBy` value, but `useSidebarSessions` downgrades it when a project filter is active (e.g. `project-status` → `status`), causing a mismatch where no rendering branch matched the returned data shape
- `useSidebarSessions` now returns `effectiveGroupBy` and the sidebar uses it for rendering conditionals

## Test plan
- [ ] Select "All Projects" in sidebar dropdown → sessions render grouped by project/status as before
- [ ] Select a specific project (e.g., "chatml") → sessions for that project render correctly
- [ ] With project filter active, toggle group-by settings → verify they still work
- [ ] Clear project filter back to "All Projects" → returns to full view

🤖 Generated with [Claude Code](https://claude.com/claude-code)