### PR TITLE
style(chat): tint user message bubbles blue via theme token

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -237,6 +237,9 @@ code.hljs { padding: 3px 5px; }
   --nav-icon-prs: #7c3aed;
   --nav-icon-skills: oklch(0.65 0.18 85);
   --brand: oklch(0.623 0.214 292);
+
+  /* User message bubble (light mode) — tailwind blue-50 */
+  --user-bubble: #eff6ff;
 }
 
 .dark {
@@ -319,6 +322,9 @@ code.hljs { padding: 3px 5px; }
   --nav-icon-prs: #a78bfa;
   --nav-icon-skills: #fbbf24;
   --brand: oklch(0.707 0.165 292);
+
+  /* User message bubble (dark mode) — tailwind blue-950 at 40% opacity over chat bg */
+  --user-bubble: rgba(23, 37, 84, 0.4);
 }
 
 @theme inline {
@@ -393,6 +399,9 @@ code.hljs { padding: 3px 5px; }
   --radius-xl: calc(var(--radius) + 4px);
   --radius-2xl: calc(var(--radius) + 8px);
   --color-brand: var(--brand);
+
+  /* User message bubble background */
+  --color-user-bubble: var(--user-bubble);
 }
 
 @layer base {

--- a/src/components/conversation/ChatSearchBar.tsx
+++ b/src/components/conversation/ChatSearchBar.tsx
@@ -184,7 +184,7 @@ export function highlightSearchMatches(
           "rounded-sm px-0.5",
           isCurrentMatch
             ? "bg-yellow-400 dark:bg-yellow-500 text-black"
-            : "bg-yellow-200 dark:bg-yellow-700/50"
+            : "bg-yellow-200 dark:bg-yellow-700/50 text-foreground"
         )}
         data-match-index={globalMatchOffset + matchCount}
       >

--- a/src/components/conversation/MentionText.tsx
+++ b/src/components/conversation/MentionText.tsx
@@ -104,7 +104,7 @@ export function MentionText({ content, className }: MentionTextProps) {
         result.push(
           <span
             key={`mention-${m.index}`}
-            className="inline-flex items-center gap-1 rounded-md bg-muted mx-0.5 px-1.5 -my-px align-middle leading-none font-medium text-sm"
+            className="inline-flex items-center gap-1 rounded-md bg-muted text-foreground mx-0.5 px-1.5 -my-px align-middle leading-none font-medium text-sm"
           >
             <FileIcon filename={fileName} className="h-3.5 w-3.5" />
             <span>{fileName}</span>

--- a/src/components/conversation/MessageBlock.tsx
+++ b/src/components/conversation/MessageBlock.tsx
@@ -32,6 +32,7 @@ import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
 import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
 import { AttachmentPreviewModal } from '@/components/conversation/AttachmentPreviewModal';
 import { MentionText } from '@/components/conversation/MentionText';
+import { UserBubble } from '@/components/conversation/UserBubble';
 import { ApprovedPlanBlock } from '@/components/conversation/ApprovedPlanBlock';
 import { CompactBoundaryCard } from '@/components/conversation/CompactBoundaryCard';
 import { TurnStatusIndicator } from '@/components/conversation/TurnStatusIndicator';
@@ -108,7 +109,7 @@ const InlineUserMessage = memo(function InlineUserMessage({
   return (
     <div className="pb-2 pt-3 flex justify-end">
       <div className="max-w-[85%]">
-        <div className="bg-surface-2 dark:bg-[#2D1B4E] rounded-lg px-4 py-2.5">
+        <UserBubble>
           {attachments && attachments.length > 0 && (
             <>
               <AttachmentGrid
@@ -130,7 +131,7 @@ const InlineUserMessage = memo(function InlineUserMessage({
           <p className="text-base leading-relaxed whitespace-pre-wrap">
             <MentionText content={content} />
           </p>
-        </div>
+        </UserBubble>
       </div>
     </div>
   );
@@ -196,7 +197,7 @@ export const MessageBlock = memo(function MessageBlock({
     return (
       <div className={cn('py-2 flex justify-end', !isFirst && 'pt-3')}>
         <div className="max-w-[85%]">
-          <div className="bg-surface-2 dark:bg-[#2D1B4E] rounded-lg px-4 py-2.5">
+          <UserBubble>
             {message.attachments && message.attachments.length > 0 && (
               <>
                 <AttachmentGrid
@@ -218,7 +219,7 @@ export const MessageBlock = memo(function MessageBlock({
             <p className="text-base leading-relaxed whitespace-pre-wrap">
               {highlightedContent || <MentionText content={message.content} />}
             </p>
-          </div>
+          </UserBubble>
         </div>
       </div>
     );

--- a/src/components/conversation/QueuedMessageBubble.tsx
+++ b/src/components/conversation/QueuedMessageBubble.tsx
@@ -5,6 +5,7 @@ import { Clock, X } from 'lucide-react';
 import { AttachmentGrid } from '@/components/conversation/AttachmentGrid';
 import { AttachmentPreviewModal } from '@/components/conversation/AttachmentPreviewModal';
 import { MentionText } from '@/components/conversation/MentionText';
+import { UserBubble } from '@/components/conversation/UserBubble';
 import type { QueuedMessage } from '@/stores/appStore';
 
 interface QueuedMessageBubbleProps {
@@ -51,7 +52,7 @@ function QueuedMessageItem({ message, index, total, onDelete }: {
 }) {
   return (
     <div className="flex justify-end group">
-      <div className="bg-surface-2 dark:bg-[#2D1B4E] rounded-lg px-4 py-2.5 opacity-70 relative max-w-[85%]">
+      <UserBubble className="opacity-70 relative max-w-[85%]">
         {/* Delete button - appears on hover */}
         <button
           onClick={onDelete}
@@ -67,7 +68,7 @@ function QueuedMessageItem({ message, index, total, onDelete }: {
             <span>#{index}</span>
           </div>
         )}
-      </div>
+      </UserBubble>
     </div>
   );
 }

--- a/src/components/conversation/StreamingMessage.tsx
+++ b/src/components/conversation/StreamingMessage.tsx
@@ -13,6 +13,7 @@ import { TurnStatusIndicator } from '@/components/conversation/TurnStatusIndicat
 import { CachedMarkdown } from '@/components/shared/CachedMarkdown';
 import { StreamingMarkdown } from '@/components/shared/StreamingMarkdown';
 import { MessageBody } from '@/components/conversation/QueuedMessageBubble';
+import { UserBubble } from '@/components/conversation/UserBubble';
 import { cn } from '@/lib/utils';
 import { PROSE_CLASSES } from '@/lib/constants';
 import { getModelInfo, buildTurnConfigLabel } from '@/lib/models';
@@ -279,9 +280,9 @@ const TimelineUserMessage = memo(function TimelineUserMessage({
   return (
     <div className="pb-2 pt-3 flex justify-end">
       <div className="max-w-[85%]">
-        <div className="bg-surface-2 dark:bg-[#2D1B4E] rounded-lg px-4 py-2.5">
+        <UserBubble>
           <MessageBody message={message} />
-        </div>
+        </UserBubble>
       </div>
     </div>
   );

--- a/src/components/conversation/UserBubble.tsx
+++ b/src/components/conversation/UserBubble.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export const USER_BUBBLE_CLASSNAME = 'bg-user-bubble text-foreground rounded-lg px-4 py-2.5';
+
+interface UserBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+/** Shared visual container for user-authored chat messages. */
+export function UserBubble({ children, className, ...props }: UserBubbleProps) {
+  return (
+    <div className={cn(USER_BUBBLE_CLASSNAME, className)} {...props}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Tint user message bubbles with a blue background (light: `blue-50`, dark: `blue-950 @ 40%`), keeping body text at `text-foreground` for maximum contrast.
- Introduce a `--user-bubble` CSS custom property (mapped to `bg-user-bubble` via `@theme inline`) so the color lives in the design system alongside `--surface-*`, `--brand`, etc.
- Extract a shared `UserBubble` wrapper so the four user-bubble sites (`InlineUserMessage`, `MessageBlock` user branch, `TimelineUserMessage`, `QueuedMessageItem`) all use the same component.
- Harden `MentionText` and `ChatSearchBar` non-active highlight with an explicit `text-foreground` so pills and yellow highlights remain readable regardless of parent text color.

## Design notes

- The previous `dark:bg-[#2D1B4E]` hardcoded hex is gone — the dark tint now flows from a token.
- Body text contrast on light mode stays at ~15:1 (`foreground` on `blue-50`) rather than the ~4.8:1 we'd have from `blue-600` on `blue-50`.
- `QueuedMessageItem` passes `opacity-70 relative max-w-[85%]` through the `className` prop.

## Test plan

- [ ] Open a conversation with existing user messages — bubbles render with light blue tint in light mode, subdued navy in dark mode.
- [ ] Send a new message mid-stream — the streaming `TimelineUserMessage` matches the persisted `MessageBlock` bubble.
- [ ] Queue a message while the agent is streaming — the queued bubble renders at 70% opacity with hover-delete working, queue index (`#1`) stays muted gray.
- [ ] Search inside a user message — non-active yellow highlights stay readable; active yellow with black text unchanged.
- [ ] Paste a file mention (`@file.ts`) inside a user message — pill renders with `text-foreground`, not tinted.
- [ ] Toggle light/dark mode — both bubble variants switch cleanly via the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)