### PR TITLE
fix: hide primary action in session popover while agent is running

### DIFF
--- a/src/components/shared/HoverCardPrimaryAction.tsx
+++ b/src/components/shared/HoverCardPrimaryAction.tsx
@@ -6,6 +6,7 @@ import { useActionState } from '@/components/shared/PrimaryActionButton/useActio
 import { ActionButton } from '@/components/shared/PrimaryActionButton/ActionButton';
 import { dispatchAppEvent } from '@/lib/custom-events';
 import { getTemplateKey, ACTION_TEMPLATES } from '@/lib/action-templates';
+import { useSessionActivityState } from '@/stores/selectors';
 import type { WorktreeSession } from '@/lib/types';
 import type { PrimaryActionType } from '@/components/shared/PrimaryActionButton/types';
 
@@ -24,6 +25,9 @@ export function HoverCardPrimaryAction({
   onSelectSession,
   onArchiveSession,
 }: HoverCardPrimaryActionProps) {
+  const sessionActivityState = useSessionActivityState(session.id);
+  const isAgentWorking = sessionActivityState === 'working';
+
   const { gitStatus, prDetails, templates, loading } = useHoverActionData(
     session.workspaceId,
     session.id,
@@ -55,6 +59,19 @@ export function HoverCardPrimaryAction({
     onClose();
     onArchiveSession?.(sessionId);
   }, [onClose, onArchiveSession]);
+
+  if (isAgentWorking) {
+    return (
+      <div className="flex items-center gap-1.5 h-6 px-2">
+        <div className="flex items-end gap-[1.5px] h-3" aria-hidden="true">
+          <div className="w-[2.5px] bg-ai-active rounded-full animate-agent-bar-1" />
+          <div className="w-[2.5px] bg-ai-active rounded-full animate-agent-bar-2" />
+          <div className="w-[2.5px] bg-ai-active rounded-full animate-agent-bar-3" />
+        </div>
+        <span className="text-xs text-muted-foreground whitespace-nowrap">Agent is working</span>
+      </div>
+    );
+  }
 
   // Show nothing while loading with no cached data, or when no action is available
   if (loading && !gitStatus && !action) {


### PR DESCRIPTION
## Summary
- Show animated "Agent is working" indicator instead of the Primary Action button in the session hover popover when the agent is actively running
- Matches existing behavior in `SessionContentToolbar` — uses `useSessionActivityState` to detect working state
- Prevents users from invoking Primary Actions while the agent is busy

## Test plan
- [ ] Hover over a session card while its agent is running — should see animated bars + "Agent is working" text
- [ ] Hover over a session card when agent is idle — should see the normal Primary Action button
- [ ] Confirm the toolbar still shows the same behavior independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)