### PR TITLE
refactor: move session badges from sidebar row to hover card

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -92,7 +92,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { getWorkspaceColor, WORKSPACE_COLORS } from '@/lib/workspace-colors';
-import { TASK_STATUS_OPTIONS, getPRStatusInfo, getSprintPhaseOption } from '@/lib/session-fields';
+import { TASK_STATUS_OPTIONS } from '@/lib/session-fields';
 import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 import { GitStatusIcon } from '@/components/icons/GitStatusIcon';
 import { useToast } from '@/components/ui/toast';
@@ -114,7 +114,6 @@ import { useSessionActivityState, useIsSessionUnread, useWorkspaceSelection, use
 import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog';
 import { useArchiveSession } from '@/hooks/useArchiveSession';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
-import { PRNumberBadge } from '@/components/shared/PRNumberBadge';
 import { CardErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
 import { SessionHoverCardBody } from '@/components/shared/SessionHoverCard';
@@ -1008,9 +1007,6 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                               onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
                               onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
                               formatTimeAgo={formatTimeAgo}
-                              showProjectIndicator={hasMultipleWorkspaces && !sidebarProjectFilter}
-                              workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
-                              workspaceName={ws?.name}
                             />
                           </ErrorBoundary>
                         );
@@ -1053,7 +1049,6 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                                   onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
                                   onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
                                   formatTimeAgo={formatTimeAgo}
-                                  showProjectIndicator={false}
                                 />
                               </ErrorBoundary>
                             ))}
@@ -1110,9 +1105,6 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                                 onOpenBranches={(e) => navigateToBranches(session.workspaceId, e)}
                                 onOpenPRs={(e) => navigateToPRs(session.workspaceId, e)}
                                 formatTimeAgo={formatTimeAgo}
-                                showProjectIndicator={hasMultipleWorkspaces && !sidebarProjectFilter}
-                                workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
-                                workspaceName={ws?.name}
                               />
                             </ErrorBoundary>
                           );
@@ -1163,7 +1155,6 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                             onOpenBranches={navigateToBranches}
                             onOpenPRs={navigateToPRs}
                             formatTimeAgo={formatTimeAgo}
-                            showProjectIndicator={hasMultipleWorkspaces && !sidebarProjectFilter}
                           />
                         ))
                       )}
@@ -1776,9 +1767,6 @@ function SessionRow({
   onOpenBranches,
   onOpenPRs,
   formatTimeAgo,
-  showProjectIndicator,
-  workspaceColor,
-  workspaceName,
   hideStatusIcon,
 }: {
   session: WorktreeSession;
@@ -1790,15 +1778,10 @@ function SessionRow({
   onOpenBranches?: (event?: React.MouseEvent) => void;
   onOpenPRs?: (event?: React.MouseEvent) => void;
   formatTimeAgo: (date: string) => string;
-  showProjectIndicator?: boolean;
-  workspaceColor?: string;
-  workspaceName?: string;
   hideStatusIcon?: boolean;
 }) {
   const isSessionSelected = contentView.type === 'conversation' && selectedSessionId === session.id;
-  const hasPR = session.prStatus && session.prStatus !== 'none';
   const hasStats = session.stats && (session.stats.additions > 0 || session.stats.deletions > 0);
-  const sidebarShowSessionMeta = useSettingsStore((s) => s.sidebarShowSessionMeta);
 
   // Derive activity state from streaming, pending questions, and plan approvals
   const sessionId = session.id;
@@ -1806,7 +1789,6 @@ function SessionRow({
   const isSessionUnread = useIsSessionUnread(sessionId);
   const lastAgentCompletedAt = useAppStore((s) => s.lastTurnCompletedAt[sessionId]);
 
-  const prStatusInfo = getPRStatusInfo(session);
   const [hoverOpen, setHoverOpen] = useState(false);
   const { success: showRowSuccess, warning: showRowWarning } = useToast();
 
@@ -1926,60 +1908,6 @@ function SessionRow({
                     )}
                   </div>
                 </div>
-                {/* Second line: sprint phase · project indicator · PR info · status */}
-                {sidebarShowSessionMeta && (hasPR || (showProjectIndicator && workspaceName) || session.sprintPhase) && (
-                  <div className="flex items-center gap-1 mt-0.5 pl-1 text-sm text-muted-foreground">
-                    {/* Sprint phase pill */}
-                    {session.sprintPhase && (() => {
-                      const phaseOpt = getSprintPhaseOption(session.sprintPhase);
-                      const PhaseIcon = phaseOpt.icon;
-                      return (
-                        <span className={cn('inline-flex items-center gap-0.5 shrink-0 text-[10px] font-medium rounded px-1 py-px', phaseOpt.activeClass)}>
-                          <PhaseIcon className="h-2.5 w-2.5" />
-                          {phaseOpt.label}
-                        </span>
-                      );
-                    })()}
-                    {/* Project indicator for non-project grouping modes */}
-                    {showProjectIndicator && workspaceColor && (
-                      <>
-                        {session.sprintPhase && <span className="text-muted-foreground/50">·</span>}
-                        <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: workspaceColor }} />
-                      </>
-                    )}
-                    {showProjectIndicator && workspaceName && (
-                      <span className="shrink-0 text-muted-foreground/70">{workspaceName}</span>
-                    )}
-                    {/* PR badge if applicable */}
-                    {hasPR && session.prNumber && (
-                      <>
-                        {(showProjectIndicator && workspaceName || session.sprintPhase) && <span className="text-muted-foreground/50">·</span>}
-                        <PRNumberBadge
-                          prNumber={session.prNumber}
-                          prStatus={session.prStatus as 'open' | 'merged' | 'closed'}
-                          checkStatus={session.checkStatus}
-                          hasMergeConflict={session.hasMergeConflict}
-                          prUrl={session.prUrl}
-                          size="sm"
-                        />
-                      </>
-                    )}
-                    {hasPR && !session.prNumber && (
-                      <>
-                        {(showProjectIndicator && workspaceName || session.sprintPhase) && <span className="text-muted-foreground/50">·</span>}
-                        <GitPullRequest className="h-3 w-3 shrink-0 text-nav-icon-prs" />
-                      </>
-                    )}
-                    {prStatusInfo && (
-                      <>
-                        <span className="text-muted-foreground/50">·</span>
-                        <span className={cn('shrink-0', prStatusInfo.color)}>
-                          {prStatusInfo.text}
-                        </span>
-                      </>
-                    )}
-                  </div>
-                )}
               </div>
             </div>
           </HoverCardTrigger>
@@ -2137,7 +2065,6 @@ function StatusGroupSection({
   onOpenBranches,
   onOpenPRs,
   formatTimeAgo,
-  showProjectIndicator,
 }: {
   group: SidebarGroup;
   isExpanded: boolean;
@@ -2152,7 +2079,6 @@ function StatusGroupSection({
   onOpenBranches: (workspaceId: string, event?: React.MouseEvent) => void;
   onOpenPRs: (workspaceId: string, event?: React.MouseEvent) => void;
   formatTimeAgo: (date: string) => string;
-  showProjectIndicator?: boolean;
 }) {
   return (
     <Collapsible open={isExpanded} onOpenChange={onToggle}>
@@ -2189,9 +2115,6 @@ function StatusGroupSection({
                   onOpenBranches={(e) => onOpenBranches(session.workspaceId, e)}
                   onOpenPRs={(e) => onOpenPRs(session.workspaceId, e)}
                   formatTimeAgo={formatTimeAgo}
-                  showProjectIndicator={showProjectIndicator}
-                  workspaceColor={workspaceColors[session.workspaceId] || getWorkspaceColor(session.workspaceId)}
-                  workspaceName={ws?.name}
                   hideStatusIcon
                 />
               </ErrorBoundary>

--- a/src/components/settings/sections/AppearanceSettings.tsx
+++ b/src/components/settings/sections/AppearanceSettings.tsx
@@ -105,8 +105,6 @@ export function AppearanceSettings() {
   const setFontSize = useSettingsStore((s) => s.setFontSize);
   const zenMode = useSettingsStore((s) => s.zenMode);
   const setZenMode = useSettingsStore((s) => s.setZenMode);
-  const sidebarShowSessionMeta = useSettingsStore((s) => s.sidebarShowSessionMeta);
-  const setSidebarShowSessionMeta = useSettingsStore((s) => s.setSidebarShowSessionMeta);
   const showTokenUsage = useSettingsStore((s) => s.showTokenUsage);
   const setShowTokenUsage = useSettingsStore((s) => s.setShowTokenUsage);
   const showChatCost = useSettingsStore((s) => s.showChatCost);
@@ -173,18 +171,6 @@ export function AppearanceSettings() {
           onReset={() => setZenMode(SETTINGS_DEFAULTS.zenMode)}
         >
           <Switch checked={zenMode} onCheckedChange={setZenMode} aria-label="Zen mode" />
-        </SettingsRow>
-      </SettingsGroup>
-
-      <SettingsGroup label="Sidebar">
-        <SettingsRow
-          settingId="sidebarShowSessionMeta"
-          title="Show session status line"
-          description="Display PR status (Merged, Ready for Merge, etc.) below session names in the sidebar"
-          isModified={sidebarShowSessionMeta !== SETTINGS_DEFAULTS.sidebarShowSessionMeta}
-          onReset={() => setSidebarShowSessionMeta(SETTINGS_DEFAULTS.sidebarShowSessionMeta)}
-        >
-          <Switch checked={sidebarShowSessionMeta} onCheckedChange={setSidebarShowSessionMeta} aria-label="Show session status line" />
         </SettingsRow>
       </SettingsGroup>
 

--- a/src/components/shared/SessionHoverCard.tsx
+++ b/src/components/shared/SessionHoverCard.tsx
@@ -3,7 +3,7 @@
 import { FolderGit2, GitBranch, GitPullRequest } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
-import { getTaskStatusOption, getPRStatusInfo } from '@/lib/session-fields';
+import { getTaskStatusOption, getPRStatusInfo, getSprintPhaseOption } from '@/lib/session-fields';
 import { PRNumberBadge } from '@/components/shared/PRNumberBadge';
 import type { WorktreeSession } from '@/lib/types';
 import type { GitStatusDTO } from '@/lib/api';
@@ -27,6 +27,8 @@ export function SessionHoverCardBody({
   const hasPR = session.prStatus && session.prStatus !== 'none';
   const statusOption = getTaskStatusOption(session.taskStatus);
   const prStatusInfo = getPRStatusInfo(session);
+  const sprintPhaseOpt = session.sprintPhase ? getSprintPhaseOption(session.sprintPhase) : null;
+  const SprintPhaseIcon = sprintPhaseOpt?.icon;
 
   return (
     <>
@@ -89,6 +91,16 @@ export function SessionHoverCardBody({
           )}
         </span>
       </div>
+
+      {/* Sprint phase */}
+      {sprintPhaseOpt && SprintPhaseIcon && (
+        <div className="px-3 pb-1.5">
+          <span className={cn('inline-flex items-center gap-1 text-[11px] font-medium rounded px-1.5 py-0.5', sprintPhaseOpt.activeClass)}>
+            <SprintPhaseIcon className="h-3 w-3" />
+            {sprintPhaseOpt.label}
+          </span>
+        </div>
+      )}
 
       {/* PR row */}
       {hasPR && session.prNumber && (

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -109,7 +109,6 @@ export const SETTINGS_DEFAULTS = {
   // Sidebar
   sidebarGroupBy: 'project' as SidebarGroupBy,
   sidebarSortBy: 'recent' as SidebarSortBy,
-  sidebarShowSessionMeta: true,
   sidebarProjectFilter: null as string | null,
   // Dictation
   dictationShortcut: 'cmd-shift-d' as DictationShortcutPreset,
@@ -192,7 +191,6 @@ interface SettingsState {
   // Sidebar grouping/sorting
   sidebarGroupBy: SidebarGroupBy;
   sidebarSortBy: SidebarSortBy;
-  sidebarShowSessionMeta: boolean; // Whether to show the second line (PR status) in session cells
   sidebarProjectFilter: string | null; // null = all projects, or a workspaceId to filter
   collapsedSidebarGroups: string[]; // composite keys toggled from default, e.g. "status:done"
   workspaceOrder: string[]; // Persisted workspace display order (array of workspace IDs)
@@ -266,7 +264,6 @@ interface SettingsState {
   resetAllSettings: () => void;
   setSidebarGroupBy: (value: SidebarGroupBy) => void;
   setSidebarSortBy: (value: SidebarSortBy) => void;
-  setSidebarShowSessionMeta: (value: boolean) => void;
   setSidebarProjectFilter: (id: string | null) => void;
   toggleSidebarGroupCollapsed: (key: string) => void;
   ensureSidebarGroupExpanded: (key: string, defaultCollapsed: boolean) => void;
@@ -449,7 +446,6 @@ export const useSettingsStore = create<SettingsState>()(
       resetAllSettings: () => set({ ...SETTINGS_DEFAULTS, statusGroupOrder: [], workspaceOrder: [] }),
       setSidebarGroupBy: (value) => set({ sidebarGroupBy: value }),
       setSidebarSortBy: (value) => set({ sidebarSortBy: value }),
-      setSidebarShowSessionMeta: (value) => set({ sidebarShowSessionMeta: value }),
       setSidebarProjectFilter: (id) => set({ sidebarProjectFilter: id }),
       setLastRepoDashboardWorkspaceId: (id) => set({ lastRepoDashboardWorkspaceId: id }),
       setWorkspaceOrder: (order) => set({ workspaceOrder: order }),


### PR DESCRIPTION
## Summary

- Remove the inline second line (sprint phase, project indicator, PR badge) from `SessionRow` in the sidebar to declutter the session list
- Show sprint phase badge in `SessionHoverCardBody` instead, keeping info accessible on hover
- Remove the now-dead `sidebarShowSessionMeta` setting from settings store and Appearance Settings UI

## Test plan

- [ ] Open sidebar with sessions that have sprint phases set — verify no second line appears below branch names
- [ ] Hover over a session with a sprint phase — verify phase badge appears in the hover card
- [ ] Hover over a session without a sprint phase — verify hover card renders normally without a phase section
- [ ] Open Settings → Appearance — verify the "Show session status line" toggle is gone
- [ ] Verify sidebar renders correctly in all grouping modes (project, status, recent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)