### PR TITLE
fix: improve right-click context menu with sub-menus, pinning, and status changes

### DIFF
--- a/src/components/data-table/DataTableRow.tsx
+++ b/src/components/data-table/DataTableRow.tsx
@@ -2,16 +2,20 @@
 
 import { forwardRef, useCallback, useState } from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Check } from 'lucide-react';
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
 import { cn } from '@/lib/utils';
-import type { DataTableRowProps, Column } from './types';
+import type { DataTableRowProps, Column, ContextMenuItem as ContextMenuItemType } from './types';
 
 // Helper to get cell value
 function getCellValue<T>(row: T, column: Column<T>): unknown {
@@ -25,6 +29,43 @@ function getCellValue<T>(row: T, column: Column<T>): unknown {
     return row[column.accessorKey];
   }
   return null;
+}
+
+// Render a single context menu item (recursive for sub-menus)
+function renderMenuItem(item: ContextMenuItemType, idx: number): React.ReactElement | null {
+  if (item.separator) {
+    return <ContextMenuSeparator key={`sep-${idx}`} />;
+  }
+
+  if (item.children && item.children.length > 0) {
+    return (
+      <ContextMenuSub key={item.label}>
+        <ContextMenuSubTrigger disabled={item.disabled}>
+          {item.icon}
+          <span>{item.label}</span>
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          {item.children.map((child, childIdx) => renderMenuItem(child, childIdx))}
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+    );
+  }
+
+  return (
+    <ContextMenuItem
+      key={item.label}
+      onClick={item.onClick}
+      disabled={item.disabled}
+      variant={item.variant}
+    >
+      {item.icon}
+      <span>{item.label}</span>
+      {item.shortcut && (
+        <ContextMenuShortcut>{item.shortcut}</ContextMenuShortcut>
+      )}
+      {item.checked && <Check className="ml-auto size-3.5 text-muted-foreground" />}
+    </ContextMenuItem>
+  );
 }
 
 // Helper to render cell alignment
@@ -170,24 +211,7 @@ function DataTableRowComponent<T>(
       <ContextMenu>
         <ContextMenuTrigger asChild>{rowContent}</ContextMenuTrigger>
         <ContextMenuContent>
-          {contextMenuItems.map((item, idx) =>
-            item.separator ? (
-              <ContextMenuSeparator key={`sep-${idx}`} />
-            ) : (
-              <ContextMenuItem
-                key={item.label}
-                onClick={item.onClick}
-                disabled={item.disabled}
-                variant={item.variant}
-              >
-                {item.icon}
-                <span>{item.label}</span>
-                {item.shortcut && (
-                  <ContextMenuShortcut>{item.shortcut}</ContextMenuShortcut>
-                )}
-              </ContextMenuItem>
-            )
-          )}
+          {contextMenuItems.map((item, idx) => renderMenuItem(item, idx))}
         </ContextMenuContent>
       </ContextMenu>
     );

--- a/src/components/data-table/types.ts
+++ b/src/components/data-table/types.ts
@@ -66,14 +66,18 @@ export interface ContextMenuItem {
   icon?: ReactNode;
   /** Keyboard shortcut hint */
   shortcut?: string;
-  /** Click handler */
-  onClick: () => void;
+  /** Click handler (optional for separators and sub-menu parents) */
+  onClick?: () => void;
   /** Visual variant */
   variant?: 'default' | 'destructive';
   /** Whether this is a separator (renders a divider) */
   separator?: boolean;
   /** Whether this item is disabled */
   disabled?: boolean;
+  /** Sub-menu items — renders as a sub-trigger with chevron when present */
+  children?: ContextMenuItem[];
+  /** Whether this item shows a checkmark (for current-state indicators) */
+  checked?: boolean;
 }
 
 // Display options for the table

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -236,7 +236,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
   }, [sessions]);
 
   // Sidebar grouping/sorting — only operates on non-scheduled sessions
-  const { groups: sidebarGroups, flatSessions, baseSessions, effectiveGroupBy } = useSidebarSessions({
+  const { groups: sidebarGroups, flatSessions, baseSessions, pinnedSessions, effectiveGroupBy } = useSidebarSessions({
     sessions: regularSessions,
     workspaces,
     groupBy: sidebarGroupBy,
@@ -979,6 +979,43 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                         {activeWorkspaceGroup && <GroupHeaderOverlay label={activeWorkspaceGroup.label} count={activeWorkspaceGroup.count} color={activeWorkspaceGroup.color} />}
                       </DragOverlay>
                     </DndContext>
+                  )}
+
+                  {/* Pinned sessions section */}
+                  {!isReorderMode && pinnedSessions.length > 0 && (
+                    <>
+                      <div className="px-3 pt-2 pb-1">
+                        <span className="text-[10px] font-semibold uppercase text-muted-foreground/60 tracking-wider">
+                          Pinned
+                        </span>
+                      </div>
+                      {pinnedSessions.map((session) => {
+                        const ws = workspaces.find((w) => w.id === session.workspaceId);
+                        return (
+                          <ErrorBoundary
+                            key={session.id}
+                            section="SessionRow"
+                            fallback={<CardErrorFallback message="Error loading session" />}
+                          >
+                            <SessionRow
+                              session={session}
+                              contentView={contentView}
+                              selectedSessionId={selectedSessionId}
+                              onSelectSession={(id, e) => handleSelectSession(session.workspaceId, id, e)}
+                              onArchiveSession={handleArchiveSession}
+                              onTaskStatusChange={handleTaskStatusChange}
+                              onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
+                              onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
+                              formatTimeAgo={formatTimeAgo}
+                              showProjectIndicator={hasMultipleWorkspaces && !sidebarProjectFilter}
+                              workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
+                              workspaceName={ws?.name}
+                            />
+                          </ErrorBoundary>
+                        );
+                      })}
+                      <div className="mx-2 my-1.5 border-t border-border/40" />
+                    </>
                   )}
 
                   {/* Scheduled task runs section */}

--- a/src/components/session-manager/SessionsDataTable.tsx
+++ b/src/components/session-manager/SessionsDataTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useCallback } from 'react';
-import { Layers, Archive, ExternalLink, Copy, FolderOpen, Eye } from 'lucide-react';
+import { Layers, Archive, ExternalLink, Copy, FolderOpen, Eye, Pin, PinOff, CircleDot } from 'lucide-react';
 import type { WorktreeSession, Workspace, SessionTaskStatus } from '@/lib/types';
 import { DataTable, type Column, type ContextMenuItem, type DisplayOptionsConfig } from '@/components/data-table';
 import {
@@ -12,7 +12,8 @@ import {
   ActionsCell,
 } from './cells';
 import { TaskStatusSelector } from '@/components/shared/TaskStatusSelector';
-import { getTaskStatusOption } from '@/lib/session-fields';
+import { getTaskStatusOption, TASK_STATUS_OPTIONS } from '@/lib/session-fields';
+import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 import { useAppStore } from '@/stores/appStore';
 import { updateSession as apiUpdateSession } from '@/lib/api';
 import { copyToClipboard } from '@/lib/tauri';
@@ -172,15 +173,49 @@ export function SessionsDataTable({
   // Context menu generator
   const handleContextMenu = useCallback(
     (row: SessionTableRow): ContextMenuItem[] => {
+      // Archived sessions: reduced menu
+      if (row.session.archived) {
+        const items: ContextMenuItem[] = [];
+        if (onPreviewSession) {
+          items.push(
+            {
+              label: 'Preview',
+              icon: <Eye className="h-4 w-4" />,
+              shortcut: '↩',
+              onClick: () => onPreviewSession(row.session.id),
+            },
+            { label: '', separator: true },
+          );
+        }
+        items.push(
+          {
+            label: 'Restore',
+            icon: <Archive className="h-4 w-4" />,
+            onClick: () => onUnarchiveSession(row.session.id),
+          },
+          {
+            label: 'Copy branch name',
+            icon: <Copy className="h-4 w-4" />,
+            shortcut: 'C',
+            onClick: async () => {
+              const success = await copyToClipboard(row.session.branch);
+              if (!success) showError('Failed to copy to clipboard');
+            },
+          },
+        );
+        return items;
+      }
+
+      // Active sessions: full menu
       const items: ContextMenuItem[] = [
         {
           label: 'Open session',
           icon: <FolderOpen className="h-4 w-4" />,
+          shortcut: '↩',
           onClick: () => onSelectSession(row.workspace.id, row.session.id),
         },
       ];
 
-      // Add PR link if exists
       if (row.session.prUrl) {
         items.push({
           label: 'View PR on GitHub',
@@ -189,47 +224,67 @@ export function SessionsDataTable({
         });
       }
 
-      items.push({
-        label: '',
-        separator: true,
-        onClick: () => {},
-      });
+      items.push(
+        { label: '', separator: true },
+        {
+          label: 'Set status',
+          icon: <CircleDot className="h-4 w-4" />,
+          children: TASK_STATUS_OPTIONS.map((option) => ({
+            label: option.label,
+            icon: <TaskStatusIcon status={option.value} className="h-4 w-4" />,
+            checked: row.session.taskStatus === option.value,
+            onClick: () => {
+              const prev = row.session.taskStatus;
+              storeUpdateSession(row.session.id, { taskStatus: option.value });
+              apiUpdateSession(row.workspace.id, row.session.id, { taskStatus: option.value }).catch(() => {
+                storeUpdateSession(row.session.id, { taskStatus: prev });
+                showError('Failed to update status');
+              });
+            },
+          })),
+        },
+      );
 
-      // Archive/Unarchive + archived-specific actions
-      if (row.session.archived) {
-        if (onPreviewSession) {
-          items.push({
-            label: 'Preview',
-            icon: <Eye className="h-4 w-4" />,
-            onClick: () => onPreviewSession(row.session.id),
-          });
-        }
+      // Pin/unpin only available for non-base sessions (base sessions have their own sidebar treatment)
+      if (row.session.sessionType !== 'base') {
         items.push({
-          label: 'Restore',
-          icon: <Archive className="h-4 w-4" />,
-          onClick: () => onUnarchiveSession(row.session.id),
-        });
-      } else {
-        items.push({
-          label: 'Archive',
-          icon: <Archive className="h-4 w-4" />,
-          onClick: () => onArchiveSession(row.session.id),
-          variant: 'destructive',
+          label: row.session.pinned ? 'Unpin' : 'Pin',
+          icon: row.session.pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />,
+          shortcut: 'P',
+          onClick: () => {
+            const newPinned = !row.session.pinned;
+            storeUpdateSession(row.session.id, { pinned: newPinned });
+            apiUpdateSession(row.workspace.id, row.session.id, { pinned: newPinned }).catch(() => {
+              storeUpdateSession(row.session.id, { pinned: !newPinned });
+              showError('Failed to update pin status');
+            });
+          },
         });
       }
 
-      items.push({
-        label: 'Copy branch name',
-        icon: <Copy className="h-4 w-4" />,
-        onClick: async () => {
-          const success = await copyToClipboard(row.session.branch);
-          if (!success) toast.error('Failed to copy to clipboard');
+      items.push(
+        {
+          label: 'Copy branch name',
+          icon: <Copy className="h-4 w-4" />,
+          shortcut: 'C',
+          onClick: async () => {
+            const success = await copyToClipboard(row.session.branch);
+            if (!success) showError('Failed to copy to clipboard');
+          },
         },
-      });
+        { label: '', separator: true },
+        {
+          label: 'Archive',
+          icon: <Archive className="h-4 w-4" />,
+          shortcut: '⌘⇧A',
+          onClick: () => onArchiveSession(row.session.id),
+          variant: 'destructive',
+        },
+      );
 
       return items;
     },
-    [onSelectSession, onArchiveSession, onUnarchiveSession, onPreviewSession, toast]
+    [onSelectSession, onArchiveSession, onUnarchiveSession, onPreviewSession, showError, storeUpdateSession]
   );
 
   // Display options configuration

--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -149,7 +149,7 @@ export function useSidebarSessions({
   workspaceColors,
   getWorkspaceColor: getDefaultColor,
   statusGroupOrder,
-}: UseSidebarSessionsOptions): { groups: SidebarGroup[]; flatSessions: WorktreeSession[]; baseSessions: WorktreeSession[]; effectiveGroupBy: SidebarGroupBy } {
+}: UseSidebarSessionsOptions): { groups: SidebarGroup[]; flatSessions: WorktreeSession[]; baseSessions: WorktreeSession[]; pinnedSessions: WorktreeSession[]; effectiveGroupBy: SidebarGroupBy } {
   return useMemo(() => {
     // When filtering to a single project, pre-filter sessions and downgrade groupBy
     const effectiveSessions = projectFilter
@@ -161,31 +161,41 @@ export function useSidebarSessions({
 
     const filtered = filterSessions(effectiveSessions, filters);
 
+    // Partition pinned sessions. Base sessions are excluded from pinning — they have
+    // their own sidebar treatment. The pin menu item is hidden for base sessions in
+    // SessionsDataTable. Note: pinned sessions honour the search filter since they
+    // are derived from `filtered` (which applies searchTerm).
+    const pinned = filtered.filter(s => s.pinned && s.sessionType !== 'base');
+    const unpinned = filtered.filter(s => !s.pinned || s.sessionType === 'base');
+    const pinnedSessions = sortSessions(pinned, sortBy);
+
     if (effectiveGroupBy === 'none') {
-      const base = sortSessions(filtered.filter(s => s.sessionType === 'base'), sortBy);
-      const regular = filtered.filter(s => s.sessionType !== 'base');
+      const base = sortSessions(unpinned.filter(s => s.sessionType === 'base'), sortBy);
+      const regular = unpinned.filter(s => s.sessionType !== 'base');
       return {
         groups: [],
         flatSessions: sortSessions(regular, sortBy),
         baseSessions: base,
+        pinnedSessions,
         effectiveGroupBy,
       };
     }
 
     if (effectiveGroupBy === 'status') {
-      const base = sortSessions(filtered.filter(s => s.sessionType === 'base'), sortBy);
-      const regular = filtered.filter(s => s.sessionType !== 'base');
+      const base = sortSessions(unpinned.filter(s => s.sessionType === 'base'), sortBy);
+      const regular = unpinned.filter(s => s.sessionType !== 'base');
       return {
         groups: applyStatusGroupOrder(buildStatusGroups(regular, sortBy), statusGroupOrder),
         flatSessions: [],
         baseSessions: base,
+        pinnedSessions,
         effectiveGroupBy,
       };
     }
 
     // For project-based grouping, bucket sessions by workspace
     const byWorkspace = new Map<string, WorktreeSession[]>();
-    for (const s of filtered) {
+    for (const s of unpinned) {
       const list = byWorkspace.get(s.workspaceId);
       if (list) list.push(s);
       else byWorkspace.set(s.workspaceId, [s]);
@@ -211,7 +221,7 @@ export function useSidebarSessions({
           sessions: sortSessions(regular, sortBy),
         });
       }
-      return { groups, flatSessions: [], baseSessions: [], effectiveGroupBy };
+      return { groups, flatSessions: [], baseSessions: [], pinnedSessions, effectiveGroupBy };
     }
 
     // project-status
@@ -237,10 +247,10 @@ export function useSidebarSessions({
           subGroups,
         });
       }
-      return { groups, flatSessions: [], baseSessions: [], effectiveGroupBy };
+      return { groups, flatSessions: [], baseSessions: [], pinnedSessions, effectiveGroupBy };
     }
 
-    return { groups: [], flatSessions: [], baseSessions: [], effectiveGroupBy };
+    return { groups: [], flatSessions: [], baseSessions: [], pinnedSessions, effectiveGroupBy };
   }, [sessions, workspaces, groupBy, sortBy, filters, projectFilter, workspaceColors, getDefaultColor, statusGroupOrder]);
 }
 


### PR DESCRIPTION
## Summary
- Add sub-menu support to `DataTableRow` with recursive `renderMenuItem` at module level, and extend `ContextMenuItem` type with `children`, `checked`, and optional `onClick`
- Add "Set status" sub-menu with checkmarks and "Pin/Unpin" action (guarded against base sessions) to session context menu, with optimistic updates
- Fix several latent bugs: shortcut/checkmark render order, leading separator when Preview is absent, unstable `toast` object in `useCallback` deps
- Add pinned sessions section to `WorkspaceSidebar` and partition logic in `useSidebarSessions` across all grouping modes

## Test plan
- [ ] Right-click a session → verify "Set status" sub-menu shows with checkmark on current status
- [ ] Right-click a non-base session → verify Pin/Unpin appears; right-click a base session → verify it does not
- [ ] Pin a session → verify it appears in the "Pinned" section at top of sidebar
- [ ] Right-click an archived session without `onPreviewSession` → verify no leading separator
- [ ] Verify shortcuts render to the left of checkmarks in menu items that have both

🤖 Generated with [Claude Code](https://claude.com/claude-code)