### PR TITLE
fix: hide redundant workspace name in session cells when filter is active

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1072,7 +1072,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                                 onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
                                 onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
                                 formatTimeAgo={formatTimeAgo}
-                                showProjectIndicator={hasMultipleWorkspaces}
+                                showProjectIndicator={hasMultipleWorkspaces && !sidebarProjectFilter}
                                 workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
                                 workspaceName={ws?.name}
                               />
@@ -1125,7 +1125,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                             onOpenBranches={navigateToBranches}
                             onOpenPRs={navigateToPRs}
                             formatTimeAgo={formatTimeAgo}
-                            showProjectIndicator={hasMultipleWorkspaces}
+                            showProjectIndicator={hasMultipleWorkspaces && !sidebarProjectFilter}
                           />
                         ))
                       )}


### PR DESCRIPTION
## Summary
- When the sidebar workspace filter is set to a single workspace, the workspace name/color dot in each session cell is now hidden
- This removes visual clutter since the active workspace is already shown in the filter dropdown

## Test plan
- [ ] Open sidebar with multiple workspaces
- [ ] Select a specific workspace from the dropdown — session cells should no longer show the workspace name line
- [ ] Switch back to "All Projects" — workspace names should reappear in session cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)