### PR TITLE
feat: add background tasks panel to bottom panel UI

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -2172,6 +2172,17 @@ func (m *Manager) StopConversation(ctx context.Context, convID string) {
 	}
 }
 
+// StopTask stops a specific background task (sub-agent) within a conversation
+func (m *Manager) StopTask(convID string, taskId string) error {
+	m.mu.RLock()
+	proc, ok := m.convProcesses[convID]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("conversation not running: %s", convID)
+	}
+	return proc.StopTask(taskId)
+}
+
 // CompleteConversation marks a conversation as completed
 func (m *Manager) CompleteConversation(ctx context.Context, convID string) {
 	m.StopConversation(ctx, convID)

--- a/backend/server/conversation_handlers.go
+++ b/backend/server/conversation_handlers.go
@@ -405,6 +405,28 @@ func (h *Handlers) StopConversation(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *Handlers) StopTask(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	convID := chi.URLParam(r, "convId")
+	taskID := chi.URLParam(r, "taskId")
+
+	conv, err := h.store.GetConversationMeta(ctx, convID)
+	if err != nil {
+		writeDBError(w, err)
+		return
+	}
+	if conv == nil {
+		writeNotFound(w, "conversation")
+		return
+	}
+
+	// Best-effort stop — succeed even if the task/conversation already stopped (idempotent).
+	if err := h.agentManager.StopTask(convID, taskID); err != nil {
+		logger.Handlers.Debugf("StopTask %s/%s: %v (may be expected if already stopped)", convID, taskID, err)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (h *Handlers) GetConversationDropStats(w http.ResponseWriter, r *http.Request) {
 	convID := chi.URLParam(r, "convId")
 	stats := h.agentManager.GetConversationDropStats(convID)

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -254,6 +254,7 @@ func NewRouter(ctx context.Context, s *store.SQLiteStore, hub *Hub, agentMgr *ag
 		r.With(messageRateLimiter).Post("/{convId}/messages", h.SendConversationMessage)
 		r.Post("/{convId}/system-message", h.AddSystemMessage)
 		r.Post("/{convId}/stop", h.StopConversation)
+		r.Post("/{convId}/tasks/{taskId}/stop", h.StopTask)
 		r.Get("/{convId}/streaming-snapshot", h.GetStreamingSnapshot)
 		r.Get("/{convId}/drop-stats", h.GetConversationDropStats)
 		r.Post("/{convId}/rewind", h.RewindConversation)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,7 @@ import { SessionToolbarContent } from '@/components/navigation/SessionToolbarCon
 import { ConversationArea } from '@/components/conversation/ConversationArea';
 import { ChatInput } from '@/components/conversation/ChatInput';
 import { ChangesPanel } from '@/components/panels/ChangesPanel';
-import { BottomTerminal } from '@/components/layout/BottomTerminal';
+import { BottomPanel } from '@/components/layout/BottomPanel';
 import { MainToolbar, ContentActionBar } from '@/components/layout/MainToolbar';
 import { SidebarToolbar } from '@/components/layout/SidebarToolbar';
 import { ContentRouter } from '@/components/layout/ContentRouter';
@@ -741,8 +741,9 @@ export default function Home() {
                         >
                           <div className="h-full">
                             <ErrorBoundary section="Terminal">
-                              <BottomTerminal
+                              <BottomPanel
                                 currentSessionId={selectedSessionId}
+                                currentConversationId={selectedConversationId}
                                 currentWorkspacePath={selectedSession?.worktreePath ?? null}
                                 isExpanded={layout.showBottomTerminal}
                                 onHide={layout.hideBottomTerminal}

--- a/src/components/layout/BackgroundTasksPanel.tsx
+++ b/src/components/layout/BackgroundTasksPanel.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { Circle, Square } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useBackgroundTasks } from '@/stores/selectors';
+import { useAppStore } from '@/stores/appStore';
+import { stopBackgroundTask } from '@/lib/api/conversations';
+import type { BackgroundTask } from '@/lib/types';
+
+function formatTokensCompact(tokens: number): string {
+  if (tokens < 1000) return `${tokens}`;
+  if (tokens < 10000) return `${(tokens / 1000).toFixed(1)}k`;
+  return `${Math.round(tokens / 1000)}k`;
+}
+
+function TaskElapsedTime({ startTime }: { startTime: number }) {
+  const [elapsed, setElapsed] = useState(() => Math.floor((Date.now() - startTime) / 1000));
+  const startRef = useRef(startTime);
+
+  useEffect(() => {
+    startRef.current = startTime;
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [startTime]);
+
+  if (elapsed < 1) return null;
+  return (
+    <span className="text-2xs text-muted-foreground/70 font-mono tabular-nums shrink-0">
+      {elapsed}s
+    </span>
+  );
+}
+
+function formatDuration(startTime: number, endTime?: number): string {
+  const ms = (endTime ?? Date.now()) - startTime;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${seconds % 60}s`;
+}
+
+interface TaskRowProps {
+  task: BackgroundTask;
+  conversationId: string;
+}
+
+const TaskRow = memo(function TaskRow({ task, conversationId }: TaskRowProps) {
+  const isRunning = task.status === 'running';
+
+  const handleStop = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await stopBackgroundTask(conversationId, task.taskId);
+      // Optimistically reflect stopped state; task_stopped WS event will confirm
+      useAppStore.getState().stopBackgroundTask(conversationId, task.taskId);
+    } catch {
+      // Stop failed — task_stopped event won't arrive, but that's OK
+    }
+  }, [conversationId, task.taskId]);
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-surface-2 transition-colors">
+      {/* Status indicator */}
+      <span className="flex items-center justify-center w-3 h-3 shrink-0">
+        {isRunning ? (
+          <span className="block w-2 h-2 rounded-full border-[1.5px] border-primary border-t-transparent animate-spin" />
+        ) : (
+          <Circle className="w-2 h-2 fill-text-success text-text-success" />
+        )}
+      </span>
+
+      {/* Description */}
+      <span className={cn(
+        'flex-1 min-w-0 truncate',
+        isRunning ? 'text-foreground' : 'text-muted-foreground'
+      )}>
+        {task.description || 'Background task'}
+      </span>
+
+      {/* Last tool name */}
+      {task.lastToolName && (
+        <span className="text-2xs text-muted-foreground/70 shrink-0 max-w-[120px] truncate">
+          {task.lastToolName}
+        </span>
+      )}
+
+      {/* Elapsed time or duration */}
+      {isRunning ? (
+        <TaskElapsedTime startTime={task.startTime} />
+      ) : task.endTime ? (
+        <span className="text-2xs text-muted-foreground/70 font-mono tabular-nums shrink-0">
+          {formatDuration(task.startTime, task.endTime)}
+        </span>
+      ) : null}
+
+      {/* Token usage */}
+      {task.usage && task.usage.totalTokens > 0 && (
+        <span className="text-2xs text-muted-foreground/70 font-mono tabular-nums shrink-0">
+          {formatTokensCompact(task.usage.totalTokens)}
+        </span>
+      )}
+
+      {/* Stop button */}
+      {isRunning && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-5 w-5 shrink-0"
+          onClick={handleStop}
+          title="Stop task"
+          aria-label="Stop task"
+        >
+          <Square className="h-2.5 w-2.5 fill-destructive text-destructive" />
+        </Button>
+      )}
+    </div>
+  );
+});
+
+interface BackgroundTasksPanelProps {
+  conversationId: string | null;
+}
+
+export function BackgroundTasksPanel({ conversationId }: BackgroundTasksPanelProps) {
+  const tasks = useBackgroundTasks(conversationId);
+
+  if (!conversationId || tasks.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+        No background tasks
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      {tasks.map((task) => (
+        <TaskRow key={task.taskId} task={task} conversationId={conversationId} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/BottomPanel.tsx
+++ b/src/components/layout/BottomPanel.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { X, TerminalSquare, ListTodo } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useAppStore } from '@/stores/appStore';
+import { useBottomPanelActiveTab, useBackgroundTasks } from '@/stores/selectors';
+import { BottomTerminal } from './BottomTerminal';
+import { BackgroundTasksPanel } from './BackgroundTasksPanel';
+
+interface BottomPanelProps {
+  currentSessionId: string | null;
+  currentConversationId: string | null;
+  currentWorkspacePath: string | null;
+  isExpanded: boolean;
+  onHide: () => void;
+}
+
+export function BottomPanel({
+  currentSessionId,
+  currentConversationId,
+  currentWorkspacePath,
+  isExpanded,
+  onHide,
+}: BottomPanelProps) {
+  const activeTab = useBottomPanelActiveTab(currentSessionId);
+  const tasks = useBackgroundTasks(currentConversationId);
+  const runningCount = tasks.filter((t) => t.status === 'running').length;
+
+  const setTab = (tab: 'terminal' | 'tasks') => {
+    if (currentSessionId) {
+      useAppStore.getState().setBottomPanelActiveTab(currentSessionId, tab);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-background border-t">
+      {/* Top-level tab bar */}
+      <div className="flex items-center gap-1 px-2 py-1 border-b bg-muted/30 shrink-0">
+        <div className="flex items-center gap-1 flex-1 min-w-0">
+          {/* Terminal tab */}
+          <button
+            role="tab"
+            aria-selected={activeTab === 'terminal'}
+            onClick={() => setTab('terminal')}
+            className={cn(
+              'flex items-center gap-1 px-2 py-1 text-xs rounded-sm shrink-0',
+              'hover:bg-surface-2 transition-colors',
+              activeTab === 'terminal'
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground'
+            )}
+          >
+            <TerminalSquare className="h-3 w-3" />
+            <span>Terminal</span>
+          </button>
+
+          {/* Tasks tab */}
+          <button
+            role="tab"
+            aria-selected={activeTab === 'tasks'}
+            onClick={() => setTab('tasks')}
+            className={cn(
+              'flex items-center gap-1 px-2 py-1 text-xs rounded-sm shrink-0',
+              'hover:bg-surface-2 transition-colors',
+              activeTab === 'tasks'
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground'
+            )}
+          >
+            <ListTodo className="h-3 w-3" />
+            <span>Tasks</span>
+            {runningCount > 0 && (
+              <span className="ml-0.5 px-1 py-0 text-2xs rounded-full bg-primary/20 text-primary font-medium tabular-nums">
+                {runningCount}
+              </span>
+            )}
+          </button>
+        </div>
+
+        {/* Close button */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 shrink-0"
+          onClick={onHide}
+          title="Hide panel"
+          aria-label="Hide panel"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 min-h-0">
+        {activeTab === 'terminal' ? (
+          <BottomTerminal
+            currentSessionId={currentSessionId}
+            currentWorkspacePath={currentWorkspacePath}
+            isExpanded={isExpanded}
+            onHide={onHide}
+          />
+        ) : (
+          <BackgroundTasksPanel conversationId={currentConversationId} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/BottomTerminal.tsx
+++ b/src/components/layout/BottomTerminal.tsx
@@ -84,9 +84,9 @@ export function BottomTerminal({ currentSessionId, currentWorkspacePath, isExpan
   };
 
   return (
-    <div className="flex flex-col h-full bg-background border-t">
-      {/* Header with tabs - shows current session's terminals */}
-      <div className="flex items-center gap-1 px-2 py-1 border-b bg-muted/30 shrink-0">
+    <div className="flex flex-col h-full bg-background">
+      {/* Header with terminal instance tabs */}
+      <div className="flex items-center gap-1 px-2 py-0.5 border-b bg-muted/20 shrink-0">
         {/* Terminal tabs */}
         <div role="tablist" aria-label="Terminal tabs" className="flex items-center gap-1 flex-1 min-w-0 overflow-x-auto">
           {instances.map((terminal) => (
@@ -136,17 +136,6 @@ export function BottomTerminal({ currentSessionId, currentWorkspacePath, isExpan
           </Button>
         </div>
 
-        {/* Hide panel button */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6 shrink-0"
-          onClick={onHide}
-          title="Hide terminal panel"
-          aria-label="Hide terminal panel"
-        >
-          <X className="h-3 w-3" />
-        </Button>
       </div>
 
       {/* Terminal content - render ALL sessions' terminals for persistence */}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,2 +1,4 @@
 export { FullContentLayout } from './FullContentLayout';
 export { BottomTerminal } from './BottomTerminal';
+export { BottomPanel } from './BottomPanel';
+export { BackgroundTasksPanel } from './BackgroundTasksPanel';

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -975,6 +975,48 @@ export function useWebSocket(enabled: boolean = true) {
         }
         break;
 
+      // ── SDK 0.2.84+ background task events ──────────────────────
+
+      case 'task_started':
+        if (event?.taskId) {
+          store.addBackgroundTask(conversationId, {
+            taskId: event.taskId!,
+            toolUseId: event.toolUseId,
+            description: event.description,
+            status: 'running',
+            startTime: Date.now(),
+          });
+          // Auto-show bottom panel and switch to tasks tab for the event's own session
+          const eventSessionId = data.sessionId;
+          if (eventSessionId) {
+            store.setTerminalPanelVisible(eventSessionId, true);
+            store.setBottomPanelActiveTab(eventSessionId, 'tasks');
+          }
+        }
+        break;
+
+      case 'task_progress':
+        if (event?.taskId) {
+          const taskUsage = event.taskUsage;
+          store.updateBackgroundTask(conversationId, event.taskId as string, {
+            lastToolName: event.lastToolName,
+            ...(taskUsage ? {
+              usage: {
+                totalTokens: taskUsage.total_tokens ?? 0,
+                toolUses: taskUsage.tool_uses ?? 0,
+                durationMs: taskUsage.duration_ms ?? 0,
+              },
+            } : {}),
+          });
+        }
+        break;
+
+      case 'task_stopped':
+        if (event?.taskId) {
+          store.stopBackgroundTask(conversationId, event.taskId as string);
+        }
+        break;
+
       // ── SDK 0.2.72+ event types ──────────────────────────────────
 
       case 'prompt_suggestion':

--- a/src/hooks/useWebSocketHelpers.ts
+++ b/src/hooks/useWebSocketHelpers.ts
@@ -138,6 +138,8 @@ export const BATCHABLE_EVENTS = new Set([
   'hook_started', 'hook_progress', 'worktree_created', 'worktree_removed',
   'instructions_loaded', 'supported_agents', 'mcp_servers_updated',
   'initialization_result', 'session_forked', 'message_cancelled',
+  // SDK 0.2.84+ background task events
+  'task_started', 'task_progress', 'task_stopped',
 ]);
 
 // Content event types that should be suppressed during reconciliation.
@@ -146,6 +148,7 @@ export const RECONCILIATION_SUPPRESSED_EVENTS = new Set([
   'assistant_text', 'tool_start', 'tool_end', 'thinking_start', 'thinking_delta',
   'thinking', 'subagent_started', 'subagent_stopped', 'subagent_output',
   'ghost_text', 'todo_update', 'tool_progress',
+  'task_started', 'task_progress', 'task_stopped',
 ]);
 
 // Map backend status to frontend session status

--- a/src/lib/api/conversations.ts
+++ b/src/lib/api/conversations.ts
@@ -290,6 +290,11 @@ export async function stopConversation(convId: string): Promise<void> {
   await handleVoidResponse(res, 'Failed to stop conversation');
 }
 
+export async function stopBackgroundTask(convId: string, taskId: string): Promise<void> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/tasks/${taskId}/stop`, { method: 'POST' });
+  await handleVoidResponse(res, 'Failed to stop background task');
+}
+
 export async function getConversationDropStats(convId: string): Promise<{ droppedMessages: number }> {
   const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/drop-stats`);
   return handleResponse(res);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -498,6 +498,11 @@ export interface AgentEvent {
 
   // Query response fields (SDK 0.2.72)
   result?: unknown;
+
+  // Background task fields (SDK 0.2.84)
+  taskId?: string;
+  lastToolName?: string;
+  taskUsage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number };
 }
 
 // Rate limit info from claude.ai subscription (SDK 0.2.72)
@@ -765,6 +770,18 @@ export interface TerminalInstance {
   slotNumber: number;   // 1-5
   status: 'active' | 'exited';
   workspacePath: string; // cwd for this terminal's PTY
+}
+
+// Background task spawned by the Agent tool with run_in_background: true
+export interface BackgroundTask {
+  taskId: string;
+  toolUseId?: string;
+  description?: string;
+  status: 'running' | 'stopped';
+  startTime: number;
+  endTime?: number;
+  lastToolName?: string;
+  usage?: { totalTokens: number; toolUses: number; durationMs: number };
 }
 
 // Review comment for code review inline comments

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -305,6 +305,7 @@ interface AppState {
   streamingState: { [conversationId: string]: StreamingState };
   activeTools: { [conversationId: string]: ActiveTool[] };
   subAgents: { [conversationId: string]: SubAgent[] };
+  backgroundTasks: { [conversationId: string]: import('@/lib/types').BackgroundTask[] };
 
   // Queued messages per conversation (submitted while agent is streaming)
   queuedMessages: { [conversationId: string]: QueuedMessage[] };
@@ -317,6 +318,7 @@ interface AppState {
   terminalInstances: Record<string, TerminalInstance[]>; // keyed by sessionId
   activeTerminalId: Record<string, string | null>;       // keyed by sessionId
   terminalPanelVisible: Record<string, boolean>;         // keyed by sessionId
+  bottomPanelActiveTab: Record<string, 'terminal' | 'tasks'>; // keyed by sessionId
 
   // MCP servers state
   mcpServers: McpServerStatus[];
@@ -531,6 +533,13 @@ interface AppState {
   setSubAgentUsage: (conversationId: string, toolUseId: string, usage: import('@/lib/types').SubAgentUsage) => void;
   clearSubAgents: (conversationId: string) => void;
 
+  // Background task actions
+  addBackgroundTask: (conversationId: string, task: import('@/lib/types').BackgroundTask) => void;
+  updateBackgroundTask: (conversationId: string, taskId: string, update: Partial<import('@/lib/types').BackgroundTask>) => void;
+  stopBackgroundTask: (conversationId: string, taskId: string) => void;
+  clearBackgroundTasks: (conversationId: string) => void;
+  setBottomPanelActiveTab: (sessionId: string, tab: 'terminal' | 'tasks') => void;
+
   restoreStreamingFromSnapshot: (conversationId: string, snapshot: {
     text: string;
     textSegments?: { text: string; timestamp: number }[];
@@ -681,12 +690,14 @@ export const useAppStore = create<AppState>((set, get) => ({
   streamingState: {},
   activeTools: {},
   subAgents: {},
+  backgroundTasks: {},
   queuedMessages: {},
   agentTodos: {},
   customTodos: {},
   terminalInstances: {},
   activeTerminalId: {},
   terminalPanelVisible: {},
+  bottomPanelActiveTab: {},
   mcpServers: [],
   mcpServerConfigs: [],
   mcpConfigLoading: false,
@@ -824,6 +835,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const cleanedTerminalInstances = { ...state.terminalInstances };
     const cleanedActiveTerminalId = { ...state.activeTerminalId };
     const cleanedTerminalPanelVisible = { ...state.terminalPanelVisible };
+    const cleanedBottomPanelActiveTab = { ...state.bottomPanelActiveTab };
     const cleanedTerminalSessions = { ...state.terminalSessions };
     const cleanedLastActive = { ...state.lastActiveConversationPerSession };
     for (const sessionId of workspaceSessionIds) {
@@ -832,6 +844,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       delete cleanedTerminalInstances[sessionId];
       delete cleanedActiveTerminalId[sessionId];
       delete cleanedTerminalPanelVisible[sessionId];
+      delete cleanedBottomPanelActiveTab[sessionId];
       delete cleanedTerminalSessions[sessionId];
       delete cleanedLastActive[sessionId];
     }
@@ -863,6 +876,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       terminalInstances: cleanedTerminalInstances,
       activeTerminalId: cleanedActiveTerminalId,
       terminalPanelVisible: cleanedTerminalPanelVisible,
+      bottomPanelActiveTab: cleanedBottomPanelActiveTab,
       terminalSessions: cleanedTerminalSessions,
       lastActiveConversationPerSession: cleanedLastActive,
       selectedFileTabId: null,
@@ -951,6 +965,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [id]: _panelVisible, ...remainingTerminalPanelVisible } = state.terminalPanelVisible;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [id]: _bottomTab, ...remainingBottomPanelActiveTab } = state.bottomPanelActiveTab;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [id]: _convsBySession, ...remainingConversationsBySession } = state.conversationsBySession;
       const cleanedScriptOutputVersions = Object.fromEntries(
         Object.entries(state.scriptOutputVersions).filter(([k]) => !k.startsWith(`${id}:`))
@@ -983,6 +999,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         terminalInstances: remainingTerminalInstances,
         activeTerminalId: remainingActiveTerminalId,
         terminalPanelVisible: remainingTerminalPanelVisible,
+        bottomPanelActiveTab: remainingBottomPanelActiveTab,
         scriptOutputVersions: cleanedScriptOutputVersions,
         selectedFileTabId: null,
         fileTabs: [],
@@ -1101,6 +1118,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     const { [id]: _activeTerminal, ...remainingActiveTerminalId } = state.activeTerminalId;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [id]: _panelVisible, ...remainingTerminalPanelVisible } = state.terminalPanelVisible;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [id]: _bottomTab, ...remainingBottomPanelActiveTab } = state.bottomPanelActiveTab;
 
     return {
       sessions: updatedSessions,
@@ -1109,6 +1128,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       terminalInstances: remainingTerminalInstances,
       activeTerminalId: remainingActiveTerminalId,
       terminalPanelVisible: remainingTerminalPanelVisible,
+      bottomPanelActiveTab: remainingBottomPanelActiveTab,
     };
   }),
   unarchiveSession: (id) => set((state) => {
@@ -2037,6 +2057,43 @@ updateFileTabContent: (id, content) => set((state) => ({
     },
   })),
 
+  // Background task mutations
+  addBackgroundTask: (conversationId, task) => set((state) => {
+    const existing = state.backgroundTasks[conversationId] || [];
+    if (existing.some((t) => t.taskId === task.taskId)) return {};
+    return {
+      backgroundTasks: {
+        ...state.backgroundTasks,
+        [conversationId]: [...existing, task],
+      },
+    };
+  }),
+  updateBackgroundTask: (conversationId, taskId, update) => set((state) => ({
+    backgroundTasks: {
+      ...state.backgroundTasks,
+      [conversationId]: (state.backgroundTasks[conversationId] || []).map((t) =>
+        t.taskId === taskId ? { ...t, ...update } : t
+      ),
+    },
+  })),
+  stopBackgroundTask: (conversationId, taskId) => set((state) => ({
+    backgroundTasks: {
+      ...state.backgroundTasks,
+      [conversationId]: (state.backgroundTasks[conversationId] || []).map((t) =>
+        t.taskId === taskId ? { ...t, status: 'stopped' as const, endTime: Date.now() } : t
+      ),
+    },
+  })),
+  clearBackgroundTasks: (conversationId) => set((state) => ({
+    backgroundTasks: {
+      ...state.backgroundTasks,
+      [conversationId]: [],
+    },
+  })),
+  setBottomPanelActiveTab: (sessionId, tab) => set((state) => ({
+    bottomPanelActiveTab: { ...state.bottomPanelActiveTab, [sessionId]: tab },
+  })),
+
   restoreStreamingFromSnapshot: (conversationId, snapshot) => {
     // Restore streaming state from a backend snapshot after WebSocket reconnection.
     // When textSegments are available, restore individual segments to preserve
@@ -2183,6 +2240,11 @@ updateFileTabContent: (id, content) => set((state) => ({
             ...state.subAgents,
             [conversationId]: [],
           },
+          // Keep running background tasks alive — they can outlive the main turn
+          backgroundTasks: {
+            ...state.backgroundTasks,
+            [conversationId]: (state.backgroundTasks[conversationId] ?? []).filter((t) => t.status === 'running'),
+          },
           // Commit first queued user message even with no streaming text (e.g. turn_complete after result)
           ...(queued ? {
             messagesByConversation: {
@@ -2311,6 +2373,11 @@ updateFileTabContent: (id, content) => set((state) => ({
         subAgents: {
           ...state.subAgents,
           [conversationId]: [],
+        },
+        // Keep running background tasks alive — they can outlive the main turn
+        backgroundTasks: {
+          ...state.backgroundTasks,
+          [conversationId]: (state.backgroundTasks[conversationId] ?? []).filter((t) => t.status === 'running'),
         },
         pendingCheckpointUuid: remainingPendingCp,
         // Update queued messages if first was committed or terminal flag clears the queue

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -462,6 +462,25 @@ export const useTerminalPanelVisible = (sessionId: string | null) =>
   useAppStore((s) => (sessionId ? s.terminalPanelVisible[sessionId] ?? false : false));
 
 // ============================================================================
+// Background Tasks State
+// ============================================================================
+
+const EMPTY_BACKGROUND_TASKS: import('@/lib/types').BackgroundTask[] = [];
+
+/**
+ * Background tasks scoped to a conversation.
+ */
+export const useBackgroundTasks = (conversationId: string | null) =>
+  useAppStore((s) => (conversationId ? s.backgroundTasks[conversationId] ?? EMPTY_BACKGROUND_TASKS : EMPTY_BACKGROUND_TASKS));
+
+/**
+ * Bottom panel active tab for a specific session.
+ * Returns 'terminal' by default.
+ */
+export const useBottomPanelActiveTab = (sessionId: string | null) =>
+  useAppStore((s) => (sessionId ? s.bottomPanelActiveTab[sessionId] ?? 'terminal' : 'terminal'));
+
+// ============================================================================
 // Script Output State
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Add a **tabbed bottom panel** (`BottomPanel`) wrapping Terminal and a new Background Tasks view
- New `BackgroundTasksPanel` shows live task rows with spinner, description, elapsed timer, last tool name, token usage, and a stop button
- Handle `task_started`, `task_progress`, `task_stopped` WebSocket events (SDK 0.2.84+) with Zustand state management
- Backend: new idempotent `POST /conversations/{convId}/tasks/{taskId}/stop` endpoint
- Auto-open panel and switch to Tasks tab when a background task starts (scoped to the event's session)
- Running tasks survive `turn_complete` — only stopped tasks are cleared
- Optimistic UI update when stopping a task (don't wait for WS confirmation)

## Changed files
| Area | Files | What |
|------|-------|------|
| Backend | `manager.go`, `conversation_handlers.go`, `router.go` | StopTask endpoint + manager method |
| Types | `types.ts` | `BackgroundTask` interface, `AgentEvent.taskUsage` field |
| WS events | `useWebSocket.ts`, `useWebSocketHelpers.ts` | Handle task_started/progress/stopped |
| State | `appStore.ts`, `selectors.ts` | Background task CRUD + bottom panel tab state |
| API client | `conversations.ts` | `stopBackgroundTask()` |
| UI | `BottomPanel.tsx` (new), `BackgroundTasksPanel.tsx` (new), `BottomTerminal.tsx`, `page.tsx`, `index.ts` | Tabbed bottom panel with Terminal + Tasks |

## Test plan
- [ ] Verify bottom panel shows Terminal and Tasks tabs
- [ ] Trigger a background task (Agent tool with `run_in_background: true`) and confirm the panel auto-opens to Tasks tab
- [ ] Confirm running tasks show spinner, description, elapsed timer, and stop button
- [ ] Click Stop on a running task — verify it stops immediately (optimistic update)
- [ ] Verify task_progress updates show last tool name and token usage
- [ ] Verify tasks survive turn_complete if still running
- [ ] Verify stopped tasks are cleared on next turn_complete
- [ ] Verify switching between Terminal and Tasks tabs preserves state
- [ ] Verify background tasks from session B don't hijack session A's panel
- [ ] Go backend builds clean (`go build ./...`)
- [ ] TypeScript compiles clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)