### PR TITLE
fix(scroll): force scroll-to-bottom when streaming ends

### DIFF
--- a/src/components/conversation/ConversationMessagePane.tsx
+++ b/src/components/conversation/ConversationMessagePane.tsx
@@ -260,6 +260,7 @@ export function ConversationMessagePane({
   const userScrolledUpRef = useRef(false);
   const isStreamingRef = useRef(selectedStreaming.isStreaming);
   const isActiveRef = useRef(isActive);
+  const prevIsStreamingForScrollRef = useRef(false);
 
   /** Reset all follow-state refs atomically. */
   const resetFollowState = useCallback(() => {
@@ -399,6 +400,40 @@ export function ConversationMessagePane({
       scrollerEl.removeEventListener('touchstart', handleTouchStart);
       scrollerEl.removeEventListener('touchmove', handleTouchMove);
       scrollerEl.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [selectedStreaming.isStreaming, isActive]);
+
+  // Bridge the gap when streaming ends: the ResizeObserver above disconnects
+  // exactly when the footer collapses (StreamingMessage → null), leaving
+  // Virtuoso with stale measurements and content above the viewport.
+  // Detect the true→false transition and force scroll-to-bottom.
+  useEffect(() => {
+    const wasStreaming = prevIsStreamingForScrollRef.current;
+    prevIsStreamingForScrollRef.current = selectedStreaming.isStreaming;
+
+    if (!wasStreaming || selectedStreaming.isStreaming) return;
+    if (!isActive) return;
+    if (userScrolledUpRef.current) return;
+
+    // Two frames: frame 1 catches the footer collapse layout shift,
+    // frame 2 catches Virtuoso's deferred measurement recalibration.
+    let cancelled = false;
+    const scroll = () => {
+      if (cancelled || userScrolledUpRef.current) return;
+      messageListRef.current?.scrollToBottom('auto');
+      setShowScrollButton(false);
+    };
+
+    let raf2: number | undefined;
+    const raf1 = requestAnimationFrame(() => {
+      scroll();
+      raf2 = requestAnimationFrame(scroll);
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf1);
+      if (raf2 !== undefined) cancelAnimationFrame(raf2);
     };
   }, [selectedStreaming.isStreaming, isActive]);
 


### PR DESCRIPTION
## Summary

- **Fix stale viewport when streaming ends**: The ResizeObserver that pins scroll-to-bottom during streaming disconnects at the exact moment the footer collapses (StreamingMessage unmounts), leaving Virtuoso with stale measurements and content stuck above the viewport. This adds a `useEffect` that detects the streaming `true→false` transition and forces scroll-to-bottom over two animation frames — frame 1 catches the footer layout shift, frame 2 catches Virtuoso's deferred recalibration.
- **Respects user intent**: Skips the forced scroll if the user has scrolled up, with a guard both at effect entry and inside each rAF callback to handle the tiny race window.
- **Clean rAF lifecycle**: Both inner and outer `requestAnimationFrame` handles are captured and cancelled on cleanup, with a `cancelled` boolean as defense-in-depth.

## Test plan

- [ ] Start a streaming response and let it complete — viewport should stay pinned to bottom
- [ ] Start a streaming response, scroll up mid-stream, let it complete — viewport should stay where the user scrolled (no jump)
- [ ] Switch tabs during streaming, switch back after it ends — should scroll to bottom on reactivation
- [ ] Rapidly start/stop multiple streaming responses — no scroll jank or stale positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)