### PR TITLE
fix(models): detect 1M context by model family, not [1m] suffix

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.116",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.116.tgz",
-      "integrity": "sha512-5NKpgaOZkzNCGCvLxJZUVGimf5IcYmpQ2x2XrR9ilK+2UkWrnnwcUfIWo8bBz9e7lSYcUf9XleGigq2eOOF7aw==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz",
+      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -30,23 +30,23 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.116",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.116",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.116",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.116",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.116",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.116",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.116",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.116"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.116.tgz",
-      "integrity": "sha512-mG19ovtXCpETmd5KmTU1JO2iIHZBG09IP8DmgZjLA3wLmTzpgn9Au9veRaeJeXb1EqiHiFZU+z+mNB79+w5v9g==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.119.tgz",
+      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
       "cpu": [
         "arm64"
       ],
@@ -57,9 +57,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.116.tgz",
-      "integrity": "sha512-qC25N0HRM8IXbM4Qi4svH9f51Y6DciDvjLV+oNYnxkdPgDG8p/+b7vQirN7qPxytIQb2TPdoFgUeCsSe7lrQyw==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.119.tgz",
+      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
       "cpu": [
         "x64"
       ],
@@ -70,9 +70,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.116.tgz",
-      "integrity": "sha512-MQIcJhhPM+RPJ7kMQdOQarkJ2FlJqOiu953c08YyJOoWdHykd3DIiHws3mf1Mwl/dfFeIyshOVpNND3hyIy5Dg==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.119.tgz",
+      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
       "cpu": [
         "arm64"
       ],
@@ -86,9 +86,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.116.tgz",
-      "integrity": "sha512-Dg/T3NkSp35ODiwdhj0KquvC6Xu+DMbyWFNkfepA3bz4oF2SVSgyOPYwVmfoJerzEUnYDldP4YhOxRrhbt0vXA==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.119.tgz",
+      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
       "cpu": [
         "arm64"
       ],
@@ -102,9 +102,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.116.tgz",
-      "integrity": "sha512-Bww1fzQB+vcF0tRhmCAlwSsN4wR2HgX7pBT9AWuwzJj6DKsVC23N54Ea80lsnM7dTUtUTrGYMTwVUHTWqfYnfQ==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.119.tgz",
+      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
       "cpu": [
         "x64"
       ],
@@ -118,9 +118,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.116.tgz",
-      "integrity": "sha512-LMYxUMa1nK4N9BPRJdcGBAvl9rjTI4ZHo+kfAKrJ3MlfB6VFF1tRIubwsWOaOtkuNazMdAYovsZJg4bdzOBBTQ==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.119.tgz",
+      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
       "cpu": [
         "x64"
       ],
@@ -134,9 +134,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.116.tgz",
-      "integrity": "sha512-h0YO1vkTIeUtffQhONrYbNC1pXmk1yjb1xxMEw7bAwucqtFoFpLDWe+q4+RhxaQr8ZOj6LtRE/U3dzPWHOlshA==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.119.tgz",
+      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
       "cpu": [
         "arm64"
       ],
@@ -147,9 +147,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.116",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.116.tgz",
-      "integrity": "sha512-3lllmtDFHgpW0ZM3iNvxsEjblrgRzF9Qm1lxTOtunP3hIn+pA/IkWMtKlN1ixxWiaBguLVQkJ90V6JHsvJJIvw==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.119.tgz",
+      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
       "cpu": [
         "x64"
       ],

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.116",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.119",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -395,8 +395,8 @@ export function useWebSocket(enabled: boolean = true) {
           : undefined;
 
         // Extract context window size BEFORE finalization — finalizeStreamingMessage
-        // clears turnStartMeta, which setContextUsage needs to detect [1m] models
-        // and clamp the SDK-reported 200K window to the correct 1M.
+        // clears turnStartMeta. supportsExtendedContext also falls back to
+        // conversation.model, but extracting early avoids a race with finalization.
         const resultModelUsage = event.modelUsage as Record<string, { contextWindow?: number }> | undefined;
         if (resultModelUsage) {
           for (const key of Object.keys(resultModelUsage)) {

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/stores/appStore', () => ({
   },
 }));
 
-const { getModelDisplayName, getModelInfo, getModelDescription, buildTurnConfigLabel, MODELS, toShortDisplayName, buildStaticModelList } = await import('../models');
+const { getModelDisplayName, getModelInfo, getModelDescription, buildTurnConfigLabel, MODELS, toShortDisplayName, buildStaticModelList, supportsExtendedContext } = await import('../models');
 
 describe('getModelDisplayName', () => {
   it('returns short display name for known static models', () => {
@@ -91,6 +91,27 @@ describe('getModelDescription', () => {
 
   it('returns undefined for unknown models', () => {
     expect(getModelDescription('custom-model')).toBeUndefined();
+  });
+});
+
+describe('supportsExtendedContext', () => {
+  it('returns true for 1M-capable families regardless of suffix', () => {
+    expect(supportsExtendedContext('claude-opus-4-7')).toBe(true);
+    expect(supportsExtendedContext('claude-opus-4-7[1m]')).toBe(true);
+    expect(supportsExtendedContext('claude-opus-4-7-20260101')).toBe(true);
+    expect(supportsExtendedContext('claude-opus-4-6')).toBe(true);
+    expect(supportsExtendedContext('claude-opus-4-6[1m]')).toBe(true);
+    expect(supportsExtendedContext('claude-opus-4-6-20251022')).toBe(true);
+    expect(supportsExtendedContext('claude-sonnet-4-6')).toBe(true);
+    expect(supportsExtendedContext('claude-sonnet-4-6[1m]')).toBe(true);
+    expect(supportsExtendedContext('claude-sonnet-4-6-20251022')).toBe(true);
+  });
+
+  it('returns false for non-1M models', () => {
+    expect(supportsExtendedContext('claude-haiku-4-5-20251001')).toBe(false);
+    expect(supportsExtendedContext('claude-haiku-4-5')).toBe(false);
+    expect(supportsExtendedContext('unknown-model')).toBe(false);
+    expect(supportsExtendedContext('')).toBe(false);
   });
 });
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -37,6 +37,27 @@ function catalogLookup(sdkValue: string): ModelCatalogEntry | undefined {
   return MODEL_CATALOG[toBaseId(sdkValue)];
 }
 
+// Keep in sync with backend/agent/manager.go:betasForModel — the backend source
+// of truth for which models receive the `context-1m-2025-08-07` beta header.
+// Note: the backend uses substring matching (strings.Contains), while this
+// frontend check requires an exact base-ID match after toBaseId() normalization.
+// This is intentionally stricter — if a new model ID pattern is added, update
+// this set (and toBaseId if it introduces a new suffix shape).
+const EXTENDED_CONTEXT_BASE_IDS = new Set<string>([
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+  'claude-sonnet-4-6',
+]);
+
+/**
+ * Does this model support the 1M extended context window?
+ * Matches on the base ID so variants like `claude-opus-4-7[1m]` or
+ * `claude-sonnet-4-6-20251022` resolve correctly.
+ */
+export function supportsExtendedContext(modelId: string): boolean {
+  return EXTENDED_CONTEXT_BASE_IDS.has(toBaseId(modelId));
+}
+
 // ---------------------------------------------------------------------------
 // Display name & description helpers
 // ---------------------------------------------------------------------------

--- a/src/stores/__tests__/appStore.contextUsage.test.ts
+++ b/src/stores/__tests__/appStore.contextUsage.test.ts
@@ -129,7 +129,7 @@ describe('appStore — contextUsage', () => {
       expect(state[CONV_ID_2].contextWindow).toBe(1000000);
     });
 
-    it('clamps SDK contextWindow to 1M for [1m] extended context models', () => {
+    it('clamps SDK contextWindow to 1M for [1m]-suffixed model variants', () => {
       useAppStore.setState({
         streamingState: {
           [CONV_ID]: streamingStateWithModel('claude-opus-4-6[1m]'),
@@ -147,10 +147,44 @@ describe('appStore — contextUsage', () => {
       expect(useAppStore.getState().contextUsage[CONV_ID].inputTokens).toBe(1000);
     });
 
-    it('allows SDK contextWindow for non-[1m] models', () => {
+    it('defaults to 1M for suffix-less 1M-capable models (claude-opus-4-7)', () => {
+      useAppStore.setState({
+        streamingState: {
+          [CONV_ID]: streamingStateWithModel('claude-opus-4-7'),
+        },
+      });
+
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 1000 });
+      expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(1_000_000);
+    });
+
+    it('clamps SDK 200K contextWindow to 1M for suffix-less 1M-capable models', () => {
+      useAppStore.setState({
+        streamingState: {
+          [CONV_ID]: streamingStateWithModel('claude-opus-4-7'),
+        },
+      });
+
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 1000 });
+      useAppStore.getState().setContextUsage(CONV_ID, { contextWindow: 200000 });
+      expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(1_000_000);
+    });
+
+    it('treats claude-sonnet-4-6 (with date suffix) as 1M-capable', () => {
       useAppStore.setState({
         streamingState: {
           [CONV_ID]: streamingStateWithModel('claude-sonnet-4-6-20250514'),
+        },
+      });
+
+      useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 1000 });
+      expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(1_000_000);
+    });
+
+    it('allows SDK contextWindow for non-1M-capable models (Haiku)', () => {
+      useAppStore.setState({
+        streamingState: {
+          [CONV_ID]: streamingStateWithModel('claude-haiku-4-5-20251001'),
         },
       });
 
@@ -170,31 +204,29 @@ describe('appStore — contextUsage', () => {
       expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(1_000_000);
     });
 
-    it('does NOT clamp when turnStartMeta is cleared (regression: result after finalization)', () => {
-      // Simulate turn 1: turnStartMeta has [1m] model, context_usage sets 1M default
+    it('falls back to conversation.model for 1M detection when turnStartMeta is cleared', () => {
+      // Simulate turn 1: turnStartMeta has model, context_usage sets 1M default
       useAppStore.setState({
         streamingState: {
-          [CONV_ID]: streamingStateWithModel('claude-opus-4-6[1m]'),
+          [CONV_ID]: streamingStateWithModel('claude-opus-4-7'),
         },
       });
       useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 5000 });
       expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(1_000_000);
 
-      // Simulate finalization clearing turnStartMeta (and no [1m] on conversation.model)
+      // After finalization clears turnStartMeta, conversation.model is still available
       useAppStore.setState({
         streamingState: { [CONV_ID]: {} as ReturnType<typeof useAppStore.getState>['streamingState'][string] },
-        conversations: [{ id: CONV_ID, model: 'claude-opus-4-6' } as ReturnType<typeof useAppStore.getState>['conversations'][number]],
+        conversations: [{ id: CONV_ID, model: 'claude-opus-4-7' } as ReturnType<typeof useAppStore.getState>['conversations'][number]],
       });
 
-      // SDK-reported contextWindow arrives AFTER finalization — no [1m] detected, NOT clamped
+      // SDK-reported 200K arrives AFTER finalization — still clamped because
+      // supportsExtendedContext resolves from the conversation's base model.
       useAppStore.getState().setContextUsage(CONV_ID, { contextWindow: 200000 });
-      // Store correctly downgrades — it has no [1m] info once turnStartMeta is cleared.
-      // The fix is in useWebSocket.ts: call setContextUsage BEFORE finalizeStreamingMessage.
-      expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(200000);
+      expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(1_000_000);
     });
 
     it('clamps correctly when called BEFORE finalization clears turnStartMeta', () => {
-      // Simulate the FIXED flow: setContextUsage called while turnStartMeta still exists
       useAppStore.setState({
         streamingState: {
           [CONV_ID]: streamingStateWithModel('claude-opus-4-6[1m]'),
@@ -202,7 +234,6 @@ describe('appStore — contextUsage', () => {
       });
       useAppStore.getState().setContextUsage(CONV_ID, { inputTokens: 5000 });
 
-      // SDK contextWindow arrives BEFORE finalization — [1m] detected, clamped to 1M
       useAppStore.getState().setContextUsage(CONV_ID, { contextWindow: 200000 });
       expect(useAppStore.getState().contextUsage[CONV_ID].contextWindow).toBe(1_000_000);
     });

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -34,7 +34,7 @@ import type {
 import type { StreamingSnapshotDTO, SnapshotSubAgent } from '@/lib/api';
 import { useSettingsStore } from './settingsStore';
 import { refreshPRStatus } from '@/lib/api';
-import { buildTurnConfigLabel } from '@/lib/models';
+import { buildTurnConfigLabel, supportsExtendedContext } from '@/lib/models';
 import { cleanupConversationState } from '@/hooks/useWebSocket';
 
 // Throttle on-select PR refresh to avoid excessive API calls.
@@ -2832,14 +2832,17 @@ updateFileTabContent: (id, content) => set((state) => ({
 
   // Context usage actions
   setContextUsage: (conversationId, usage) => set((state) => {
-    // Derive default from model — extended context [1m] = 1M tokens
+    // Derive default from model — 1M-capable families (opus-4-7, opus-4-6,
+    // sonnet-4-6) get a 1M default even without the `[1m]` suffix in the ID,
+    // since the backend always attaches the context-1m beta for these models.
     const model = state.streamingState[conversationId]?.turnStartMeta?.model
       ?? state.conversations.find((c) => c.id === conversationId)?.model;
-    const isExtendedContext = model?.includes('[1m]');
+    const isExtendedContext = model ? supportsExtendedContext(model) : false;
     const defaultContextWindow = isExtendedContext ? 1_000_000 : 200_000;
 
-    // If the model is a [1m] variant, don't allow the SDK-reported contextWindow
-    // to downgrade from 1M (the SDK reports the base 200K window, not the extended one)
+    // For 1M-capable models, don't let SDK-reported contextWindow downgrade
+    // below 1M (the SDK sometimes reports the base 200K window even when the
+    // context-1m beta is active).
     const sanitizedUsage = (isExtendedContext && usage.contextWindow !== undefined && usage.contextWindow < 1_000_000)
       ? { ...usage, contextWindow: 1_000_000 }
       : usage;


### PR DESCRIPTION
## Summary

- Replaces `model?.includes('[1m]')` 1M-context detection with a `supportsExtendedContext()` helper that matches by base model ID (opus-4-7, opus-4-6, sonnet-4-6)
- Mirrors the backend's `betasForModel` in `backend/agent/manager.go:2325-2332`, which always attaches the `context-1m` beta for these three families regardless of suffix
- Bumps `@anthropic-ai/claude-agent-sdk` from `^0.2.116` to `^0.2.119`

## Why

The old suffix-based check had two failure modes that caused the context usage bar to incorrectly show 200K capacity for 1M-capable models:

1. **Plain `claude-opus-4-7`** (the most common model form) was never detected as 1M-capable because the ID lacks the `[1m]` suffix.
2. **After turn finalization**, `turnStartMeta` is cleared and `setContextUsage` falls back to `conversation.model` — which never stores the `[1m]` suffix. This caused the context window to silently downgrade from 1M to 200K mid-session.

The backend has always sent the `context-1m` beta for these model families, so the frontend's stricter detection was the bug.

## How to test

- [x] `npm run test:run -- src/lib/__tests__/models.test.ts src/stores/__tests__/appStore.contextUsage.test.ts` — 65 tests pass
- [ ] Start a session with `claude-opus-4-7`; verify context usage bar shows 1M capacity from the first message and stays at 1M across turn boundaries
- [ ] Start a session with `claude-haiku-4-5`; verify context usage bar correctly shows 200K capacity

## Notes

The `EXTENDED_CONTEXT_BASE_IDS` set is kept in sync manually with `backend/agent/manager.go:betasForModel`. The backend uses substring matching (`strings.Contains`) while this frontend check requires exact base-ID match after `toBaseId()` normalization — intentionally stricter so new model IDs require an explicit code change rather than a silent match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)