### PR TITLE
fix(watcher): stop file watchers for archived sessions

### DIFF
--- a/src/components/session-manager/SessionManager.tsx
+++ b/src/components/session-manager/SessionManager.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { navigate } from '@/lib/navigation';
 import { updateSession as updateSessionApi } from '@/lib/api';
+import { registerSession, getSessionDirName } from '@/lib/tauri';
 import { HistoryList } from './HistoryList';
 import { ArchiveSessionDialog } from '@/components/dialogs/ArchiveSessionDialog';
 import { ArchivedSessionPreviewDialog } from '@/components/dialogs/ArchivedSessionPreviewDialog';
@@ -20,6 +21,14 @@ export function SessionManager() {
   const unarchiveSession = useAppStore((s) => s.unarchiveSession);
   const { expandWorkspace } = useSettingsStore();
   const { requestArchive, dialogProps: archiveDialogProps } = useArchiveSession();
+
+  // Re-register a session with the file watcher after unarchiving
+  const reregisterWatcher = useCallback((session: WorktreeSession) => {
+    if (session.worktreePath) {
+      const dirName = getSessionDirName(session.worktreePath);
+      if (dirName) registerSession(dirName, session.id);
+    }
+  }, []);
 
   // Preview dialog state
   const [previewTarget, setPreviewTarget] = useState<{ session: WorktreeSession; workspace: Workspace } | null>(null);
@@ -64,6 +73,7 @@ export function SessionManager() {
         try {
           await updateSessionApi(workspaceId, sessionId, { archived: false });
           unarchiveSession(sessionId);
+          reregisterWatcher(session);
         } catch (error) {
           console.error('Failed to unarchive session:', error);
           return;
@@ -76,7 +86,7 @@ export function SessionManager() {
         contentView: { type: 'conversation' },
       });
     },
-    [sessions, expandWorkspace, unarchiveSession]
+    [sessions, expandWorkspace, unarchiveSession, reregisterWatcher]
   );
 
   // Handle archive session
@@ -110,11 +120,12 @@ export function SessionManager() {
         await updateSessionApi(session.workspaceId, sessionId, { archived: false });
         // Update local store
         unarchiveSession(sessionId);
+        reregisterWatcher(session);
       } catch (error) {
         console.error('Failed to unarchive session:', error);
       }
     },
-    [sessions, unarchiveSession]
+    [sessions, unarchiveSession, reregisterWatcher]
   );
 
   return (

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -241,9 +241,9 @@ export function useAppInitialization() {
         const allSessions = sessionDTOs.map(s => mapSessionDTO(s));
         setSessions(allSessions);
 
-        // Register all sessions with the global file watcher for event routing
+        // Register non-archived sessions with the global file watcher for event routing
         for (const session of allSessions) {
-          if (session.worktreePath) {
+          if (session.worktreePath && !session.archived) {
             const dirName = getSessionDirName(session.worktreePath);
             if (dirName) {
               registerSession(dirName, session.id);

--- a/src/hooks/useArchiveSession.ts
+++ b/src/hooks/useArchiveSession.ts
@@ -4,6 +4,7 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { useTabStore } from '@/stores/tabStore';
 import { ENABLE_BROWSER_TABS } from '@/lib/constants';
 import { updateSession as updateSessionApi, getGitStatus } from '@/lib/api';
+import { unregisterSession, getSessionDirName } from '@/lib/tauri';
 import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 import type { ArchiveSessionDialogGitStatus } from '@/components/dialogs/ArchiveSessionDialog';
 
@@ -52,6 +53,12 @@ export function useArchiveSession(options?: {
           archived: true,
           ...(deleteBranchOnArchive ? { deleteBranch: true } : {}),
         });
+
+        // Unregister from file watcher — no need to watch archived/deleted sessions
+        if (session.worktreePath) {
+          const dirName = getSessionDirName(session.worktreePath);
+          if (dirName) unregisterSession(dirName);
+        }
 
         if (result === null) {
           // Blank session was deleted by backend (no messages)

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -21,6 +21,7 @@ import { useBranchCacheStore } from '@/stores/branchCacheStore';
 import { useSlashCommandStore } from '@/stores/slashCommandStore';
 import { notifyDesktop, getConversationLabel } from '@/hooks/useDesktopNotifications';
 import { trackEvent } from '@/lib/telemetry';
+import { unregisterSession, getSessionDirName } from '@/lib/tauri';
 
 // Import extracted modules
 import { markPlanModeExited, isInPlanModeExitCooldown, clearPlanModeState } from '@/hooks/useWebSocketPlanMode';
@@ -1598,6 +1599,11 @@ export function useWebSocket(enabled: boolean = true) {
                     archived: true,
                     ...(deleteBranchOnArchive ? { deleteBranch: true } : {}),
                   }).then((result) => {
+                    // Unregister from file watcher — no need to watch archived/deleted sessions
+                    if (session.worktreePath) {
+                      const dirName = getSessionDirName(session.worktreePath);
+                      if (dirName) unregisterSession(dirName);
+                    }
                     if (result === null) {
                       getStore().removeSession(sid);
                     } else {


### PR DESCRIPTION
## Summary
- Skip registering archived sessions with the global file watcher at app init
- Unregister sessions from the file watcher when archiving (manual + auto-archive on PR merge)
- Re-register sessions with the file watcher when unarchiving (select + explicit unarchive)
- Extract `reregisterWatcher` helper in SessionManager to deduplicate two identical blocks

## Changed files
- `src/hooks/useAppInitialization.ts` — filter out archived sessions during init registration
- `src/hooks/useArchiveSession.ts` — unregister on archive
- `src/hooks/useWebSocket.ts` — unregister on auto-archive-on-merge
- `src/components/session-manager/SessionManager.tsx` — re-register on unarchive via extracted helper

## Test plan
- [ ] Archive a session → verify file watcher events stop for that session's worktree
- [ ] Unarchive a session (both via History click and explicit unarchive) → verify file watcher events resume
- [ ] Merge a PR with `archiveOnMerge` enabled → verify session is unregistered from watcher
- [ ] Restart app with mix of archived/active sessions → verify only active sessions register

🤖 Generated with [Claude Code](https://claude.com/claude-code)