### PR TITLE
fix(about-dialog): widen dialog so Feedback link fits

### DIFF
--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -118,7 +118,7 @@ export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="sm:max-w-[360px] p-0 overflow-hidden gap-0"
+        className="sm:max-w-[400px] p-0 overflow-hidden gap-0"
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">About ChatML</DialogTitle>
@@ -164,13 +164,13 @@ export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
         </div>
 
         {/* Links */}
-        <div className="flex items-center justify-center gap-1 px-6 py-3 border-t border-border/50">
+        <div className="flex items-center justify-center gap-0.5 px-4 py-3 border-t border-border/50">
           {links.map(({ label, icon: Icon, url }) => (
             <Button
               key={label}
               variant="ghost"
               size="sm"
-              className="gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+              className="h-8 px-2 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
               onClick={() => openUrlInBrowser(url)}
             >
               <Icon className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary

- The About dialog's footer row (Docs, Changelog, GitHub, Feedback) was overflowing a fixed 360px dialog, clipping the "Feedback" label on the right edge.
- Widens the dialog to 400px and tightens the links row (smaller gap, reduced padding, compact button sizing) so all four link labels render in full alongside their icons.
- Pure layout change — no logic, state, or functionality touched.

## Test plan

- [ ] `make dev` (or `npm run dev`)
- [ ] Open menu → ChatML → About ChatML
- [ ] Verify all four link labels render fully (Docs, Changelog, GitHub, Feedback) with icons and no right-edge clipping
- [ ] Verify update button, version string, tagline, and copyright footer are unchanged
- [ ] `npm run lint` — 0 errors (only pre-existing warnings)
- [ ] `npm run build` — compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)