### PR TITLE
fix(review): propagate model to store when creating review conversation

### DIFF
--- a/src/hooks/useReviewTrigger.ts
+++ b/src/hooks/useReviewTrigger.ts
@@ -321,6 +321,7 @@ export function useReviewTrigger() {
           type: conv.type,
           name: conv.name,
           status: conv.status,
+          model: conv.model,
           messages: [],
           toolSummary: [],
           createdAt: conv.createdAt,


### PR DESCRIPTION
## Summary

- When starting a Review tab, the `reviewModel` was sent to the backend but not stored in the frontend Zustand store — causing the composer to show the wrong model.
- The composer fell back to `defaultModel` (e.g. Opus) initially, then switched to the actual review model (e.g. Haiku) only after the `model_changed` WebSocket event arrived.

## Changes Made

- **`src/hooks/useReviewTrigger.ts`** — Added `model: conv.model` to the `addConversation` call so the frontend store immediately reflects the model the backend assigned to the review conversation.

## Test Plan

- [ ] Set `reviewModel` in Settings to a model different from `defaultModel` (e.g. Haiku vs Opus)
- [ ] Start a Review tab — composer should immediately show the review model, not the default
- [ ] Confirm no flash/switch occurs once the agent starts running
- [ ] `npm run lint` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)