### PR TITLE
fix(background-tasks): bridge subagent_stopped to task_stopped and harden cleanup

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -694,9 +694,17 @@ function setupInputQueue(): void {
       if (input.type === "stop_task" && input.taskId) {
         if (queryRef) {
           debug(`Stopping task: ${input.taskId}`);
+          // Pre-mark as user-stopped so subagentStopHook skips the bridge emission
+          userStoppedTaskIds.add(input.taskId);
           void queryRef.stopTask(input.taskId).then(() => {
             emit({ type: "task_stopped", taskId: input.taskId! });
           }).catch((cmdErr: unknown) => {
+            // If subagentStopHook already consumed the entry, it suppressed the
+            // bridge emission — emit task_stopped defensively so the task doesn't
+            // become a ghost in the UI.
+            if (!userStoppedTaskIds.delete(input.taskId!)) {
+              emit({ type: "task_stopped", taskId: input.taskId! });
+            }
             emit({ type: "command_error", command: "stop_task", error: String(cmdErr) });
           });
         } else {
@@ -1127,6 +1135,10 @@ const sessionToAgentId = new Map<string, string>();
 const subagentActiveTools = new Map<string, { agentId: string; tool: string; startTime: number }>();
 // Track Task tool descriptions by tool_use_id for sub-agent description plumbing (Issue 3)
 const taskToolDescriptions = new Map<string, string>();
+// Track background task session → taskId for bridging subagent_stopped → task_stopped
+const sessionIdToTaskId = new Map<string, string>();
+// Track user-stopped task IDs to avoid duplicate task_stopped emissions
+const userStoppedTaskIds = new Set<string>();
 
 // Track statistics for the run
 interface RunStats {
@@ -1500,6 +1512,19 @@ const subagentStopHook: HookCallback = async (input) => {
     transcriptPath: hookInput.agent_transcript_path,
     sessionId: hookInput.session_id,
   });
+
+  // Bridge: emit task_stopped for background agents that completed naturally.
+  // The SDK emits task_started/task_progress but has no task completion event.
+  // We bridge subagent_stopped → task_stopped so the UI can clean up.
+  const taskId = sessionIdToTaskId.get(hookInput.session_id);
+  if (taskId) {
+    sessionIdToTaskId.delete(hookInput.session_id);
+    if (!userStoppedTaskIds.delete(taskId)) {
+      // Natural completion — emit task_stopped (user-stopped tasks already emit from stop_task handler)
+      emit({ type: "task_stopped", taskId });
+    }
+  }
+
   return {};
 };
 
@@ -2934,6 +2959,14 @@ function handleMessage(message: SDKMessage): void {
       } else if (sysMsg.subtype === "task_started") {
         // Background task (sub-agent) started (SDK 0.2.51+)
         const taskMsg = sysMsg as SDKTaskStartedMessage;
+        // Track session → task mapping so subagentStopHook can emit task_stopped on completion
+        if (taskMsg.session_id && taskMsg.task_id) {
+          const existing = sessionIdToTaskId.get(taskMsg.session_id);
+          if (existing) {
+            debug(`Warning: session ${taskMsg.session_id} already mapped to task ${existing}, overwriting with ${taskMsg.task_id}`);
+          }
+          sessionIdToTaskId.set(taskMsg.session_id, taskMsg.task_id);
+        }
         emit({
           type: "task_started",
           taskId: taskMsg.task_id,
@@ -3151,6 +3184,8 @@ async function cleanup(reason: string): Promise<void> {
     });
   }
   subagentActiveTools.clear();
+  sessionIdToTaskId.clear();
+  userStoppedTaskIds.clear();
 
   // 5. Flush any remaining buffered text
   flushBlockBuffer();

--- a/src/components/panels/BackgroundTasksPanel.tsx
+++ b/src/components/panels/BackgroundTasksPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { Circle, Square } from 'lucide-react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Circle, Square, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useBackgroundTasks } from '@/stores/selectors';
@@ -134,6 +134,13 @@ interface BackgroundTasksPanelProps {
 
 export function BackgroundTasksPanel({ conversationId }: BackgroundTasksPanelProps) {
   const tasks = useBackgroundTasks(conversationId);
+  const hasStoppedTasks = useMemo(() => tasks.some((t) => t.status === 'stopped'), [tasks]);
+
+  const handleClear = useCallback(() => {
+    if (conversationId) {
+      useAppStore.getState().clearStoppedBackgroundTasks(conversationId);
+    }
+  }, [conversationId]);
 
   if (!conversationId || tasks.length === 0) {
     return (
@@ -145,6 +152,19 @@ export function BackgroundTasksPanel({ conversationId }: BackgroundTasksPanelPro
 
   return (
     <div className="h-full overflow-y-auto">
+      {hasStoppedTasks && (
+        <div className="flex justify-end px-3 py-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 text-2xs text-muted-foreground hover:text-foreground"
+            onClick={handleClear}
+          >
+            <X className="h-3 w-3 mr-1" />
+            Clear
+          </Button>
+        </div>
+      )}
       {tasks.map((task) => (
         <TaskRow key={task.taskId} task={task} conversationId={conversationId} />
       ))}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -438,6 +438,7 @@ export function useWebSocket(enabled: boolean = true) {
         freshStore.clearPendingUserQuestion(conversationId);
         freshStore.clearPendingToolApproval(conversationId);
         freshStore.clearPendingPlanApproval(conversationId);
+        freshStore.clearBackgroundTasks(conversationId);
         const resultConv = freshStore.conversations.find((c) => c.id === conversationId);
         if (resultConv) {
           freshStore.setLastTurnCompletedAt(resultConv.sessionId, Date.now());
@@ -474,6 +475,7 @@ export function useWebSocket(enabled: boolean = true) {
           turnStore.clearAgentTodos(conversationId);
           turnStore.clearPendingToolApproval(conversationId);
           turnStore.clearPendingPlanApproval(conversationId);
+          turnStore.clearBackgroundTasks(conversationId);
           const turnConvSkip = turnStore.conversations.find((c) => c.id === conversationId);
           if (turnConvSkip) {
             turnStore.setLastTurnCompletedAt(turnConvSkip.sessionId, Date.now());
@@ -506,6 +508,7 @@ export function useWebSocket(enabled: boolean = true) {
         turnStore.clearAgentTodos(conversationId);
         turnStore.clearPendingToolApproval(conversationId);
         turnStore.clearPendingPlanApproval(conversationId);
+        turnStore.clearBackgroundTasks(conversationId);
         const turnConv = turnStore.conversations.find((c) => c.id === conversationId);
         if (turnConv) {
           turnStore.setLastTurnCompletedAt(turnConv.sessionId, Date.now());
@@ -521,6 +524,7 @@ export function useWebSocket(enabled: boolean = true) {
         store.clearPendingUserQuestion(conversationId);
         store.clearPendingToolApproval(conversationId);
         store.clearPendingPlanApproval(conversationId);
+        store.clearBackgroundTasks(conversationId);
         store.updateConversation(conversationId, { status: 'idle' });
         const completeConv = store.conversations.find((c) => c.id === conversationId);
         if (completeConv) {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -553,6 +553,7 @@ interface AppState {
   updateBackgroundTask: (conversationId: string, taskId: string, update: Partial<import('@/lib/types').BackgroundTask>) => void;
   stopBackgroundTask: (conversationId: string, taskId: string) => void;
   clearBackgroundTasks: (conversationId: string) => void;
+  clearStoppedBackgroundTasks: (conversationId: string) => void;
   removeBackgroundTask: (conversationId: string, taskId: string) => void;
 
   restoreStreamingFromSnapshot: (conversationId: string, snapshot: {
@@ -2136,6 +2137,12 @@ updateFileTabContent: (id, content) => set((state) => ({
     backgroundTasks: {
       ...state.backgroundTasks,
       [conversationId]: [],
+    },
+  })),
+  clearStoppedBackgroundTasks: (conversationId) => set((state) => ({
+    backgroundTasks: {
+      ...state.backgroundTasks,
+      [conversationId]: (state.backgroundTasks[conversationId] || []).filter((t) => t.status !== 'stopped'),
     },
   })),
   removeBackgroundTask: (conversationId, taskId) => set((state) => {


### PR DESCRIPTION
## Summary

- **Bridge subagent_stopped → task_stopped**: The SDK emits `task_started`/`task_progress` but has no task completion event. Maps session IDs to task IDs so the `subagentStopHook` can emit `task_stopped` when background agents finish naturally, allowing the UI to reflect completion.
- **Clear button preserves running tasks**: Added `clearStoppedBackgroundTasks` store action so the "Clear" button only removes stopped tasks instead of wiping all tasks (including still-running ones that would become invisible and un-stoppable).
- **Hardened edge cases**: Defensive `task_stopped` emission in `stop_task` catch path prevents ghost tasks; cleanup() clears new tracking maps; `clearBackgroundTasks` added to `complete` and `result` event handlers; debug warning on session→task mapping overwrite.

## Changed files

| File | Change |
|------|--------|
| `agent-runner/src/index.ts` | Session→task tracking maps, bridge in subagentStopHook, race-safe stop_task catch, cleanup() clears |
| `src/stores/appStore.ts` | New `clearStoppedBackgroundTasks` action |
| `src/components/panels/BackgroundTasksPanel.tsx` | Clear button + uses `clearStoppedBackgroundTasks` |
| `src/hooks/useWebSocket.ts` | `clearBackgroundTasks` in `turn_complete`, `result`, and `complete` handlers |

## Test plan

- [ ] Start a background task (sub-agent), verify it shows as running in the Background Tasks panel
- [ ] Wait for the background task to complete naturally — verify it transitions to stopped (green dot)
- [ ] Click "Clear" with a mix of running and stopped tasks — verify only stopped tasks are removed
- [ ] User-stop a running task — verify it transitions to stopped without duplicate events
- [ ] Verify no ghost tasks remain after session completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)