### PR TITLE
feat: upgrade Claude Agent SDK to 0.2.112, add Opus 4.7 support

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.94",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.112",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -18,13 +18,13 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.96",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.96.tgz",
-      "integrity": "sha512-EK2L4xpcWMNRSE7Zr0mjty/LCB4q60FmUjI+Z0ui91sd3xL1BVj6fhoZsfZFb9IYWkA309IIcrDIfvJXD8yNbw==",
+      "version": "0.2.112",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.112.tgz",
+      "integrity": "sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.80.0",
-        "@modelcontextprotocol/sdk": "^1.27.1"
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
-      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.94",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.112",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -1,5 +1,6 @@
 import {
   query,
+  startup,
   forkSession as sdkForkSession,
   // Message types
   type SDKMessage,
@@ -25,6 +26,8 @@ import {
   // Message types (SDK 0.2.84)
   type SDKAPIRetryMessage,
   type SDKSessionStateChangedMessage,
+  // Message types (SDK 0.2.105)
+  type SDKMemoryRecallMessage,
   // Core types
   type AgentDefinition,
   type Query,
@@ -2071,21 +2074,9 @@ async function main(): Promise<void> {
   lifecycle("input queue ready");
 
   // Pre-warm the CLI subprocess so the first query() is ~20x faster (SDK 0.2.89+)
-  // startup() is exported at runtime but not yet in the SDK's .d.ts — access via require().
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const sdkModule = require("@anthropic-ai/claude-agent-sdk") as Record<string, unknown>;
-    const startupFn = sdkModule.startup as ((opts: { cwd: string }) => Promise<void>) | undefined;
-    if (startupFn) {
-      const STARTUP_TIMEOUT_MS = 5_000;
-      await Promise.race([
-        startupFn({ cwd }),
-        new Promise<void>((_, reject) =>
-          setTimeout(() => reject(new Error("startup() timed out")), STARTUP_TIMEOUT_MS),
-        ),
-      ]);
-      lifecycle("CLI subprocess pre-warmed");
-    }
+    await startup({ initializeTimeoutMs: 5_000 });
+    lifecycle("CLI subprocess pre-warmed");
   } catch (e) {
     // Non-fatal: failure or timeout just means normal cold start on first query
     lifecycle(`startup() pre-warm failed (non-fatal): ${e}`);
@@ -2783,7 +2774,7 @@ function handleMessage(message: SDKMessage): void {
           subtype: "success",
           summary: resultMsg.result,
           stopReason: resultMsg.stop_reason,
-          terminalReason: (resultMsg as Record<string, unknown>).terminal_reason,
+          terminalReason: resultMsg.terminal_reason,
           cost: resultMsg.total_cost_usd,
           turns: resultMsg.num_turns,
           durationMs: resultMsg.duration_ms,
@@ -2814,7 +2805,7 @@ function handleMessage(message: SDKMessage): void {
           success: false,
           subtype: resultMsg.subtype,
           stopReason: resultMsg.stop_reason,
-          terminalReason: (resultMsg as Record<string, unknown>).terminal_reason,
+          terminalReason: resultMsg.terminal_reason,
           errors: resultErrors,
           cost: resultMsg.total_cost_usd,
           turns: resultMsg.num_turns,
@@ -2872,7 +2863,7 @@ function handleMessage(message: SDKMessage): void {
     }
 
     case "system": {
-      const sysMsg = message as SDKSystemMessage | SDKCompactBoundaryMessage | SDKStatusMessage | SDKHookResponseMessage | SDKTaskNotificationMessage | SDKTaskStartedMessage | SDKTaskProgressMessage | SDKFilesPersistedEvent | SDKElicitationCompleteMessage | SDKHookProgressMessage | SDKHookStartedMessage | SDKAPIRetryMessage | SDKSessionStateChangedMessage;
+      const sysMsg = message as SDKSystemMessage | SDKCompactBoundaryMessage | SDKStatusMessage | SDKHookResponseMessage | SDKTaskNotificationMessage | SDKTaskStartedMessage | SDKTaskProgressMessage | SDKFilesPersistedEvent | SDKElicitationCompleteMessage | SDKHookProgressMessage | SDKHookStartedMessage | SDKAPIRetryMessage | SDKSessionStateChangedMessage | SDKMemoryRecallMessage;
 
       if (sysMsg.subtype === "init") {
         const initMsg = sysMsg as SDKSystemMessage;
@@ -3052,6 +3043,14 @@ function handleMessage(message: SDKMessage): void {
           type: "session_state_changed",
           state: stateMsg.state,
           sessionId: stateMsg.session_id,
+        });
+      } else if (sysMsg.subtype === "memory_recall") {
+        // Memory recall (SDK 0.2.105) — agent surfaced relevant memories
+        const memMsg = sysMsg as SDKMemoryRecallMessage;
+        emit({
+          type: "memory_recall",
+          mode: memMsg.mode,
+          memories: memMsg.memories,
         });
       }
       break;

--- a/backend/agent/core_types.go
+++ b/backend/agent/core_types.go
@@ -143,6 +143,8 @@ const (
 	EventTypeAPIRetry            = coreagent.EventTypeAPIRetry
 	EventTypeSessionStateChanged = coreagent.EventTypeSessionStateChanged
 
+	EventTypeMemoryRecall = coreagent.EventTypeMemoryRecall
+
 	// ChatML-specific events (emitted by agent-runner, not the Claude SDK)
 	EventTypeMessageReceived = "message_received"
 )

--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -1077,8 +1077,8 @@ outer:
 			case EventTypeAPIRetry:
 				logger.Manager.Debugf("[%s] API retry attempt %d/%d (status %d, delay %dms)", convID, event.Attempt, event.MaxRetries, event.ErrorStatus, event.RetryDelayMs)
 
-			case EventTypeCwdChanged, EventTypeFileChanged, EventTypeTaskCreated, EventTypeSessionStateChanged:
-				// Informational — no state tracking needed
+			case EventTypeCwdChanged, EventTypeFileChanged, EventTypeTaskCreated, EventTypeSessionStateChanged, EventTypeMemoryRecall:
+				// Informational — no state tracking needed, forwarded to frontend via onConversationEvent
 
 			case EventTypeTurnComplete, EventTypeComplete, EventTypeResult:
 				// Atomically clear the active turn flag and take any deferred
@@ -2323,9 +2323,9 @@ func (m *Manager) GetActiveStreamingConversations() []string {
 }
 
 // betasForModel returns comma-separated beta flags for the given model.
-// Opus 4.6 and Sonnet 4.6 support 1M context window via the context-1m beta.
+// Opus 4.7, Opus 4.6, and Sonnet 4.6 support 1M context window via the context-1m beta.
 func betasForModel(model string) string {
-	if strings.Contains(model, "opus-4-6") || strings.Contains(model, "sonnet-4-6") {
+	if strings.Contains(model, "opus-4-7") || strings.Contains(model, "opus-4-6") || strings.Contains(model, "sonnet-4-6") {
 		return "context-1m-2025-08-07"
 	}
 	return ""

--- a/core/agent/parser.go
+++ b/core/agent/parser.go
@@ -440,6 +440,9 @@ const (
 	EventTypeTaskCreated         = "task_created"
 	EventTypeAPIRetry            = "api_retry"
 	EventTypeSessionStateChanged = "session_state_changed"
+
+	// New event types from SDK 0.2.105
+	EventTypeMemoryRecall = "memory_recall"
 )
 
 // TodoItem represents a single todo item from the agent's TodoWrite tool

--- a/core/cmd/nativeloop/wizard.go
+++ b/core/cmd/nativeloop/wizard.go
@@ -140,7 +140,7 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "enter":
 				switch m.selected {
 				case 0:
-					m.model = "claude-opus-4-6"
+					m.model = "claude-opus-4-7"
 				case 1:
 					m.model = "claude-sonnet-4-6"
 				case 2:

--- a/core/loop/factory.go
+++ b/core/loop/factory.go
@@ -270,6 +270,8 @@ func modelInfo(model string) (marketingName, modelID, cutoff string) {
 	}
 
 	switch {
+	case strings.Contains(model, "opus-4-7"):
+		return "Opus 4.7 (1M context)", model, "May 2025"
 	case strings.Contains(model, "opus-4-6"):
 		return "Opus 4.6 (1M context)", model, "May 2025"
 	case strings.Contains(model, "sonnet-4-6"):
@@ -304,7 +306,7 @@ func resolveModelAlias(model string) string {
 	case "sonnet":
 		return "claude-sonnet-4-6"
 	case "opus":
-		return "claude-opus-4-6"
+		return "claude-opus-4-7"
 	default:
 		return model // Already a full model ID
 	}

--- a/core/prompt/builder.go
+++ b/core/prompt/builder.go
@@ -222,7 +222,7 @@ func (b *Builder) environmentSection() string {
 	}
 
 	// Latest model family info
-	parts = append(parts, " - The most recent Claude model family is Claude 4.5/4.6. Model IDs — Opus 4.6: 'claude-opus-4-6', Sonnet 4.6: 'claude-sonnet-4-6', Haiku 4.5: 'claude-haiku-4-5-20251001'. When building AI applications, default to the latest and most capable Claude models.")
+	parts = append(parts, " - The latest Claude models include: Opus 4.7 ('claude-opus-4-7'), Sonnet 4.6 ('claude-sonnet-4-6'), Haiku 4.5 ('claude-haiku-4-5-20251001'). When building AI applications, default to the latest and most capable Claude models.")
 
 	// Claude Code availability
 	parts = append(parts, " - Claude Code is available as a CLI in the terminal, desktop app (Mac/Windows), web app (claude.ai/code), and IDE extensions (VS Code, JetBrains).")

--- a/core/provider/anthropic/client.go
+++ b/core/provider/anthropic/client.go
@@ -28,6 +28,7 @@ const (
 
 // modelContextWindows maps model IDs to their context window sizes.
 var modelContextWindows = map[string]int{
+	"claude-opus-4-7":            1000000,
 	"claude-opus-4-6":            1000000,
 	"claude-sonnet-4-6":          200000,
 	"claude-haiku-4-5-20251001":  200000,

--- a/core/provider/cost.go
+++ b/core/provider/cost.go
@@ -12,6 +12,12 @@ type modelCost struct {
 
 // Model pricing as of 2025 (USD per million tokens).
 var modelCosts = map[string]modelCost{
+	"claude-opus-4-7": {
+		InputPerMillion:         15.0,
+		OutputPerMillion:        75.0,
+		CacheReadPerMillion:     1.5,
+		CacheCreationPerMillion: 18.75,
+	},
 	"claude-opus-4-6": {
 		InputPerMillion:         15.0,
 		OutputPerMillion:        75.0,

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1158,6 +1158,12 @@ export function useWebSocket(enabled: boolean = true) {
         break;
       }
 
+      case 'memory_recall': {
+        // Memory recall (SDK 0.2.105) — agent surfaced relevant memories into the turn
+        // Informational; no state tracking needed for now
+        break;
+      }
+
       case 'cwd_changed': {
         // Working directory changed — dispatch custom event for file tree refresh
         window.dispatchEvent(new CustomEvent('cwd-changed', {

--- a/src/hooks/useWebSocketHelpers.ts
+++ b/src/hooks/useWebSocketHelpers.ts
@@ -142,6 +142,8 @@ export const BATCHABLE_EVENTS = new Set([
   'api_retry', 'session_state_changed', 'stop_failure',
   'cwd_changed', 'file_changed', 'task_created',
   'task_started', 'task_progress', 'task_stopped',
+  // SDK 0.2.105+ events
+  'memory_recall',
   // Agent-runner custom events
   'message_received',
 ]);

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -13,7 +13,7 @@ const { getModelDisplayName, getModelInfo, getModelDescription, buildTurnConfigL
 
 describe('getModelDisplayName', () => {
   it('returns short display name for known static models', () => {
-    expect(getModelDisplayName('claude-opus-4-6')).toBe('Opus 4.6 (1M context)');
+    expect(getModelDisplayName('claude-opus-4-7')).toBe('Opus 4.7 (1M context)');
     expect(getModelDisplayName('claude-sonnet-4-6')).toBe('Sonnet 4.6');
     expect(getModelDisplayName('claude-haiku-4-5-20251001')).toBe('Haiku 4.5');
   });
@@ -56,13 +56,13 @@ describe('getModelDisplayName', () => {
 
 describe('toShortDisplayName', () => {
   it('returns canonical name for known models', () => {
-    expect(toShortDisplayName('claude-opus-4-6', 'Claude Opus 4.6')).toBe('Opus 4.6 (1M context)');
+    expect(toShortDisplayName('claude-opus-4-7', 'Claude Opus 4.7')).toBe('Opus 4.7 (1M context)');
     expect(toShortDisplayName('claude-sonnet-4-6', 'Claude Sonnet 4.6')).toBe('Sonnet 4.6');
     expect(toShortDisplayName('claude-haiku-4-5-20251001', 'Claude Haiku 4.5')).toBe('Haiku 4.5');
   });
 
   it('returns same canonical name for extended context variant', () => {
-    expect(toShortDisplayName('claude-opus-4-6[1m]', 'Claude Opus 4.6 1M')).toBe('Opus 4.6 (1M context)');
+    expect(toShortDisplayName('claude-opus-4-7[1m]', 'Claude Opus 4.7 1M')).toBe('Opus 4.7 (1M context)');
   });
 
   it('handles dated model variants', () => {
@@ -80,13 +80,13 @@ describe('toShortDisplayName', () => {
 
 describe('getModelDescription', () => {
   it('returns description for known models', () => {
-    expect(getModelDescription('claude-opus-4-6')).toBe('Most capable for ambitious work');
+    expect(getModelDescription('claude-opus-4-7')).toBe('Most capable for ambitious work');
     expect(getModelDescription('claude-sonnet-4-6')).toBe('Most efficient for everyday tasks');
     expect(getModelDescription('claude-haiku-4-5-20251001')).toBe('Fastest for quick answers');
   });
 
   it('returns same description for extended context variant', () => {
-    expect(getModelDescription('claude-opus-4-6[1m]')).toBe('Most capable for ambitious work');
+    expect(getModelDescription('claude-opus-4-7[1m]')).toBe('Most capable for ambitious work');
   });
 
   it('returns undefined for unknown models', () => {
@@ -96,10 +96,10 @@ describe('getModelDescription', () => {
 
 describe('getModelInfo', () => {
   it('returns info for known static models', () => {
-    const opus = getModelInfo('claude-opus-4-6');
+    const opus = getModelInfo('claude-opus-4-7');
     expect(opus).toBeDefined();
-    expect(opus!.id).toBe('claude-opus-4-6');
-    expect(opus!.name).toBe('Opus 4.6 (1M context)');
+    expect(opus!.id).toBe('claude-opus-4-7');
+    expect(opus!.name).toBe('Opus 4.7 (1M context)');
     expect(opus!.description).toBe('Most capable for ambitious work');
     expect(opus!.supportsThinking).toBe(true);
     expect(opus!.supportsEffort).toBe(true);
@@ -110,10 +110,10 @@ describe('getModelInfo', () => {
   });
 
   it('resolves variant model IDs with [1m] suffix', () => {
-    const info = getModelInfo('claude-opus-4-6[1m]');
+    const info = getModelInfo('claude-opus-4-7[1m]');
     expect(info).toBeDefined();
-    expect(info!.id).toBe('claude-opus-4-6');
-    expect(info!.name).toBe('Opus 4.6 (1M context)');
+    expect(info!.id).toBe('claude-opus-4-7');
+    expect(info!.name).toBe('Opus 4.7 (1M context)');
     expect(info!.supportsThinking).toBe(true);
   });
 
@@ -136,8 +136,8 @@ describe('getModelInfo', () => {
       ...useAppStore.getState(),
       supportedModels: [
         {
-          value: 'claude-opus-4-6',
-          displayName: 'Claude Opus 4.6',
+          value: 'claude-opus-4-7',
+          displayName: 'Claude Opus 4.7',
           description: 'Most capable',
           supportsAdaptiveThinking: true,
           supportsEffort: true,
@@ -156,7 +156,7 @@ describe('getModelInfo', () => {
     } as ReturnType<typeof useAppStore.getState>);
 
     try {
-      const opus = getModelInfo('claude-opus-4-6');
+      const opus = getModelInfo('claude-opus-4-7');
       expect(opus).toBeDefined();
       expect(opus!.supportsFastMode).toBe(true);
 
@@ -186,7 +186,7 @@ describe('buildTurnConfigLabel', () => {
   });
 
   it('returns model display name only', () => {
-    expect(buildTurnConfigLabel({ model: 'claude-opus-4-6' })).toBe('Opus 4.6 (1M context)');
+    expect(buildTurnConfigLabel({ model: 'claude-opus-4-7' })).toBe('Opus 4.7 (1M context)');
   });
 
   it('returns effort only', () => {
@@ -203,8 +203,8 @@ describe('buildTurnConfigLabel', () => {
   });
 
   it('combines all three parts', () => {
-    const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', effort: 'high', permissionMode: 'plan' });
-    expect(label).toBe('Opus 4.6 (1M context) \u00b7 high effort \u00b7 plan mode');
+    const label = buildTurnConfigLabel({ model: 'claude-opus-4-7', effort: 'high', permissionMode: 'plan' });
+    expect(label).toBe('Opus 4.7 (1M context) \u00b7 high effort \u00b7 plan mode');
   });
 
   it('handles Bedrock ARN in label', () => {
@@ -224,8 +224,8 @@ describe('buildTurnConfigLabel', () => {
   });
 
   it('shows fast label when fastModeState is on', () => {
-    const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', fastModeState: 'on' });
-    expect(label).toBe('Opus 4.6 (1M context) \u00b7 fast');
+    const label = buildTurnConfigLabel({ model: 'claude-opus-4-7', fastModeState: 'on' });
+    expect(label).toBe('Opus 4.7 (1M context) \u00b7 fast');
   });
 
   it('shows cooldown label when fastModeState is cooldown', () => {
@@ -234,8 +234,8 @@ describe('buildTurnConfigLabel', () => {
   });
 
   it('omits fast label when fastModeState is off', () => {
-    const label = buildTurnConfigLabel({ model: 'claude-opus-4-6', fastModeState: 'off' });
-    expect(label).toBe('Opus 4.6 (1M context)');
+    const label = buildTurnConfigLabel({ model: 'claude-opus-4-7', fastModeState: 'off' });
+    expect(label).toBe('Opus 4.7 (1M context)');
   });
 });
 
@@ -243,8 +243,8 @@ describe('buildStaticModelList', () => {
   it('returns static entries with defaults when SDK models is empty', () => {
     const result = buildStaticModelList([]);
     expect(result).toHaveLength(MODELS.length);
-    expect(result[0].id).toBe('claude-opus-4-6');
-    expect(result[0].name).toBe('Opus 4.6 (1M context)');
+    expect(result[0].id).toBe('claude-opus-4-7');
+    expect(result[0].name).toBe('Opus 4.7 (1M context)');
     expect(result[0].supportsEffort).toBe(true);
     expect(result[0].supportsFastMode).toBe(true);
   });
@@ -252,8 +252,8 @@ describe('buildStaticModelList', () => {
   it('enriches capabilities from SDK models', () => {
     const sdkModels = [
       {
-        value: 'claude-opus-4-6',
-        displayName: 'Claude Opus 4.6',
+        value: 'claude-opus-4-7',
+        displayName: 'Claude Opus 4.7',
         supportsAdaptiveThinking: true,
         supportsEffort: true,
         supportedEffortLevels: ['low', 'medium', 'high', 'max'] as const,
@@ -261,7 +261,7 @@ describe('buildStaticModelList', () => {
       },
     ];
     const result = buildStaticModelList(sdkModels);
-    const opus = result.find((m) => m.id === 'claude-opus-4-6')!;
+    const opus = result.find((m) => m.id === 'claude-opus-4-7')!;
     expect(opus.supportsEffort).toBe(true);
     expect(opus.supportedEffortLevels).toEqual(['low', 'medium', 'high', 'max']);
     expect(opus.supportsFastMode).toBe(true);
@@ -270,14 +270,14 @@ describe('buildStaticModelList', () => {
   it('matches SDK variants with [1m] suffix to catalog entries', () => {
     const sdkModels = [
       {
-        value: 'claude-opus-4-6[1m]',
-        displayName: 'Claude Opus 4.6 1M',
+        value: 'claude-opus-4-7[1m]',
+        displayName: 'Claude Opus 4.7 1M',
         supportsEffort: true,
         supportedEffortLevels: ['low', 'high'] as const,
       },
     ];
     const result = buildStaticModelList(sdkModels);
-    const opus = result.find((m) => m.id === 'claude-opus-4-6')!;
+    const opus = result.find((m) => m.id === 'claude-opus-4-7')!;
     expect(opus.supportedEffortLevels).toEqual(['low', 'high']);
   });
 
@@ -300,7 +300,7 @@ describe('buildStaticModelList', () => {
   it('does not add unknown SDK models to the list', () => {
     const sdkModels = [
       { value: 'claude-opus-4', displayName: 'Claude Opus (1M context)' },
-      { value: 'claude-opus-4-6', displayName: 'Claude Opus 4.6 (1M context)' },
+      { value: 'claude-opus-4-7', displayName: 'Claude Opus 4.7 (1M context)' },
       { value: 'some-unknown-model', displayName: 'Unknown Model' },
     ];
     const result = buildStaticModelList(sdkModels);
@@ -311,25 +311,25 @@ describe('buildStaticModelList', () => {
   it('always returns models in catalog order', () => {
     const sdkModels = [
       { value: 'claude-haiku-4-5-20251001', displayName: 'Claude Haiku 4.5' },
-      { value: 'claude-opus-4-6', displayName: 'Claude Opus 4.6' },
+      { value: 'claude-opus-4-7', displayName: 'Claude Opus 4.7' },
       { value: 'claude-sonnet-4-6', displayName: 'Claude Sonnet 4.6' },
     ];
     const result = buildStaticModelList(sdkModels);
-    expect(result[0].id).toBe('claude-opus-4-6');
+    expect(result[0].id).toBe('claude-opus-4-7');
     expect(result[1].id).toBe('claude-sonnet-4-6');
     expect(result[2].id).toBe('claude-haiku-4-5-20251001');
   });
 
   it('never shows duplicate opus entries regardless of SDK variants', () => {
     const sdkModels = [
-      { value: 'claude-opus-4-6', displayName: 'Claude Opus 4.6 (1M context)' },
+      { value: 'claude-opus-4-7', displayName: 'Claude Opus 4.7 (1M context)' },
+      { value: 'claude-opus-4-7[1m]', displayName: 'Claude Opus 4.7 1M' },
       { value: 'claude-opus-4', displayName: 'Claude Opus (1M context)' },
-      { value: 'claude-opus-4-6[1m]', displayName: 'Claude Opus 4.6 1M' },
     ];
     const result = buildStaticModelList(sdkModels);
     const opusEntries = result.filter((m) => m.id.includes('opus'));
     expect(opusEntries).toHaveLength(1);
-    expect(opusEntries[0].id).toBe('claude-opus-4-6');
+    expect(opusEntries[0].id).toBe('claude-opus-4-7');
   });
 });
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -13,7 +13,7 @@ interface ModelCatalogEntry {
 /** Canonical display names and descriptions, keyed by base model ID. */
 const MODEL_CATALOG: Record<string, ModelCatalogEntry> = {
   // Cloud models (Anthropic)
-  'claude-opus-4-6':   { displayName: 'Opus 4.6 (1M context)', description: 'Most capable for ambitious work' },
+  'claude-opus-4-7':   { displayName: 'Opus 4.7 (1M context)', description: 'Most capable for ambitious work' },
   'claude-sonnet-4-6': { displayName: 'Sonnet 4.6',            description: 'Most efficient for everyday tasks' },
   'claude-haiku-4-5':  { displayName: 'Haiku 4.5',             description: 'Fastest for quick answers' },
   // Local models (Ollama) — keep in sync with backend/ollama/models.go
@@ -66,7 +66,7 @@ export function getModelDescription(sdkValue: string): string | undefined {
 // toBaseId handles the mapping transparently.
 export const MODELS = [
   // Cloud models
-  { id: 'claude-opus-4-6', name: MODEL_CATALOG['claude-opus-4-6'].displayName, description: MODEL_CATALOG['claude-opus-4-6'].description, provider: 'claude' as const, supportsThinking: true, supportsEffort: true, supportsFastMode: true },
+  { id: 'claude-opus-4-7', name: MODEL_CATALOG['claude-opus-4-7'].displayName, description: MODEL_CATALOG['claude-opus-4-7'].description, provider: 'claude' as const, supportsThinking: true, supportsEffort: true, supportsFastMode: true },
   { id: 'claude-sonnet-4-6', name: MODEL_CATALOG['claude-sonnet-4-6'].displayName, description: MODEL_CATALOG['claude-sonnet-4-6'].description, provider: 'claude' as const, supportsThinking: true, supportsEffort: true, supportsFastMode: true },
   { id: 'claude-haiku-4-5-20251001', name: MODEL_CATALOG['claude-haiku-4-5'].displayName, description: MODEL_CATALOG['claude-haiku-4-5'].description, provider: 'claude' as const, supportsThinking: true, supportsEffort: false, supportsFastMode: false },
   // Local models

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -540,6 +540,9 @@ export interface AgentEvent {
   // Session state changed fields (SDK 0.2.84)
   state?: string;
 
+  // Memory recall fields (SDK 0.2.105)
+  memories?: unknown[];
+
   // Agent-runner message acknowledgment
   messageUuid?: string;
 }


### PR DESCRIPTION
## Summary

- **SDK upgrade**: Bumps `@anthropic-ai/claude-agent-sdk` from `0.2.94` to `0.2.112`
- **New model**: Adds `claude-opus-4-7` support across all layers — pricing, context window, model catalog, betas, wizard, prompt builder, and frontend
- **New event**: Adds `memory_recall` event type (SDK 0.2.105) through agent-runner → Go backend → React frontend
- **Cleanup**: Replaces `startup()` workaround with proper typed import, removes `terminal_reason` type casts now that SDK exports proper types

### Changed files by area

| Area | Files | What changed |
|------|-------|-------------|
| Agent Runner | `package.json`, `package-lock.json`, `src/index.ts` | SDK bump, `startup()` migration, `memory_recall` handler, `terminal_reason` cleanup |
| Core (Go) | `parser.go`, `factory.go`, `wizard.go`, `builder.go`, `cost.go`, `client.go` | Opus 4.7 model info, pricing, context window, alias, prompt text |
| Backend (Go) | `core_types.go`, `manager.go` | `memory_recall` event constant, betas for opus-4-7 |
| Frontend (TS) | `models.ts`, `models.test.ts`, `types.ts`, `useWebSocket.ts`, `useWebSocketHelpers.ts` | Opus 4.7 catalog entry, `memory_recall` handler + batching, `memories` type field |

## Test plan

- [ ] `npm run test:run` — frontend model tests updated for opus-4-7
- [ ] `cd backend && go test -race ./...` — backend tests pass
- [ ] Verify opus-4-7 appears in model picker and resolves from "opus" alias
- [ ] Verify `startup()` pre-warm still works on agent launch
- [ ] Verify `memory_recall` events are forwarded without flushing text batcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)