### PR TITLE
fix(tools): remove 5-min frontend tool timeout that mis-flagged long runs

### DIFF
--- a/docs/architecture/frontend-state-and-rendering.md
+++ b/docs/architecture/frontend-state-and-rendering.md
@@ -235,10 +235,6 @@ File tabs use LRU (Least Recently Used) eviction with `MAX_TABS` (20). When a ne
 
 Script run output is stored in a plain `Map` outside the Zustand store to avoid O(n^2) array copies on every output line. The store only tracks the current `Map` reference, not the individual lines.
 
-### Tool Timeout
-
-Active tools have a timeout of `TOOL_TIMEOUT_MS` (5 minutes). If a tool hasn't completed within this time, it's considered stale and can be cleaned up.
-
 ## Plan Mode UI
 
 Plan mode has a dedicated UI flow:

--- a/docs/troubleshooting/debugging-guide.md
+++ b/docs/troubleshooting/debugging-guide.md
@@ -343,7 +343,7 @@ If a process crashes:
 1. Check the WebSocket for a matching `tool_end` event
 2. If no `tool_end`: the agent may be stuck. Stop the conversation and retry
 3. If `tool_end` was sent: check if the frontend received it (WS Messages tab)
-4. The frontend has a tool timeout display — tools showing "timed out" had no `tool_end` within the expected window
+4. Long-running tools (sub-agents, Bash) can legitimately run for many minutes — the SDK has no built-in timeout. The frontend keeps the spinner active until `tool_end` arrives or the turn finalizes.
 
 ### Scenario: Session creation fails
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -310,13 +310,12 @@ export function useWebSocket(enabled: boolean = true) {
               agentId,
             });
           } else {
-            const isUserInteractiveTool = event.tool === 'ExitPlanMode' || event.tool === 'AskUserQuestion';
             store.addActiveTool(conversationId, {
               id: event.id,
               tool: event.tool,
               params: event.params,
               startTime: Date.now(),
-            }, isUserInteractiveTool ? { skipTimeout: true } : undefined);
+            });
           }
         }
         break;
@@ -342,7 +341,7 @@ export function useWebSocket(enabled: boolean = true) {
                 tool: event.tool as string,
                 startTime: Date.now(),
                 untracked: true,
-              }, { skipTimeout: true });
+              });
               store.completeActiveTool(conversationId, event.id, event.success, event.summary, stdout, stderr, metadata);
             }
           }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -139,46 +139,6 @@ export function clearScriptOutputBuffers(sessionId: string) {
   for (const key of keysToDelete) scriptOutputBuffers.delete(key);
 }
 
-// Timeout tracking for orphaned tool cleanup
-const toolTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
-
-// Maximum time a tool can be active before forced completion (5 minutes)
-const TOOL_TIMEOUT_MS = 5 * 60 * 1000;
-
-/** Clear all tool timeouts for a given conversation */
-function clearToolTimeoutsForConversation(conversationId: string, tools: { id: string }[]) {
-  for (const tool of tools) {
-    const key = `${conversationId}:${tool.id}`;
-    const timeout = toolTimeouts.get(key);
-    if (timeout) {
-      clearTimeout(timeout);
-      toolTimeouts.delete(key);
-    }
-  }
-}
-
-/** Clear all tool timeouts for conversations matching the given IDs */
-function clearToolTimeoutsForConversations(conversationIds: string[]) {
-  const convIdSet = new Set(conversationIds);
-  const keysToDelete: string[] = [];
-  for (const [key, timeout] of toolTimeouts) {
-    const convId = key.split(':')[0];
-    if (convIdSet.has(convId)) {
-      clearTimeout(timeout);
-      keysToDelete.push(key);
-    }
-  }
-  for (const key of keysToDelete) toolTimeouts.delete(key);
-}
-
-/** Clear all tool timeouts globally (for HMR, tests, or app teardown) */
-export function clearAllToolTimeouts() {
-  for (const timeout of toolTimeouts.values()) {
-    clearTimeout(timeout);
-  }
-  toolTimeouts.clear();
-}
-
 // Default streaming state for a conversation (avoids repeating defaults across actions)
 const DEFAULT_STREAMING: StreamingState = {
   text: '',
@@ -536,7 +496,7 @@ interface AppState {
   clearPendingBatchToolApproval: (conversationId: string) => void;
   setApprovedPlanContent: (conversationId: string, content: string) => void;
   clearApprovedPlanContent: (conversationId: string) => void;
-  addActiveTool: (conversationId: string, tool: ActiveTool, opts?: { skipTimeout?: boolean }) => void;
+  addActiveTool: (conversationId: string, tool: ActiveTool) => void;
   completeActiveTool: (conversationId: string, toolId: string, success?: boolean, summary?: string, stdout?: string, stderr?: string, metadata?: import('@/lib/types').ToolMetadata) => void;
   updateToolProgress: (conversationId: string, toolId: string, progress: ToolProgressUpdate) => void;
   updateToolProgressBatch: (updates: Array<{ conversationId: string; toolId: string; progress: ToolProgressUpdate }>) => void;
@@ -952,7 +912,6 @@ export const useAppStore = create<AppState>((set, get) => ({
       .filter((c) => c.sessionId === id)
       .map((c) => c.id);
     clearScriptOutputBuffers(id);
-    clearToolTimeoutsForConversations(sessionConvIds);
     sessionConvIds.forEach(cleanupConversationState);
 
     set((state) => {
@@ -1240,11 +1199,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       },
     };
   }),
-  removeConversation: (id) => {
-    // Clean up external buffers before updating Zustand state
-    clearToolTimeoutsForConversations([id]);
-
-    return set((state) => {
+  removeConversation: (id) => set((state) => {
     // Clean up orphaned state for the removed conversation
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [id]: _streaming, ...remainingStreamingState } = state.streamingState;
@@ -1317,8 +1272,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       messagePagination: remainingPagination,
       messagesLoading: remainingMessagesLoading,
     };
-  });
-  },
+  }),
   selectConversation: (id) => {
     const state = get();
     const conversation = id ? state.conversations.find(c => c.id === id) : undefined;
@@ -1967,33 +1921,12 @@ updateFileTabContent: (id, content) => set((state) => ({
       approvedPlanTimestamp: undefined,
     }),
   })),
-  addActiveTool: (conversationId, tool, opts) => {
+  addActiveTool: (conversationId, tool) => {
     return set((state) => {
       const existing = state.activeTools[conversationId] || [];
       // Dedup: skip if a tool with this id is already tracked (snapshot + live event race)
       if (existing.some(t => t.id === tool.id)) {
         return {};
-      }
-
-      // Set up timeout to force-complete orphaned tools (skip for synthetic entries that will be completed immediately).
-      // Registered after dedup check so a duplicate call doesn't orphan the original tool's timeout.
-      if (!opts?.skipTimeout) {
-        const timeoutKey = `${conversationId}:${tool.id}`;
-        const existingTimeout = toolTimeouts.get(timeoutKey);
-        if (existingTimeout) clearTimeout(existingTimeout);
-
-        const timeout = setTimeout(() => {
-          toolTimeouts.delete(timeoutKey);
-          const current = useAppStore.getState().activeTools[conversationId] || [];
-          const stillActive = current.find(t => t.id === tool.id && !t.endTime);
-          if (stillActive) {
-            console.warn(`[Store] Tool timeout: ${tool.tool} (${tool.id}) - forcing completion after ${TOOL_TIMEOUT_MS}ms`);
-            useAppStore.getState().completeActiveTool(
-              conversationId, tool.id, false, 'Tool timed out', undefined, undefined
-            );
-          }
-        }, TOOL_TIMEOUT_MS);
-        toolTimeouts.set(timeoutKey, timeout);
       }
 
       return {
@@ -2009,14 +1942,6 @@ updateFileTabContent: (id, content) => set((state) => ({
     });
   },
   completeActiveTool: (conversationId, toolId, success, summary, stdout, stderr, metadata) => {
-    // Clear the timeout for this tool
-    const timeoutKey = `${conversationId}:${toolId}`;
-    const timeout = toolTimeouts.get(timeoutKey);
-    if (timeout) {
-      clearTimeout(timeout);
-      toolTimeouts.delete(timeoutKey);
-    }
-
     return set((state) => {
       const tools = state.activeTools[conversationId] || [];
       if (!tools.some(t => t.id === toolId)) {
@@ -2066,18 +1991,12 @@ updateFileTabContent: (id, content) => set((state) => ({
     }
     return changed ? { activeTools: newActiveTools } : state;
   }),
-  clearActiveTools: (conversationId) => {
-    // Clear all timeouts for this conversation's tools
-    const tools = useAppStore.getState().activeTools[conversationId] || [];
-    clearToolTimeoutsForConversation(conversationId, tools);
-
-    return set((state) => ({
-      activeTools: {
-        ...state.activeTools,
-        [conversationId]: [],
-      },
-    }));
-  },
+  clearActiveTools: (conversationId) => set((state) => ({
+    activeTools: {
+      ...state.activeTools,
+      [conversationId]: [],
+    },
+  })),
 
   // Sub-agent actions
   addSubAgent: (conversationId, agent) => set((state) => {
@@ -2300,10 +2219,6 @@ updateFileTabContent: (id, content) => set((state) => ({
   // Atomic streaming finalization - creates message and clears streaming in one update
   // This prevents the data loss bug where streaming text could be cleared before message is saved
   finalizeStreamingMessage: (conversationId, metadata) => {
-    // Clear tool timeouts before clearing active tools
-    const currentTools = useAppStore.getState().activeTools[conversationId] || [];
-    clearToolTimeoutsForConversation(conversationId, currentTools);
-
     return set((state) => {
       const streaming = state.streamingState[conversationId];
       const queuedQueue = state.queuedMessages[conversationId] ?? [];


### PR DESCRIPTION
## Summary

- Long-running tools (sub-agents, Bash) can legitimately exceed 5 minutes. The frontend's force-complete timer was marking them as failed even though the SDK was still streaming, producing spurious *"Tool timed out"* messages.
- Removes the `toolTimeouts` Map, `TOOL_TIMEOUT_MS`, the three `clearToolTimeouts*` helpers, the `skipTimeout` option on `addActiveTool`, and the `isUserInteractiveTool` special case in `useWebSocket`.
- Updates `docs/architecture/frontend-state-and-rendering.md` (drops the now-obsolete "Tool Timeout" section) and `docs/troubleshooting/debugging-guide.md` (notes that the SDK has no built-in timeout and the spinner waits for `tool_end` or turn finalization).

## Behavior change

Active tools are now cleared exclusively via:
1. `tool_end` from the backend
2. Terminal turn events (`result`, `turn_complete`, `error`, …) → `finalizeStreamingMessage` resets `activeTools[conversationId] = []`
3. `clearActiveTools` on stop
4. Snapshot reconciliation on WebSocket reconnect
5. `removeConversation` / `removeSession`

Trade-off: rare permanently-stuck spinners (if both `tool_end` is dropped *and* the turn never finalizes) instead of the prior false-positive timeouts on legitimate >5min runs. Documented in the debugging guide.

## Test plan

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm run test:run` — existing `addActiveTool` / `clearActiveTools` / `finalizeStreamingMessage` tests still pass under the new single-arg signature
- [ ] Manual: kick off a sub-agent or `Bash` invocation that runs >5 minutes; verify the spinner stays active and resolves cleanly when `tool_end` arrives
- [ ] Manual: stop a long-running conversation; verify `clearActiveTools` removes the spinner immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)