### PR TITLE
perf(frontend): reduce re-renders, listener churn, and animation overhead

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -804,6 +804,10 @@ html:not(.dark) .xterm .scrollbar .slider:hover {
   }
 }
 
+.plan-mode-marching-ants {
+  animation: marching-ants-dash 1s linear infinite;
+}
+
 /* Plan approval border styling (awaiting approval state) */
 .plan-approval-border {
   position: relative;
@@ -954,6 +958,12 @@ html:not(.dark) .xterm .scrollbar .slider:hover {
   .hover-scale:hover,
   .hover-scale:active {
     transform: none;
+  }
+
+  /* Disable continuous marching/dashed border animations */
+  .streaming-border-svg rect,
+  .plan-mode-marching-ants {
+    animation: none;
   }
 }
 

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -1067,6 +1067,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             preserveAspectRatio="none"
           >
             <rect
+              className="plan-mode-marching-ants"
               x="0"
               y="0"
               width="100%"
@@ -1078,7 +1079,6 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
               strokeWidth="2"
               strokeDasharray="6 4"
               strokeOpacity="0.6"
-              style={{ animation: 'marching-ants-dash 1s linear infinite' }}
             />
           </svg>
         )}

--- a/src/components/conversation/ConversationMessagePane.tsx
+++ b/src/components/conversation/ConversationMessagePane.tsx
@@ -254,7 +254,15 @@ export function ConversationMessagePane({
 
   // Auto-scroll management via Virtuoso
   const messageListRef = useRef<VirtualizedMessageListHandle>(null);
-  const [showScrollButton, setShowScrollButton] = useState(false);
+  const [showScrollButton, setShowScrollButtonRaw] = useState(false);
+  const showScrollButtonRef = useRef(false);
+  // Wrapper that deduplicates state updates — avoids redundant React reconciliation
+  // when scroll handlers fire 60+ times/sec with the same value.
+  const setShowScrollButton = useCallback((show: boolean) => {
+    if (showScrollButtonRef.current === show) return;
+    showScrollButtonRef.current = show;
+    setShowScrollButtonRaw(show);
+  }, []);
   const isAtBottomRef = useRef(true);
   const forceFollowRef = useRef(false);
   const userScrolledUpRef = useRef(false);
@@ -299,13 +307,13 @@ export function ConversationMessagePane({
     if (!isActiveRef.current) return;
     if (atBottom) resetFollowState();
     setShowScrollButton(!atBottom);
-  }, [resetFollowState]);
+  }, [resetFollowState, setShowScrollButton]);
 
   const forceScrollToBottom = useCallback(() => {
     setShowScrollButton(false);
     resetFollowState();
     messageListRef.current?.scrollToBottom('auto');
-  }, [resetFollowState]);
+  }, [resetFollowState, setShowScrollButton]);
 
   // Footer for VirtualizedMessageList
   const messageListFooter = useMemo(() => (
@@ -446,20 +454,24 @@ export function ConversationMessagePane({
     if (!isActive || !hasMessages) return;
 
     let scrollCleanup: (() => void) | null = null;
+    let cancelled = false;
+    let rafId = 0;
 
-    // Poll until Virtuoso mounts and exposes the scroller element
-    const timerId = setInterval(() => {
+    // Wait for Virtuoso to mount and expose its scroller element using rAF
+    // instead of polling with setInterval. Typically resolves in 1-2 frames.
+    function tryAttach() {
+      if (cancelled) return;
       const scrollerEl = messageListRef.current?.getScrollerElement();
-      if (!scrollerEl) return;
-      clearInterval(timerId);
+      if (!scrollerEl) {
+        rafId = requestAnimationFrame(tryAttach);
+        return;
+      }
 
       const handleScroll = () => {
         const threshold = isStreamingRef.current ? 200 : 50;
         const atBottom = scrollerEl.scrollHeight - scrollerEl.scrollTop - scrollerEl.clientHeight <= threshold;
         // Only override to show the pill; let Virtuoso handle the "returned to bottom" case.
-        // No guard on isAtBottomRef — the pill must show whenever we're not at
-        // bottom, even if the ref was already false (e.g. atBottomStateChange
-        // fired while the pane was inactive, setting the ref but not the state).
+        // setShowScrollButton wrapper deduplicates redundant updates automatically.
         if (!atBottom) {
           isAtBottomRef.current = false;
           setShowScrollButton(true);
@@ -473,13 +485,15 @@ export function ConversationMessagePane({
       scrollCleanup = () => {
         scrollerEl.removeEventListener('scroll', handleScroll);
       };
-    }, 100);
+    }
+    rafId = requestAnimationFrame(tryAttach);
 
     return () => {
-      clearInterval(timerId);
+      cancelled = true;
+      cancelAnimationFrame(rafId);
       scrollCleanup?.();
     };
-  }, [isActive, hasMessages]);
+  }, [isActive, hasMessages, setShowScrollButton]);
 
   // Scroll handler for conversation markers minimap
   const handleMarkerScrollToIndex = useCallback((index: number) => {

--- a/src/components/conversation/ConversationMessagePane.tsx
+++ b/src/components/conversation/ConversationMessagePane.tsx
@@ -443,7 +443,7 @@ export function ConversationMessagePane({
       cancelAnimationFrame(raf1);
       if (raf2 !== undefined) cancelAnimationFrame(raf2);
     };
-  }, [selectedStreaming.isStreaming, isActive]);
+  }, [selectedStreaming.isStreaming, isActive, setShowScrollButton]);
 
   // Supplementary scroll listener: ensures the scroll-to-bottom pill shows
   // even when Virtuoso's atBottomStateChange doesn't fire on initial scroll

--- a/src/components/conversation/PlateInput.tsx
+++ b/src/components/conversation/PlateInput.tsx
@@ -45,17 +45,19 @@ interface PlateInputProps {
   onBlur?: () => void;
 }
 
-// Extract text and mentioned files from Plate value in a single pass
+// Extract text and mentioned files from Plate value in a single pass.
+// Uses array-join instead of string concatenation for better performance
+// on large pastes where the node tree can be deep.
 function extractContent(value: Value): { text: string; mentionedFiles: string[] } {
-  let text = '';
+  const parts: string[] = [];
   const mentionedFiles: string[] = [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plate nodes have dynamic structure
   const processNode = (node: any) => {
     if (node.text !== undefined) {
-      text += node.text;
+      parts.push(node.text);
     } else if (node.type === 'mention') {
-      text += `@${node.value}`;
+      parts.push(`@${node.value}`);
       if (node.value) {
         mentionedFiles.push(node.value);
       }
@@ -68,11 +70,11 @@ function extractContent(value: Value): { text: string; mentionedFiles: string[] 
     processNode(node);
     // Add newline between paragraphs (except after last one)
     if (index < value.length - 1) {
-      text += '\n';
+      parts.push('\n');
     }
   });
 
-  return { text: text.trim(), mentionedFiles };
+  return { text: parts.join('').trim(), mentionedFiles };
 }
 
 const emptyValue: Value = [{ type: 'p', children: [{ text: '' }] }];

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -86,7 +86,7 @@ const ElapsedTimer = memo(function ElapsedTimer({ startTime, isStreaming }: { st
       if (startTimeRef.current) {
         setElapsedMs(Date.now() - startTimeRef.current);
       }
-    }, 50);
+    }, 100);
 
     return () => clearInterval(interval);
   }, [isStreaming, startTime]);

--- a/src/components/conversation/useChatInputKeyboardShortcuts.ts
+++ b/src/components/conversation/useChatInputKeyboardShortcuts.ts
@@ -159,5 +159,5 @@ export function useChatInputKeyboardShortcuts({
       window.removeEventListener('toggle-fast-mode', handleToggleFastMode);
       window.removeEventListener('session-home-template-selected', handleTemplateSelected);
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- deps accessed via ref
+  }, []);
 }

--- a/src/components/conversation/useChatInputKeyboardShortcuts.ts
+++ b/src/components/conversation/useChatInputKeyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import type { PlateInputHandle } from './PlateInput';
 import type { ThinkingLevel } from '@/lib/thinkingLevels';
 import type { ModelEntry } from '@/lib/models';
@@ -20,6 +20,11 @@ interface UseChatInputKeyboardShortcutsOptions {
 /**
  * Registers global keyboard shortcuts and native Tauri menu event listeners
  * for the chat input area.
+ *
+ * All callback and state dependencies are stored in a ref so the event
+ * listeners are mounted once and never torn down / re-added on parent
+ * re-renders. This eliminates listener churn from the previous 11-dependency
+ * useEffect.
  */
 export function useChatInputKeyboardShortcuts({
   plateInputRef,
@@ -34,29 +39,63 @@ export function useChatInputKeyboardShortcuts({
   setLinearPickerOpen,
   getAvailableThinkingLevels,
 }: UseChatInputKeyboardShortcutsOptions) {
+  // Keep all mutable deps in a ref so handlers always read the latest values
+  // without requiring effect re-runs.
+  const depsRef = useRef({
+    plateInputRef,
+    selectedModel,
+    MODELS,
+    setSelectedModel,
+    setThinkingLevel,
+    setMessage,
+    handlePlanModeToggle,
+    handleFastModeToggle,
+    handleOpenFilePicker,
+    setLinearPickerOpen,
+    getAvailableThinkingLevels,
+  });
+  // Sync on every render (intentional — keeps ref current for event handlers)
+  useEffect(() => {
+    depsRef.current = {
+      plateInputRef,
+      selectedModel,
+      MODELS,
+      setSelectedModel,
+      setThinkingLevel,
+      setMessage,
+      handlePlanModeToggle,
+      handleFastModeToggle,
+      handleOpenFilePicker,
+      setLinearPickerOpen,
+      getAvailableThinkingLevels,
+    };
+  });
+
+  // Mount all listeners once — handlers close over depsRef, not the values.
   useEffect(() => {
     const handleGlobalKeyDown = (e: globalThis.KeyboardEvent) => {
+      const d = depsRef.current;
       // Cmd+L to focus input
       if (e.code === 'KeyL' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        plateInputRef.current?.focus();
+        d.plateInputRef.current?.focus();
       }
       // Alt+1..9 to select model by index
       if (e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
         const digit = e.code.match(/^Digit([1-9])$/)?.[1];
         if (digit) {
           const idx = parseInt(digit, 10) - 1;
-          if (idx >= 0 && idx < MODELS.length) {
+          if (idx >= 0 && idx < d.MODELS.length) {
             e.preventDefault();
-            setSelectedModel(MODELS[idx]);
+            d.setSelectedModel(d.MODELS[idx]);
           }
         }
       }
       // Alt+T to cycle thinking levels
       if (e.code === 'KeyT' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
-        setThinkingLevel(prev => {
-          const available = getAvailableThinkingLevels(selectedModel);
+        d.setThinkingLevel(prev => {
+          const available = d.getAvailableThinkingLevels(d.selectedModel);
           const idx = available.indexOf(prev);
           return available[(idx + 1) % available.length];
         });
@@ -64,44 +103,46 @@ export function useChatInputKeyboardShortcuts({
       // Shift+Tab to toggle plan mode
       if (e.code === 'Tab' && e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
         e.preventDefault();
-        handlePlanModeToggle();
+        d.handlePlanModeToggle();
       }
       // Alt+F to toggle fast mode
       if (e.code === 'KeyF' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
-        handleFastModeToggle();
+        d.handleFastModeToggle();
       }
       // Cmd+U to open file picker
       if (e.code === 'KeyU' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        handleOpenFilePicker();
+        d.handleOpenFilePicker();
       }
       // Cmd+I to open Linear issue picker
       if (e.code === 'KeyI' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        setLinearPickerOpen(true);
+        d.setLinearPickerOpen(true);
       }
     };
 
     // Handle menu events from native Tauri menu
-    const handleFocusInput = () => plateInputRef.current?.focus();
+    const handleFocusInput = () => depsRef.current.plateInputRef.current?.focus();
     const handleToggleThinking = () => {
-      setThinkingLevel(prev => {
-        const available = getAvailableThinkingLevels(selectedModel);
+      const d = depsRef.current;
+      d.setThinkingLevel(prev => {
+        const available = d.getAvailableThinkingLevels(d.selectedModel);
         const idx = available.indexOf(prev);
         return available[(idx + 1) % available.length];
       });
     };
-    const handleTogglePlanMode = () => handlePlanModeToggle();
-    const handleToggleFastMode = () => handleFastModeToggle();
+    const handleTogglePlanMode = () => depsRef.current.handlePlanModeToggle();
+    const handleToggleFastMode = () => depsRef.current.handleFastModeToggle();
 
     // Handle template selection from SessionHomeState quick actions
     const handleTemplateSelected = (e: Event) => {
+      const d = depsRef.current;
       const text = (e as CustomEvent<{ text: string }>).detail.text;
-      plateInputRef.current?.setText(text);
-      setMessage(text);
+      d.plateInputRef.current?.setText(text);
+      d.setMessage(text);
       // Use requestAnimationFrame to ensure the editor has updated before focusing
-      requestAnimationFrame(() => plateInputRef.current?.focus());
+      requestAnimationFrame(() => d.plateInputRef.current?.focus());
     };
 
     document.addEventListener('keydown', handleGlobalKeyDown);
@@ -118,5 +159,5 @@ export function useChatInputKeyboardShortcuts({
       window.removeEventListener('toggle-fast-mode', handleToggleFastMode);
       window.removeEventListener('session-home-template-selected', handleTemplateSelected);
     };
-  }, [handlePlanModeToggle, handleFastModeToggle, handleOpenFilePicker, selectedModel, MODELS, setMessage, plateInputRef, setSelectedModel, setThinkingLevel, setLinearPickerOpen, getAvailableThinkingLevels]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- deps accessed via ref
 }

--- a/src/components/tabs/useTabScroll.ts
+++ b/src/components/tabs/useTabScroll.ts
@@ -62,7 +62,9 @@ export function useTabScroll(
     [scrollRef]
   );
 
-  // Set up scroll event listener and resize observer
+  // Set up scroll event listener and resize observer.
+  // All three triggers (scroll, resize, mutation) are batched through rAF
+  // so checkScroll runs at most once per frame even when multiple fire together.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -70,19 +72,33 @@ export function useTabScroll(
     // Check initial scroll state
     checkScroll();
 
+    let rafPending = false;
+    let rafId = 0;
+    const scheduleCheck = () => {
+      if (rafPending) return;
+      rafPending = true;
+      rafId = requestAnimationFrame(() => {
+        rafPending = false;
+        checkScroll();
+      });
+    };
+
     // Listen to scroll events
-    el.addEventListener('scroll', checkScroll, { passive: true });
+    el.addEventListener('scroll', scheduleCheck, { passive: true });
 
     // Listen to resize events (tabs may overflow differently)
-    const resizeObserver = new ResizeObserver(checkScroll);
+    const resizeObserver = new ResizeObserver(scheduleCheck);
     resizeObserver.observe(el);
 
-    // Also observe content changes via mutation observer
-    const mutationObserver = new MutationObserver(checkScroll);
+    // Observe child and subtree changes — subtree is needed so that tab label
+    // renames (text node mutations inside tab elements) trigger a scroll check
+    // when the new width pushes content past the overflow boundary.
+    const mutationObserver = new MutationObserver(scheduleCheck);
     mutationObserver.observe(el, { childList: true, subtree: true });
 
     return () => {
-      el.removeEventListener('scroll', checkScroll);
+      cancelAnimationFrame(rafId);
+      el.removeEventListener('scroll', scheduleCheck);
       resizeObserver.disconnect();
       mutationObserver.disconnect();
     };

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -10,10 +10,9 @@
  * - Use direct selector for single primitives or existing store values
  * - Scope to specific conversation/session IDs where possible
  *
- * IMPORTANT: Some array selectors (useMessages) create new array references on every
- * store update — consumers should wrap results with useMemo if referential stability
- * is needed. Others (useActiveTools, useSubAgents) use a custom shallow-array equality
- * function so Zustand preserves the previous snapshot automatically.
+ * IMPORTANT: Array selectors (useMessages, useActiveTools, useSubAgents) use useShallow
+ * to provide referential stability — Zustand preserves the previous snapshot when the
+ * array contents haven't changed, even if the store creates a new array reference.
  */
 
 import { useCallback, useMemo, useRef } from 'react';
@@ -39,10 +38,6 @@ const EMPTY_ACTIVE_IDS: readonly string[] = [];
 const EMPTY_SEGMENT_STUBS: readonly { id: string; timestamp: number }[] = [];
 const EMPTY_SENT_QUEUED: readonly import('./appStore').QueuedMessage[] = [];
 
-/** Shallow element-wise equality for array selectors — avoids re-renders when
- *  the store creates a new array reference but the elements are identical. */
-const shallowArrayEquals = <T>(a: readonly T[], b: readonly T[]) =>
-  a === b || (a.length === b.length && a.every((t, i) => t === b[i]));
 const EMPTY_FILE_COMMENT_STATS = new Map<string, { total: number; unresolved: number }>();
 
 // ============================================================================
@@ -396,28 +391,26 @@ export const useStreamingChatInput = (conversationId: string | null) =>
 
 /**
  * Active tools scoped to a conversation.
- * Uses a custom equality function so Zustand preserves the previous snapshot
- * when the store creates a new activeTools record (via spread) but this
- * conversation's tools haven't actually changed.
+ * Uses useShallow so Zustand preserves the previous snapshot when the store
+ * creates a new activeTools record (via spread) but this conversation's
+ * tools haven't actually changed.
  * Use in: StreamingMessage, ToolDisplay
  */
 export const useActiveTools = (conversationId: string | null) =>
   useAppStore(
-    (s) => (conversationId ? s.activeTools[conversationId] ?? EMPTY_TOOLS : EMPTY_TOOLS),
-    shallowArrayEquals
+    useShallow((s) => (conversationId ? s.activeTools[conversationId] ?? EMPTY_TOOLS : EMPTY_TOOLS))
   );
 
 /**
  * Sub-agents scoped to a conversation.
- * Uses a custom equality function so Zustand preserves the previous snapshot
- * when unrelated store mutations create a new subAgents record but this
- * conversation's agents haven't changed.
+ * Uses useShallow so Zustand preserves the previous snapshot when unrelated
+ * store mutations create a new subAgents record but this conversation's
+ * agents haven't changed.
  * Use in: StreamingMessage, SubAgentGroup
  */
 export const useSubAgents = (conversationId: string | null) =>
   useAppStore(
-    (s) => (conversationId ? s.subAgents[conversationId] ?? EMPTY_SUB_AGENTS : EMPTY_SUB_AGENTS),
-    shallowArrayEquals
+    useShallow((s) => (conversationId ? s.subAgents[conversationId] ?? EMPTY_SUB_AGENTS : EMPTY_SUB_AGENTS))
   );
 
 // ============================================================================

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -10,9 +10,10 @@
  * - Use direct selector for single primitives or existing store values
  * - Scope to specific conversation/session IDs where possible
  *
- * IMPORTANT: Selectors that filter arrays (useMessages, useActiveTools) create new
- * array references on every store update. Consumers should wrap results with useMemo
- * if referential stability is needed for downstream dependencies.
+ * IMPORTANT: Some array selectors (useMessages) create new array references on every
+ * store update — consumers should wrap results with useMemo if referential stability
+ * is needed. Others (useActiveTools, useSubAgents) use a custom shallow-array equality
+ * function so Zustand preserves the previous snapshot automatically.
  */
 
 import { useCallback, useMemo, useRef } from 'react';
@@ -37,6 +38,11 @@ const EMPTY_SUB_AGENTS: readonly SubAgent[] = [];
 const EMPTY_ACTIVE_IDS: readonly string[] = [];
 const EMPTY_SEGMENT_STUBS: readonly { id: string; timestamp: number }[] = [];
 const EMPTY_SENT_QUEUED: readonly import('./appStore').QueuedMessage[] = [];
+
+/** Shallow element-wise equality for array selectors — avoids re-renders when
+ *  the store creates a new array reference but the elements are identical. */
+const shallowArrayEquals = <T>(a: readonly T[], b: readonly T[]) =>
+  a === b || (a.length === b.length && a.every((t, i) => t === b[i]));
 const EMPTY_FILE_COMMENT_STATS = new Map<string, { total: number; unresolved: number }>();
 
 // ============================================================================
@@ -390,17 +396,29 @@ export const useStreamingChatInput = (conversationId: string | null) =>
 
 /**
  * Active tools scoped to a conversation.
+ * Uses a custom equality function so Zustand preserves the previous snapshot
+ * when the store creates a new activeTools record (via spread) but this
+ * conversation's tools haven't actually changed.
  * Use in: StreamingMessage, ToolDisplay
  */
 export const useActiveTools = (conversationId: string | null) =>
-  useAppStore((s) => (conversationId ? s.activeTools[conversationId] ?? EMPTY_TOOLS : EMPTY_TOOLS));
+  useAppStore(
+    (s) => (conversationId ? s.activeTools[conversationId] ?? EMPTY_TOOLS : EMPTY_TOOLS),
+    shallowArrayEquals
+  );
 
 /**
  * Sub-agents scoped to a conversation.
+ * Uses a custom equality function so Zustand preserves the previous snapshot
+ * when unrelated store mutations create a new subAgents record but this
+ * conversation's agents haven't changed.
  * Use in: StreamingMessage, SubAgentGroup
  */
 export const useSubAgents = (conversationId: string | null) =>
-  useAppStore((s) => (conversationId ? s.subAgents[conversationId] ?? EMPTY_SUB_AGENTS : EMPTY_SUB_AGENTS));
+  useAppStore(
+    (s) => (conversationId ? s.subAgents[conversationId] ?? EMPTY_SUB_AGENTS : EMPTY_SUB_AGENTS),
+    shallowArrayEquals
+  );
 
 // ============================================================================
 // File Tab State


### PR DESCRIPTION
## Summary

- **CSS animation extraction**: Move marching-ants inline style to a CSS class, enabling `prefers-reduced-motion` to properly disable it. Also disable streaming border animations under reduced motion.
- **Scroll state deduplication**: Wrap `setShowScrollButton` in a ref-guarded callback to skip redundant React reconciliation when scroll handlers fire 60+ times/sec.
- **rAF for Virtuoso scroller attachment**: Replace `setInterval(100)` polling with a `requestAnimationFrame` loop — resolves in 1-2 frames instead of up to 100ms.
- **Ref-bag pattern for keyboard shortcuts**: Store all 11 dependencies in a ref so event listeners mount once and never churn on parent re-renders.
- **rAF batching in useTabScroll**: Coalesce scroll/resize/mutation callbacks so `checkScroll` runs at most once per frame.
- **Zustand selector equality**: Add `shallowArrayEquals` for `useActiveTools` and `useSubAgents` to prevent re-renders when the store creates new array references but contents are unchanged.
- **PlateInput array-join**: Switch `extractContent` from string concatenation to array-join for better performance on large paste operations.
- **ElapsedTimer interval**: Reduce update frequency from 50ms to 100ms — imperceptible for an elapsed time display, halves timer overhead.

## Test plan

- [ ] Verify marching-ants animation still plays in plan mode
- [ ] Enable "Reduce motion" in macOS Accessibility settings and confirm marching-ants and streaming border animations are disabled
- [ ] Scroll up during streaming, confirm scroll-to-bottom pill appears and hides correctly
- [ ] Test keyboard shortcuts (Cmd+L, Alt+T, Shift+Tab, Alt+F, Cmd+U, Cmd+I, Alt+1-9) still work
- [ ] Rename a tab and confirm scroll arrows update if content overflows
- [ ] Paste a large block of text into the chat input and confirm it renders correctly
- [ ] Confirm elapsed timer during streaming still updates smoothly
- [ ] Run `npm run lint` — no new warnings
- [ ] Run `npm run build` — TypeScript passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)