### PR TITLE
fix: remove duplicate Enter Full Screen menu item

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -167,12 +167,6 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
                 .accelerator("CmdOrCtrl+Shift+R")
                 .build(app)?,
         )
-        .separator()
-        .item(
-            &MenuItemBuilder::with_id("enter_full_screen", "Enter Full Screen")
-                .accelerator("Ctrl+Super+F")
-                .build(app)?,
-        )
         .build()?;
 
     // 5. Go menu

--- a/src/hooks/useMenuHandlers.ts
+++ b/src/hooks/useMenuHandlers.ts
@@ -236,15 +236,6 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
           options.resetLayouts();
           window.location.reload();
           break;
-        case 'enter_full_screen':
-          getCurrentWindow().then(async (win) => {
-            if (win) {
-              const isFullscreen = await win.isFullscreen();
-              await win.setFullscreen(!isFullscreen);
-            }
-          });
-          break;
-
         // Go menu
         case 'navigate_back':
           useNavigationStore.getState().goBack();

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -88,14 +88,6 @@ export const SHORTCUTS: Shortcut[] = [
     label: 'Toggle zen mode',
     category: 'General',
   },
-  {
-    id: 'enterFullScreen',
-    key: 'f',
-    modifiers: ['ctrl', 'meta'],
-    label: 'Enter full screen',
-    category: 'General',
-  },
-
   // Navigation
   {
     id: 'navigateBack',


### PR DESCRIPTION
## Summary
- Remove custom "Enter Full Screen" menu item from View menu — macOS automatically injects a native one, causing duplicates
- Clean up the associated menu handler and keyboard shortcut entry

## Test plan
- [ ] Open View menu → only one "Enter Full Screen" item should appear (the native macOS one with 🌐F)
- [ ] Fullscreen via green traffic light button still works
- [ ] Keyboard shortcuts panel no longer shows the removed shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)