### PR TITLE
fix: restrict view options by context and auto-upgrade on filter clear

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -195,6 +195,13 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
     else if (sidebarGroupBy === 'project-status') setSidebarGroupBy('status');
   }, [sidebarProjectFilter, sidebarGroupBy, setSidebarGroupBy]);
 
+  // Auto-upgrade view when clearing project filter (entering ALL PROJECTS)
+  useEffect(() => {
+    if (sidebarProjectFilter) return;
+    if (sidebarGroupBy === 'none') setSidebarGroupBy('project');
+    else if (sidebarGroupBy === 'status') setSidebarGroupBy('project-status');
+  }, [sidebarProjectFilter, sidebarGroupBy, setSidebarGroupBy]);
+
   // Scheduled task data for sidebar grouping
   const scheduledTasks = useScheduledTaskStore((s) => s.tasks);
 
@@ -490,9 +497,9 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
   const sectionHeaderLabel = filteredWorkspaceName ?? 'All Projects';
 
   // View options — single selector replacing Group by + Sort by
-  const VIEW_OPTIONS: { value: SidebarGroupBy; label: string; projectOnly?: boolean }[] = [
-    { value: 'none', label: 'Recent' },
-    { value: 'status', label: 'By Status' },
+  const VIEW_OPTIONS: { value: SidebarGroupBy; label: string; projectOnly?: boolean; singleProjectOnly?: boolean }[] = [
+    { value: 'none', label: 'Recent', singleProjectOnly: true },
+    { value: 'status', label: 'By Status', singleProjectOnly: true },
     { value: 'project', label: 'By Project', projectOnly: true },
     { value: 'project-status', label: 'By Project > Status', projectOnly: true },
   ];
@@ -696,7 +703,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuLabel>View</DropdownMenuLabel>
-                    {VIEW_OPTIONS.filter((o) => !o.projectOnly || !sidebarProjectFilter).map((option) => (
+                    {VIEW_OPTIONS.filter((o) => (!o.projectOnly || !sidebarProjectFilter) && (!o.singleProjectOnly || sidebarProjectFilter)).map((option) => (
                       <DropdownMenuCheckboxItem
                         key={option.value}
                         checked={sidebarGroupBy === option.value}
@@ -1140,7 +1147,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                 <ContextMenuSub>
                   <ContextMenuSubTrigger>View</ContextMenuSubTrigger>
                   <ContextMenuSubContent>
-                    {VIEW_OPTIONS.filter((o) => !o.projectOnly || !sidebarProjectFilter).map((option) => (
+                    {VIEW_OPTIONS.filter((o) => (!o.projectOnly || !sidebarProjectFilter) && (!o.singleProjectOnly || sidebarProjectFilter)).map((option) => (
                       <ContextMenuItem key={option.value} onClick={() => setSidebarGroupBy(option.value)}>
                         <Check className={cn("h-3.5 w-3.5", sidebarGroupBy !== option.value && "opacity-0")} />
                         {option.label}


### PR DESCRIPTION
## What changed

The sidebar View selector now shows context-appropriate options only:

- **Single project mode** (filter active): shows `Recent` and `By Status`
- **All Projects mode** (no filter): shows `By Project` and `By Project > Status`

Previously, all options were visible regardless of context, which was confusing since `Recent`/`By Status` are redundant when no project is filtered, and `By Project`/`By Project > Status` are redundant when a single project is selected.

## How it works

- Added `singleProjectOnly` flag to `VIEW_OPTIONS` entries for `Recent` and `By Status`
- Updated the filter predicate in both the dropdown menu and context menu to hide options that don't apply to the current mode
- Added a `useEffect` that auto-upgrades `sidebarGroupBy` when the project filter is cleared: `none → project`, `status → project-status` (mirrors the existing downgrade effect that fires when a filter is applied)

## How to test

1. Open the sidebar in All Projects mode — only `By Project` and `By Project > Status` should appear in the View menu
2. Click a project to filter — only `Recent` and `By Status` should appear
3. Clear the filter — view should auto-upgrade back to a project-based grouping