### PR TITLE
fix: wrap menu SubContent in Portal to restore sub-menu visibility

### DIFF
--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -225,14 +225,16 @@ function ContextMenuSubContent({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
   return (
-    <ContextMenuPrimitive.SubContent
-      data-slot="context-menu-sub-content"
-      className={cn(
-        "bg-(--menu-bg) backdrop-blur-xl backdrop-saturate-150 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border border-(--menu-border) p-[5px] shadow-popover",
-        className
-      )}
-      {...props}
-    />
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.SubContent
+        data-slot="context-menu-sub-content"
+        className={cn(
+          "bg-(--menu-bg) backdrop-blur-xl backdrop-saturate-150 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border border-(--menu-border) p-[5px] shadow-popover",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
   )
 }
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -232,15 +232,17 @@ function DropdownMenuSubContent({
   sideOffset?: number
 }) {
   return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      sideOffset={sideOffset}
-      className={cn(
-        "bg-(--menu-bg) backdrop-blur-xl backdrop-saturate-150 text-popover-foreground z-50 min-w-[8rem] overflow-hidden rounded-lg border border-(--menu-border) p-[5px] shadow-popover",
-        className
-      )}
-      {...props}
-    />
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.SubContent
+        data-slot="dropdown-menu-sub-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-(--menu-bg) backdrop-blur-xl backdrop-saturate-150 text-popover-foreground z-50 min-w-[8rem] overflow-hidden rounded-lg border border-(--menu-border) p-[5px] shadow-popover",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
   )
 }
 


### PR DESCRIPTION
## Summary
- Wraps `DropdownMenuSubContent` and `ContextMenuSubContent` in a `<Portal>` so sub-menus render outside the parent DOM
- Fixes sub-menus being clipped by `overflow-x-hidden` on parent `Content` components introduced in #1165

## Root cause
The vibrancy styling redesign (#1165) added `overflow-x-hidden overflow-y-auto` to menu Content. Since SubContent rendered inside the parent DOM without a Portal, the overflow clipping made sub-menus invisible (only shadows visible).

## Test plan
- [ ] Open a context menu with sub-menus (e.g., data table row)
- [ ] Hover over sub-menu triggers — sub-menus should appear fully
- [ ] Open a dropdown menu with sub-menus (e.g., data table filters, workspace sidebar)
- [ ] Verify sub-menu animations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)