### PR TITLE
fix: auto-expand collapsed sidebar groups when session is selected

### DIFF
--- a/src/components/navigation/BrowserTabBar.tsx
+++ b/src/components/navigation/BrowserTabBar.tsx
@@ -32,6 +32,7 @@ import { useNavigationStore } from '@/stores/navigationStore';
 import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { buildNavigationLabel } from '@/lib/navigation';
+import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 import { cn } from '@/lib/utils';
 
 /**
@@ -69,6 +70,11 @@ export function switchToTab(tabId: string) {
         appStore.selectConversation(newTab.selectedConversationId);
       }
       settingsStore.setContentView(newTab.contentView);
+      // Auto-expand collapsed sidebar groups so the selected session is visible
+      if (newTab.selectedSessionId) {
+        const session = appStore.sessions.find(s => s.id === newTab.selectedSessionId && !s.archived);
+        if (session) expandGroupsForSession(session);
+      }
     });
     useNavigationStore.getState().setActiveTabId(tabId);
   }

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -14,6 +14,7 @@ import { initAuth, listenForOAuthCallback, validateStoredToken, OAUTH_TIMEOUT_MS
 import { getLinearAuthStatus } from '@/lib/linearAuth';
 import { registerSession, getSessionDirName } from '@/lib/tauri';
 import { navigate } from '@/lib/navigation';
+import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 import { useToast } from '@/components/ui/toast';
 import {
   listRepos, listAllSessions, listConversations, listWorkspaceConversations,
@@ -296,6 +297,13 @@ export function useAppInitialization() {
           if (targetSessionId) {
             selectSession(targetSessionId);
           }
+        }
+
+        // Auto-expand collapsed sidebar groups so the restored session is visible
+        const selectedId = useAppStore.getState().selectedSessionId;
+        if (selectedId) {
+          const selectedSession = allSessions.find(s => s.id === selectedId && !s.archived);
+          if (selectedSession) expandGroupsForSession(selectedSession);
         }
 
         // Shell is ready — sidebar, toolbar, and layout chrome can render

--- a/src/hooks/useDesktopNotifications.ts
+++ b/src/hooks/useDesktopNotifications.ts
@@ -5,6 +5,7 @@ import { sendNotification } from '@/lib/tauri';
 import { playSound } from '@/lib/sounds';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useAppStore } from '@/stores/appStore';
+import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 
 const DEBOUNCE_MS = 5000;
 // Short window so only actual notification clicks (near-instant focus) trigger navigation,
@@ -85,6 +86,8 @@ function navigateToConversation(conversationId: string): void {
     }
 
     state.selectSession(session.id);
+    // Auto-expand collapsed sidebar groups so the selected session is visible
+    expandGroupsForSession(session);
   }
   state.selectConversation(conversationId);
 }

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -12,6 +12,7 @@ import { useSettingsStore, type ContentView } from '@/stores/settingsStore';
 import { useNavigationStore, type NavigationEntry } from '@/stores/navigationStore';
 import { useTabStore } from '@/stores/tabStore';
 import { ENABLE_BROWSER_TABS } from '@/lib/constants';
+import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 
 /**
  * Check if a session's target conversation has messages cached in the store.
@@ -202,6 +203,9 @@ function applyEntry(entry: NavigationEntry): void {
     // But if we have a specific conversationId, override after
     if (entry.sessionId !== undefined) {
       appStore.selectSession(entry.sessionId);
+      // Auto-expand collapsed sidebar groups so the selected session is visible
+      const session = appStore.sessions.find(s => s.id === entry.sessionId && !s.archived);
+      if (session) expandGroupsForSession(session);
     }
     if (entry.conversationId !== undefined) {
       appStore.selectConversation(entry.conversationId);
@@ -240,9 +244,11 @@ export function navigate(params: NavigateParams): void {
 
   // Auto-clear unread when navigating into a workspace or session
   if (params.sessionId) {
-    const session = useAppStore.getState().sessions.find(s => s.id === params.sessionId);
+    const session = useAppStore.getState().sessions.find(s => s.id === params.sessionId && !s.archived);
     if (session) {
       useSettingsStore.getState().markWorkspaceRead(session.workspaceId);
+      // Auto-expand collapsed sidebar groups so the selected session is visible
+      expandGroupsForSession(session);
     }
     useSettingsStore.getState().markSessionRead(params.sessionId);
   } else if (params.workspaceId) {


### PR DESCRIPTION
## Summary
- Auto-expand collapsed sidebar groups when a session is selected, ensuring the session is always visible in the sidebar
- Covers all navigation paths: tab switching, app initialization/restore, notification click, and `navigate()`/`applyEntry()` (back/forward)
- Uses the existing `expandGroupsForSession()` utility which handles all `sidebarGroupBy` modes (`none`, `status`, `project`, `project-status`)

## Test plan
- [ ] Select a session that's inside a collapsed status group (e.g. "Done") — group should auto-expand
- [ ] Switch browser tabs to a tab whose session is in a collapsed group — group should expand
- [ ] Restart the app with a session selected inside a collapsed group — group should expand on restore
- [ ] Click a desktop notification for a session in a collapsed group — group should expand
- [ ] Use browser back/forward to navigate to a session in a collapsed group — group should expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)