### PR TITLE
fix: handle enqueued messages during agent turn transitions

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1094,13 +1094,13 @@ outer:
 
 			case EventTypeTurnComplete, EventTypeComplete, EventTypeResult:
 				// Atomically clear the active turn flag and take any deferred
-				// user message. Store BEFORE the assistant message so the DB
-				// position ordering is: [queued_user_N, assistant_N+1].
-				// This must be atomic so a concurrent SendConversationMessage
-				// cannot slip a new message between clearing the flag and
-				// flushing the old deferred one.
+				// user message. When an assistant message exists, both are
+				// stored in a single DB transaction so neither can be lost
+				// independently. Position ordering: [assistant, queued_user].
+				// EndTurnAndTakePending is atomic so a concurrent
+				// SendConversationMessage cannot slip a new message between
+				// clearing the flag and flushing the old deferred one.
 				pending := proc.EndTurnAndTakePending()
-				m.storePendingUserMessage(ctx, convID, pending)
 
 				// Store accumulated message and reset streaming state.
 				if currentAssistantMessage != "" {
@@ -1235,7 +1235,7 @@ outer:
 						}
 					}
 
-					if err := m.store.AddMessageToConversation(ctx, convID, models.Message{
+					assistantMsg := models.Message{
 						ID:              uuid.New().String()[:8],
 						Role:            "assistant",
 						Content:         currentAssistantMessage,
@@ -1247,10 +1247,27 @@ outer:
 						Timeline:        timeline,
 						RunSummary:      runSummary,
 						Timestamp:       time.Now(),
-					}); err != nil {
-						logger.Manager.Errorf("Failed to store assistant message for conv %s: %v", convID, err)
 					}
+					// Atomically store assistant + deferred user message in a
+					// single transaction so both succeed or fail together.
+					msgs := []models.Message{assistantMsg}
+					if pending != nil {
+						msgs = append(msgs, *pending)
+					}
+					if err := m.store.AddMessagesToConversation(ctx, convID, msgs); err != nil {
+						logger.Manager.Errorf("Failed to store messages for conv %s: %v", convID, err)
+					}
+					// Save attachments for the deferred user message (best-effort)
+					if pending != nil && len(pending.Attachments) > 0 {
+						if err := m.store.SaveAttachments(ctx, pending.ID, pending.Attachments); err != nil {
+							logger.Manager.Errorf("Failed to save attachments for deferred message: %v", err)
+						}
+					}
+					pending = nil // consumed
 					currentAssistantMessage = ""
+				} else if pending != nil {
+					// No assistant message — just persist the deferred user message
+					m.storePendingUserMessage(ctx, convID, pending)
 				}
 
 				// Reset per-turn accumulation state
@@ -1406,11 +1423,10 @@ outer:
 	flushCtx, flushCancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer flushCancel()
 
-	// Atomically clear active turn flag and flush any remaining deferred user
-	// message. Store BEFORE the assistant message so the DB position ordering
-	// is: [queued_user_N, assistant_N+1].
+	// Atomically clear active turn flag and take any deferred user message.
+	// When an assistant message exists, both are stored in a single DB
+	// transaction. Position ordering: [assistant, queued_user].
 	pendingFinal := proc.EndTurnAndTakePending()
-	m.storePendingUserMessage(flushCtx, convID, pendingFinal)
 
 	// Store any remaining assistant message (with full enrichment)
 	if currentAssistantMessage != "" {
@@ -1472,7 +1488,7 @@ outer:
 
 		durationMs := int(time.Since(turnStartTime).Milliseconds())
 
-		if err := m.store.AddMessageToConversation(flushCtx, convID, models.Message{
+		finalAssistantMsg := models.Message{
 			ID:              uuid.New().String()[:8],
 			Role:            "assistant",
 			Content:         currentAssistantMessage,
@@ -1483,9 +1499,26 @@ outer:
 			DurationMs:      durationMs,
 			Timeline:        timeline,
 			Timestamp:       time.Now(),
-		}); err != nil {
-			logger.Manager.Errorf("Failed to store final assistant message for conv %s: %v", convID, err)
 		}
+		// Atomically store assistant + deferred user message in a
+		// single transaction so both succeed or fail together.
+		finalMsgs := []models.Message{finalAssistantMsg}
+		if pendingFinal != nil {
+			finalMsgs = append(finalMsgs, *pendingFinal)
+		}
+		if err := m.store.AddMessagesToConversation(flushCtx, convID, finalMsgs); err != nil {
+			logger.Manager.Errorf("Failed to store final messages for conv %s: %v", convID, err)
+		}
+		// Save attachments for the deferred user message (best-effort)
+		if pendingFinal != nil && len(pendingFinal.Attachments) > 0 {
+			if err := m.store.SaveAttachments(flushCtx, pendingFinal.ID, pendingFinal.Attachments); err != nil {
+				logger.Manager.Errorf("Failed to save attachments for deferred message: %v", err)
+			}
+		}
+		pendingFinal = nil // consumed
+	} else if pendingFinal != nil {
+		// No assistant message — just persist the deferred user message
+		m.storePendingUserMessage(flushCtx, convID, pendingFinal)
 	}
 
 	// Clear snapshot on process exit — but only if this process is still the current

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -2029,6 +2029,121 @@ func (s *SQLiteStore) AddMessageToConversation(ctx context.Context, convID strin
 	})
 }
 
+// preparedMessage holds pre-serialized fields for a message insert.
+type preparedMessage struct {
+	msg             models.Message
+	setupInfoJSON   sql.NullString
+	runSummaryJSON  sql.NullString
+	toolUsageJSON   sql.NullString
+	timelineJSON    sql.NullString
+	thinkingContent sql.NullString
+	planContent     sql.NullString
+	checkpointUuid  sql.NullString
+	durationMs      sql.NullInt64
+}
+
+func prepareMessage(msg models.Message) (preparedMessage, error) {
+	p := preparedMessage{msg: msg}
+
+	if msg.SetupInfo != nil {
+		data, err := json.Marshal(msg.SetupInfo)
+		if err != nil {
+			return p, fmt.Errorf("marshal setupInfo: %w", err)
+		}
+		p.setupInfoJSON = sql.NullString{String: string(data), Valid: true}
+	}
+	if msg.RunSummary != nil {
+		data, err := json.Marshal(msg.RunSummary)
+		if err != nil {
+			return p, fmt.Errorf("marshal runSummary: %w", err)
+		}
+		p.runSummaryJSON = sql.NullString{String: string(data), Valid: true}
+	}
+	if len(msg.ToolUsage) > 0 {
+		data, err := json.Marshal(msg.ToolUsage)
+		if err != nil {
+			return p, fmt.Errorf("marshal toolUsage: %w", err)
+		}
+		p.toolUsageJSON = sql.NullString{String: string(data), Valid: true}
+	}
+	if len(msg.Timeline) > 0 {
+		data, err := json.Marshal(msg.Timeline)
+		if err != nil {
+			return p, fmt.Errorf("marshal timeline: %w", err)
+		}
+		p.timelineJSON = sql.NullString{String: string(data), Valid: true}
+	}
+
+	p.thinkingContent = nullString(msg.ThinkingContent)
+	p.planContent = nullString(msg.PlanContent)
+	p.checkpointUuid = nullString(msg.CheckpointUuid)
+	if msg.DurationMs > 0 {
+		p.durationMs = sql.NullInt64{Int64: int64(msg.DurationMs), Valid: true}
+	}
+	return p, nil
+}
+
+func insertPreparedMessage(ctx context.Context, tx *sql.Tx, convID string, p preparedMessage, pos int) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO messages (id, conversation_id, role, content, setup_info, run_summary,
+			tool_usage, thinking_content, duration_ms, timeline,
+			plan_content, checkpoint_uuid, timestamp, position)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		p.msg.ID, convID, p.msg.Role, p.msg.Content, p.setupInfoJSON, p.runSummaryJSON,
+		p.toolUsageJSON, p.thinkingContent, p.durationMs, p.timelineJSON,
+		p.planContent, p.checkpointUuid, p.msg.Timestamp, pos)
+	return err
+}
+
+// AddMessagesToConversation inserts multiple messages atomically in a single transaction.
+// Messages are inserted in slice order with sequential positions.
+func (s *SQLiteStore) AddMessagesToConversation(ctx context.Context, convID string, msgs []models.Message) error {
+	if len(msgs) == 0 {
+		return nil
+	}
+	// Fast path: single message delegates to existing method
+	if len(msgs) == 1 {
+		return s.AddMessageToConversation(ctx, convID, msgs[0])
+	}
+
+	// Pre-serialize all messages outside the retry loop (deterministic)
+	prepared := make([]preparedMessage, len(msgs))
+	for i, msg := range msgs {
+		p, err := prepareMessage(msg)
+		if err != nil {
+			return fmt.Errorf("AddMessagesToConversation[%d]: %w", i, err)
+		}
+		prepared[i] = p
+	}
+
+	return RetryDBExec(ctx, "AddMessagesToConversation", DefaultRetryConfig(), func(ctx context.Context) error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin: %w", err)
+		}
+
+		// Get next position within transaction
+		var maxPos sql.NullInt64
+		if err := tx.QueryRowContext(ctx, `SELECT MAX(position) FROM messages WHERE conversation_id = ?`, convID).Scan(&maxPos); err != nil && err != sql.ErrNoRows {
+			tx.Rollback()
+			return fmt.Errorf("get position: %w", err)
+		}
+		nextPos := 0
+		if maxPos.Valid {
+			nextPos = int(maxPos.Int64) + 1
+		}
+
+		for i, p := range prepared {
+			if err := insertPreparedMessage(ctx, tx, convID, p, nextPos+i); err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+
+		return tx.Commit()
+	})
+}
+
 func (s *SQLiteStore) AddToolActionToConversation(ctx context.Context, convID string, action models.ToolAction) error {
 	return RetryDBExec(ctx, "AddToolActionToConversation", DefaultRetryConfig(), func(ctx context.Context) error {
 		// Use transaction to make position query + insert atomic

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -35,6 +35,11 @@ import {
 // Re-export for backward compatibility (ChatInput.tsx imports markPlanModeExited from here)
 export { markPlanModeExited };
 
+// Track conversations where `result` already finalized streaming + committed queued messages.
+// Prevents `turn_complete` (which always follows `result`) from double-finalizing and
+// setting isStreaming=false in the gap before the next turn's `init`.
+const resultFinalizedSet = new Set<string>();
+
 /**
  * Clean up module-level state for a conversation that is being removed.
  * Call this when deleting sessions to prevent stale entries from lingering
@@ -43,6 +48,7 @@ export { markPlanModeExited };
 export function cleanupConversationState(conversationId: string) {
   clearReconciliationState(conversationId);
   clearPlanModeState(conversationId);
+  resultFinalizedSet.delete(conversationId);
 }
 
 
@@ -121,6 +127,7 @@ export function useWebSocket(enabled: boolean = true) {
           if (streaming?.pendingToolApproval || streaming?.pendingPlanApproval || store.pendingUserQuestion[conversationId]) {
             return;
           }
+          resultFinalizedSet.delete(conversationId);
           const startTime = streaming?.startTime;
           const durationMs = startTime ? Date.now() - startTime : undefined;
           // Finalize streaming and commit any queued user message atomically.
@@ -159,6 +166,9 @@ export function useWebSocket(enabled: boolean = true) {
 
     switch (data.type) {
       case 'init':
+        // Clear result-finalized flag — a new turn is starting
+        resultFinalizedSet.delete(conversationId);
+
         // If an init event arrives for an already-streaming conversation, finalize
         // the previous turn. When queued messages exist, this is the earliest signal
         // that the agent picked up the queued message — commit it to the timeline.
@@ -178,6 +188,12 @@ export function useWebSocket(enabled: boolean = true) {
           store.clearThinking(conversationId);
           store.clearSubAgents(conversationId);
         }
+        // Always activate streaming on init — a new turn is starting.
+        // This bridges the isStreaming gap that occurs when result+turn_complete
+        // set isStreaming=false before the next turn's assistant_text arrives.
+        // Safety: if the process stalls after init without sending further events,
+        // the conversation_status:'idle' safety-net (above) will clear isStreaming.
+        store.setStreaming(conversationId, true);
         // Clear recovery state — the agent recovered successfully
         store.clearAgentRecovery(conversationId);
         // Clear interrupted state — the agent resumed successfully after app restart
@@ -374,6 +390,9 @@ export function useWebSocket(enabled: boolean = true) {
             permissionDenials,
           },
         });
+        // Mark that result already finalized — turn_complete should skip re-finalization
+        resultFinalizedSet.add(conversationId);
+
         const resultModelUsage = event.modelUsage as Record<string, { contextWindow?: number }> | undefined;
         if (resultModelUsage) {
           for (const key of Object.keys(resultModelUsage)) {
@@ -385,7 +404,13 @@ export function useWebSocket(enabled: boolean = true) {
             }
           }
         }
-        freshStore.updateConversation(conversationId, { status: 'completed' });
+        // Only mark completed if there were no queued messages at the time of result.
+        // If there were queued messages, the agent will pick them up for the next turn.
+        // Note: freshStore is a pre-finalization snapshot, so this checks the pre-commit count.
+        const hadQueuedMessages = (freshStore.queuedMessages[conversationId] ?? []).length > 0;
+        if (!hadQueuedMessages) {
+          freshStore.updateConversation(conversationId, { status: 'completed' });
+        }
         freshStore.clearAgentTodos(conversationId);
         freshStore.clearPendingUserQuestion(conversationId);
         freshStore.clearPendingToolApproval(conversationId);
@@ -408,6 +433,28 @@ export function useWebSocket(enabled: boolean = true) {
 
       case 'turn_complete': {
         const turnStore = getStore();
+        // If `result` already finalized streaming + committed queued messages,
+        // skip re-finalization to avoid setting isStreaming=false in the gap
+        // before the next turn's `init`. Just do cleanup.
+        if (resultFinalizedSet.has(conversationId)) {
+          resultFinalizedSet.delete(conversationId);
+          // Only override status to 'active' if there are queued messages the agent
+          // will process next. Otherwise leave status as 'completed' (set by result).
+          const hasQueuedForNextTurn = (turnStore.queuedMessages[conversationId] ?? []).length > 0;
+          if (hasQueuedForNextTurn) {
+            turnStore.updateConversation(conversationId, { status: 'active' });
+          }
+          turnStore.clearAgentTodos(conversationId);
+          turnStore.clearPendingToolApproval(conversationId);
+          turnStore.clearPendingPlanApproval(conversationId);
+          const turnConvSkip = turnStore.conversations.find((c) => c.id === conversationId);
+          if (turnConvSkip) {
+            turnStore.setLastTurnCompletedAt(turnConvSkip.sessionId, Date.now());
+          }
+          notifyBackgroundSession(conversationId);
+          break;
+        }
+
         const turnStartTime = turnStore.streamingState[conversationId]?.startTime;
         const turnDurationMs = turnStartTime ? Date.now() - turnStartTime : undefined;
 
@@ -441,6 +488,7 @@ export function useWebSocket(enabled: boolean = true) {
       }
 
       case 'complete': {
+        resultFinalizedSet.delete(conversationId);
         store.finalizeStreamingMessage(conversationId, { commitQueued: true, terminal: true });
         store.clearAgentTodos(conversationId);
         store.clearPendingUserQuestion(conversationId);

--- a/src/stores/__tests__/appStore.queuedMessages.test.ts
+++ b/src/stores/__tests__/appStore.queuedMessages.test.ts
@@ -147,10 +147,10 @@ describe('appStore - queued message ordering', () => {
     const queued = useAppStore.getState().queuedMessages[conversationId] ?? [];
     expect(queued).toHaveLength(0);
 
-    // keepStreaming is computed before the queue is drained, so isStreaming
-    // remains true (queue had 1 message → hasQueuedMessages was true, non-terminal).
+    // keepStreaming now uses post-commit remaining count. With 1 queued message
+    // committed, remaining is empty, so isStreaming should be false.
     const streaming = useAppStore.getState().streamingState[conversationId];
-    expect(streaming?.isStreaming).toBe(true);
+    expect(streaming?.isStreaming).toBe(false);
   });
 
   it('places queued user message AFTER assistant message on terminal event', () => {
@@ -382,6 +382,123 @@ describe('appStore - queued message ordering', () => {
     expect(messages[1].content).toBe('Already finalized response.');
     expect(messages[2].role).toBe('user');
     expect(messages[2].content).toBe('Second user message');
+  });
+
+  it('keeps streaming when multiple queued messages exist (commits first, preserves rest)', () => {
+    useAppStore.setState({
+      messagesByConversation: {
+        [conversationId]: [
+          {
+            id: 'msg-user1',
+            conversationId,
+            role: 'user',
+            content: 'First user message',
+            timestamp: '2025-07-01T12:00:00Z',
+          },
+        ],
+      },
+      streamingState: {
+        [conversationId]: {
+          text: 'Assistant response.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {
+        [conversationId]: [
+          {
+            id: 'msg-user2',
+            content: 'Second user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:05Z',
+          },
+          {
+            id: 'msg-user3',
+            content: 'Third user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:10Z',
+          },
+        ],
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 5000,
+      commitQueued: true,
+    });
+
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
+    expect(messages).toHaveLength(3);
+    expect(messages[2].role).toBe('user');
+    expect(messages[2].content).toBe('Second user message');
+
+    // With 2 queued messages, committing first leaves 1 remaining → keepStreaming = true
+    const streaming = useAppStore.getState().streamingState[conversationId];
+    expect(streaming?.isStreaming).toBe(true);
+
+    // Queue should have 1 remaining
+    const queued = useAppStore.getState().queuedMessages[conversationId] ?? [];
+    expect(queued).toHaveLength(1);
+    expect(queued[0].content).toBe('Third user message');
+  });
+
+  it('keeps streaming in no-text path with multiple queued messages', () => {
+    useAppStore.setState({
+      streamingState: {
+        [conversationId]: {
+          text: '',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: false,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {
+        [conversationId]: [
+          {
+            id: 'msg-user2',
+            content: 'Second user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:05Z',
+          },
+          {
+            id: 'msg-user3',
+            content: 'Third user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:10Z',
+          },
+        ],
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      commitQueued: true,
+    });
+
+    // No-text early-return path should still commit first queued message
+    const messages = useAppStore.getState().messagesByConversation[conversationId] ?? [];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('user');
+    expect(messages[0].content).toBe('Second user message');
+
+    // With 2 queued messages, committing first leaves 1 remaining → keepStreaming = true
+    const streaming = useAppStore.getState().streamingState[conversationId];
+    expect(streaming?.isStreaming).toBe(true);
+
+    // Queue should have 1 remaining
+    const queued = useAppStore.getState().queuedMessages[conversationId] ?? [];
+    expect(queued).toHaveLength(1);
+    expect(queued[0].content).toBe('Third user message');
   });
 
   it('does not add queued message when none exists', () => {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -2126,9 +2126,15 @@ updateFileTabContent: (id, content) => set((state) => ({
     return set((state) => {
       const streaming = state.streamingState[conversationId];
       const queuedQueue = state.queuedMessages[conversationId] ?? [];
-      const hasQueuedMessages = queuedQueue.length > 0;
+
+      // Compute queued message commit EARLY so keepStreaming uses post-commit count.
+      // Previously keepStreaming used pre-commit count, causing isStreaming to stay true
+      // even when the queue would be empty after commit — leading to a stale streaming
+      // state that turn_complete then had to clean up, causing a visual flash.
+      const queued = metadata.commitQueued && queuedQueue.length > 0 ? queuedQueue[0] : null;
+      const remaining = metadata.terminal ? [] : (queued ? queuedQueue.slice(1) : queuedQueue);
       // When terminal, force streaming off and clear queue regardless
-      const keepStreaming = !metadata.terminal && hasQueuedMessages;
+      const keepStreaming = !metadata.terminal && remaining.length > 0;
 
       // Build cleared streaming state (preserve planModeActive and pending approvals)
       // If there are remaining queued messages (non-terminal), keep isStreaming true to avoid flash
@@ -2152,9 +2158,7 @@ updateFileTabContent: (id, content) => set((state) => ({
 
       // If no streaming text, just clear the state (but still commit first queued message if requested)
       if (!streaming?.text) {
-        const queued = metadata.commitQueued && queuedQueue.length > 0 ? queuedQueue[0] : null;
-        // Terminal: clear entire queue after committing first; otherwise preserve remaining
-        const remaining = metadata.terminal ? [] : (queued ? queuedQueue.slice(1) : queuedQueue);
+        // queued and remaining already computed above
         const convPagination = state.messagePagination[conversationId];
         return {
           streamingState: {
@@ -2273,9 +2277,7 @@ updateFileTabContent: (id, content) => set((state) => ({
 
       // Atomically: add message AND clear streaming state
       // When commitQueued is set, commit the first queued user message AFTER the assistant message
-      const queued = metadata.commitQueued && queuedQueue.length > 0 ? queuedQueue[0] : null;
-      // Terminal: clear entire queue after committing first; otherwise preserve remaining
-      const remaining = metadata.terminal ? [] : (queued ? queuedQueue.slice(1) : queuedQueue);
+      // (queued and remaining already computed above)
       const existing = state.messagesByConversation[conversationId] ?? [];
       const updatedMessages = queued
         ? [...existing, newMessage, queuedToMessage(queued, conversationId)]


### PR DESCRIPTION
## Summary

- **Fix stale streaming indicator** when users send messages during agent processing — `keepStreaming` now uses post-commit remaining count, so with 1 queued message the spinner stops correctly after commit
- **Atomic DB writes** for assistant + pending user messages via new `AddMessagesToConversation` batch method — prevents message loss if one write fails between the two
- **Prevent double-finalization** between `result` and `turn_complete` events using `resultFinalizedSet` — eliminates the `isStreaming` flash in the gap before the next turn's `init`
- **Conditional status override** in `turn_complete` fast-path — only sets `active` when queued messages remain, preserving `completed` for done conversations

## Test plan

- [x] `npm run test -- --run src/stores/__tests__/appStore.queuedMessages.test.ts` — 9 tests pass
- [x] `go test -race ./store/...` — store tests pass with race detector
- [x] `go test -race ./agent/...` — agent tests pass with race detector
- [ ] Manual: send a message while agent is streaming, verify queued message appears in correct order after assistant response
- [ ] Manual: verify no streaming indicator flash between consecutive turns when queued messages are processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)