### PR TITLE
fix: reduce sidebar diff stats badge font size

### DIFF
--- a/src/components/session-manager/SessionRow.tsx
+++ b/src/components/session-manager/SessionRow.tsx
@@ -103,7 +103,7 @@ export function SessionRow({ session, workspace, onSelect, onUnarchive, onPrevie
 
       {/* Diff stats */}
       {hasStats && (
-        <span className="text-xs px-1.5 py-0.5 rounded border border-text-success/40 font-mono tabular-nums shrink-0">
+        <span className="text-2xs px-1 py-px rounded border border-text-success/40 font-mono tabular-nums shrink-0">
           <span className="text-text-success">+{session.stats!.additions}</span>
           <span className="text-text-error ml-1">-{session.stats!.deletions}</span>
         </span>

--- a/src/components/session-manager/cells/DiffStatsCell.tsx
+++ b/src/components/session-manager/cells/DiffStatsCell.tsx
@@ -16,7 +16,7 @@ export function DiffStatsCell({ session }: DiffStatsCellProps) {
 
   return (
     <span className={cn(
-      'text-xs px-1.5 py-0.5 rounded border font-mono tabular-nums',
+      'text-2xs px-1 py-px rounded border font-mono tabular-nums',
       session.archived
         ? 'border-border/50 text-muted-foreground/60'
         : 'border-text-success/40'


### PR DESCRIPTION
## Summary
- Reduce diff stats badge font from `text-xs` (12px) to `text-2xs` (11px) in sidebar session cells
- Tighten padding (`px-1.5 py-0.5` → `px-1 py-px`) to match smaller text

## Test plan
- [ ] Open sidebar with sessions grouped by status
- [ ] Verify line badges (e.g. "+80 -44") appear smaller but still readable
- [ ] Check both data table view (DiffStatsCell) and list view (SessionRow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)