### PR TITLE
fix: polish sprint phase toolbar with progress rail and node design

### DIFF
--- a/src/components/shared/SprintPhaseToolbar.tsx
+++ b/src/components/shared/SprintPhaseToolbar.tsx
@@ -6,7 +6,7 @@ import { SPRINT_PHASE_OPTIONS } from '@/lib/session-fields';
 import { SPRINT_PHASES } from '@/lib/types';
 import type { SprintPhase } from '@/lib/types';
 import { cn } from '@/lib/utils';
-import { Check, ChevronRight, X } from 'lucide-react';
+import { Check, X } from 'lucide-react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
 interface SprintPhaseToolbarProps {
@@ -20,6 +20,10 @@ export function SprintPhaseToolbar({ onClose }: SprintPhaseToolbarProps) {
 
   const phase = selectedSession?.sprintPhase;
   const currentIndex = phase ? SPRINT_PHASES.indexOf(phase) : -1;
+  const totalPhases = SPRINT_PHASE_OPTIONS.length;
+  const progressPercent = currentIndex >= 0 && totalPhases > 1
+    ? (currentIndex / (totalPhases - 1)) * 100
+    : 0;
 
   // Delegate phase changes to SessionToolbarContent via the existing event bus,
   // ensuring PHASE_TO_STATUS sync happens in one place.
@@ -40,48 +44,79 @@ export function SprintPhaseToolbar({ onClose }: SprintPhaseToolbarProps) {
 
         <div className="w-px h-4 bg-border/60 shrink-0" />
 
-        {/* Center: Phase stepper */}
-        <div className="flex-1 flex items-center justify-center">
-          {SPRINT_PHASE_OPTIONS.map((opt, idx) => {
-            const isActive = opt.value === phase;
-            const isCompleted = idx < currentIndex;
-            const Icon = opt.icon;
-            const isLast = idx === SPRINT_PHASE_OPTIONS.length - 1;
+        {/* Center: Phase stepper with progress rail */}
+        <div className="flex-1 flex items-center justify-center px-2">
+          <div className="relative flex items-center w-full max-w-xl">
+            {/* Background rail (full width, muted) */}
+            <div className="absolute inset-x-3 top-1/2 -translate-y-1/2 h-[2px] bg-border/50 rounded-full" />
 
-            return (
-              <div key={opt.value} className="flex items-center">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={() => handleChange(isActive ? null : opt.value)}
-                      disabled={isAgentWorking}
-                      aria-label={opt.label}
-                      aria-pressed={isActive}
-                      className={cn(
-                        'flex items-center gap-1.5 h-7 px-2.5 rounded-md text-xs font-medium transition-all',
-                        isActive && [opt.activeClass, 'shadow-sm'],
-                        isCompleted && 'text-muted-foreground/50 hover:text-muted-foreground/80 hover:bg-accent/50',
-                        !isActive && !isCompleted && 'text-muted-foreground/30 hover:text-muted-foreground/70 hover:bg-accent/50',
-                        isAgentWorking && 'pointer-events-none opacity-50',
-                      )}
-                    >
-                      {isCompleted
-                        ? <Check className="h-3 w-3 shrink-0" />
-                        : <Icon className={cn('h-3 w-3 shrink-0', isActive && opt.color)} />
-                      }
-                      <span className={cn('hidden sm:inline', isActive && 'inline')}>
-                        {opt.label}
-                      </span>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{opt.description}</TooltipContent>
-                </Tooltip>
-                {!isLast && (
-                  <ChevronRight className="h-3 w-3 text-muted-foreground/20 shrink-0 mx-0.5" />
-                )}
-              </div>
-            );
-          })}
+            {/* Completed rail (fills from left to active phase) */}
+            <div
+              className="absolute left-3 top-1/2 -translate-y-1/2 h-[2px] rounded-full bg-muted-foreground/30 transition-all duration-300 ease-out"
+              style={{ width: `calc(${progressPercent}% - ${progressPercent > 0 ? '24px' : '0px'})` }}
+            />
+
+            {/* Phase nodes */}
+            <div className="relative flex items-center justify-between w-full">
+              {SPRINT_PHASE_OPTIONS.map((opt, idx) => {
+                const isActive = opt.value === phase;
+                const isCompleted = idx < currentIndex;
+                const Icon = opt.icon;
+
+                return (
+                  <Tooltip key={opt.value}>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => handleChange(isActive ? null : opt.value)}
+                        disabled={isAgentWorking}
+                        aria-label={opt.label}
+                        aria-pressed={isActive}
+                        className={cn(
+                          'relative flex items-center gap-1.5 group transition-all duration-200',
+                          isAgentWorking && 'opacity-50',
+                        )}
+                      >
+                        {/* Node circle */}
+                        <div className={cn(
+                          'flex items-center justify-center h-5 w-5 rounded-full border-[1.5px] transition-all duration-200',
+                          isActive && [
+                            opt.color,
+                            'border-current bg-current/15 scale-110 shadow-[0_0_8px_-2px_currentColor]',
+                          ],
+                          isCompleted && [
+                            'border-muted-foreground/40 bg-muted-foreground/10 text-muted-foreground/70',
+                            'group-hover:border-muted-foreground/60 group-hover:bg-muted-foreground/20',
+                          ],
+                          !isActive && !isCompleted && [
+                            'border-border bg-transparent text-muted-foreground/50',
+                            'group-hover:border-muted-foreground/40 group-hover:bg-accent/30 group-hover:text-muted-foreground/70',
+                          ],
+                        )}>
+                          {isCompleted
+                            ? <Check className="h-2.5 w-2.5" />
+                            : <Icon className={cn('h-2.5 w-2.5', isActive && opt.color)} />
+                          }
+                        </div>
+
+                        {/* Label */}
+                        <span className={cn(
+                          'text-[10px] font-medium leading-none transition-colors duration-200',
+                          isActive && [opt.color, 'font-semibold'],
+                          isCompleted && 'text-muted-foreground/60 group-hover:text-muted-foreground/80',
+                          !isActive && !isCompleted && 'text-muted-foreground/45 group-hover:text-muted-foreground/70',
+                          'hidden sm:inline',
+                          isActive && '!inline',
+                        )}>
+                          {opt.label}
+                        </span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{opt.description}</TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </div>
         </div>
 
         <div className="w-px h-4 bg-border/60 shrink-0" />


### PR DESCRIPTION
## Summary

- Redesigns the sprint phase stepper from chevron-separated pill buttons to a visual progress rail with circular node indicators
- Fixes progress rail overflow at the last phase (was overshooting by 12px)
- Wires up `group-hover:` so hovering anywhere on a phase button highlights both the circle and label together
- Removes redundant `pointer-events-none` (native `disabled` already handles it)
- Adds division-by-zero guard for `totalPhases - 1`

## Test plan

- [ ] Open a session with sprint phases enabled
- [ ] Verify the progress rail fills correctly from Think through Reflect without overflowing
- [ ] Hover over phase labels and circles — both should highlight together
- [ ] Set phase to Reflect (last) and confirm the filled rail aligns with the background rail
- [ ] Verify disabled state (agent working) dims buttons correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)