### PR TITLE
fix(checks): use unique keys for CI checks with duplicate names

### DIFF
--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -769,12 +769,12 @@ function CIChecksSection({
           ) : (
             // Fallback: flat list from checkDetails (no workflow data available)
             <div className="space-y-0.5">
-              {sortedChecks.map((check) => {
+              {sortedChecks.map((check, index) => {
                 const statusInfo = getCheckStatusInfo(check.status, check.conclusion);
                 const StatusIcon = statusInfo.icon;
 
                 return (
-                  <div key={check.name} className="flex items-center gap-2 py-0.5 px-1 min-w-0">
+                  <div key={`${check.name}-${index}`} className="flex items-center gap-2 py-0.5 px-1 min-w-0">
                     <StatusIcon className={cn('h-3 w-3 shrink-0', statusInfo.color)} />
                     <span className="text-xs truncate flex-1">{check.name}</span>
                     {check.durationSeconds !== undefined && check.conclusion !== 'skipped' && check.conclusion !== 'cancelled' && (


### PR DESCRIPTION
## Summary

- Fix React duplicate key warning in `ChecksPanel.tsx` when multiple CI checks share the same name (e.g., "Manage Security Review Label")
- Use `name+index` as the key since `CheckDetail` has no unique ID field

## Test plan

- [ ] Open a PR with duplicate CI check names and verify no console warning about duplicate keys
- [ ] Verify CI checks list still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)