### PR TITLE
fix: use sans-serif font for Pierre inline comments

### DIFF
--- a/src/components/comments/CommentThread.tsx
+++ b/src/components/comments/CommentThread.tsx
@@ -135,7 +135,7 @@ export const CommentThread = memo(function CommentThread({
   return (
     <div
       className={cn(
-        'border-l-4 bg-muted/60 backdrop-blur-sm p-3 my-1 rounded-r text-sm',
+        'border-l-4 bg-muted/60 backdrop-blur-sm p-3 my-1 rounded-r text-sm font-sans',
         'shadow-sm',
         borderClass,
         comment.resolved && 'opacity-60'

--- a/src/components/comments/InlineCommentInput.tsx
+++ b/src/components/comments/InlineCommentInput.tsx
@@ -40,7 +40,7 @@ export function InlineCommentInput({ onSubmit, onCancel }: InlineCommentInputPro
   );
 
   return (
-    <div className="border-l-4 border-l-blue-500 bg-muted/60 backdrop-blur-sm p-3 my-1 rounded-r text-sm shadow-sm">
+    <div className="border-l-4 border-l-blue-500 bg-muted/60 backdrop-blur-sm p-3 my-1 rounded-r text-sm font-sans shadow-sm">
       <textarea
         ref={textareaRef}
         value={text}


### PR DESCRIPTION
## Summary
- Pierre inline comments and comment input rendered in monospace because they inherit Monaco editor's font inside view zones
- Added `font-sans` to `CommentThread` and `InlineCommentInput` root containers so comment text matches the conversation area's sans-serif (Geist Sans) rendering
- Inline `code` and code blocks still render in monospace via prose/markdown classes

## Test plan
- [ ] Open Pierre diff view with inline comments containing markdown (headings, bold, lists, code)
- [ ] Verify comment text renders in sans-serif matching the conversation area
- [ ] Verify inline `code` and code blocks still use monospace
- [ ] Verify the comment input textarea also uses sans-serif

🤖 Generated with [Claude Code](https://claude.com/claude-code)