### PR TITLE
feat: replace native About panel with custom About dialog

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -8,7 +8,7 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     // 1. App menu (macOS shows as the app name; on other platforms it's a regular menu)
     #[allow(unused_mut)]
     let mut app_menu_builder = SubmenuBuilder::new(app, "ChatML")
-        .item(&PredefinedMenuItem::about(app, Some("About ChatML"), None)?)
+        .item(&MenuItemBuilder::with_id("about", "About ChatML").build(app)?)
         .separator()
         .item(&MenuItemBuilder::with_id("check_for_updates", "Check for Updates...").build(app)?)
         .separator()

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import {
+  RefreshCw,
+  Loader2,
+  CheckCircle2,
+  Download,
+  RotateCcw,
+  BookOpen,
+  FileText,
+  Github,
+  MessageSquare,
+} from 'lucide-react';
+import { useUpdateStore } from '@/stores/updateStore';
+import { openUrlInBrowser } from '@/lib/tauri';
+
+interface AboutDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
+  const [version, setVersion] = useState<string | null>(null);
+  const [checkedOnce, setCheckedOnce] = useState(false);
+
+  const updateStatus = useUpdateStore((s) => s.status);
+  const updateVersion = useUpdateStore((s) => s.version);
+  const progress = useUpdateStore((s) => s.progress);
+  const checkForUpdates = useUpdateStore((s) => s.checkForUpdates);
+  const downloadAndInstall = useUpdateStore((s) => s.downloadAndInstall);
+  const relaunch = useUpdateStore((s) => s.relaunch);
+
+  const isChecking = updateStatus === 'checking';
+  const isUpToDate = checkedOnce && updateStatus === 'idle';
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window) {
+      import('@tauri-apps/api/app').then(({ getVersion }) => {
+        getVersion().then(setVersion);
+      }).catch(() => {});
+    }
+  }, []);
+
+  const handleCheckForUpdates = useCallback(async () => {
+    const result = await checkForUpdates();
+    if (result !== null) {
+      setCheckedOnce(true);
+    }
+  }, [checkForUpdates]);
+
+  const handleUpdateClick = useCallback(() => {
+    switch (updateStatus) {
+      case 'available':
+      case 'error':
+        downloadAndInstall();
+        break;
+      case 'ready':
+        relaunch();
+        break;
+      default:
+        handleCheckForUpdates();
+    }
+  }, [updateStatus, downloadAndInstall, relaunch, handleCheckForUpdates]);
+
+  const buttonLabel = (() => {
+    switch (updateStatus) {
+      case 'checking':
+        return 'Checking...';
+      case 'available':
+        return updateVersion ? `Download v${updateVersion}` : 'Download update';
+      case 'downloading':
+        return `Downloading ${Math.round(progress)}%`;
+      case 'ready':
+        return 'Restart to update';
+      case 'waiting':
+        return 'Waiting for agents...';
+      case 'error':
+        return 'Retry download';
+      default:
+        return isUpToDate ? 'Up to date' : 'Check for updates';
+    }
+  })();
+
+  const buttonIcon = (() => {
+    switch (updateStatus) {
+      case 'checking':
+      case 'downloading':
+      case 'waiting':
+        return <Loader2 className="w-3.5 h-3.5 animate-spin" />;
+      case 'available':
+        return <Download className="w-3.5 h-3.5 text-blue-400" />;
+      case 'ready':
+        return <RefreshCw className="w-3.5 h-3.5 text-emerald-400" />;
+      case 'error':
+        return <RotateCcw className="w-3.5 h-3.5 text-red-400" />;
+      default:
+        return isUpToDate
+          ? <CheckCircle2 className="w-3.5 h-3.5 text-text-success" />
+          : <RefreshCw className="w-3.5 h-3.5" />;
+    }
+  })();
+
+  const links = [
+    { label: 'Docs', icon: BookOpen, url: 'https://docs.chatml.com' },
+    { label: 'Changelog', icon: FileText, url: 'https://chatml.com/changelog' },
+    { label: 'GitHub', icon: Github, url: 'https://github.com/chatml/chatml' },
+    { label: 'Feedback', icon: MessageSquare, url: 'https://github.com/chatml/chatml/issues' },
+  ];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-[360px] p-0 overflow-hidden gap-0"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">About ChatML</DialogTitle>
+        <DialogDescription className="sr-only">
+          App version information and update controls.
+        </DialogDescription>
+
+        <div className="flex flex-col items-center px-8 pt-8 pb-6">
+          {/* Mascot */}
+          <img
+            src="/mascot.png"
+            alt="ChatML"
+            className="w-20 h-20 rounded-2xl shadow-[0_0_40px_oklch(0.5_0.2_290/0.35)]"
+            draggable={false}
+          />
+
+          {/* App name */}
+          <h2 className="font-display text-[1.75rem] leading-tight tracking-tight mt-4">
+            ChatML
+          </h2>
+
+          {/* Version */}
+          <p className="text-sm text-muted-foreground mt-1">
+            {version ? `Version ${version}` : '\u00A0'}
+          </p>
+
+          {/* Tagline */}
+          <p className="text-xs text-muted-foreground/70 mt-0.5">
+            AI-Powered Development Studio
+          </p>
+
+          {/* Update button */}
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5 mt-5"
+            disabled={isChecking || updateStatus === 'downloading' || updateStatus === 'waiting'}
+            onClick={handleUpdateClick}
+          >
+            {buttonIcon}
+            {buttonLabel}
+          </Button>
+        </div>
+
+        {/* Links */}
+        <div className="flex items-center justify-center gap-1 px-6 py-3 border-t border-border/50">
+          {links.map(({ label, icon: Icon, url }) => (
+            <Button
+              key={label}
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => openUrlInBrowser(url)}
+            >
+              <Icon className="w-3.5 h-3.5" />
+              {label}
+            </Button>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-3 border-t border-border/50 text-center">
+          <p className="text-[11px] text-muted-foreground/60">
+            © {new Date().getFullYear()} ChatML · GPL-3.0
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/DialogManager.tsx
+++ b/src/components/layout/DialogManager.tsx
@@ -13,6 +13,7 @@ import { GitHubReposDialog } from '@/components/dialogs/GitHubReposDialog';
 import { CloseTabConfirmDialog } from '@/components/dialogs/CloseTabConfirmDialog';
 import { CloseFileConfirmDialog } from '@/components/dialogs/CloseFileConfirmDialog';
 import { KeyboardShortcutsDialog } from '@/components/dialogs/KeyboardShortcutsDialog';
+import { AboutDialog } from '@/components/dialogs/AboutDialog';
 import { DotMcpTrustDialog } from '@/components/dialogs/DotMcpTrustDialog';
 import { FilePicker } from '@/components/dialogs/FilePicker';
 import { WorkspaceSearch } from '@/components/dialogs/WorkspaceSearch';
@@ -91,6 +92,14 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
     const handleShowShortcuts = () => setShowShortcuts(true);
     window.addEventListener('show-shortcuts', handleShowShortcuts);
     return () => window.removeEventListener('show-shortcuts', handleShowShortcuts);
+  }, []);
+
+  // About dialog
+  const [showAbout, setShowAbout] = useState(false);
+  useEffect(() => {
+    const handleShowAbout = () => setShowAbout(true);
+    window.addEventListener('show-about', handleShowAbout);
+    return () => window.removeEventListener('show-about', handleShowAbout);
   }, []);
 
   useShortcut('createSession', useCallback(() => {
@@ -231,6 +240,9 @@ export const DialogManager = forwardRef<DialogManagerHandles, DialogManagerProps
 
       {/* Command Palette (Cmd+K) */}
       <CommandPalette />
+
+      {/* About Dialog */}
+      <AboutDialog open={showAbout} onOpenChange={setShowAbout} />
 
       {/* .mcp.json Trust Dialog */}
       <DotMcpTrustDialog

--- a/src/hooks/useMenuHandlers.ts
+++ b/src/hooks/useMenuHandlers.ts
@@ -82,6 +82,9 @@ export function useMenuHandlers(options: MenuHandlersOptions) {
     safeListen<string>('menu-event', (menuId) => {
       switch (menuId) {
         // App menu
+        case 'about':
+          window.dispatchEvent(new CustomEvent('show-about'));
+          break;
         case 'check_for_updates':
           useUpdateStore.getState().checkForUpdates().then((result) => {
             if (result === 'up-to-date') {


### PR DESCRIPTION
## Summary

- Replace the macOS predefined `About ChatML` menu item with a custom dialog showing the app mascot, version, update controls, and quick links (Docs, Changelog, GitHub, Feedback)
- Route the `about` menu event through the existing `menu-event` → `CustomEvent` → `DialogManager` pattern, consistent with other dialogs
- Fix false "Up to date" display when update check fails silently (only set `checkedOnce` on successful check result)
- Add explicit handling for the `'waiting'` update status (spinner, label, disabled button)
- Add `DialogDescription` for screen reader accessibility
- Use dynamic copyright year

## Changed files

| File | Change |
|------|--------|
| `src-tauri/src/menu.rs` | Replace `PredefinedMenuItem::about` with custom `MenuItemBuilder` |
| `src/hooks/useMenuHandlers.ts` | Handle `'about'` menu event → dispatch `show-about` |
| `src/components/layout/DialogManager.tsx` | Wire up `showAbout` state and render `<AboutDialog>` |
| `src/components/dialogs/AboutDialog.tsx` | New custom About dialog component |

## Test plan

- [ ] Click ChatML → About ChatML — dialog opens with mascot, version, and links
- [ ] Click "Check for updates" — button transitions through checking → result states
- [ ] Disconnect network, click "Check for updates" — button should NOT show "Up to date ✓"
- [ ] Verify links (Docs, Changelog, GitHub, Feedback) open in external browser
- [ ] Close dialog via Escape or clicking outside
- [ ] VoiceOver: verify dialog title and description are announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)