### PR TITLE
fix: prevent speech recognition text loss from macOS 15 transcript resets

### DIFF
--- a/src-tauri/src/speech.rs
+++ b/src-tauri/src/speech.rs
@@ -609,7 +609,10 @@ mod platform {
 
                     // Reset last_task_text for the new generation — the new task
                     // starts with a clean slate for regression detection.
-                    *state.last_task_text.lock().unwrap_or_else(|e| e.into_inner()) = String::new();
+                    *state
+                        .last_task_text
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner()) = String::new();
 
                     // Create a fresh recognition task
                     let restart_tx = match &state.restart_tx {


### PR DESCRIPTION
## Summary

- Fix macOS 15 (Sequoia) bug where `SFSpeechRecognizer` silently resets `formattedString` after speech pauses, dropping all pre-pause text
- Add `last_task_text` tracker with generation-aware reset detection that promotes lost text into `accumulated_text`
- Guard `setAddsPunctuation:` behind runtime macOS 13+ check (`isOperatingSystemAtLeastVersion:`) to prevent crash on older macOS
- Use `chars().count()` instead of byte `.len()` for Unicode-safe reset detection
- Add 20-char threshold to distinguish Apple's full transcript reset from normal mid-recognition word corrections
- Prevent double-spaces when appending promoted text
- Clear `last_task_text` on `isFinal` to prevent stale text bleed-through on restart error paths

## Test plan

- [ ] Dictate with natural pauses on macOS 15 — verify text accumulates across pauses without loss
- [ ] Dictate continuously without pauses — verify no duplicate text from false-positive reset detection
- [ ] Verify mid-sentence corrections (recognizer revising words) don't trigger reset promotion
- [ ] Test on macOS 14 or earlier if available — verify `setAddsPunctuation:` guard prevents crash
- [ ] Dictate with non-ASCII content (accented characters) — verify Unicode-safe comparison works

🤖 Generated with [Claude Code](https://claude.com/claude-code)