### PR TITLE
fix: hide redundant workspace name in sidebar when single workspace

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -250,6 +250,8 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
     statusGroupOrder,
   });
 
+  const hasMultipleWorkspaces = workspaces.length > 1;
+
   // Auto-exit reorder mode when group-by changes to 'none' (nothing to reorder)
   useEffect(() => {
     if (effectiveGroupBy === 'none') setIsReorderMode(false);
@@ -1070,7 +1072,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                                 onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
                                 onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
                                 formatTimeAgo={formatTimeAgo}
-                                showProjectIndicator
+                                showProjectIndicator={hasMultipleWorkspaces}
                                 workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
                                 workspaceName={ws?.name}
                               />
@@ -1123,7 +1125,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                             onOpenBranches={navigateToBranches}
                             onOpenPRs={navigateToPRs}
                             formatTimeAgo={formatTimeAgo}
-                            showProjectIndicator
+                            showProjectIndicator={hasMultipleWorkspaces}
                           />
                         ))
                       )}


### PR DESCRIPTION
## Summary
- Hide the workspace name subtitle (e.g., "chatml") on sidebar session cells when there's only one workspace, since the information is redundant
- The second line still appears when there's a PR badge or other metadata
- No behavior change when multiple workspaces exist

## Test plan
- [ ] With a single workspace, verify session cells no longer show the workspace name on the second line
- [ ] With multiple workspaces, verify the workspace name still appears as before
- [ ] Verify PR badges still display on the second line regardless of workspace count

🤖 Generated with [Claude Code](https://claude.com/claude-code)