### PR TITLE
feat: standardize macOS menu icons with SF Symbols

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,8 +46,8 @@ base64 = "0.22"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 block2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSImage", "NSBitmapImageRep", "NSGraphicsContext", "NSGraphics"] }
-objc2-foundation = { version = "0.3", features = ["NSString", "NSData", "NSArray", "NSDictionary", "NSError", "NSLocale"] }
+objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSImage", "NSBitmapImageRep", "NSGraphicsContext", "NSGraphics", "NSMenu", "NSMenuItem", "NSApplication"] }
+objc2-foundation = { version = "0.3", features = ["NSString", "NSData", "NSArray", "NSDictionary", "NSError", "NSLocale", "NSProcessInfo"] }
 
 [dev-dependencies]
 serial_test = "3.1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 mod error;
 mod icons;
 mod menu;
+mod sf_symbols;
 mod sidecar;
 mod speech;
 mod state;
@@ -181,6 +182,9 @@ pub fn run() {
             // Create and set the menu
             let menu_result = menu::create_menu(app.handle())?;
             app.set_menu(menu_result)?;
+
+            // Apply SF Symbol icons to native menu items (no-op on non-macOS and macOS < 11)
+            sf_symbols::apply_sf_symbols_to_menu();
 
             // Set macOS traffic light position
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,7 +1,4 @@
-use tauri::menu::{
-    IconMenuItemBuilder, Menu, MenuBuilder, MenuItemBuilder, NativeIcon, PredefinedMenuItem,
-    SubmenuBuilder,
-};
+use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 
 /// Create the application menu.
 ///
@@ -16,8 +13,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(&MenuItemBuilder::with_id("check_for_updates", "Check for Updates...").build(app)?)
         .separator()
         .item(
-            &IconMenuItemBuilder::with_id("settings", "Settings...")
-                .native_icon(NativeIcon::PreferencesGeneral)
+            &MenuItemBuilder::with_id("settings", "Settings...")
                 .accelerator("CmdOrCtrl+,")
                 .build(app)?,
         )
@@ -58,11 +54,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
                 .build(app)?,
         )
         .separator()
-        .item(
-            &IconMenuItemBuilder::with_id("add_workspace", "Add Repository...")
-                .native_icon(NativeIcon::Folder)
-                .build(app)?,
-        )
+        .item(&MenuItemBuilder::with_id("add_workspace", "Add Repository...").build(app)?)
         .separator()
         .item(
             &MenuItemBuilder::with_id("save_file", "Save")
@@ -121,14 +113,12 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     // 4. View menu
     let view_menu = SubmenuBuilder::new(app, "View")
         .item(
-            &IconMenuItemBuilder::with_id("toggle_left_sidebar", "Left Sidebar")
-                .native_icon(NativeIcon::ColumnView)
+            &MenuItemBuilder::with_id("toggle_left_sidebar", "Left Sidebar")
                 .accelerator("CmdOrCtrl+B")
                 .build(app)?,
         )
         .item(
-            &IconMenuItemBuilder::with_id("toggle_right_sidebar", "Right Sidebar")
-                .native_icon(NativeIcon::ColumnView)
+            &MenuItemBuilder::with_id("toggle_right_sidebar", "Right Sidebar")
                 .accelerator("CmdOrCtrl+Alt+B")
                 .enabled(false)
                 .build(app)?,
@@ -179,8 +169,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         )
         .separator()
         .item(
-            &IconMenuItemBuilder::with_id("enter_full_screen", "Enter Full Screen")
-                .native_icon(NativeIcon::EnterFullScreen)
+            &MenuItemBuilder::with_id("enter_full_screen", "Enter Full Screen")
                 .accelerator("Ctrl+Super+F")
                 .build(app)?,
         )
@@ -189,15 +178,13 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     // 5. Go menu
     let go_menu = SubmenuBuilder::new(app, "Go")
         .item(
-            &IconMenuItemBuilder::with_id("navigate_back", "Back")
-                .native_icon(NativeIcon::GoLeft)
+            &MenuItemBuilder::with_id("navigate_back", "Back")
                 .accelerator("CmdOrCtrl+[")
                 .enabled(false)
                 .build(app)?,
         )
         .item(
-            &IconMenuItemBuilder::with_id("navigate_forward", "Forward")
-                .native_icon(NativeIcon::GoRight)
+            &MenuItemBuilder::with_id("navigate_forward", "Forward")
                 .accelerator("CmdOrCtrl+]")
                 .enabled(false)
                 .build(app)?,
@@ -216,8 +203,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         )
         .separator()
         .item(
-            &IconMenuItemBuilder::with_id("search_workspaces", "Search Workspaces")
-                .native_icon(NativeIcon::QuickLook)
+            &MenuItemBuilder::with_id("search_workspaces", "Search Workspaces")
                 .accelerator("CmdOrCtrl+Shift+F")
                 .build(app)?,
         )
@@ -309,14 +295,12 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(&review_submenu)
         .separator()
         .item(
-            &IconMenuItemBuilder::with_id("open_in_vscode", "Open in VS Code")
-                .native_icon(NativeIcon::Share)
+            &MenuItemBuilder::with_id("open_in_vscode", "Open in VS Code")
                 .enabled(false)
                 .build(app)?,
         )
         .item(
-            &IconMenuItemBuilder::with_id("open_terminal", "Open in Terminal")
-                .native_icon(NativeIcon::Computer)
+            &MenuItemBuilder::with_id("open_terminal", "Open in Terminal")
                 .enabled(false)
                 .build(app)?,
         )
@@ -325,27 +309,23 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     // 7. Git menu - all items start disabled
     let git_menu = SubmenuBuilder::new(app, "Git")
         .item(
-            &IconMenuItemBuilder::with_id("git_commit", "Commit Changes...")
-                .native_icon(NativeIcon::MenuOnState)
+            &MenuItemBuilder::with_id("git_commit", "Commit Changes...")
                 .enabled(false)
                 .build(app)?,
         )
         .item(
-            &IconMenuItemBuilder::with_id("git_create_pr", "Create Pull Request...")
-                .native_icon(NativeIcon::Share)
+            &MenuItemBuilder::with_id("git_create_pr", "Create Pull Request...")
                 .enabled(false)
                 .build(app)?,
         )
         .item(
-            &IconMenuItemBuilder::with_id("git_sync", "Sync with Main")
-                .native_icon(NativeIcon::Refresh)
+            &MenuItemBuilder::with_id("git_sync", "Sync with Main")
                 .enabled(false)
                 .build(app)?,
         )
         .separator()
         .item(
-            &IconMenuItemBuilder::with_id("git_copy_branch", "Copy Branch Name")
-                .native_icon(NativeIcon::MultipleDocuments)
+            &MenuItemBuilder::with_id("git_copy_branch", "Copy Branch Name")
                 .enabled(false)
                 .build(app)?,
         )
@@ -369,28 +349,15 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
 
     // 9. Help menu
     let help_menu = SubmenuBuilder::new(app, "Help")
+        .item(&MenuItemBuilder::with_id("help", "ChatML Help").build(app)?)
         .item(
-            &IconMenuItemBuilder::with_id("help", "ChatML Help")
-                .native_icon(NativeIcon::Info)
-                .build(app)?,
-        )
-        .item(
-            &IconMenuItemBuilder::with_id("keyboard_shortcuts", "Keyboard Shortcuts")
-                .native_icon(NativeIcon::Bookmarks)
+            &MenuItemBuilder::with_id("keyboard_shortcuts", "Keyboard Shortcuts")
                 .accelerator("CmdOrCtrl+/")
                 .build(app)?,
         )
         .separator()
-        .item(
-            &IconMenuItemBuilder::with_id("release_notes", "Release Notes")
-                .native_icon(NativeIcon::Bookmarks)
-                .build(app)?,
-        )
-        .item(
-            &IconMenuItemBuilder::with_id("report_issue", "Report an Issue...")
-                .native_icon(NativeIcon::Caution)
-                .build(app)?,
-        )
+        .item(&MenuItemBuilder::with_id("release_notes", "Release Notes").build(app)?)
+        .item(&MenuItemBuilder::with_id("report_issue", "Report an Issue...").build(app)?)
         .build()?;
 
     // Build the full menu bar

--- a/src-tauri/src/sf_symbols.rs
+++ b/src-tauri/src/sf_symbols.rs
@@ -1,0 +1,182 @@
+/// Apply SF Symbol icons to native macOS menu items after Tauri builds the menu.
+///
+/// This post-processes the NSMenu tree set by Tauri, adding SF Symbol images
+/// directly on NSMenuItems. Using native NSImage (not RGBA conversion) preserves
+/// template image behavior — icons automatically adapt to dark mode, disabled
+/// state, and hover highlighting.
+#[cfg(target_os = "macos")]
+pub fn apply_sf_symbols_to_menu() {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSApplication;
+    use objc2_foundation::NSProcessInfo;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        log::warn!("apply_sf_symbols_to_menu must be called from the main thread");
+        return;
+    };
+
+    // SF Symbols require macOS 11+ (NSProcessInfo is thread-safe, but we
+    // acquire the MainThreadMarker first so subsequent calls are protected)
+    let version = NSProcessInfo::processInfo().operatingSystemVersion();
+    if version.majorVersion < 11 {
+        log::info!("SF Symbols require macOS 11+, skipping menu icons");
+        return;
+    }
+
+    let app = NSApplication::sharedApplication(mtm);
+    let Some(main_menu) = app.mainMenu() else {
+        log::warn!("No main menu found");
+        return;
+    };
+
+    // Walk each top-level submenu
+    for item in main_menu.itemArray().to_vec() {
+        if let Some(submenu) = item.submenu() {
+            let menu_title = submenu.title().to_string();
+            apply_symbols_to_submenu(&submenu, &menu_title);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn apply_symbols_to_submenu(menu: &objc2_app_kit::NSMenu, menu_title: &str) {
+    for item in menu.itemArray().to_vec() {
+        if item.isSeparatorItem() {
+            continue;
+        }
+
+        let item_title = item.title().to_string();
+
+        // Recurse into submenus
+        if let Some(submenu) = item.submenu() {
+            let sub_title = submenu.title().to_string();
+            // Set icon on the submenu parent item itself
+            if let Some(symbol) = lookup_symbol(menu_title, &item_title) {
+                set_sf_symbol(&item, symbol);
+            }
+            apply_symbols_to_submenu(&submenu, &sub_title);
+            continue;
+        }
+
+        if let Some(symbol) = lookup_symbol(menu_title, &item_title) {
+            set_sf_symbol(&item, symbol);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn set_sf_symbol(item: &objc2_app_kit::NSMenuItem, symbol_name: &str) {
+    use objc2_app_kit::NSImage;
+    use objc2_foundation::NSString;
+
+    let name = NSString::from_str(symbol_name);
+    if let Some(image) = NSImage::imageWithSystemSymbolName_accessibilityDescription(&name, None) {
+        item.setImage(Some(&image));
+    } else {
+        log::debug!("SF Symbol not found: {}", symbol_name);
+    }
+}
+
+/// Look up the SF Symbol name for a menu item by (menu_title, item_title).
+///
+/// KEEP IN SYNC WITH menu.rs — title strings must match exactly.
+/// All symbols must be available on macOS 11+ (SF Symbols 2).
+#[cfg(target_os = "macos")]
+fn lookup_symbol(menu_title: &str, item_title: &str) -> Option<&'static str> {
+    match (menu_title, item_title) {
+        // ── App Menu ──
+        ("ChatML", "Check for Updates...") => Some("arrow.triangle.2.circlepath"),
+        ("ChatML", "Settings...") => Some("gearshape"),
+
+        // ── File Menu ──
+        ("File", "New Session") => Some("plus"),
+        ("File", "New Conversation") => Some("plus.bubble"),
+        ("File", "Create Session from...") => Some("doc.badge.plus"),
+        ("File", "Add Repository...") => Some("folder.badge.plus"),
+        ("File", "Save") => Some("square.and.arrow.down"),
+        ("File", "Close Tab") => Some("xmark"),
+
+        // ── Edit Menu ──
+        ("Edit", "Undo") => Some("arrow.uturn.backward"),
+        ("Edit", "Redo") => Some("arrow.uturn.forward"),
+        ("Edit", "Cut") => Some("scissors"),
+        ("Edit", "Copy") => Some("doc.on.doc"),
+        ("Edit", "Paste") => Some("doc.on.clipboard"),
+        ("Edit", "Select All") => Some("checkmark.rectangle"),
+        ("Edit", "Find") => Some("magnifyingglass"), // submenu parent
+
+        // ── Edit > Find Submenu ──
+        ("Find", "Find...") => Some("magnifyingglass"),
+        ("Find", "Find Next") => Some("chevron.down"),
+        ("Find", "Find Previous") => Some("chevron.up"),
+
+        // ── View Menu ──
+        ("View", "Left Sidebar") => Some("sidebar.left"),
+        ("View", "Right Sidebar") => Some("sidebar.right"),
+        ("View", "Terminal") => Some("terminal"),
+        ("View", "Next Tab") => Some("chevron.right"),
+        ("View", "Previous Tab") => Some("chevron.left"),
+        ("View", "Command Palette") => Some("command"),
+        ("View", "File Picker") => Some("doc.text.magnifyingglass"),
+        ("View", "Session Manager") => Some("list.bullet.rectangle"),
+        ("View", "Repositories") => Some("folder"),
+        ("View", "Zen Mode") => Some("eye"),
+        ("View", "Reset Panel Layouts") => Some("rectangle.3.group"),
+        ("View", "Enter Full Screen") => Some("arrow.up.backward.and.arrow.down.forward"),
+
+        // ── Go Menu ──
+        ("Go", "Back") => Some("chevron.left"),
+        ("Go", "Forward") => Some("chevron.right"),
+        ("Go", "Go to Workspace...") => Some("folder"),
+        ("Go", "Go to Session...") => Some("bubble.left"),
+        ("Go", "Go to Conversation...") => Some("text.bubble"),
+        ("Go", "Search Workspaces") => Some("magnifyingglass"),
+
+        // ── Session Menu ──
+        ("Session", "Thinking Level") => Some("brain"), // submenu parent
+        ("Session", "Plan Mode") => Some("map"),
+        ("Session", "Approve Plan") => Some("checkmark.circle"),
+        ("Session", "Focus Chat Input") => Some("text.cursor"),
+        ("Session", "Review") => Some("eye"), // submenu parent
+        ("Session", "Open in VS Code") => Some("arrow.up.forward.app"),
+        ("Session", "Open in Terminal") => Some("terminal"),
+
+        // ── Session > Thinking Level Submenu (all symbols macOS 11+) ──
+        ("Thinking Level", "Off") => Some("circle.slash"),
+        ("Thinking Level", "Low") => Some("sparkle"),
+        ("Thinking Level", "Medium") => Some("sparkles"),
+        ("Thinking Level", "High") => Some("brain"),
+        ("Thinking Level", "Max") => Some("brain.head.profile"),
+
+        // ── Session > Review Submenu ──
+        ("Review", "Quick Scan") => Some("magnifyingglass"),
+        ("Review", "Deep Review") => Some("doc.text.magnifyingglass"),
+        ("Review", "Security Audit") => Some("lock.shield"),
+        ("Review", "Performance") => Some("speedometer"),
+        ("Review", "Architecture") => Some("square.stack.3d.up"),
+        ("Review", "Pre-merge Check") => Some("checkmark.shield"),
+
+        // ── Git Menu ──
+        ("Git", "Commit Changes...") => Some("checkmark.circle"),
+        ("Git", "Create Pull Request...") => Some("arrow.triangle.branch"),
+        ("Git", "Sync with Main") => Some("arrow.triangle.2.circlepath"),
+        ("Git", "Copy Branch Name") => Some("doc.on.doc"),
+
+        // ── Window Menu ──
+        ("Window", "Minimize") => Some("minus.square"),
+        ("Window", "Zoom") => Some("arrow.up.left.and.arrow.down.right"),
+        ("Window", "Bring All to Front") => Some("rectangle.stack"),
+
+        // ── Help Menu ──
+        ("Help", "ChatML Help") => Some("questionmark.circle"),
+        ("Help", "Keyboard Shortcuts") => Some("keyboard"),
+        ("Help", "Release Notes") => Some("sparkles"),
+        ("Help", "Report an Issue...") => Some("exclamationmark.bubble"),
+
+        _ => None,
+    }
+}
+
+// No-op on non-macOS platforms
+#[cfg(not(target_os = "macos"))]
+pub fn apply_sf_symbols_to_menu() {}


### PR DESCRIPTION
## Summary

- Replace Tauri's `IconMenuItemBuilder` + `NativeIcon` API with native SF Symbol images applied via post-processing the NSMenu tree
- New `sf_symbols.rs` module walks the menu after Tauri builds it and sets SF Symbol images on matching items
- Icons automatically adapt to dark mode, disabled state, and hover highlighting (template image behavior)
- All symbols target macOS 11+ (SF Symbols 2); graceful no-op on non-macOS and macOS < 11

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/sf_symbols.rs` | New module — post-processes NSMenu to apply SF Symbols by `(menu_title, item_title)` matching |
| `src-tauri/src/menu.rs` | Converted all `IconMenuItemBuilder` to plain `MenuItemBuilder` (removed NativeIcon usage) |
| `src-tauri/src/lib.rs` | Added `mod sf_symbols` and call to `apply_sf_symbols_to_menu()` in setup |
| `src-tauri/Cargo.toml` | Added `NSMenu`, `NSMenuItem`, `NSApplication`, `NSProcessInfo` features to objc2 crates |

## Test plan

- [ ] Build and run on macOS — verify menu items show SF Symbol icons
- [ ] Check dark mode — icons should adapt automatically
- [ ] Verify disabled menu items show dimmed icons
- [ ] Confirm no regressions on menu accelerators and event handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)