### PR TITLE
feat: add sprint phase grouping to sidebar

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -92,7 +92,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { getWorkspaceColor, WORKSPACE_COLORS } from '@/lib/workspace-colors';
-import { TASK_STATUS_OPTIONS } from '@/lib/session-fields';
+import { TASK_STATUS_OPTIONS, getSprintPhaseOption } from '@/lib/session-fields';
 import { TaskStatusIcon } from '@/components/icons/TaskStatusIcon';
 import { GitStatusIcon } from '@/components/icons/GitStatusIcon';
 import { useToast } from '@/components/ui/toast';
@@ -109,7 +109,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import type { Workspace, WorktreeSession, SessionTaskStatus } from '@/lib/types';
+import type { Workspace, WorktreeSession, SessionTaskStatus, SprintPhase } from '@/lib/types';
 import { useSessionActivityState, useIsSessionUnread, useWorkspaceSelection, useSidebarActions } from '@/stores/selectors';
 import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog';
 import { useArchiveSession } from '@/hooks/useArchiveSession';
@@ -556,8 +556,10 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
   const VIEW_OPTIONS: { value: SidebarGroupBy; label: string; projectOnly?: boolean; singleProjectOnly?: boolean }[] = [
     { value: 'none', label: 'Recent', singleProjectOnly: true },
     { value: 'status', label: 'By Status', singleProjectOnly: true },
+    { value: 'sprint', label: 'By Sprint Phase', singleProjectOnly: true },
     { value: 'project', label: 'By Project', projectOnly: true },
     { value: 'project-status', label: 'By Project > Status', projectOnly: true },
+    { value: 'project-sprint', label: 'By Project > Sprint', projectOnly: true },
   ];
 
   return (
@@ -1161,6 +1163,52 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                     </>
                   )}
 
+                  {/* Mode: Sprint — sprint phase group headers with sessions */}
+                  {!isReorderMode && effectiveGroupBy === 'sprint' && (
+                    <>
+                      {baseSessions.map((session) => (
+                        <ErrorBoundary
+                          key={session.id}
+                          section="BaseSessionCard"
+                          fallback={<CardErrorFallback message="Error loading session" />}
+                        >
+                          <BaseSessionCard
+                            session={session}
+                            contentView={contentView}
+                            selectedSessionId={selectedSessionId}
+                            onSelectSession={(id, e) => handleSelectSession(session.workspaceId, id, e)}
+                            formatTimeAgo={formatTimeAgo}
+                          />
+                        </ErrorBoundary>
+                      ))}
+                      {baseSessions.length > 0 && sidebarGroups.length > 0 && (
+                        <div className="mx-2 my-1.5 border-t border-border/40" />
+                      )}
+                      {sidebarGroups.length === 0 && baseSessions.length === 0 && scheduledGroups.length === 0 ? (
+                        <div className="py-2 px-2 text-sm text-muted-foreground/70">
+                          No sessions found
+                        </div>
+                      ) : (
+                        sidebarGroups.map((group) => (
+                          <SprintPhaseGroupSection
+                            key={group.key}
+                            group={group}
+                            isExpanded={isGroupExpanded(group.key, group.defaultCollapsed)}
+                            onToggle={() => toggleSidebarGroupCollapsed(group.key)}
+                            contentView={contentView}
+                            selectedSessionId={selectedSessionId}
+                            onSelectSession={handleSelectSession}
+                            onArchiveSession={handleArchiveSession}
+                            onTaskStatusChange={handleTaskStatusChange}
+                            onOpenBranches={navigateToBranches}
+                            onOpenPRs={navigateToPRs}
+                            formatTimeAgo={formatTimeAgo}
+                          />
+                        ))
+                      )}
+                    </>
+                  )}
+
                   {/* Mode: Project — workspace headers with sessions (with DnD) */}
                   {!isReorderMode && effectiveGroupBy === 'project' && (
                     <DndContext
@@ -1212,6 +1260,56 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
 
                   {/* Mode: Project > Status — workspace headers with status sub-groups */}
                   {!isReorderMode && effectiveGroupBy === 'project-status' && (
+                    <DndContext
+                      sensors={sensors}
+                      collisionDetection={closestCenter}
+                      onDragEnd={handleDragEnd}
+                    >
+                      <SortableContext
+                        items={workspaces.map((w) => w.id)}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        {sidebarGroups.map((group) => {
+                          const ws = workspaces.find((w) => w.id === group.workspaceId);
+                          if (!ws) return null;
+                          const isUnread = unreadWorkspaces.includes(ws.id);
+                          return (
+                            <SortableProjectStatusItem
+                              key={ws.id}
+                              workspace={ws}
+                              group={group}
+                              isExpanded={isWorkspaceExpanded(ws.id)}
+                              selectedSessionId={selectedSessionId}
+                              onToggle={() => toggleWorkspaceCollapsed(ws.id)}
+                              onCreateSession={() => handleCreateSession(ws.id)}
+                              onSelectSession={(sessionId, event) => handleSelectSession(ws.id, sessionId, event)}
+                              onArchiveSession={handleArchiveSession}
+                              onTaskStatusChange={handleTaskStatusChange}
+                              onRemoveWorkspace={() => setWorkspaceToRemove({ id: ws.id, name: ws.name })}
+                              onOpenBranches={(event) => navigateToBranches(ws.id, event)}
+                              onOpenPRs={(event) => navigateToPRs(ws.id, event)}
+                              onOpenWorkspaceSettings={() => onOpenWorkspaceSettings?.(ws.id)}
+                              isUnread={isUnread}
+                              onToggleUnread={() => {
+                                if (isUnread) {
+                                  markWorkspaceRead(ws.id);
+                                } else {
+                                  markWorkspaceUnread(ws.id);
+                                }
+                              }}
+                              contentView={contentView}
+                              formatTimeAgo={formatTimeAgo}
+                              isSubGroupExpanded={isGroupExpanded}
+                              onToggleSubGroup={toggleSidebarGroupCollapsed}
+                            />
+                          );
+                        })}
+                      </SortableContext>
+                    </DndContext>
+                  )}
+
+                  {/* Mode: Project > Sprint — workspace headers with sprint phase sub-groups */}
+                  {!isReorderMode && effectiveGroupBy === 'project-sprint' && (
                     <DndContext
                       sensors={sensors}
                       collisionDetection={closestCenter}
@@ -2126,6 +2224,86 @@ function StatusGroupSection({
   );
 }
 
+// --- Sprint phase icon helper ---
+
+function SprintPhaseIcon({ phase, className }: { phase: SprintPhase | null; className?: string }) {
+  if (!phase) {
+    return <Circle className={cn(className, 'text-muted-foreground')} />;
+  }
+  const option = getSprintPhaseOption(phase);
+  const Icon = option.icon;
+  return <Icon className={cn(className, option.color)} />;
+}
+
+// --- Sprint phase group section ---
+
+function SprintPhaseGroupSection({
+  group,
+  isExpanded,
+  onToggle,
+  contentView,
+  selectedSessionId,
+  onSelectSession,
+  onArchiveSession,
+  onTaskStatusChange,
+  onOpenBranches,
+  onOpenPRs,
+  formatTimeAgo,
+}: {
+  group: SidebarGroup;
+  isExpanded: boolean;
+  onToggle: () => void;
+  contentView: ContentView;
+  selectedSessionId: string | null;
+  onSelectSession: (workspaceId: string, sessionId: string, event?: React.MouseEvent) => void;
+  onArchiveSession: (sessionId: string) => void;
+  onTaskStatusChange: (sessionId: string, status: SessionTaskStatus) => void;
+  onOpenBranches: (workspaceId: string, event?: React.MouseEvent) => void;
+  onOpenPRs: (workspaceId: string, event?: React.MouseEvent) => void;
+  formatTimeAgo: (date: string) => string;
+}) {
+  return (
+    <Collapsible open={isExpanded} onOpenChange={onToggle}>
+      <CollapsibleTrigger asChild>
+        <div className="group flex items-center gap-1.5 px-2 py-1.5 rounded-md cursor-pointer hover:bg-surface-1 transition-colors">
+          <SprintPhaseIcon phase={group.sprintPhaseValue ?? null} className="w-3.5 h-3.5 shrink-0" />
+          <span className="text-sm font-semibold text-muted-foreground">{group.label}</span>
+          <ChevronDown className={cn(
+            'h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 shrink-0',
+            !isExpanded && '-rotate-90'
+          )} />
+          <span className="text-xs text-muted-foreground/50 ml-auto">{group.count}</span>
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="ml-2">
+          {group.sessions.map((session) => {
+            return (
+              <ErrorBoundary
+                key={session.id}
+                section="SessionRow"
+                fallback={<CardErrorFallback message="Error loading session" />}
+              >
+                <SessionRow
+                  session={session}
+                  contentView={contentView}
+                  selectedSessionId={selectedSessionId}
+                  onSelectSession={(id, e) => onSelectSession(session.workspaceId, id, e)}
+                  onArchiveSession={onArchiveSession}
+                  onTaskStatusChange={onTaskStatusChange}
+                  onOpenBranches={(e) => onOpenBranches(session.workspaceId, e)}
+                  onOpenPRs={(e) => onOpenPRs(session.workspaceId, e)}
+                  formatTimeAgo={formatTimeAgo}
+                />
+              </ErrorBoundary>
+            );
+          })}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
 // --- Project > Status sortable item ---
 
 interface SortableProjectStatusItemProps {
@@ -2349,8 +2527,11 @@ function SortableProjectStatusItem({
                     >
                       <CollapsibleTrigger asChild>
                         <div className="group flex items-center gap-1.5 px-2 py-1 rounded-md cursor-pointer hover:bg-surface-1 transition-colors">
-                          {subGroup.statusValue && (
+                          {subGroup.type === 'status' && subGroup.statusValue && (
                             <TaskStatusIcon status={subGroup.statusValue} className="w-3 h-3 shrink-0" />
+                          )}
+                          {subGroup.type === 'sprint' && (
+                            <SprintPhaseIcon phase={subGroup.sprintPhaseValue ?? null} className="w-3 h-3 shrink-0" />
                           )}
                           <span className="text-xs font-semibold text-muted-foreground">{subGroup.label}</span>
                           <ChevronDown className={cn(
@@ -2378,7 +2559,7 @@ function SortableProjectStatusItem({
                                 onOpenBranches={onOpenBranches}
                                 onOpenPRs={onOpenPRs}
                                 formatTimeAgo={formatTimeAgo}
-                                hideStatusIcon
+                                hideStatusIcon={subGroup.type === 'status'}
                               />
                             </ErrorBoundary>
                           ))}

--- a/src/hooks/useSidebarSessions.ts
+++ b/src/hooks/useSidebarSessions.ts
@@ -1,16 +1,18 @@
 import { useMemo } from 'react';
-import type { Workspace, WorktreeSession, SessionTaskStatus } from '@/lib/types';
+import type { Workspace, WorktreeSession, SessionTaskStatus, SprintPhase } from '@/lib/types';
+import { SPRINT_PHASES } from '@/lib/types';
 import { useSettingsStore, applyStatusGroupOrder } from '@/stores/settingsStore';
 import type { SidebarGroupBy, SidebarSortBy } from '@/stores/settingsStore';
 
 export interface SidebarGroup {
   key: string;
   label: string;
-  type: 'project' | 'status';
+  type: 'project' | 'status' | 'sprint';
   count: number;
   defaultCollapsed: boolean;
   workspaceId?: string;
   statusValue?: SessionTaskStatus;
+  sprintPhaseValue?: SprintPhase | null;
   color?: string;
   baseSessions?: WorktreeSession[];
   sessions: WorktreeSession[];
@@ -120,10 +122,59 @@ function buildStatusGroups(
   return groups;
 }
 
+// Sprint phase display order: "Not Started" first, then canonical phase order
+const SPRINT_PHASE_ORDER: (SprintPhase | 'not_started')[] = ['not_started', ...SPRINT_PHASES];
+
+const SPRINT_PHASE_LABELS: Record<SprintPhase | 'not_started', string> = {
+  not_started: 'Not Started',
+  think: 'Think',
+  plan: 'Plan',
+  build: 'Build',
+  review: 'Review',
+  test: 'Test',
+  ship: 'Ship',
+  reflect: 'Reflect',
+};
+
+const DEFAULT_COLLAPSED_SPRINT_PHASES = new Set<SprintPhase | 'not_started'>(['reflect']);
+
+function buildSprintPhaseGroups(
+  sessions: WorktreeSession[],
+  sortBy: SidebarSortBy,
+  keyPrefix: string = '',
+): SidebarGroup[] {
+  const byPhase = new Map<string, WorktreeSession[]>();
+  for (const s of sessions) {
+    const phase = s.sprintPhase ?? 'not_started';
+    const list = byPhase.get(phase) || [];
+    list.push(s);
+    byPhase.set(phase, list);
+  }
+
+  const groups: SidebarGroup[] = [];
+  for (const phase of SPRINT_PHASE_ORDER) {
+    const phaseSessions = byPhase.get(phase);
+    if (!phaseSessions || phaseSessions.length === 0) continue;
+
+    const key = keyPrefix ? `${keyPrefix}:sprint:${phase}` : `sprint:${phase}`;
+    groups.push({
+      key,
+      label: SPRINT_PHASE_LABELS[phase],
+      type: 'sprint',
+      count: phaseSessions.length,
+      defaultCollapsed: DEFAULT_COLLAPSED_SPRINT_PHASES.has(phase),
+      sprintPhaseValue: phase === 'not_started' ? null : phase as SprintPhase,
+      sessions: sortSessions(phaseSessions, sortBy),
+    });
+  }
+  return groups;
+}
+
 /** When filtering to a single project, project-level grouping is redundant. */
 function downgradeGroupBy(groupBy: SidebarGroupBy): SidebarGroupBy {
   if (groupBy === 'project') return 'none';
   if (groupBy === 'project-status') return 'status';
+  if (groupBy === 'project-sprint') return 'sprint';
   return groupBy;
 }
 
@@ -193,6 +244,18 @@ export function useSidebarSessions({
       };
     }
 
+    if (effectiveGroupBy === 'sprint') {
+      const base = sortSessions(unpinned.filter(s => s.sessionType === 'base'), sortBy);
+      const regular = unpinned.filter(s => s.sessionType !== 'base');
+      return {
+        groups: buildSprintPhaseGroups(regular, sortBy),
+        flatSessions: [],
+        baseSessions: base,
+        pinnedSessions,
+        effectiveGroupBy,
+      };
+    }
+
     // For project-based grouping, bucket sessions by workspace
     const byWorkspace = new Map<string, WorktreeSession[]>();
     for (const s of unpinned) {
@@ -250,6 +313,32 @@ export function useSidebarSessions({
       return { groups, flatSessions: [], baseSessions: [], pinnedSessions, effectiveGroupBy };
     }
 
+    // project-sprint
+    if (effectiveGroupBy === 'project-sprint') {
+      const groups: SidebarGroup[] = [];
+      for (const ws of workspaces) {
+        const wsSessions = byWorkspace.get(ws.id) ?? [];
+        if (wsSessions.length === 0 && filters.searchTerm) continue;
+        const color = workspaceColors[ws.id] || getDefaultColor(ws.id);
+        const base = wsSessions.filter(s => s.sessionType === 'base');
+        const regular = wsSessions.filter(s => s.sessionType !== 'base');
+        const subGroups = buildSprintPhaseGroups(regular, sortBy, `project:${ws.id}`);
+        groups.push({
+          key: `project:${ws.id}`,
+          label: ws.name,
+          type: 'project',
+          count: wsSessions.length,
+          defaultCollapsed: false,
+          workspaceId: ws.id,
+          color,
+          baseSessions: base,
+          sessions: [],
+          subGroups,
+        });
+      }
+      return { groups, flatSessions: [], baseSessions: [], pinnedSessions, effectiveGroupBy };
+    }
+
     return { groups: [], flatSessions: [], baseSessions: [], pinnedSessions, effectiveGroupBy };
   }, [sessions, workspaces, groupBy, sortBy, filters, projectFilter, workspaceColors, getDefaultColor, statusGroupOrder]);
 }
@@ -300,5 +389,23 @@ export function expandGroupsForSession(session: WorktreeSession): void {
     const subKey = `project:${session.workspaceId}:status:${session.taskStatus}`;
     const defaultCollapsed = DEFAULT_COLLAPSED_STATUSES.has(session.taskStatus);
     ensureSidebarGroupExpanded(subKey, defaultCollapsed);
+    return;
+  }
+
+  if (sidebarGroupBy === 'sprint') {
+    const phaseKey = session.sprintPhase ?? 'not_started';
+    const key = `sprint:${phaseKey}`;
+    const defaultCollapsed = DEFAULT_COLLAPSED_SPRINT_PHASES.has(phaseKey);
+    ensureSidebarGroupExpanded(key, defaultCollapsed);
+    return;
+  }
+
+  if (sidebarGroupBy === 'project-sprint') {
+    expandWorkspace(session.workspaceId);
+    const phaseKey = session.sprintPhase ?? 'not_started';
+    const subKey = `project:${session.workspaceId}:sprint:${phaseKey}`;
+    const defaultCollapsed = DEFAULT_COLLAPSED_SPRINT_PHASES.has(phaseKey);
+    ensureSidebarGroupExpanded(subKey, defaultCollapsed);
+    return;
   }
 }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -39,7 +39,7 @@ export type DictationShortcutPreset = 'capslock' | 'cmd-shift-d' | 'custom';
 export type BranchPrefixType = 'github' | 'custom' | 'none';
 
 // Sidebar grouping options
-export type SidebarGroupBy = 'none' | 'project' | 'status' | 'project-status';
+export type SidebarGroupBy = 'none' | 'project' | 'status' | 'project-status' | 'sprint' | 'project-sprint';
 
 // Sidebar sorting options
 export type SidebarSortBy = 'recent' | 'status' | 'priority' | 'name';


### PR DESCRIPTION
## Summary

- Adds two new sidebar grouping modes: **By Sprint Phase** and **By Project > Sprint Phase**
- Sessions are grouped by their current sprint workflow phase (Think → Plan → Build → Review → Test → Ship → Reflect), with a "Not Started" group for sessions without a phase
- Reuses existing `SortableProjectStatusItem` for the nested project-sprint view, with type-aware icon rendering and conditional `hideStatusIcon`

## Changes

- **`settingsStore.ts`** — Extend `SidebarGroupBy` union with `'sprint'` and `'project-sprint'`
- **`useSidebarSessions.ts`** — Add `buildSprintPhaseGroups()`, `SPRINT_PHASE_ORDER`, typed label/collapsed maps, `downgradeGroupBy` for single-project filter, and `expandGroupsForSession` support for both new modes
- **`WorkspaceSidebar.tsx`** — Add `SprintPhaseIcon`, `SprintPhaseGroupSection` components, render blocks for both modes, and conditional `hideStatusIcon` (only hides when grouped by status, not sprint)

## Test plan

- [ ] Switch sidebar to "By Sprint Phase" — sessions group by phase, empty phases hidden, "Reflect" collapsed by default
- [ ] Switch to "By Project > Sprint" — workspace headers with sprint sub-groups, DnD reorder works
- [ ] Filter to single project — "By Project > Sprint" downgrades to "By Sprint Phase"
- [ ] Select a session in a collapsed sprint group — group auto-expands
- [ ] Verify task status icons remain visible in sprint sub-groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)