### PR TITLE
feat(flags): hide unreleased features behind SHOW_UNRELEASED gate

### DIFF
--- a/src/components/layout/ContentRouter.tsx
+++ b/src/components/layout/ContentRouter.tsx
@@ -10,6 +10,7 @@ import { SessionManager } from '@/components/session-manager';
 import { SkillsStore } from '@/components/skills/SkillsStore';
 import { ScheduledTasksDashboard } from '@/components/scheduled/ScheduledTasksDashboard';
 import { ScheduledTaskDetailView } from '@/components/scheduled/ScheduledTaskDetailView';
+import { SHOW_UNRELEASED } from '@/lib/constants';
 
 interface ContentRouterProps {
   selectedSessionId: string | null;
@@ -39,7 +40,7 @@ export function ContentRouter({
 
   return (
     <ErrorBoundary section="FullContent">
-      {contentView.type === 'dashboard' && (
+      {SHOW_UNRELEASED && contentView.type === 'dashboard' && (
         <MissionControlDashboard />
       )}
       {contentView.type === 'pr-dashboard' && (
@@ -68,14 +69,40 @@ export function ContentRouter({
       {contentView.type === 'skills-store' && (
         <SkillsStore />
       )}
-      {contentView.type === 'scheduled-tasks' && (
+      {SHOW_UNRELEASED && contentView.type === 'scheduled-tasks' && (
         <ScheduledTasksDashboard />
       )}
-      {contentView.type === 'scheduled-task-detail' && (
+      {SHOW_UNRELEASED && contentView.type === 'scheduled-task-detail' && (
         <ScheduledTaskDetailView taskId={contentView.taskId} />
       )}
       {!selectedSessionId && contentView.type === 'conversation' && (
-        <MissionControlDashboard />
+        SHOW_UNRELEASED ? (
+          <MissionControlDashboard />
+        ) : (
+          <RepositoriesDashboard
+            onOpenProject={onOpenProject}
+            onCloneFromUrl={onCloneFromUrl}
+            onGitHubRepos={onGitHubRepos}
+            onOpenSettings={onOpenSettings}
+            onOpenShortcuts={onOpenShortcuts}
+            onOpenWorkspaceSettings={onOpenWorkspaceSettings}
+          />
+        )
+      )}
+      {/* Fallback for gated views reached via tab history or deep links */}
+      {!SHOW_UNRELEASED && (
+        contentView.type === 'dashboard' ||
+        contentView.type === 'scheduled-tasks' ||
+        contentView.type === 'scheduled-task-detail'
+      ) && (
+        <RepositoriesDashboard
+          onOpenProject={onOpenProject}
+          onCloneFromUrl={onCloneFromUrl}
+          onGitHubRepos={onGitHubRepos}
+          onOpenSettings={onOpenSettings}
+          onOpenShortcuts={onOpenShortcuts}
+          onOpenWorkspaceSettings={onOpenWorkspaceSettings}
+        />
       )}
     </ErrorBoundary>
   );

--- a/src/components/navigation/WorkspaceSidebar.tsx
+++ b/src/components/navigation/WorkspaceSidebar.tsx
@@ -27,6 +27,7 @@ import { navigate, navigateOrOpenTab } from '@/lib/navigation';
 import { useSettingsStore, getBranchPrefix, getWorkspaceBranchPrefix, type ContentView, type SidebarGroupBy } from '@/stores/settingsStore';
 import { useSidebarSessions, isSidebarGroupExpanded, type SidebarGroup } from '@/hooks/useSidebarSessions';
 import { createSession as createSessionApi, listConversations as listConversationsApi, updateSession as updateSessionApi, deleteRepo as deleteRepoApi, addRepo as addRepoApi, mapSessionDTO, refreshPRStatus, unlinkPR } from '@/lib/api';
+import { SHOW_UNRELEASED } from '@/lib/constants';
 import { registerSession, getSessionDirName } from '@/lib/tauri';
 import { prefetchSessionData, cancelPrefetch } from '@/lib/sessionPrefetch';
 import { Button } from '@/components/ui/button';
@@ -236,12 +237,16 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
   const scheduledTasks = useScheduledTaskStore((s) => s.tasks);
 
   useEffect(() => {
+    if (!SHOW_UNRELEASED) return;
     useScheduledTaskStore.getState().fetchTasks();
   }, []);
 
   // Separate scheduled sessions from regular sessions BEFORE they enter useSidebarSessions
   // so they don't appear in workspace groups or status groups.
   const { regularSessions, scheduledSessionsList } = useMemo(() => {
+    if (!SHOW_UNRELEASED) {
+      return { regularSessions: sessions, scheduledSessionsList: [] as typeof sessions };
+    }
     const regular: typeof sessions = [];
     const scheduled: typeof sessions = [];
     for (const s of sessions) {
@@ -608,7 +613,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
 
       {/* Global Navigation */}
       <div className="px-1 py-2 shrink-0">
-        <div
+        {SHOW_UNRELEASED && (<div
           className={cn(
             "group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer",
             contentView.type === 'dashboard'
@@ -634,7 +639,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
               {attentionCount > 9 ? '9+' : attentionCount}
             </span>
           )}
-        </div>
+        </div>)}
         <div
           className={cn(
             "group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer",
@@ -745,7 +750,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
             Skills
           </span>
         </div>
-        <div
+        {SHOW_UNRELEASED && (<div
           className={cn(
             "group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer",
             contentView.type === 'scheduled-tasks'
@@ -766,7 +771,7 @@ export function WorkspaceSidebar({ onOpenProject, onCloneFromUrl, onGitHubRepos,
           )}>
             Scheduled
           </span>
-        </div>
+        </div>)}
       </div>
 
       {/* Session List */}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -36,3 +36,11 @@ export const TOOL_COMMAND_TRUNCATE = 80;
 // Feature flags (build-time)
 /** Enable browser-style multi-tab navigation. Set to false to disable. */
 export const ENABLE_BROWSER_TABS = true;
+
+/**
+ * Show unreleased features in dev only. Set NEXT_PUBLIC_SIMULATE_PROD=1 to
+ * simulate a production build while running `npm run dev`.
+ */
+export const SHOW_UNRELEASED =
+  process.env.NODE_ENV === 'development' &&
+  process.env.NEXT_PUBLIC_SIMULATE_PROD !== '1';

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAppStore } from '@/stores/appStore';
+import { SHOW_UNRELEASED } from './constants';
 
 // ---------------------------------------------------------------------------
 // Canonical model catalog — single source of truth for display names & descriptions
@@ -64,7 +65,7 @@ export function getModelDescription(sdkValue: string): string | undefined {
 // its catalog key ('claude-haiku-4-5'). This is intentional — the SDK reports
 // the dated variant and stored user settings reference it. catalogLookup via
 // toBaseId handles the mapping transparently.
-export const MODELS = [
+const ALL_MODELS = [
   // Cloud models
   { id: 'claude-opus-4-6', name: MODEL_CATALOG['claude-opus-4-6'].displayName, description: MODEL_CATALOG['claude-opus-4-6'].description, provider: 'claude' as const, supportsThinking: true, supportsEffort: true, supportsFastMode: true },
   { id: 'claude-sonnet-4-6', name: MODEL_CATALOG['claude-sonnet-4-6'].displayName, description: MODEL_CATALOG['claude-sonnet-4-6'].description, provider: 'claude' as const, supportsThinking: true, supportsEffort: true, supportsFastMode: true },
@@ -76,7 +77,11 @@ export const MODELS = [
   { id: 'gemma-4-31b', name: MODEL_CATALOG['gemma-4-31b'].displayName, description: MODEL_CATALOG['gemma-4-31b'].description, provider: 'ollama' as const, supportsThinking: false, supportsEffort: false, supportsFastMode: false },
 ] as const;
 
-export type ModelId = (typeof MODELS)[number]['id'];
+export const MODELS: ReadonlyArray<(typeof ALL_MODELS)[number]> = SHOW_UNRELEASED
+  ? ALL_MODELS
+  : ALL_MODELS.filter((m) => m.provider !== 'ollama');
+
+export type ModelId = (typeof ALL_MODELS)[number]['id'];
 
 export type ModelProvider = 'claude' | 'ollama';
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 import type { Workspace, SessionTaskStatus } from '@/lib/types';
 import { useAuthStore } from '@/stores/authStore';
 import type { ThinkingLevel } from '@/lib/thinkingLevels';
+import { SHOW_UNRELEASED } from '@/lib/constants';
 
 // Bottom panel tab IDs that can be toggled (Tasks is always visible)
 // TODO: Re-add 'scripts' to BottomPanelTab when the Scripts feature is reintroduced (see ScriptsPanel.tsx)
@@ -550,6 +551,17 @@ export const useSettingsStore = create<SettingsState>()(
         }
         if (merged.reviewModel === 'auto') {
           merged.reviewModel = 'claude-haiku-4-5-20251001';
+        }
+
+        // Coerce gated local models (Gemma) when unreleased features are hidden,
+        // so devs switching to prod builds don't land on an unselectable model.
+        if (!SHOW_UNRELEASED) {
+          if (typeof merged.defaultModel === 'string' && merged.defaultModel.startsWith('gemma-')) {
+            merged.defaultModel = SETTINGS_DEFAULTS.defaultModel;
+          }
+          if (typeof merged.reviewModel === 'string' && merged.reviewModel.startsWith('gemma-')) {
+            merged.reviewModel = SETTINGS_DEFAULTS.reviewModel;
+          }
         }
 
         // Migrate removed sprint groupBy options → project


### PR DESCRIPTION
## Summary
- Introduces a `SHOW_UNRELEASED` build-time feature flag (`src/lib/constants.ts`) that's `true` only during `npm run dev` — gated by `NODE_ENV === 'development'` so it's dead-code-eliminated in production builds. Set `NEXT_PUBLIC_SIMULATE_PROD=1` to simulate prod while developing.
- Hides in-progress features in production: Mission Control dashboard, Scheduled Tasks (nav + routes + detail view + fetching), and local Ollama/Gemma models in the model selector.
- When a session isn't selected, the welcome view falls back to `RepositoriesDashboard` instead of Mission Control in prod.

## Details

**Sidebar (`WorkspaceSidebar.tsx`)**: Gated Dashboard and Scheduled nav items; `fetchTasks()` early-returns; `scheduledSessionsList` is empty in prod so the sidebar scheduled section naturally disappears.

**Content router (`ContentRouter.tsx`)**: Mission Control and Scheduled Task routes are gated. Includes a defensive fallback that renders `RepositoriesDashboard` if a stale tab-history/deep-link entry targets a gated view, preventing blank screens.

**Models (`models.ts`)**: `MODELS` export filters out `provider === 'ollama'` when gated. `ModelId` type still derives from the full list so stored settings remain type-compatible. `LOCAL_MODEL_IDS` is derived from `MODELS`, so `isLocalModel()` returns `false` in prod and all consumers (AI settings, toolbar) hide local model sections automatically.

**Settings migration (`settingsStore.ts`)**: On rehydration, coerces persisted `defaultModel` and `reviewModel` away from `gemma-*` IDs to the default when the gate is off, so devs switching to prod builds don't land on an unselectable model.

## Test plan
- [ ] `npm run dev` — confirm Dashboard, Scheduled, and local models are visible
- [ ] `NEXT_PUBLIC_SIMULATE_PROD=1 npm run dev` — confirm those items are hidden, welcome view shows Repositories, model selector has no "Local Models" section
- [ ] In simulated-prod mode, use browser tab back-navigation to a previous dashboard/scheduled view and confirm RepositoriesDashboard fallback renders (not blank)
- [ ] With a Gemma model persisted as `defaultModel`, reload in simulated-prod and confirm it resets to `claude-sonnet-4-6`
- [ ] Production build (`npm run build`) — confirm the gated imports are tree-shaken (optional spot check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)