### PR TITLE
fix: hide status icon in session cells when grouped by status

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1779,6 +1779,7 @@ function SessionRow({
   showProjectIndicator,
   workspaceColor,
   workspaceName,
+  hideStatusIcon,
 }: {
   session: WorktreeSession;
   contentView: ContentView;
@@ -1792,6 +1793,7 @@ function SessionRow({
   showProjectIndicator?: boolean;
   workspaceColor?: string;
   workspaceName?: string;
+  hideStatusIcon?: boolean;
 }) {
   const isSessionSelected = contentView.type === 'conversation' && selectedSessionId === session.id;
   const hasPR = session.prStatus && session.prStatus !== 'none';
@@ -1856,7 +1858,7 @@ function SessionRow({
                     <div className="w-4 shrink-0 flex items-center justify-center">
                       <FolderGit2 className="w-3.5 h-3.5 text-blue-500" />
                     </div>
-                  ) : (
+                  ) : hideStatusIcon ? null : (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <button
@@ -2176,6 +2178,7 @@ function StatusGroupSection({
                   showProjectIndicator={showProjectIndicator}
                   workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
                   workspaceName={ws?.name}
+                  hideStatusIcon
                 />
               </ErrorBoundary>
             );
@@ -2438,6 +2441,7 @@ function SortableProjectStatusItem({
                                 onOpenBranches={onOpenBranches}
                                 onOpenPRs={onOpenPRs}
                                 formatTimeAgo={formatTimeAgo}
+                                hideStatusIcon
                               />
                             </ErrorBoundary>
                           ))}


### PR DESCRIPTION
## Summary
- Hide the redundant TaskStatusIcon in session cells when the sidebar is grouped by **Status** or **Project > Status**, since the group header already displays the status icon
- Activity indicators (streaming, awaiting input/approval) and base session icons are unaffected

## Test plan
- [ ] Group sidebar by Status → verify session cells do **not** show the status icon
- [ ] Group sidebar by Project > Status → verify session cells under status sub-groups do **not** show the status icon
- [ ] Group by None or Project → verify session cells **still** show the status icon
- [ ] Verify streaming/awaiting indicators still render in all grouping modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)