### PR TITLE
fix(scheduled): remove permission modes that block unattended tasks

### DIFF
--- a/backend/scheduler/scheduler.go
+++ b/backend/scheduler/scheduler.go
@@ -313,13 +313,15 @@ func (sc *Scheduler) dispatchTask(ctx context.Context, task *models.ScheduledTas
 		return run, fmt.Errorf("failed to create session: %w", err)
 	}
 
-	// Start conversation with the task prompt
-	var opts *agent.StartConversationOptions
-	if task.Model != "" || task.PermissionMode != "" {
-		opts = &agent.StartConversationOptions{
-			Model:          task.Model,
-			PermissionMode: task.PermissionMode,
-		}
+	// Start conversation with the task prompt.
+	// Scheduled tasks must not use modes that prompt a human — no one is present to approve.
+	permMode := task.PermissionMode
+	if permMode == "" || permMode == "default" || permMode == "acceptEdits" {
+		permMode = "bypassPermissions"
+	}
+	opts := &agent.StartConversationOptions{
+		Model:          task.Model,
+		PermissionMode: permMode,
 	}
 
 	_, err = sc.agentMgr.StartConversation(ctx, sessionID, "task", task.Prompt, opts)

--- a/backend/server/scheduled_task_handlers.go
+++ b/backend/server/scheduled_task_handlers.go
@@ -44,6 +44,16 @@ type UpdateScheduledTaskRequest struct {
 	Enabled            *bool   `json:"enabled,omitempty"`
 }
 
+// isValidScheduledPermissionMode reports whether mode is safe for unattended execution.
+// Only modes that never prompt a human are allowed.
+func isValidScheduledPermissionMode(mode string) bool {
+	switch mode {
+	case "bypassPermissions", "dontAsk":
+		return true
+	}
+	return false
+}
+
 // validateScheduleParams checks that schedule fields are within valid ranges
 func validateScheduleParams(hour, minute, dayOfWeek, dayOfMonth int) string {
 	if hour < 0 || hour > 23 {
@@ -112,6 +122,15 @@ func (h *Handlers) CreateScheduledTask(w http.ResponseWriter, r *http.Request) {
 	}
 	if msg := validateScheduleParams(req.ScheduleHour, req.ScheduleMinute, req.ScheduleDayOfWeek, req.ScheduleDayOfMonth); msg != "" {
 		writeValidationError(w, msg)
+		return
+	}
+	// Scheduled tasks run unattended — "default" and "acceptEdits" can prompt for
+	// tool approval with no human present, blocking forever.
+	if req.PermissionMode == "" || req.PermissionMode == "default" || req.PermissionMode == "acceptEdits" {
+		req.PermissionMode = "bypassPermissions"
+	}
+	if !isValidScheduledPermissionMode(req.PermissionMode) {
+		writeValidationError(w, "permissionMode must be one of: bypassPermissions, dontAsk")
 		return
 	}
 
@@ -206,6 +225,17 @@ func (h *Handlers) UpdateScheduledTask(w http.ResponseWriter, r *http.Request) {
 	if req.ScheduleDayOfMonth != nil && (*req.ScheduleDayOfMonth < 1 || *req.ScheduleDayOfMonth > 28) {
 		writeValidationError(w, "scheduleDayOfMonth must be 1–28")
 		return
+	}
+	if req.PermissionMode != nil {
+		mode := *req.PermissionMode
+		if mode == "default" || mode == "" || mode == "acceptEdits" {
+			mode = "bypassPermissions"
+		}
+		if !isValidScheduledPermissionMode(mode) {
+			writeValidationError(w, "permissionMode must be one of: bypassPermissions, dontAsk")
+			return
+		}
+		req.PermissionMode = &mode
 	}
 
 	err := h.store.UpdateScheduledTask(r.Context(), taskID, func(task *models.ScheduledTask) {

--- a/backend/store/migrations.go
+++ b/backend/store/migrations.go
@@ -160,6 +160,14 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		Version:     9,
+		Description: "Default scheduled task permission_mode to bypassPermissions",
+		Up: func(_ context.Context, tx *sql.Tx) error {
+			_, err := tx.Exec(`UPDATE scheduled_tasks SET permission_mode = 'bypassPermissions' WHERE permission_mode IN ('default', '', 'acceptEdits')`)
+			return err
+		},
+	},
 }
 
 // RunMigrations ensures the schema_version table exists, applies the baseline

--- a/src/components/scheduled/ScheduledTaskDialog.tsx
+++ b/src/components/scheduled/ScheduledTaskDialog.tsx
@@ -40,8 +40,6 @@ const FREQUENCY_OPTIONS: { value: ScheduledTaskFrequency; label: string }[] = [
 ];
 
 const PERMISSION_OPTIONS = [
-  { value: 'default', label: 'Ask permissions' },
-  { value: 'acceptEdits', label: 'Accept edits' },
   { value: 'bypassPermissions', label: 'Bypass permissions' },
   { value: 'dontAsk', label: "Don't ask" },
 ];
@@ -68,7 +66,7 @@ export function ScheduledTaskDialog({ open, onOpenChange, editTask }: ScheduledT
   const [description, setDescription] = useState('');
   const [prompt, setPrompt] = useState('');
   const [model, setModel] = useState('');
-  const [permissionMode, setPermissionMode] = useState('default');
+  const [permissionMode, setPermissionMode] = useState('bypassPermissions');
   const [workspaceId, setWorkspaceId] = useState('');
   const [frequency, setFrequency] = useState<ScheduledTaskFrequency>('daily');
   const [scheduleHour, setScheduleHour] = useState(9);
@@ -90,7 +88,11 @@ export function ScheduledTaskDialog({ open, onOpenChange, editTask }: ScheduledT
       setDescription(editTask.description);
       setPrompt(editTask.prompt);
       setModel(editTask.model || '');
-      setPermissionMode(editTask.permissionMode || 'default');
+      setPermissionMode(
+        editTask.permissionMode === 'default' || editTask.permissionMode === 'acceptEdits'
+          ? 'bypassPermissions'
+          : (editTask.permissionMode || 'bypassPermissions'),
+      );
       setWorkspaceId(editTask.workspaceId);
       setFrequency(editTask.frequency);
       setScheduleHour(editTask.scheduleHour);
@@ -102,7 +104,7 @@ export function ScheduledTaskDialog({ open, onOpenChange, editTask }: ScheduledT
       setDescription('');
       setPrompt('');
       setModel('');
-      setPermissionMode('default');
+      setPermissionMode('bypassPermissions');
       setWorkspaceId(workspaces[0]?.id || '');
       setFrequency('daily');
       setScheduleHour(9);


### PR DESCRIPTION
## Summary
- Removed `default` ("Ask permissions") and `acceptEdits` from the scheduled task permission mode options — both prompt for human approval, which blocks forever in unattended execution
- Only `bypassPermissions` and `dontAsk` are now offered (both fully autonomous)
- Backend coerces `default`, `acceptEdits`, and empty strings to `bypassPermissions` in create, update, and dispatch paths
- Added `isValidScheduledPermissionMode()` validation to reject unknown modes
- Migration 9 fixes any existing rows with stale permission modes

## Test plan
- [ ] Create a new scheduled task — verify only "Bypass permissions" and "Don't ask" appear in the dropdown
- [ ] Edit an existing task that had `acceptEdits` — verify it shows as "Bypass permissions"
- [ ] Send `permissionMode: "foobar"` via API — verify 400 validation error
- [ ] Send `permissionMode: "acceptEdits"` via API — verify it's silently coerced to `bypassPermissions`
- [ ] Trigger a scheduled task and confirm it runs without blocking on permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)