### PR TITLE
fix: show scroll-to-bottom pill whenever not at bottom

### DIFF
--- a/src/components/conversation/ConversationMessagePane.tsx
+++ b/src/components/conversation/ConversationMessagePane.tsx
@@ -397,8 +397,11 @@ export function ConversationMessagePane({
       const handleScroll = () => {
         const threshold = isStreamingRef.current ? 200 : 50;
         const atBottom = scrollerEl.scrollHeight - scrollerEl.scrollTop - scrollerEl.clientHeight <= threshold;
-        // Only override to show the pill; let Virtuoso handle the "returned to bottom" case
-        if (!atBottom && isAtBottomRef.current) {
+        // Only override to show the pill; let Virtuoso handle the "returned to bottom" case.
+        // No guard on isAtBottomRef — the pill must show whenever we're not at
+        // bottom, even if the ref was already false (e.g. atBottomStateChange
+        // fired while the pane was inactive, setting the ref but not the state).
+        if (!atBottom) {
           isAtBottomRef.current = false;
           setShowScrollButton(true);
         }


### PR DESCRIPTION
## Summary
- Fixes the "Scroll to bottom" pill not appearing until the user visits the bottom of the conversation first
- Removes the `isAtBottomRef.current` guard from the supplementary scroll listener so the pill shows whenever the user isn't at the bottom, regardless of prior scroll history
- Root cause: `handleAtBottomStateChange(false)` could fire while the pane was inactive, setting `isAtBottomRef` to `false` (early return) without updating `showScrollButton` state — after that, the guard `!atBottom && isAtBottomRef.current` always failed

## Test plan
- [ ] Open a long conversation — pill should appear if not scrolled to the bottom
- [ ] Scroll to bottom — pill should disappear
- [ ] Scroll back up — pill should reappear
- [ ] Switch between conversation panes — pill should show correctly on the active pane
- [ ] During streaming, scroll up — pill should appear; scroll back down — pill should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)