### PR TITLE
fix: improve MentionText URL handling, sidebar status dots, and toast UX

### DIFF
--- a/src/components/conversation/MentionText.tsx
+++ b/src/components/conversation/MentionText.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { FileIcon } from '@/components/files/FileTree';
+import { openUrlInBrowser } from '@/lib/tauri';
 
 interface MentionTextProps {
   content: string;
@@ -11,6 +12,9 @@ interface MentionTextProps {
 // Regex pattern to match @filepath mentions. Lookbehind ensures @ is not preceded by a word character,
 // aligning with MentionPlugin's triggerPreviousCharPattern which requires start-of-input, whitespace, or quote.
 const MENTION_PATTERN = /(?<!\w)@([\w./-]+)/g;
+
+// URL pattern — matches http(s) URLs, stops before trailing punctuation that's likely sentence-level
+const URL_PATTERN = /https?:\/\/[^\s<]+[^\s<.,;:!?"')}\]]/g;
 
 /** Known extensionless filenames that should be treated as file paths. */
 const KNOWN_EXTENSIONLESS_FILES = new Set([
@@ -33,48 +37,99 @@ function looksLikeFilePath(path: string): boolean {
   return /\.\w{1,10}$/.test(lastSegment) || KNOWN_EXTENSIONLESS_FILES.has(lastSegment);
 }
 
+interface MatchEntry {
+  index: number;
+  length: number;
+  type: 'mention' | 'url';
+  value: string;
+}
+
 /**
- * Renders text content with @mentions styled as pills.
- * Mentions are detected by the pattern @filepath (e.g., @src/lib/utils.ts)
+ * Renders text content with @mentions styled as pills and URLs as clickable links.
  */
 export function MentionText({ content, className }: MentionTextProps) {
   const parts = React.useMemo(() => {
-    const result: React.ReactNode[] = [];
-    let lastIndex = 0;
+    // Collect all matches (mentions + URLs) with positions
+    const mentions: MatchEntry[] = [];
+    const urls: MatchEntry[] = [];
+
+    // Find mentions
+    const mentionRegex = new RegExp(MENTION_PATTERN.source, MENTION_PATTERN.flags);
     let match: RegExpExecArray | null;
-
-    // Create new regex instance to avoid shared state issues
-    const regex = new RegExp(MENTION_PATTERN.source, MENTION_PATTERN.flags);
-
-    while ((match = regex.exec(content)) !== null) {
-      const filePath = match[1];
-
-      // Skip matches that don't look like file paths (e.g., npm scoped packages)
-      if (!looksLikeFilePath(filePath)) {
-        continue;
+    while ((match = mentionRegex.exec(content)) !== null) {
+      if (looksLikeFilePath(match[1])) {
+        mentions.push({ index: match.index, length: match[0].length, type: 'mention', value: match[1] });
       }
-
-      // Add text before the mention
-      if (match.index > lastIndex) {
-        result.push(content.slice(lastIndex, match.index));
-      }
-
-      // Add the mention as a pill
-      const fileName = filePath.split('/').pop()!;
-      result.push(
-        <span
-          key={`${match.index}-${filePath}`}
-          className="inline-flex items-center gap-1 rounded-md bg-muted mx-0.5 px-1.5 -my-px align-middle leading-none font-medium text-sm"
-        >
-          <FileIcon filename={fileName} className="h-3.5 w-3.5" />
-          <span>{fileName}</span>
-        </span>
-      );
-
-      lastIndex = match.index + match[0].length;
     }
 
-    // Add remaining text after last mention
+    // Find URLs
+    const urlRegex = new RegExp(URL_PATTERN.source, URL_PATTERN.flags);
+    while ((match = urlRegex.exec(content)) !== null) {
+      urls.push({ index: match.index, length: match[0].length, type: 'url', value: match[0] });
+    }
+
+    // Remove mentions that are contained within a URL (e.g. @user in https://github.com/@user/repo)
+    const filteredMentions = mentions.filter((m) => {
+      const mEnd = m.index + m.length;
+      return !urls.some((u) => m.index >= u.index && mEnd <= u.index + u.length);
+    });
+
+    // Remove URLs that overlap with remaining mentions
+    const filteredUrls = urls.filter((u) => {
+      const uEnd = u.index + u.length;
+      return !filteredMentions.some((m) => {
+        const mEnd = m.index + m.length;
+        return u.index < mEnd && uEnd > m.index;
+      });
+    });
+
+    const matches = [...filteredMentions, ...filteredUrls];
+
+    if (matches.length === 0) return null;
+
+    // Sort by position
+    matches.sort((a, b) => a.index - b.index);
+
+    const result: React.ReactNode[] = [];
+    let lastIndex = 0;
+
+    for (const m of matches) {
+      // Add text before this match
+      if (m.index > lastIndex) {
+        result.push(content.slice(lastIndex, m.index));
+      }
+
+      if (m.type === 'mention') {
+        const fileName = m.value.split('/').pop()!;
+        result.push(
+          <span
+            key={`mention-${m.index}`}
+            className="inline-flex items-center gap-1 rounded-md bg-muted mx-0.5 px-1.5 -my-px align-middle leading-none font-medium text-sm"
+          >
+            <FileIcon filename={fileName} className="h-3.5 w-3.5" />
+            <span>{fileName}</span>
+          </span>
+        );
+      } else {
+        result.push(
+          <a
+            key={`url-${m.index}`}
+            href={m.value}
+            onClick={(e) => {
+              e.preventDefault();
+              openUrlInBrowser(m.value);
+            }}
+            className="text-brand underline underline-offset-2 hover:text-brand/80 cursor-pointer"
+          >
+            {m.value}
+          </a>
+        );
+      }
+
+      lastIndex = m.index + m.length;
+    }
+
+    // Add remaining text
     if (lastIndex < content.length) {
       result.push(content.slice(lastIndex));
     }
@@ -82,8 +137,8 @@ export function MentionText({ content, className }: MentionTextProps) {
     return result;
   }, [content]);
 
-  // If no mentions found, return plain text
-  if (parts.length === 1 && typeof parts[0] === 'string') {
+  // If no special content found, return plain text
+  if (!parts) {
     return <span className={className}>{content}</span>;
   }
 

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1853,6 +1853,16 @@ function SessionRow({
                     )}>
                       {session.branch || session.name}
                     </span>
+                    {/* Always-visible status indicators */}
+                    {session.hasMergeConflict && (
+                      <span className="w-2 h-2 rounded-full bg-orange-500 shrink-0" title="Merge conflict" />
+                    )}
+                    {session.hasCheckFailures && !session.hasMergeConflict && session.prStatus !== 'merged' && (
+                      <span className="w-2 h-2 rounded-full bg-red-500 shrink-0" title="Checks failing" />
+                    )}
+                    {session.prStatus === 'merged' && (
+                      <span className="w-2 h-2 rounded-full bg-purple-500 shrink-0" title="PR merged" />
+                    )}
                   </div>
                   {/* Git line stats badge and actions container */}
                   <div className="shrink-0 flex items-center">

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -2,7 +2,9 @@
 
 import * as React from 'react';
 import { createContext, useContext, useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from 'lucide-react';
+import { AlertCircle, AlertTriangle, CheckCircle2, Copy, Check, Info, X } from 'lucide-react';
+import { copyToClipboard } from '@/lib/tauri';
+import { COPY_FEEDBACK_DURATION_MS } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
 // Toast types
@@ -135,7 +137,9 @@ const toastStyles: Record<ToastType, string> = {
 
 function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: () => void }) {
   const [isLeaving, setIsLeaving] = useState(false);
+  const [copied, setCopied] = useState(false);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const copyTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     const duration = toast.duration ?? DEFAULT_DURATION[toast.type];
@@ -146,6 +150,7 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: () => void }) 
 
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
     };
   }, [toast, onRemove]);
 
@@ -153,6 +158,16 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: () => void }) 
     if (timerRef.current) clearTimeout(timerRef.current);
     setIsLeaving(true);
     setTimeout(onRemove, 200);
+  };
+
+  const handleCopy = async () => {
+    const text = [toast.title, toast.message].filter(Boolean).join(': ');
+    const success = await copyToClipboard(text);
+    if (success) {
+      setCopied(true);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_DURATION_MS);
+    }
   };
 
   const Icon = ToastIcon[toast.type];
@@ -177,13 +192,24 @@ function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: () => void }) 
           {toast.message}
         </p>
       </div>
-      <button
-        onClick={handleDismiss}
-        className="shrink-0 rounded-sm opacity-70 hover:opacity-100 transition-opacity"
-        aria-label="Dismiss notification"
-      >
-        <X className="w-4 h-4" />
-      </button>
+      <div className="flex items-center gap-1 shrink-0">
+        {(toast.type === 'error' || toast.type === 'warning') && (
+          <button
+            onClick={handleCopy}
+            className="rounded-sm opacity-70 hover:opacity-100 transition-opacity"
+            aria-label="Copy message"
+          >
+            {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+          </button>
+        )}
+        <button
+          onClick={handleDismiss}
+          className="rounded-sm opacity-70 hover:opacity-100 transition-opacity"
+          aria-label="Dismiss notification"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **MentionText**: Add clickable URL linkification that opens links in the system browser via Tauri. Uses two-pass overlap resolution so URLs take priority over `@mentions` contained within them (e.g. `https://github.com/@user/repo` renders as a single link, not a broken mention pill)
- **WorkspaceSidebar**: Add always-visible colored status dots next to session names for merge conflicts (orange), check failures (red), and merged PRs (purple). Check-failure dot is suppressed when the PR is already merged since it's no longer actionable
- **Toast**: Add copy-to-clipboard button on error/warning toasts with checkmark feedback. Includes proper timer cleanup on unmount and correct `aria-label`

## Test plan

- [ ] Verify URLs in conversation messages are rendered as clickable links that open in browser
- [ ] Verify `@file/path.ts` mentions inside URLs (e.g. `https://example.com/@scope/pkg.ts`) render as a single URL link, not a broken mention
- [ ] Verify sidebar status dots appear for sessions with merge conflicts, check failures, and merged PRs
- [ ] Verify check-failure dot is hidden when PR status is merged
- [ ] Verify error/warning toasts show a copy button; clicking it copies title + message and shows checkmark feedback
- [ ] Verify success/info toasts do NOT show a copy button

🤖 Generated with [Claude Code](https://claude.com/claude-code)