### PR TITLE
fix: show workspace color dots in project filter dropdown

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -672,7 +672,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                             className="flex items-center justify-between"
                           >
                             <div className="flex items-center gap-2 min-w-0">
-                              <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                              <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: workspaceColors[ws.id] || getWorkspaceColor(ws.id) }} />
                               <span className="truncate">{ws.name}</span>
                             </div>
                             {sidebarProjectFilter === ws.id && <Check className="h-4 w-4 shrink-0" />}


### PR DESCRIPTION
## Summary
- Replace generic folder icons with workspace color dots in the sidebar's "All Projects" filter dropdown
- Matches the color dot pattern used consistently throughout the rest of the app
- "All Projects" option retains the folder icon since it doesn't represent a specific workspace

## Test plan
- [ ] Open the sidebar and click the "ALL PROJECTS" dropdown
- [ ] Verify each workspace shows its assigned color dot instead of a folder icon
- [ ] Verify "All Projects" still shows the folder icon
- [ ] Verify colors match those shown in workspace headers and other views

🤖 Generated with [Claude Code](https://claude.com/claude-code)