### PR TITLE
fix: remove duplicate "Enter Full Screen" menu item

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -167,12 +167,6 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
                 .accelerator("CmdOrCtrl+Shift+R")
                 .build(app)?,
         )
-        .separator()
-        .item(
-            &MenuItemBuilder::with_id("enter_full_screen", "Enter Full Screen")
-                .accelerator("Ctrl+Super+F")
-                .build(app)?,
-        )
         .build()?;
 
     // 5. Go menu

--- a/src/lib/menuContext.ts
+++ b/src/lib/menuContext.ts
@@ -67,8 +67,6 @@ export function computeMenuState(inputs: MenuContextInputs): Record<string, bool
     open_repositories: true,
     toggle_zen_mode: sessionInConversation,
     reset_layouts: true,
-    enter_full_screen: true,
-
     // Go menu
     navigate_back: canGoBack,
     navigate_forward: canGoForward,


### PR DESCRIPTION
## Summary
- Remove custom "Enter Full Screen" menu item from the View menu that duplicated the native macOS one
- The custom item had no event handler and did nothing when clicked
- The native macOS fullscreen entry remains and works correctly

## Test plan
- [ ] Open View menu → confirm only one "Enter Full Screen" item appears
- [ ] Verify native fullscreen toggle works (globe+F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)