### PR TITLE
fix: widen sidebar add menu to prevent text wrapping

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1189,7 +1189,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                 </Button>
               </DropdownMenuTrigger>
             </TooltipTrigger>
-            <DropdownMenuContent align="start" side="top" className="w-56">
+            <DropdownMenuContent align="start" side="top" className="w-60">
               {/* Session creation group */}
               {workspaces.length > 0 && (
                 <>


### PR DESCRIPTION
## Summary
- Widened the bottom `+` menu dropdown from `w-56` (224px) to `w-60` (240px) so "Create Session from..." and its keyboard shortcut fit on a single line

## Test plan
- [ ] Click the `+` icon at the bottom of the sidebar
- [ ] Verify "Create Session from..." no longer wraps to a second line
- [ ] Verify other menu items still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)