### PR TITLE
fix(scheduled): seed session name generator with stale branch names

### DIFF
--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -17,6 +17,25 @@ type Repo struct {
 	CreatedAt    time.Time `json:"createdAt"`
 }
 
+// ResolveBranchPrefix returns the effective branch prefix for this repo.
+// Pass the GitHub username when available (from ghClient); pass "" otherwise.
+// Falls back to "session" when the prefix cannot be resolved.
+func (r *Repo) ResolveBranchPrefix(githubUsername string) string {
+	switch r.BranchPrefix {
+	case "custom":
+		if r.CustomPrefix != "" {
+			return r.CustomPrefix
+		}
+	case "none":
+		return ""
+	case "github":
+		if githubUsername != "" {
+			return githubUsername
+		}
+	}
+	return "session"
+}
+
 // Session represents a worktree session within a workspace
 type Session struct {
 	ID               string        `json:"id"`

--- a/backend/scheduler/scheduler.go
+++ b/backend/scheduler/scheduler.go
@@ -243,12 +243,32 @@ func (sc *Scheduler) dispatchTask(ctx context.Context, task *models.ScheduledTas
 		logger.Main.Warnf("Scheduler: could not read workspaces dir for name seeding: %v", err)
 	}
 
+	// Resolve branch prefix from repo settings (no GitHub client in scheduler,
+	// so "github" prefix falls back to "session").
+	branchPrefix := repo.ResolveBranchPrefix("")
+
+	// Also seed with existing branch names — stale branches from
+	// previously deleted sessions can cause worktree creation failures even
+	// when no matching directory exists.
+	if branchPrefix != "" {
+		if branchNames, err := git.LocalBranchNamesWithPrefix(ctx, repo.Path, branchPrefix+"/"); err == nil {
+			for _, name := range branchNames {
+				existingNames = append(existingNames, strings.ToLower(name))
+			}
+		} else {
+			logger.Main.Warnf("Scheduler: could not list %s branches for name seeding: %v", branchPrefix, err)
+		}
+	}
+
 	// Generate session name and create worktree with retry on collisions
 	const maxRetries = 10
 	var sessionName, branchName, worktreePath, baseCommitSHA string
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		candidateName := naming.GenerateUniqueSessionName(existingNames)
-		candidateBranch := fmt.Sprintf("session/%s", candidateName)
+		candidateBranch := candidateName
+		if branchPrefix != "" {
+			candidateBranch = fmt.Sprintf("%s/%s", branchPrefix, candidateName)
+		}
 
 		sessionPath, dirErr := git.CreateSessionDirectoryAtomic(workspacesDir, candidateName)
 		if dirErr != nil {

--- a/backend/server/session_handlers.go
+++ b/backend/server/session_handlers.go
@@ -227,8 +227,10 @@ func (h *Handlers) initBaseSession(ctx context.Context, workspaceID, name, branc
 // Returns "session" as the default fallback.
 func (h *Handlers) resolveRepoBranchPrefix(repo *models.Repo) string {
 	var githubUsername string
-	if user := h.ghClient.GetStoredUser(); user != nil {
-		githubUsername = user.Login
+	if h.ghClient != nil {
+		if user := h.ghClient.GetStoredUser(); user != nil {
+			githubUsername = user.Login
+		}
 	}
 	return repo.ResolveBranchPrefix(githubUsername)
 }

--- a/backend/server/session_handlers.go
+++ b/backend/server/session_handlers.go
@@ -226,20 +226,11 @@ func (h *Handlers) initBaseSession(ctx context.Context, workspaceID, name, branc
 // For the "github" case, it resolves to the authenticated GitHub user's login.
 // Returns "session" as the default fallback.
 func (h *Handlers) resolveRepoBranchPrefix(repo *models.Repo) string {
-	switch repo.BranchPrefix {
-	case "custom":
-		if repo.CustomPrefix != "" {
-			return repo.CustomPrefix
-		}
-	case "none":
-		return ""
-	case "github":
-		if user := h.ghClient.GetStoredUser(); user != nil && user.Login != "" {
-			return user.Login
-		}
+	var githubUsername string
+	if user := h.ghClient.GetStoredUser(); user != nil {
+		githubUsername = user.Login
 	}
-	// "", or anything else → "session" (backend default)
-	return "session"
+	return repo.ResolveBranchPrefix(githubUsername)
 }
 
 func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
@@ -371,6 +362,17 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 		// Atomic session name generation with retry loop.
 		// Retries on both directory collisions AND branch collisions, so stale
 		// git branches from previously deleted sessions don't block the user.
+
+		// Seed the name cache with existing branch names so the generator
+		// avoids names that would collide with stale branches.
+		if branchPrefix != "" {
+			if branchNames, err := git.LocalBranchNamesWithPrefix(ctx, repo.Path, branchPrefix+"/"); err == nil {
+				for _, name := range branchNames {
+					h.sessionNameCache.Add(name)
+				}
+			}
+		}
+
 		const maxRetries = 10
 		for attempt := 0; attempt < maxRetries; attempt++ {
 			// Get existing names from cache (initializes on first call)
@@ -423,9 +425,10 @@ func (h *Handlers) CreateSession(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 
-			// Branch collision - roll back directory and retry with a new name
+			// Branch collision - roll back directory and retry with a new name.
+			// Keep the name in the cache: the branch still exists even though
+			// the directory was rolled back, so this name should not be retried.
 			if errors.Is(wtErr, git.ErrLocalBranchExists) || errors.Is(wtErr, git.ErrBranchAlreadyCheckedOut) {
-				h.sessionNameCache.Remove(candidateName)
 				if removeErr := os.RemoveAll(path); removeErr != nil {
 					logger.Handlers.Warnf("Failed to rollback session directory %s: %v", path, removeErr)
 				}

--- a/core/git/repo.go
+++ b/core/git/repo.go
@@ -160,6 +160,32 @@ func (rm *RepoManager) ListRemoteBranches(ctx context.Context, repoPath string, 
 	return branches, nil
 }
 
+// LocalBranchNamesWithPrefix returns local branch names matching the given prefix,
+// with the prefix stripped. For example, prefix "session/" returns ["orion", "vega"]
+// for branches "session/orion" and "session/vega".
+// Returns nil (not an error) if prefix is empty.
+// Returns an error if the git command fails (e.g. repo doesn't exist).
+func LocalBranchNamesWithPrefix(ctx context.Context, repoPath, prefix string) ([]string, error) {
+	if prefix == "" {
+		return nil, nil
+	}
+	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "branch", "--list", "--format=%(refname:short)", prefix+"*")
+	defer cancel()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list local branches with prefix %q: %w", prefix, err)
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		names = append(names, strings.TrimPrefix(line, prefix))
+	}
+	return names, nil
+}
+
 // RefExists checks whether a git ref (branch, tag, or commit) exists in the repository.
 func (rm *RepoManager) RefExists(ctx context.Context, repoPath, ref string) bool {
 	cmd, cancel := gitCmdWithContext(ctx, TimeoutFast, repoPath, "rev-parse", "--verify", "--quiet", ref)

--- a/core/git/repo_test.go
+++ b/core/git/repo_test.go
@@ -1134,6 +1134,59 @@ func TestListRemoteBranches_Success(t *testing.T) {
 }
 
 // ============================================================================
+// LocalBranchNamesWithPrefix Tests
+// ============================================================================
+
+func TestLocalBranchNamesWithPrefix_MatchingBranches(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+
+	// Create session branches
+	createBranch(t, repoPath, "session/orion")
+	createBranch(t, repoPath, "session/vega")
+	createBranch(t, repoPath, "session/sirius")
+	// Create a non-session branch to verify it's excluded
+	createBranch(t, repoPath, "feature/unrelated")
+
+	names, err := LocalBranchNamesWithPrefix(context.Background(), repoPath, "session/")
+	require.NoError(t, err)
+	assert.Len(t, names, 3)
+	assert.Contains(t, names, "orion")
+	assert.Contains(t, names, "vega")
+	assert.Contains(t, names, "sirius")
+}
+
+func TestLocalBranchNamesWithPrefix_NoMatches(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+
+	names, err := LocalBranchNamesWithPrefix(context.Background(), repoPath, "session/")
+	require.NoError(t, err)
+	assert.Empty(t, names)
+}
+
+func TestLocalBranchNamesWithPrefix_EmptyPrefix(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+
+	names, err := LocalBranchNamesWithPrefix(context.Background(), repoPath, "")
+	require.NoError(t, err)
+	assert.Nil(t, names)
+}
+
+func TestLocalBranchNamesWithPrefix_NestedPrefix(t *testing.T) {
+	repoPath := createTestGitRepo(t)
+
+	// Branch with nested prefix (e.g., "mcastilho/session-name")
+	createBranch(t, repoPath, "mcastilho/orion")
+	createBranch(t, repoPath, "mcastilho/vega")
+	createBranch(t, repoPath, "session/other")
+
+	names, err := LocalBranchNamesWithPrefix(context.Background(), repoPath, "mcastilho/")
+	require.NoError(t, err)
+	assert.Len(t, names, 2)
+	assert.Contains(t, names, "orion")
+	assert.Contains(t, names, "vega")
+}
+
+// ============================================================================
 // RefExists Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- **Seed name generators with existing branch names** — both the scheduler and `CreateSession` handler now query local branches by prefix before generating session names, preventing collisions with stale branches from previously deleted sessions
- **Extract `ResolveBranchPrefix` to `models.Repo`** — the scheduler previously hardcoded `"session/"` as the branch prefix; it now respects repo-level settings (`custom`, `none`, `github`) via the shared method
- **Fix branch collision retry logic** — stop removing colliding names from the session name cache on branch collision, since the branch still exists and the name should not be retried
- **Add `LocalBranchNamesWithPrefix` git helper** — standalone function to query and strip-prefix local branches, with tests covering matching, no-match, empty-prefix, and nested-prefix cases

## Test plan

- [x] `go build ./...` passes
- [x] `LocalBranchNamesWithPrefix` unit tests pass (4 test cases)
- [ ] Create sessions on a repo with stale branches — verify no collision errors
- [ ] Create sessions on a repo with custom branch prefix — verify correct prefix used
- [ ] Trigger a scheduled task on a repo with stale `session/*` branches — verify it picks a non-colliding name

🤖 Generated with [Claude Code](https://claude.com/claude-code)