### PR TITLE
fix(sidebar): prevent scheduled session timestamp from clipping

### DIFF
--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -1112,25 +1112,27 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
                               </span>
                             </div>
                             <CollapsibleContent>
-                              {group.sessions.map((session) => {
-                                const runDate = new Date(session.createdAt ?? session.updatedAt);
-                                const dateLabel = runDate.toLocaleDateString([], { month: 'short', day: 'numeric' });
-                                const isSelected = selectedSessionId === session.id && contentView.type === 'conversation';
-                                return (
-                                  <button
-                                    key={session.id}
-                                    className={`flex items-center gap-1.5 px-2 py-1 ml-4 mr-1 rounded-md text-sm cursor-pointer w-full text-left ${isSelected ? 'bg-accent' : 'hover:bg-surface-1'}`}
-                                    onClick={(e) => handleSelectSession(session.workspaceId, session.id, e)}
-                                  >
-                                    <span className="truncate flex-1 text-muted-foreground">
-                                      {dateLabel} – {group.taskName}
-                                    </span>
-                                    <span className="text-[10px] text-muted-foreground shrink-0">
-                                      {formatTimeAgo(session.updatedAt ?? session.createdAt)}
-                                    </span>
-                                  </button>
-                                );
-                              })}
+                              <div className="pl-4 pr-1">
+                                {group.sessions.map((session) => {
+                                  const runDate = new Date(session.createdAt ?? session.updatedAt);
+                                  const dateLabel = runDate.toLocaleDateString([], { month: 'short', day: 'numeric' });
+                                  const isSelected = selectedSessionId === session.id && contentView.type === 'conversation';
+                                  return (
+                                    <button
+                                      key={session.id}
+                                      className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-sm cursor-pointer w-full text-left ${isSelected ? 'bg-accent' : 'hover:bg-surface-1'}`}
+                                      onClick={(e) => handleSelectSession(session.workspaceId, session.id, e)}
+                                    >
+                                      <span className="truncate flex-1 text-muted-foreground">
+                                        {dateLabel} – {group.taskName}
+                                      </span>
+                                      <span className="text-[10px] text-muted-foreground shrink-0">
+                                        {formatTimeAgo(session.updatedAt ?? session.createdAt)}
+                                      </span>
+                                    </button>
+                                  );
+                                })}
+                              </div>
                             </CollapsibleContent>
                           </Collapsible>
                         );


### PR DESCRIPTION
## Summary

- Fixes the scheduled session row timestamp being clipped out of bounds in the sidebar
- The `w-full ml-4` on the button caused it to extend 16px past the parent's right edge, cutting off the right-side timestamp (e.g., "now" rendered as "nov")
- Wraps session items in a `<div className="pl-4 pr-1">` container and removes margin from the button so `w-full` fills the correct bounds

## Test plan

- [ ] Open app with scheduled sessions visible in sidebar
- [ ] Verify the timestamp on the right side of each scheduled session row is fully visible and not clipped
- [ ] Verify indentation of scheduled session rows still looks correct (indented under the parent task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)