### PR TITLE
fix(messages): resolve race condition in queued message delivery acknowledgment

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -872,6 +872,11 @@ function setupInputQueue(): void {
 
       // Queue "message" type inputs for the next turn
       if (input.type === "message" && input.content) {
+        // Acknowledge receipt to backend → frontend before processing
+        if (input.messageUuid) {
+          emit({ type: "message_received", messageUuid: input.messageUuid });
+        }
+
         const queued: QueuedMessage = {
           content: input.content,
           attachments: input.attachments,

--- a/backend/agent/backend.go
+++ b/backend/agent/backend.go
@@ -37,7 +37,9 @@ type ConversationBackend interface {
 	SendMessage(content string) error
 
 	// SendMessageWithAttachments sends a user message with file attachments.
-	SendMessageWithAttachments(content string, attachments []models.Attachment) error
+	// messageUuid is the frontend's message ID used for delivery acknowledgment
+	// (only meaningful for agent-runner Process backends; ignored by native loop).
+	SendMessageWithAttachments(content string, attachments []models.Attachment, messageUuid string) error
 
 	// SendStop sends a graceful stop signal.
 	SendStop() error

--- a/backend/agent/core_types.go
+++ b/backend/agent/core_types.go
@@ -142,4 +142,7 @@ const (
 	EventTypeTaskCreated         = coreagent.EventTypeTaskCreated
 	EventTypeAPIRetry            = coreagent.EventTypeAPIRetry
 	EventTypeSessionStateChanged = coreagent.EventTypeSessionStateChanged
+
+	// ChatML-specific events (emitted by agent-runner, not the Claude SDK)
+	EventTypeMessageReceived = "message_received"
 )

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -450,7 +450,7 @@ func (m *Manager) StartConversation(ctx context.Context, sessionID, conversation
 			}
 		}
 
-		if err := backend.SendMessageWithAttachments(initialMessage, attachments); err != nil {
+		if err := backend.SendMessageWithAttachments(initialMessage, attachments, ""); err != nil {
 			return conv, fmt.Errorf("failed to send initial message: %w", err)
 		}
 
@@ -1064,6 +1064,11 @@ outer:
 			case EventTypeMessageCancelled:
 				logger.Manager.Debugf("[%s] Message cancelled", convID)
 
+			case EventTypeMessageReceived:
+				// Agent-runner acknowledged receipt of a queued user message.
+				// Already forwarded to frontend via onConversationEvent above.
+				logger.Manager.Debugf("[%s] Message received by agent-runner: %s", convID, event.MessageUuid)
+
 			// ── SDK 0.2.84+ event types ──────────────────────────────────
 
 			case EventTypeStopFailure:
@@ -1165,6 +1170,25 @@ outer:
 							sortPriority: 0, // Sort before other items at the same timestamp
 							entry:        models.TimelineEntry{Type: "status", Content: statusContent, Variant: "config"},
 						})
+					}
+					// Embed pending user message at its chronological position in the timeline
+					if pending != nil {
+						entry := models.TimelineEntry{
+							Type:      "user_message",
+							Content:   pending.Content,
+							MessageID: pending.ID,
+						}
+						if len(pending.Attachments) > 0 {
+							for _, a := range pending.Attachments {
+								entry.AttachmentIDs = append(entry.AttachmentIDs, a.ID)
+							}
+						}
+						items = append(items, timelineItem{
+							timestamp:    pending.Timestamp,
+							sortPriority: 1,
+							entry:        entry,
+						})
+						pending.EmbeddedInTimeline = true
 					}
 					sort.Slice(items, func(i, j int) bool {
 						if items[i].timestamp.Equal(items[j].timestamp) {
@@ -1659,8 +1683,9 @@ func (m *Manager) handleConversationCompletion(convID string, proc ConversationB
 	}
 }
 
-// SendConversationMessage sends a follow-up message to an existing conversation
-func (m *Manager) SendConversationMessage(ctx context.Context, convID, message string, attachments []models.Attachment, planMode *bool) error {
+// SendConversationMessage sends a follow-up message to an existing conversation.
+// messageUuid is the frontend's message ID used for agent-runner delivery acknowledgment.
+func (m *Manager) SendConversationMessage(ctx context.Context, convID, message string, attachments []models.Attachment, planMode *bool, messageUuid string) error {
 	// Track whether we should generate a title (set in the idle-start path)
 	var shouldGenerateTitle bool
 	var titleSessionID string
@@ -1902,7 +1927,7 @@ func (m *Manager) SendConversationMessage(ctx context.Context, convID, message s
 	// Send to process with attachments
 	logger.Manager.Infof("Sending message to conv %s (content=%d chars, attachments=%d, processRestarted=%v)",
 		convID, len(message), len(attachments), needsRestart)
-	if err := proc.SendMessageWithAttachments(message, attachments); err != nil {
+	if err := proc.SendMessageWithAttachments(message, attachments, messageUuid); err != nil {
 		// Discard the pending message — it was never delivered to the agent,
 		// so it should not be flushed to the DB later.
 		proc.TakePendingUserMessage()
@@ -3644,7 +3669,7 @@ func (m *Manager) prepareOllamaAndStart(convID, sessionID string, session *model
 			}
 		}
 
-		if err := backend.SendMessageWithAttachments(initialMessage, attachments); err != nil {
+		if err := backend.SendMessageWithAttachments(initialMessage, attachments, ""); err != nil {
 			logger.Manager.Errorf("Failed to send initial message for conversation %s: %v", convID, err)
 		}
 
@@ -3727,7 +3752,7 @@ func (m *Manager) prepareOllamaAndRestart(convID string, session *models.Session
 		}
 
 		if len(attachments) > 0 {
-			if err := backend.SendMessageWithAttachments(message, attachments); err != nil {
+			if err := backend.SendMessageWithAttachments(message, attachments, ""); err != nil {
 				logger.Manager.Errorf("Failed to send message after restart for conversation %s: %v", convID, err)
 			}
 		} else {

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -299,7 +299,7 @@ func TestManager_StartConversation_SessionNotFound(t *testing.T) {
 func TestManager_SendConversationMessage_ConversationNotFound(t *testing.T) {
 	manager, _ := setupTestManager(t)
 
-	err := manager.SendConversationMessage(context.Background(), "nonexistent", "hello", nil, nil)
+	err := manager.SendConversationMessage(context.Background(), "nonexistent", "hello", nil, nil, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "conversation not found")
 }

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -70,6 +70,7 @@ type InputMessage struct {
 	PermissionMode string              `json:"permissionMode,omitempty"`
 	CheckpointUuid string              `json:"checkpointUuid,omitempty"`
 	Attachments    []models.Attachment `json:"attachments,omitempty"`
+	MessageUuid    string              `json:"messageUuid,omitempty"` // Frontend message ID for receipt acknowledgment
 	// User question response fields (for AskUserQuestion tool)
 	QuestionRequestID string            `json:"questionRequestId,omitempty"`
 	Answers           map[string]string `json:"answers,omitempty"`
@@ -503,7 +504,7 @@ func (p *Process) SendMessage(content string) error {
 // SendMessageWithAttachments sends a user message with file attachments to the running agent process.
 // For image attachments, the base64 data is offloaded to a temp file so only the path
 // travels through stdin — avoiding pipe buffer saturation in the SDK → cli.js chain.
-func (p *Process) SendMessageWithAttachments(content string, attachments []models.Attachment) error {
+func (p *Process) SendMessageWithAttachments(content string, attachments []models.Attachment, messageUuid string) error {
 	// Offload image base64 data to temp files to keep stdin payloads small.
 	// The agent-runner reads the temp file and instructs Claude to use the Read tool.
 	processed := make([]models.Attachment, len(attachments))
@@ -563,6 +564,7 @@ func (p *Process) SendMessageWithAttachments(content string, attachments []model
 		Type:        "message",
 		Content:     content,
 		Attachments: processed,
+		MessageUuid: messageUuid,
 	})
 }
 

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -991,7 +991,7 @@ func TestProcess_PlanModeActive_InitFromOptions(t *testing.T) {
 
 func TestProcess_SendMessageWithAttachments_NotRunning(t *testing.T) {
 	p := NewProcess("test-attach", "/tmp", "conv-attach")
-	err := p.SendMessageWithAttachments("test", nil)
+	err := p.SendMessageWithAttachments("test", nil, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not running")
 }

--- a/backend/loop/adapter.go
+++ b/backend/loop/adapter.go
@@ -93,7 +93,8 @@ func (r *Runner) ProducedOutput() bool                 { return r.core.ProducedO
 // --- Type-adapting methods ---
 
 // SendMessageWithAttachments converts backend Attachment types to core types.
-func (r *Runner) SendMessageWithAttachments(content string, attachments []models.Attachment) error {
+// messageUuid is ignored by the native loop (no agent-runner ack signal).
+func (r *Runner) SendMessageWithAttachments(content string, attachments []models.Attachment, messageUuid string) error {
 	return r.core.SendMessageWithAttachments(content, convertAttachments(attachments))
 }
 

--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -221,9 +221,10 @@ type Message struct {
 	ThinkingContent string             `json:"thinkingContent,omitempty"` // Extended thinking/reasoning content
 	DurationMs      int                `json:"durationMs,omitempty"`      // Turn duration in milliseconds
 	Timeline        []TimelineEntry    `json:"timeline,omitempty"`        // Interleaved text/tool ordering
-	PlanContent     string             `json:"planContent,omitempty"`     // Approved plan content
-	CheckpointUuid  string             `json:"checkpointUuid,omitempty"`  // File checkpoint UUID for revert
-	Timestamp       time.Time          `json:"timestamp"`
+	PlanContent        string             `json:"planContent,omitempty"`        // Approved plan content
+	CheckpointUuid     string             `json:"checkpointUuid,omitempty"`     // File checkpoint UUID for revert
+	EmbeddedInTimeline bool               `json:"embeddedInTimeline,omitempty"` // When true, rendered inline in preceding assistant message's timeline
+	Timestamp          time.Time          `json:"timestamp"`
 }
 
 // ToolUsageRecord represents detailed tool usage information stored per-message
@@ -242,10 +243,13 @@ type ToolUsageRecord struct {
 
 // TimelineEntry represents an entry in the interleaved message timeline
 type TimelineEntry struct {
-	Type    string `json:"type"`              // "text", "tool", "thinking", "plan", or "status"
-	Content string `json:"content,omitempty"` // For text, thinking, plan, and status entries
-	ToolID  string `json:"toolId,omitempty"`  // For tool entries, references ToolUsageRecord.ID
-	Variant string `json:"variant,omitempty"` // For status entries: "thinking_enabled", "config", "info"
+	Type          string   `json:"type"`                      // "text", "tool", "thinking", "plan", "status", "compact", or "user_message"
+	Content       string   `json:"content,omitempty"`         // For text, thinking, plan, status, compact, and user_message entries
+	ToolID        string   `json:"toolId,omitempty"`          // For tool entries, references ToolUsageRecord.ID
+	Variant       string   `json:"variant,omitempty"`         // For status entries: "thinking_enabled", "config", "info"
+	Summary       string   `json:"summary,omitempty"`         // For compact entries
+	MessageID     string   `json:"messageId,omitempty"`       // For user_message entries, references the standalone Message.ID
+	AttachmentIDs []string `json:"attachmentIds,omitempty"`   // For user_message entries, references attachment IDs
 }
 
 // ToolAction represents a tool usage record for the summary

--- a/backend/server/conversation_handlers.go
+++ b/backend/server/conversation_handlers.go
@@ -317,9 +317,10 @@ func (h *Handlers) GetMessage(w http.ResponseWriter, r *http.Request) {
 
 type SendConversationMessageRequest struct {
 	Content     string              `json:"content"`
-	Attachments []models.Attachment `json:"attachments"` // File attachments (optional)
-	Model       string              `json:"model"`       // Model override for this message (optional)
-	PlanMode    *bool               `json:"planMode"`    // Plan mode override for restart (optional)
+	Attachments []models.Attachment `json:"attachments"`   // File attachments (optional)
+	Model       string              `json:"model"`         // Model override for this message (optional)
+	PlanMode    *bool               `json:"planMode"`      // Plan mode override for restart (optional)
+	MessageUuid string              `json:"messageUuid"`   // Frontend message ID for agent-runner ack signal
 }
 
 func (h *Handlers) SendConversationMessage(w http.ResponseWriter, r *http.Request) {
@@ -375,7 +376,7 @@ func (h *Handlers) SendConversationMessage(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	if err := h.agentManager.SendConversationMessage(ctx, convID, req.Content, req.Attachments, req.PlanMode); err != nil {
+	if err := h.agentManager.SendConversationMessage(ctx, convID, req.Content, req.Attachments, req.PlanMode, req.MessageUuid); err != nil {
 		writeInternalError(w, "failed to send message", err)
 		return
 	}

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -918,15 +918,23 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
         await sendConversationMessage(
           selectedConversationId,
           trimmedContent,
-          loadedAttachments.length > 0 ? loadedAttachments : undefined,
-          modelChanged ? modelToSend : undefined,
-          mentionedFiles.length > 0 ? mentionedFiles : undefined,
-          planModeEnabled
+          {
+            attachments: loadedAttachments.length > 0 ? loadedAttachments : undefined,
+            model: modelChanged ? modelToSend : undefined,
+            mentionedFiles: mentionedFiles.length > 0 ? mentionedFiles : undefined,
+            planMode: planModeEnabled,
+            messageUuid: shouldQueue ? messageId : undefined,
+          },
         );
-        // Mark queued message as sent once backend acknowledges receipt,
-        // so it renders as a regular user message instead of "Queued".
+        // markQueuedMessageSent is normally called when the agent-runner
+        // emits a message_received event via WebSocket (see useWebSocket.ts).
+        // Fallback: if the ack never arrives (agent crash, WS drop), mark
+        // as sent after 10 s so the message doesn't stay "Queued" forever.
+        // markQueuedMessageSent is idempotent so double-calls are safe.
         if (shouldQueue) {
-          markQueuedMessageSent(selectedConversationId, messageId);
+          const convId = selectedConversationId;
+          const msgId = messageId;
+          setTimeout(() => markQueuedMessageSent(convId, msgId), 10_000);
         }
       }
 

--- a/src/components/conversation/ConversationMessagePane.tsx
+++ b/src/components/conversation/ConversationMessagePane.tsx
@@ -96,10 +96,34 @@ export function ConversationMessagePane({
     [queuedMessages]
   );
 
-  // Hide the setupInfo system card once the user has sent their first message
+  // Hide the setupInfo system card once the user has sent their first message.
+  // Also filter out user messages embedded in an assistant's timeline — they
+  // render inline within the assistant message, not as standalone rows.
+  // The embeddedInTimeline flag is set in memory during streaming but is NOT
+  // persisted to the DB. On reload, we reconstruct it by scanning assistant
+  // timelines for user_message entries referencing standalone message IDs.
   const conversationMessages = useMemo(() => {
-    if (!hasUserMessages) return allConversationMessages;
-    return allConversationMessages.filter(m => !(m.role === 'system' && m.setupInfo));
+    // Build set of message IDs referenced by assistant timeline user_message entries.
+    // This reconstructs the embeddedInTimeline flag for messages loaded from the DB.
+    const embeddedIds = new Set<string>();
+    for (const m of allConversationMessages) {
+      if (m.role === 'assistant' && m.timeline) {
+        for (const entry of m.timeline) {
+          if (entry.type === 'user_message') {
+            embeddedIds.add(entry.messageId);
+          }
+        }
+      }
+    }
+
+    let msgs = allConversationMessages;
+    if (hasUserMessages) {
+      msgs = msgs.filter(m => !(m.role === 'system' && m.setupInfo));
+    }
+    // Filter using both the in-memory flag (streaming path) and the
+    // reconstructed set (historical/reload path).
+    msgs = msgs.filter(m => !m.embeddedInTimeline && !embeddedIds.has(m.id));
+    return msgs;
   }, [allConversationMessages, hasUserMessages]);
 
   const hasMessages = conversationMessages.length > 0;

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useCallback, useMemo, memo } from 'react';
+import { useState, useCallback, useMemo, memo, type ReactNode } from 'react';
+import { useAppStore } from '@/stores/appStore';
 import { Button } from '@/components/ui/button';
 import {
   ContextMenu,
@@ -82,6 +83,56 @@ const ToolUsageSummary = memo(function ToolUsageSummary({ tools, worktreePath, c
         </div>
       </CollapsibleContent>
     </Collapsible>
+  );
+});
+
+/** Inline user message rendered within an assistant's timeline.
+ *  Looks up the referenced message's attachments from the store. */
+const InlineUserMessage = memo(function InlineUserMessage({
+  messageId,
+  content,
+  conversationId,
+}: {
+  messageId: string;
+  content: string;
+  conversationId: string;
+}) {
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const attachments = useAppStore((s) => {
+    const msgs = s.messagesByConversation[conversationId];
+    if (!msgs) return undefined;
+    const msg = msgs.find(m => m.id === messageId);
+    return msg?.attachments;
+  });
+
+  return (
+    <div className="pb-2 pt-3 flex justify-end">
+      <div className="max-w-[85%]">
+        <div className="bg-surface-2 dark:bg-[#2D1B4E] rounded-lg px-4 py-2.5">
+          {attachments && attachments.length > 0 && (
+            <>
+              <AttachmentGrid
+                attachments={attachments}
+                onPreview={(index) => setPreviewIndex(index)}
+                readOnly
+              />
+              {previewIndex !== null && (
+                <AttachmentPreviewModal
+                  open
+                  onOpenChange={(open) => { if (!open) setPreviewIndex(null); }}
+                  attachments={attachments}
+                  initialIndex={previewIndex}
+                  fromHistory
+                />
+              )}
+            </>
+          )}
+          <p className="text-base leading-relaxed whitespace-pre-wrap">
+            <MentionText content={content} />
+          </p>
+        </div>
+      </div>
+    </div>
   );
 });
 
@@ -270,6 +321,15 @@ export const MessageBlock = memo(function MessageBlock({
                         cacheKey={`compact:${message.id}`}
                         content={entry.content}
                         compactSummary={entry.summary}
+                      />
+                    );
+                  } else if (entry.type === 'user_message') {
+                    return (
+                      <InlineUserMessage
+                        key={`tl-user-${idx}`}
+                        messageId={entry.messageId}
+                        content={entry.content}
+                        conversationId={message.conversationId}
                       />
                     );
                   }

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -206,7 +206,7 @@ export function SessionToolbarContent() {
     updateConversation(selectedConversationId, { status: 'active' });
     setStreaming(selectedConversationId, true);
 
-    sendConversationMessage(selectedConversationId, content, [templateAttachment]).catch((error) => {
+    sendConversationMessage(selectedConversationId, content, { attachments: [templateAttachment] }).catch((error) => {
       console.error('Failed to send action message:', error);
       setStreaming(selectedConversationId, false);
       updateConversation(selectedConversationId, { status: 'idle' });
@@ -336,7 +336,7 @@ export function SessionToolbarContent() {
       console.error('Failed to fetch CI failure context:', error);
       // Fallback: send without failure details
       try {
-        await sendConversationMessage(selectedConversationId, 'Fix the failing CI checks', [templateAttachment]);
+        await sendConversationMessage(selectedConversationId, 'Fix the failing CI checks', { attachments: [templateAttachment] });
         showWarning('Could not fetch CI details. Sent generic request.');
       } catch {
         setStreaming(selectedConversationId, false);
@@ -377,7 +377,7 @@ export function SessionToolbarContent() {
       isInstruction: false,
     };
     try {
-      await sendConversationMessage(selectedConversationId, 'Fix the failing CI checks', [templateAttachment, failureAttachment]);
+      await sendConversationMessage(selectedConversationId, 'Fix the failing CI checks', { attachments: [templateAttachment, failureAttachment] });
     } catch {
       setStreaming(selectedConversationId, false);
       updateConversation(selectedConversationId, { status: 'idle' });

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1107,6 +1107,13 @@ export function useWebSocket(enabled: boolean = true) {
         // Informational events — no frontend state changes needed
         break;
 
+      case 'message_received':
+        // Agent-runner acknowledged receipt of a queued user message
+        if (event.messageUuid) {
+          store.markQueuedMessageSent(conversationId, event.messageUuid as string);
+        }
+        break;
+
       // SDK 0.2.84+ events
 
       case 'api_retry': {

--- a/src/hooks/useWebSocketHelpers.ts
+++ b/src/hooks/useWebSocketHelpers.ts
@@ -142,6 +142,8 @@ export const BATCHABLE_EVENTS = new Set([
   'api_retry', 'session_state_changed', 'stop_failure',
   'cwd_changed', 'file_changed', 'task_created',
   'task_started', 'task_progress', 'task_stopped',
+  // Agent-runner custom events
+  'message_received',
 ]);
 
 // Content event types that should be suppressed during reconciliation.

--- a/src/lib/api/conversations.ts
+++ b/src/lib/api/conversations.ts
@@ -107,10 +107,13 @@ export interface ToolUsageDTO {
 }
 
 export interface TimelineEntryDTO {
-  type: 'text' | 'tool' | 'thinking' | 'plan' | 'status';
+  type: 'text' | 'tool' | 'thinking' | 'plan' | 'status' | 'compact' | 'user_message';
   content?: string;
   toolId?: string;
   variant?: 'thinking_enabled' | 'config' | 'info';
+  summary?: string;
+  messageId?: string;       // For user_message entries
+  attachmentIds?: string[]; // For user_message entries
 }
 
 export interface MessageDTO {
@@ -127,6 +130,7 @@ export interface MessageDTO {
   planContent?: string;
   checkpointUuid?: string;
   timestamp: string;
+  embeddedInTimeline?: boolean;
 }
 
 export interface ToolActionDTO {
@@ -176,6 +180,7 @@ export function toStoreMessage(dto: MessageDTO, conversationId: string, opts?: {
     checkpointUuid: dto.checkpointUuid,
     timestamp: dto.timestamp,
     compacted: opts?.compacted,
+    embeddedInTimeline: dto.embeddedInTimeline,
   };
 }
 
@@ -258,18 +263,23 @@ export async function getMessage(convId: string, msgId: string): Promise<Message
   return handleResponse<MessageDTO>(res);
 }
 
+export interface SendMessageOptions {
+  attachments?: AttachmentDTO[];
+  model?: string;
+  mentionedFiles?: string[];
+  planMode?: boolean;
+  messageUuid?: string;
+}
+
 export async function sendConversationMessage(
   convId: string,
   content: string,
-  attachments?: AttachmentDTO[],
-  model?: string,
-  mentionedFiles?: string[],
-  planMode?: boolean
+  options?: SendMessageOptions,
 ): Promise<void> {
   const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/messages`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content, attachments, model, mentionedFiles, planMode }),
+    body: JSON.stringify({ content, ...options }),
   });
   if (!res.ok) {
     const text = await res.text();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -165,7 +165,8 @@ export type TimelineEntry =
   | { type: 'thinking'; content: string }
   | { type: 'plan'; content: string }
   | { type: 'status'; content: string; variant: 'thinking_enabled' | 'config' | 'info' }
-  | { type: 'compact'; content: string; summary?: string };
+  | { type: 'compact'; content: string; summary?: string }
+  | { type: 'user_message'; messageId: string; content: string; attachmentIds?: string[] };
 
 // Active tool during streaming (real-time tracking)
 export interface ActiveTool {
@@ -294,6 +295,9 @@ export interface Message {
   checkpointUuid?: string;
   // True when loaded in compact mode (heavy fields stripped); needs hydration for full details
   compacted?: boolean;
+  // When true, this user message is rendered inline in the preceding assistant message's timeline.
+  // VirtualizedMessageList should skip rendering it as a standalone bubble.
+  embeddedInTimeline?: boolean;
 }
 
 // Run statistics from agent
@@ -529,6 +533,9 @@ export interface AgentEvent {
 
   // Session state changed fields (SDK 0.2.84)
   state?: string;
+
+  // Agent-runner message acknowledgment
+  messageUuid?: string;
 }
 
 // Rate limit info from claude.ai subscription (SDK 0.2.72)

--- a/src/stores/__tests__/appStore.queuedMessages.test.ts
+++ b/src/stores/__tests__/appStore.queuedMessages.test.ts
@@ -24,7 +24,7 @@ describe('appStore - queued message ordering', () => {
     vi.useRealTimers();
   });
 
-  it('places queued user message AFTER assistant message on turn_complete', () => {
+  it('places queued user message AFTER assistant message on turn_complete with embeddedInTimeline', () => {
     // Set up: user1 already in messages, assistant is streaming, user2 is queued
     useAppStore.setState({
       messagesByConversation: {
@@ -78,6 +78,15 @@ describe('appStore - queued message ordering', () => {
     expect(messages[1].content).toBe('Assistant response to first message.');
     expect(messages[2].role).toBe('user');
     expect(messages[2].content).toBe('Second user message');
+    // Queued message committed on main path should be embedded in timeline
+    expect(messages[2].embeddedInTimeline).toBe(true);
+    // Assistant message timeline should contain the user_message entry
+    expect(messages[1].timeline).toBeDefined();
+    const userEntry = messages[1].timeline!.find(e => e.type === 'user_message');
+    expect(userEntry).toBeDefined();
+    if (userEntry!.type !== 'user_message') throw new Error('expected user_message timeline entry');
+    expect(userEntry!.messageId).toBe('msg-user2');
+    expect(userEntry!.content).toBe('Second user message');
   });
 
   it('commits queued user message on result event with runSummary', () => {
@@ -208,7 +217,7 @@ describe('appStore - queued message ordering', () => {
     expect(queued).toHaveLength(0);
   });
 
-  it('appends queued message correctly when no streaming text exists', () => {
+  it('appends queued message correctly when no streaming text exists (NOT embedded)', () => {
     // This covers the !streaming?.text branch (e.g. turn_complete after result already finalized)
     useAppStore.setState({
       messagesByConversation: {
@@ -264,6 +273,8 @@ describe('appStore - queued message ordering', () => {
     expect(messages[1].role).toBe('assistant');
     expect(messages[2].role).toBe('user');
     expect(messages[2].content).toBe('Second user message');
+    // No streaming text → no assistant timeline to embed into → not embedded
+    expect(messages[2].embeddedInTimeline).toBeUndefined();
   });
 
   it('commits queued message on init-triggered finalize (streaming text still present)', () => {
@@ -499,6 +510,58 @@ describe('appStore - queued message ordering', () => {
     const queued = useAppStore.getState().queuedMessages[conversationId] ?? [];
     expect(queued).toHaveLength(1);
     expect(queued[0].content).toBe('Third user message');
+  });
+
+  it('does not increment totalCount for embedded queued messages', () => {
+    useAppStore.setState({
+      messagesByConversation: {
+        [conversationId]: [
+          {
+            id: 'msg-user1',
+            conversationId,
+            role: 'user',
+            content: 'First user message',
+            timestamp: '2025-07-01T12:00:00Z',
+          },
+        ],
+      },
+      streamingState: {
+        [conversationId]: {
+          text: 'Assistant response.',
+          segments: [],
+          currentSegmentId: null,
+          isStreaming: true,
+          error: null,
+          thinking: null,
+          isThinking: false,
+          planModeActive: false,
+          pendingPlanApproval: null,
+        },
+      },
+      queuedMessages: {
+        [conversationId]: [
+          {
+            id: 'msg-user2',
+            content: 'Second user message',
+            attachments: [],
+            timestamp: '2025-07-01T12:00:05Z',
+          },
+        ],
+      },
+      messagePagination: {
+        [conversationId]: { totalCount: 1, pageSize: 50, hasMore: false },
+      },
+    });
+
+    useAppStore.getState().finalizeStreamingMessage(conversationId, {
+      durationMs: 5000,
+      commitQueued: true,
+    });
+
+    // totalCount should only increment by 1 (assistant message),
+    // not 2, because the embedded queued message doesn't count as a standalone row
+    const pagination = useAppStore.getState().messagePagination[conversationId];
+    expect(pagination?.totalCount).toBe(2);
   });
 
   it('does not add queued message when none exists', () => {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -235,7 +235,7 @@ export interface QueuedMessage {
 }
 
 /** Convert a QueuedMessage into a store Message for a given conversation. */
-function queuedToMessage(queued: QueuedMessage, conversationId: string): Message {
+function queuedToMessage(queued: QueuedMessage, conversationId: string, opts?: { embeddedInTimeline?: boolean }): Message {
   return {
     id: queued.id,
     conversationId,
@@ -243,6 +243,7 @@ function queuedToMessage(queued: QueuedMessage, conversationId: string): Message
     content: queued.content,
     attachments: queued.attachments,
     timestamp: queued.timestamp,
+    ...(opts?.embeddedInTimeline ? { embeddedInTimeline: true } : {}),
   };
 }
 
@@ -2362,6 +2363,20 @@ updateFileTabContent: (id, content) => set((state) => ({
           entry: { type: 'compact', content: streaming.compactBoundary.label, summary: streaming.compactBoundary.summary },
         });
       }
+      // Embed queued user message at its chronological position in the timeline
+      if (queued) {
+        const queuedTs = new Date(queued.timestamp).getTime();
+        const attachmentIds = queued.attachments?.map(a => a.id);
+        timelineItems.push({
+          timestamp: queuedTs,
+          entry: {
+            type: 'user_message',
+            messageId: queued.id,
+            content: queued.content,
+            ...(attachmentIds && attachmentIds.length > 0 ? { attachmentIds } : {}),
+          },
+        });
+      }
       timelineItems.sort((a, b) => a.timestamp - b.timestamp);
       const timeline: TimelineEntry[] | undefined =
         timelineItems.length > 0 ? timelineItems.map(item => item.entry) : undefined;
@@ -2407,7 +2422,7 @@ updateFileTabContent: (id, content) => set((state) => ({
       // (queued and remaining already computed above)
       const existing = state.messagesByConversation[conversationId] ?? [];
       const updatedMessages = queued
-        ? [...existing, newMessage, queuedToMessage(queued, conversationId)]
+        ? [...existing, newMessage, queuedToMessage(queued, conversationId, { embeddedInTimeline: true })]
         : [...existing, newMessage];
 
       const convPagination = state.messagePagination[conversationId];
@@ -2439,14 +2454,15 @@ updateFileTabContent: (id, content) => set((state) => ({
         ...((queued || metadata.terminal) ? {
           queuedMessages: { ...state.queuedMessages, [conversationId]: remaining },
         } : {}),
-        // Keep pagination totalCount in sync: +1 for the assistant message,
-        // +1 more if a queued user message was also committed.
+        // Keep pagination totalCount in sync: +1 for the assistant message.
+        // Queued user messages embedded in the timeline don't count — they
+        // render inline, not as standalone rows.
         ...(convPagination ? {
           messagePagination: {
             ...state.messagePagination,
             [conversationId]: {
               ...convPagination,
-              totalCount: convPagination.totalCount + 1 + (queued ? 1 : 0),
+              totalCount: convPagination.totalCount + 1,
             },
           },
         } : {}),


### PR DESCRIPTION
## Summary

- **Fix race condition**: Replace synchronous `markQueuedMessageSent` (fired on HTTP response before agent-runner received the message) with an explicit `message_received` WebSocket event from the agent-runner, ensuring the UI only transitions from "Queued" after actual delivery
- **Inline timeline embedding**: Queued user messages now render at their chronological position inside the preceding assistant message's timeline, with frontend reconstruction on reload (no DB migration)
- **Resilience**: 10-second fallback timeout marks messages as sent if the ack never arrives (agent crash, WS drop)

## Changes

### Backend (Go)
- Added `messageUuid` to `SendMessageWithAttachments` interface and REST API
- New `EventTypeMessageReceived` constant for the custom agent-runner event
- Embed pending user messages as `user_message` timeline entries in assistant messages
- New `user_message` and `compact` types in `TimelineEntry` struct

### Agent Runner (TypeScript)
- Emit `message_received` event with `messageUuid` on queued message receipt

### Frontend (React/TypeScript)
- Handle `message_received` WebSocket event to call `markQueuedMessageSent`
- `InlineUserMessage` component renders embedded messages with attachment support
- Frontend reconstruction: derive `embeddedInTimeline` from assistant timelines on reload
- Refactored `sendConversationMessage` from 7 positional params to options object
- 10s fallback timeout for ack resilience

### Tests
- Updated existing tests for new signatures
- New test: `does not increment totalCount for embedded queued messages`
- Improved type-narrowing pattern in test assertions

## Test plan

- [x] `npm run lint` — no new errors
- [x] `npm run test:run` — 1748/1748 tests pass
- [x] `go test -race ./...` — all packages pass
- [x] `npx tsc --noEmit` — no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)