### PR TITLE
fix: catch stale path error in InlineCombobox on slash command click

### DIFF
--- a/src/components/ui/inline-combobox.tsx
+++ b/src/components/ui/inline-combobox.tsx
@@ -397,7 +397,12 @@ const InlineComboboxItem = ({
     <ComboboxItem
       className={cn(comboboxItemVariants(), className)}
       onClick={(event) => {
-        removeInput(onClick ? false : focusEditor);
+        try {
+          removeInput(onClick ? false : focusEditor);
+        } catch {
+          // Element path may be stale if the editor was reset before removeInput completed.
+          // Safe to ignore: the subsequent onClick handler will clean up the editor state.
+        }
         onClick?.(event);
       }}
       {...props}


### PR DESCRIPTION
## Summary
- Wraps the `removeInput()` call in `InlineComboboxItem.onClick` with a try-catch to prevent `TypeError: undefined is not an object (evaluating 'Editor.node(editor, path)')` when clicking action-type slash commands like `/sprint`
- The error occurs because Plate's `useComboboxInput` hook holds a stale path reference by the time the click handler fires
- Safe to catch: the subsequent `onClick` handler (e.g. `editor.tf.reset()` for action commands) cleans up the editor state regardless

## Test plan
- [ ] Type `/sprint` in chat input and click the command — executes without error
- [ ] Type `/` and select any other slash command — works correctly
- [ ] Type `@` and select a mention — works correctly (mentions share `InlineComboboxItem`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)