### PR TITLE
fix: harden polling-based branch change detection

### DIFF
--- a/backend/git/repo.go
+++ b/backend/git/repo.go
@@ -618,7 +618,13 @@ func (rm *RepoManager) HasMergeConflicts(ctx context.Context, repoPath string) (
 
 // GitStatus represents the comprehensive git status of a worktree
 type GitStatus struct {
-	WorkingDirectory WorkingDirectoryStatus `json:"workingDirectory"`
+	// CurrentBranch is the actual checked-out branch name. Only populated by
+	// GetSessionGitStatus (polling endpoint), not by GetSessionSnapshot.
+	CurrentBranch      string                 `json:"currentBranch,omitempty"`
+	// CurrentSessionName is the derived display name for the session when a
+	// branch change is detected. Only populated alongside CurrentBranch.
+	CurrentSessionName string                 `json:"currentSessionName,omitempty"`
+	WorkingDirectory   WorkingDirectoryStatus `json:"workingDirectory"`
 	Sync             SyncStatus             `json:"sync"`
 	InProgress       InProgressStatus       `json:"inProgress"`
 	Conflicts        ConflictStatus         `json:"conflicts"`

--- a/backend/server/session_git_handlers.go
+++ b/backend/server/session_git_handlers.go
@@ -8,9 +8,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/chatml/chatml-backend/git"
 	"github.com/chatml/chatml-backend/logger"
+	"github.com/chatml/chatml-backend/models"
+	"github.com/chatml/chatml-backend/naming"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -33,11 +36,68 @@ func (h *Handlers) GetSessionGitStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get comprehensive git status
-	status, err := h.repoManager.GetStatus(ctx, workingPath, baseRef)
-	if err != nil {
-		writeInternalError(w, "failed to get git status", err)
+	// Get comprehensive git status and current branch in parallel
+	var (
+		status        *git.GitStatus
+		currentBranch string
+		statusErr     error
+		branchErr     error
+		wg            sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		status, statusErr = h.repoManager.GetStatus(ctx, workingPath, baseRef)
+	}()
+	go func() {
+		defer wg.Done()
+		currentBranch, branchErr = h.repoManager.GetCurrentBranch(ctx, workingPath)
+	}()
+	wg.Wait()
+
+	if statusErr != nil {
+		writeInternalError(w, "failed to get git status", statusErr)
 		return
+	}
+
+	// Include current branch in the response so polling can detect external branch changes.
+	// Skip detached HEAD state ("HEAD" or "") — the branch watcher handles this correctly
+	// via readCurrentBranch, but the subprocess fallback returns "HEAD" for detached state.
+	if branchErr == nil && currentBranch != "" && currentBranch != "HEAD" {
+		status.CurrentBranch = currentBranch
+		// If branch changed since last DB record, update DB (mirrors branch watcher behavior)
+		if currentBranch != session.Branch {
+			newName := naming.ExtractSessionNameFromBranch(currentBranch)
+			status.CurrentSessionName = newName
+			if newName == "" {
+				newName = currentBranch
+			}
+			if updateErr := h.store.UpdateSession(ctx, sessionID, func(s *models.Session) {
+				s.Branch = currentBranch
+				s.Name = newName
+				s.UpdatedAt = time.Now()
+			}); updateErr != nil {
+				logger.Handlers.Warnf("Failed to update branch in DB for session %s: %v", sessionID, updateErr)
+			} else if h.hub != nil {
+				// Broadcast WebSocket events to match branch watcher behavior
+				h.hub.Broadcast(Event{
+					Type:      "session_name_update",
+					SessionID: sessionID,
+					Payload: map[string]interface{}{
+						"type":   "session_name_update",
+						"name":   newName,
+						"branch": currentBranch,
+					},
+				})
+				h.hub.Broadcast(Event{
+					Type: "branch_dashboard_update",
+					Payload: map[string]interface{}{
+						"sessionId": sessionID,
+						"updatedAt": time.Now().Unix(),
+					},
+				})
+			}
+		}
 	}
 
 	// The baseRef used for ahead/behind may be a merge-base SHA.

--- a/src/hooks/useBaseSessionGitStatus.ts
+++ b/src/hooks/useBaseSessionGitStatus.ts
@@ -13,6 +13,7 @@ export interface UseBaseSessionGitStatusResult {
 /**
  * Lightweight git status hook for base session cards in the sidebar.
  * Calls getGitStatus (not the full snapshot) and polls at 2x the normal interval.
+ * Also detects external branch changes via the currentBranch field in the response.
  */
 export function useBaseSessionGitStatus(
   workspaceId: string | null,
@@ -39,6 +40,19 @@ export function useBaseSessionGitStatus(
       if (isMountedRef.current) {
         setGitStatus(status);
         setLoading(false);
+
+        // If backend reports a different branch, update both branch and name in the store.
+        // This acts as a fallback for when the WebSocket broadcast is missed.
+        if (status.currentBranch) {
+          const session = useAppStore.getState().sessions.find(s => s.id === sessionId);
+          if (session && session.branch !== status.currentBranch) {
+            const updates: { branch: string; name?: string } = { branch: status.currentBranch };
+            if (status.currentSessionName) {
+              updates.name = status.currentSessionName;
+            }
+            useAppStore.getState().updateSession(sessionId, updates);
+          }
+        }
       }
     } catch (err) {
       if (isMountedRef.current) {
@@ -101,6 +115,20 @@ export function useBaseSessionGitStatus(
       debouncedRefetch();
     }
   }, [active, lastFileChange, workspaceId, debouncedRefetch]);
+
+  // Refetch immediately when the app becomes visible (e.g., user tabs back from terminal)
+  useEffect(() => {
+    if (!active || !workspaceId || !sessionId) return;
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden && isMountedRef.current) {
+        fetchStatus();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [active, workspaceId, sessionId, fetchStatus]);
 
   return { gitStatus, loading };
 }

--- a/src/lib/api/git.ts
+++ b/src/lib/api/git.ts
@@ -40,8 +40,12 @@ export async function getSessionBranchCommits(workspaceId: string, sessionId: st
   return handleResponse<BranchChangesResponseDTO>(res);
 }
 
-// Git status types matching backend response
+// Git status types matching backend response.
+// currentBranch and currentSessionName are only populated by the /git-status
+// polling endpoint, not by /snapshot.
 export interface GitStatusDTO {
+  currentBranch?: string;
+  currentSessionName?: string;
   workingDirectory: {
     stagedCount: number;
     unstagedCount: number;


### PR DESCRIPTION
## Summary
- Guard against detached HEAD state (`"HEAD"` or `""`) corrupting session branch in the DB during polling
- Parallelize `GetCurrentBranch` with `GetStatus` using `sync.WaitGroup` to eliminate serial latency
- Set `UpdatedAt` on DB update and broadcast WebSocket events (`session_name_update`, `branch_dashboard_update`) to match the branch watcher code path
- Add `currentSessionName` to the git-status API response so the frontend updates both `branch` and `name` in the store (previously only `branch` was updated)
- Add `isMountedRef.current` guard to the `visibilitychange` handler for defensive cleanup
- Document that `currentBranch`/`currentSessionName` fields are only populated by the polling endpoint, not the snapshot endpoint

## Test plan
- [ ] Verify base session cards in sidebar update branch + name after external `git checkout`
- [ ] Verify detached HEAD state (e.g., during rebase) does not overwrite session branch with `"HEAD"`
- [ ] Verify multiple open windows receive branch change updates via WebSocket
- [ ] Verify `go test -race ./...` passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)