### PR TITLE
fix(sessions): skip hidden base session when auto-selecting after archive

### DIFF
--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1130,8 +1130,12 @@ export const useAppStore = create<AppState>((set, get) => ({
     let newSelectedConversationId = state.selectedConversationId;
 
     if (state.selectedSessionId === id) {
+      const { showBaseBranchSessions } = useSettingsStore.getState();
       const otherSessions = updatedSessions.filter(
-        (s) => s.workspaceId === session.workspaceId && !s.archived
+        (s) =>
+          s.workspaceId === session.workspaceId &&
+          !s.archived &&
+          (s.sessionType !== 'base' || showBaseBranchSessions)
       );
       newSelectedSessionId = otherSessions[0]?.id || null;
 


### PR DESCRIPTION
## Summary

- When archiving the last non-base session in a project, the app incorrectly auto-selected the base session even when it was hidden in settings (`showBaseBranchSessions = false`, the default).
- The replacement-session picker now reads `showBaseBranchSessions` from the settings store and excludes base sessions from candidates when the setting is off.

## Changes Made

- **`src/stores/appStore.ts`** — `archiveSession` action: added `showBaseBranchSessions` check to the `otherSessions` filter so base sessions are only considered as fallback when they are actually visible in the sidebar.

## Test Plan

- [ ] Create a project with one worktree session; ensure base session is hidden (default setting). Archive the session — confirm no session is selected (not the base session).
- [ ] Enable `showBaseBranchSessions`, archive the last worktree session — confirm the base session is now correctly selected.
- [ ] `npm run lint` passes
- [ ] `npm run build` passes (TypeScript clean)