### PR TITLE
feat: replace sidebar status dots with GitStatusIcon component

### DIFF
--- a/src/components/icons/GitStatusIcon.tsx
+++ b/src/components/icons/GitStatusIcon.tsx
@@ -1,0 +1,39 @@
+import { GitBranch, GitMerge, GitPullRequest, GitPullRequestClosed } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface GitStatusIconProps {
+  prStatus?: 'none' | 'open' | 'merged' | 'closed';
+  checkStatus?: 'none' | 'pending' | 'success' | 'failure';
+  hasMergeConflict?: boolean;
+  className?: string;
+}
+
+export function GitStatusIcon({ prStatus, checkStatus, hasMergeConflict, className = 'h-3.5 w-3.5 shrink-0' }: GitStatusIconProps) {
+  if (prStatus === 'merged') {
+    return <GitMerge className={cn(className, 'text-nav-icon-prs')} />;
+  }
+
+  if (prStatus === 'closed') {
+    if (checkStatus === 'failure' || hasMergeConflict) {
+      return <GitPullRequestClosed className={cn(className, 'text-text-error')} />;
+    }
+    return <GitPullRequestClosed className={cn(className, 'text-muted-foreground')} />;
+  }
+
+  if (prStatus === 'open') {
+    // Priority: failure > conflict > pending > passing
+    if (checkStatus === 'failure') {
+      return <GitPullRequest className={cn(className, 'text-text-error')} />;
+    }
+    if (hasMergeConflict) {
+      return <GitPullRequest className={cn(className, 'text-orange-400')} />;
+    }
+    if (checkStatus === 'pending') {
+      return <GitPullRequest className={cn(className, 'text-amber-500')} />;
+    }
+    return <GitPullRequest className={cn(className, 'text-text-success')} />;
+  }
+
+  // No PR — show muted branch icon
+  return <GitBranch className={cn(className, 'text-muted-foreground/50')} />;
+}

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -94,6 +94,7 @@ import { cn } from '@/lib/utils';
 import { getWorkspaceColor, WORKSPACE_COLORS } from '@/lib/workspace-colors';
 import { TASK_STATUS_OPTIONS, getPRStatusInfo } from '@/lib/session-fields';
 import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
+import { GitStatusIcon } from '@/components/icons/GitStatusIcon';
 import { useToast } from '@/components/ui/toast';
 import {
   Dialog,
@@ -1844,6 +1845,13 @@ function SessionRow({
                       </DropdownMenuContent>
                     </DropdownMenu>
                   )}
+                  {/* Git/PR status icon */}
+                  <GitStatusIcon
+                    prStatus={session.prStatus}
+                    checkStatus={session.checkStatus}
+                    hasMergeConflict={session.hasMergeConflict}
+                    className="w-3.5 h-3.5 shrink-0"
+                  />
                   {/* Branch name container - grows and truncates */}
                   <div className="flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
                     <span className={cn(
@@ -1853,16 +1861,6 @@ function SessionRow({
                     )}>
                       {session.branch || session.name}
                     </span>
-                    {/* Always-visible status indicators */}
-                    {session.hasMergeConflict && (
-                      <span className="w-2 h-2 rounded-full bg-orange-500 shrink-0" title="Merge conflict" />
-                    )}
-                    {session.hasCheckFailures && !session.hasMergeConflict && session.prStatus !== 'merged' && (
-                      <span className="w-2 h-2 rounded-full bg-red-500 shrink-0" title="Checks failing" />
-                    )}
-                    {session.prStatus === 'merged' && (
-                      <span className="w-2 h-2 rounded-full bg-purple-500 shrink-0" title="PR merged" />
-                    )}
                   </div>
                   {/* Git line stats badge and actions container */}
                   <div className="shrink-0 flex items-center">


### PR DESCRIPTION
## Summary

- Replaces inline colored status dots in the sidebar session row with a new `GitStatusIcon` component
- Shows contextual lucide-react icons (`GitBranch`, `GitPullRequest`, `GitMerge`, `GitPullRequestClosed`) with status-aware coloring for each PR lifecycle state
- Preserves failure/conflict signals on closed PRs (red icon when checks fail or merge conflict exists)

## Test plan

- [ ] Verify sessions without a PR show a muted branch icon
- [ ] Verify open PRs with passing checks show a green PR icon
- [ ] Verify open PRs with failing checks show a red PR icon
- [ ] Verify open PRs with merge conflicts show an orange PR icon
- [ ] Verify open PRs with pending checks show an amber PR icon
- [ ] Verify merged PRs show a purple merge icon
- [ ] Verify closed PRs show a muted closed-PR icon
- [ ] Verify closed PRs with check failures show a red closed-PR icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)