### PR TITLE
feat(scheduled): add archive button to scheduled task detail view

### DIFF
--- a/backend/models/types.go
+++ b/backend/models/types.go
@@ -587,6 +587,7 @@ type ScheduledTask struct {
 	ScheduleDayOfWeek  int        `json:"scheduleDayOfWeek"`            // 0=Sun..6=Sat (for weekly)
 	ScheduleDayOfMonth int        `json:"scheduleDayOfMonth"`           // 1-31 (for monthly)
 	Enabled            bool       `json:"enabled"`
+	Archived           bool       `json:"archived"`
 	LastRunAt          *time.Time `json:"lastRunAt,omitempty"`
 	NextRunAt          *time.Time `json:"nextRunAt,omitempty"`
 	CreatedAt          time.Time  `json:"createdAt"`

--- a/backend/server/scheduled_task_handlers.go
+++ b/backend/server/scheduled_task_handlers.go
@@ -42,6 +42,7 @@ type UpdateScheduledTaskRequest struct {
 	ScheduleDayOfWeek  *int    `json:"scheduleDayOfWeek,omitempty"`
 	ScheduleDayOfMonth *int    `json:"scheduleDayOfMonth,omitempty"`
 	Enabled            *bool   `json:"enabled,omitempty"`
+	Archived           *bool   `json:"archived,omitempty"`
 }
 
 // isValidScheduledPermissionMode reports whether mode is safe for unattended execution.
@@ -274,6 +275,12 @@ func (h *Handlers) UpdateScheduledTask(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.Enabled != nil {
 			task.Enabled = *req.Enabled
+		}
+		if req.Archived != nil {
+			task.Archived = *req.Archived
+			if *req.Archived {
+				task.NextRunAt = nil
+			}
 		}
 
 		// Recompute next_run_at if schedule changed

--- a/backend/store/migrations.go
+++ b/backend/store/migrations.go
@@ -168,6 +168,14 @@ var migrations = []Migration{
 			return err
 		},
 	},
+	{
+		Version:     10,
+		Description: "Add archived column to scheduled_tasks",
+		Up: func(_ context.Context, tx *sql.Tx) error {
+			_, err := tx.Exec(`ALTER TABLE scheduled_tasks ADD COLUMN archived INTEGER NOT NULL DEFAULT 0`)
+			return err
+		},
+	},
 }
 
 // RunMigrations ensures the schema_version table exists, applies the baseline

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -3182,31 +3182,31 @@ func (s *SQLiteStore) AddScheduledTask(ctx context.Context, task *models.Schedul
 			INSERT INTO scheduled_tasks (id, workspace_id, name, description, prompt, model,
 				permission_mode, frequency, cron_expression,
 				schedule_hour, schedule_minute, schedule_day_of_week, schedule_day_of_month,
-				enabled, last_run_at, next_run_at, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				enabled, archived, last_run_at, next_run_at, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			task.ID, task.WorkspaceID, task.Name, task.Description, task.Prompt, task.Model,
 			task.PermissionMode, task.Frequency, task.CronExpression,
 			task.ScheduleHour, task.ScheduleMinute, task.ScheduleDayOfWeek, task.ScheduleDayOfMonth,
-			boolToInt(task.Enabled), task.LastRunAt, task.NextRunAt, task.CreatedAt, task.UpdatedAt)
+			boolToInt(task.Enabled), boolToInt(task.Archived), task.LastRunAt, task.NextRunAt, task.CreatedAt, task.UpdatedAt)
 		return err
 	})
 }
 
 func (s *SQLiteStore) GetScheduledTask(ctx context.Context, id string) (*models.ScheduledTask, error) {
 	var task models.ScheduledTask
-	var enabled int
+	var enabled, archived int
 	var lastRunAt, nextRunAt sql.NullTime
 
 	err := s.db.QueryRowContext(ctx, `
 		SELECT id, workspace_id, name, description, prompt, model,
 			permission_mode, frequency, cron_expression,
 			schedule_hour, schedule_minute, schedule_day_of_week, schedule_day_of_month,
-			enabled, last_run_at, next_run_at, created_at, updated_at
+			enabled, archived, last_run_at, next_run_at, created_at, updated_at
 		FROM scheduled_tasks WHERE id = ?`, id).Scan(
 		&task.ID, &task.WorkspaceID, &task.Name, &task.Description, &task.Prompt, &task.Model,
 		&task.PermissionMode, &task.Frequency, &task.CronExpression,
 		&task.ScheduleHour, &task.ScheduleMinute, &task.ScheduleDayOfWeek, &task.ScheduleDayOfMonth,
-		&enabled, &lastRunAt, &nextRunAt, &task.CreatedAt, &task.UpdatedAt)
+		&enabled, &archived, &lastRunAt, &nextRunAt, &task.CreatedAt, &task.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -3215,6 +3215,7 @@ func (s *SQLiteStore) GetScheduledTask(ctx context.Context, id string) (*models.
 	}
 
 	task.Enabled = intToBool(enabled)
+	task.Archived = intToBool(archived)
 	if lastRunAt.Valid {
 		task.LastRunAt = &lastRunAt.Time
 	}
@@ -3229,8 +3230,8 @@ func (s *SQLiteStore) ListAllScheduledTasks(ctx context.Context) ([]*models.Sche
 		SELECT id, workspace_id, name, description, prompt, model,
 			permission_mode, frequency, cron_expression,
 			schedule_hour, schedule_minute, schedule_day_of_week, schedule_day_of_month,
-			enabled, last_run_at, next_run_at, created_at, updated_at
-		FROM scheduled_tasks ORDER BY created_at DESC`)
+			enabled, archived, last_run_at, next_run_at, created_at, updated_at
+		FROM scheduled_tasks WHERE archived = 0 ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("ListAllScheduledTasks: %w", err)
 	}
@@ -3243,8 +3244,8 @@ func (s *SQLiteStore) ListScheduledTasks(ctx context.Context, workspaceID string
 		SELECT id, workspace_id, name, description, prompt, model,
 			permission_mode, frequency, cron_expression,
 			schedule_hour, schedule_minute, schedule_day_of_week, schedule_day_of_month,
-			enabled, last_run_at, next_run_at, created_at, updated_at
-		FROM scheduled_tasks WHERE workspace_id = ? ORDER BY created_at DESC`, workspaceID)
+			enabled, archived, last_run_at, next_run_at, created_at, updated_at
+		FROM scheduled_tasks WHERE workspace_id = ? AND archived = 0 ORDER BY created_at DESC`, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("ListScheduledTasks: %w", err)
 	}
@@ -3256,18 +3257,19 @@ func (s *SQLiteStore) scanScheduledTasks(rows *sql.Rows) ([]*models.ScheduledTas
 	tasks := []*models.ScheduledTask{}
 	for rows.Next() {
 		var task models.ScheduledTask
-		var enabled int
+		var enabled, archived int
 		var lastRunAt, nextRunAt sql.NullTime
 
 		if err := rows.Scan(
 			&task.ID, &task.WorkspaceID, &task.Name, &task.Description, &task.Prompt, &task.Model,
 			&task.PermissionMode, &task.Frequency, &task.CronExpression,
 			&task.ScheduleHour, &task.ScheduleMinute, &task.ScheduleDayOfWeek, &task.ScheduleDayOfMonth,
-			&enabled, &lastRunAt, &nextRunAt, &task.CreatedAt, &task.UpdatedAt); err != nil {
+			&enabled, &archived, &lastRunAt, &nextRunAt, &task.CreatedAt, &task.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scanScheduledTasks: %w", err)
 		}
 
 		task.Enabled = intToBool(enabled)
+		task.Archived = intToBool(archived)
 		if lastRunAt.Valid {
 			task.LastRunAt = &lastRunAt.Time
 		}
@@ -3299,12 +3301,12 @@ func (s *SQLiteStore) UpdateScheduledTask(ctx context.Context, id string, update
 				name = ?, description = ?, prompt = ?, model = ?,
 				permission_mode = ?, frequency = ?, cron_expression = ?,
 				schedule_hour = ?, schedule_minute = ?, schedule_day_of_week = ?, schedule_day_of_month = ?,
-				enabled = ?, last_run_at = ?, next_run_at = ?, updated_at = ?
+				enabled = ?, archived = ?, last_run_at = ?, next_run_at = ?, updated_at = ?
 			WHERE id = ?`,
 			task.Name, task.Description, task.Prompt, task.Model,
 			task.PermissionMode, task.Frequency, task.CronExpression,
 			task.ScheduleHour, task.ScheduleMinute, task.ScheduleDayOfWeek, task.ScheduleDayOfMonth,
-			boolToInt(task.Enabled), task.LastRunAt, task.NextRunAt, task.UpdatedAt, id)
+			boolToInt(task.Enabled), boolToInt(task.Archived), task.LastRunAt, task.NextRunAt, task.UpdatedAt, id)
 		return err
 	})
 }
@@ -3329,9 +3331,9 @@ func (s *SQLiteStore) ListDueScheduledTasks(ctx context.Context, before time.Tim
 		SELECT id, workspace_id, name, description, prompt, model,
 			permission_mode, frequency, cron_expression,
 			schedule_hour, schedule_minute, schedule_day_of_week, schedule_day_of_month,
-			enabled, last_run_at, next_run_at, created_at, updated_at
+			enabled, archived, last_run_at, next_run_at, created_at, updated_at
 		FROM scheduled_tasks
-		WHERE enabled = 1 AND next_run_at IS NOT NULL AND next_run_at <= ?
+		WHERE enabled = 1 AND archived = 0 AND next_run_at IS NOT NULL AND next_run_at <= ?
 		ORDER BY next_run_at ASC`, before)
 	if err != nil {
 		return nil, fmt.Errorf("ListDueScheduledTasks: %w", err)

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -333,12 +333,14 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
       grouped[taskId].sessions.push(session);
     }
 
-    return Object.entries(grouped).map(([taskId, data]) => ({
-      taskId,
-      taskName: data.taskName,
-      task: scheduledTasks.find((t) => t.id === taskId),
-      sessions: data.sessions,
-    }));
+    return Object.entries(grouped)
+      .filter(([taskId]) => scheduledTasks.some((t) => t.id === taskId))
+      .map(([taskId, data]) => ({
+        taskId,
+        taskName: data.taskName,
+        task: scheduledTasks.find((t) => t.id === taskId),
+        sessions: data.sessions,
+      }));
   }, [scheduledSessionsList, scheduledTasks]);
 
   const formatTimeAgo = (date: string) => {

--- a/src/components/scheduled/ScheduledTaskDetailView.tsx
+++ b/src/components/scheduled/ScheduledTaskDetailView.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/dialog';
 import {
   AlertCircle,
+  Archive,
   ChevronLeft,
   Clock,
   Folder,
@@ -42,7 +43,7 @@ interface ScheduledTaskDetailViewProps {
 }
 
 export function ScheduledTaskDetailView({ taskId }: ScheduledTaskDetailViewProps) {
-  const { tasks, runs, fetchTasks, fetchRuns, toggleEnabled, deleteTask, triggerNow } =
+  const { tasks, runs, fetchTasks, fetchRuns, toggleEnabled, deleteTask, archiveTask, triggerNow } =
     useScheduledTaskStore();
   const workspaces = useAppStore(useShallow((s) => s.workspaces));
 
@@ -55,6 +56,7 @@ export function ScheduledTaskDetailView({ taskId }: ScheduledTaskDetailViewProps
 
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [isTriggering, setIsTriggering] = useState(false);
 
@@ -98,6 +100,18 @@ export function ScheduledTaskDetailView({ taskId }: ScheduledTaskDetailViewProps
       setDeleteDialogOpen(false);
     }
   }, [taskId, deleteTask]);
+
+  const handleConfirmArchive = useCallback(async () => {
+    setActionError(null);
+    try {
+      await archiveTask(taskId);
+      navigate({ contentView: { type: 'scheduled-tasks' } });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to archive task');
+    } finally {
+      setArchiveDialogOpen(false);
+    }
+  }, [taskId, archiveTask]);
 
   const handleToggleEnabled = useCallback(async () => {
     setActionError(null);
@@ -214,6 +228,14 @@ export function ScheduledTaskDetailView({ taskId }: ScheduledTaskDetailViewProps
                   onClick={() => setEditDialogOpen(true)}
                 >
                   <Pencil className="w-4 h-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => setArchiveDialogOpen(true)}
+                >
+                  <Archive className="w-4 h-4" />
                 </Button>
                 <Button
                   variant="ghost"
@@ -372,6 +394,25 @@ export function ScheduledTaskDetailView({ taskId }: ScheduledTaskDetailViewProps
             <Button variant="destructive" onClick={handleConfirmDelete}>
               Delete
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Archive confirmation dialog */}
+      <Dialog open={archiveDialogOpen} onOpenChange={(open) => !open && setArchiveDialogOpen(false)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Archive scheduled task</DialogTitle>
+            <DialogDescription>
+              &ldquo;{task.name}&rdquo; will be hidden from the sidebar. Its run history is
+              preserved.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setArchiveDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleConfirmArchive}>Archive</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -938,6 +938,7 @@ export interface ScheduledTask {
   scheduleDayOfWeek: number;
   scheduleDayOfMonth: number;
   enabled: boolean;
+  archived: boolean;
   lastRunAt?: string;
   nextRunAt?: string;
   createdAt: string;

--- a/src/stores/scheduledTaskStore.ts
+++ b/src/stores/scheduledTaskStore.ts
@@ -13,6 +13,7 @@ interface ScheduledTaskState {
   createTask: (workspaceId: string, data: CreateScheduledTaskRequest) => Promise<ScheduledTask>;
   updateTask: (taskId: string, updates: Partial<ScheduledTask>) => Promise<void>;
   deleteTask: (taskId: string) => Promise<void>;
+  archiveTask: (taskId: string) => Promise<void>;
   toggleEnabled: (taskId: string) => Promise<void>;
   fetchRuns: (taskId: string) => Promise<void>;
   triggerNow: (taskId: string) => Promise<void>;
@@ -50,6 +51,17 @@ export const useScheduledTaskStore = create<ScheduledTaskState>((set, get) => ({
 
   deleteTask: async (taskId) => {
     await api.deleteScheduledTask(taskId);
+    set((state) => {
+      const { [taskId]: _, ...remainingRuns } = state.runs;
+      return {
+        tasks: state.tasks.filter((t) => t.id !== taskId),
+        runs: remainingRuns,
+      };
+    });
+  },
+
+  archiveTask: async (taskId) => {
+    await api.updateScheduledTask(taskId, { archived: true });
     set((state) => {
       const { [taskId]: _, ...remainingRuns } = state.runs;
       return {


### PR DESCRIPTION
## Summary

- Adds an **Archive** button to the scheduled task detail view, which soft-deletes the task (preserving run history)
- Archived tasks are excluded from all list/scheduler queries via `WHERE archived = 0`, so they stop running immediately
- Sidebar filters out scheduled session groups whose parent task is archived
- Archiving an enabled task clears `next_run_at` to prevent stale immediate-fire if an unarchive feature is added later

## Changes

| Layer | Change |
|-------|--------|
| DB | Migration v10: `ALTER TABLE scheduled_tasks ADD COLUMN archived INTEGER NOT NULL DEFAULT 0` |
| Go model | `Archived bool` field on `ScheduledTask` |
| Go store | `archived` column in all 4 queries (INSERT, GET, LIST×2, UPDATE, LIST_DUE); list queries filter `archived = 0` |
| Go handler | `Archived *bool` in `UpdateScheduledTaskRequest`; clearing `NextRunAt` on archive |
| TS types | `archived: boolean` (non-optional, matching backend contract) |
| TS store | `archiveTask(taskId)` action — calls PATCH, removes from local state |
| Frontend | Archive icon button + confirmation dialog in `ScheduledTaskDetailView` |
| Sidebar | Filters `scheduledGroups` to only tasks present in the active (non-archived) task list |

## Test plan

- [ ] Create a scheduled task and navigate to its detail view
- [ ] Click the archive icon button — confirm dialog appears with task name
- [ ] Confirm archive — view navigates back to the scheduled tasks list; task is no longer shown
- [ ] Verify the task's run history sessions are still accessible (via direct navigation if needed)
- [ ] Confirm the scheduler does not fire the archived task at its next scheduled time
- [ ] Check DB directly: `archived = 1`, `next_run_at = NULL` for the archived task

🤖 Generated with [Claude Code](https://claude.com/claude-code)