### PR TITLE
fix: remove colored icons from sidebar navigation

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -577,7 +577,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
         >
           <Layers className={cn(
             "w-4 h-4",
-            contentView.type === 'session-manager' ? "text-nav-icon-sessions" : "text-nav-icon-sessions/70"
+            contentView.type === 'session-manager' ? "text-foreground" : "text-foreground/70"
           )} />
           <span className={cn(
             "text-base font-medium",
@@ -665,7 +665,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
         >
           <Sparkles className={cn(
             "w-4 h-4",
-            contentView.type === 'skills-store' ? "text-nav-icon-skills" : "text-nav-icon-skills/70"
+            contentView.type === 'skills-store' ? "text-foreground" : "text-foreground/70"
           )} />
           <span className={cn(
             "text-base font-medium",
@@ -687,7 +687,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
         >
           <Clock className={cn(
             "w-4 h-4",
-            contentView.type === 'scheduled-tasks' ? "text-muted-foreground" : "text-muted-foreground/70"
+            contentView.type === 'scheduled-tasks' ? "text-foreground" : "text-foreground/70"
           )} />
           <span className={cn(
             "text-base font-medium",


### PR DESCRIPTION
## Summary
- Replace per-item accent colors (orange Sessions, gold Skills, gray Scheduled) with uniform `text-foreground` color for sidebar navigation icons
- Icons now use near-black in light mode and near-white in dark mode, matching the standard text color
- Active/inactive distinction preserved via 70% opacity on inactive icons

## Test plan
- [ ] Verify sidebar icons appear in uniform near-black color in light mode
- [ ] Verify sidebar icons appear in uniform near-white color in dark mode
- [ ] Confirm active icon is full opacity, inactive icons are slightly dimmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)