### PR TITLE
feat(attachments): bump image upload limit from 5MB to 10MB

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -996,13 +996,13 @@ function buildUserMessage(msg: QueuedMessage): SDKUserMessage {
       // SDK → CLI child process chain). Instead, write to a temp file and use
       // the same text-instruction approach as the file-based path.
       const rawSizeBytes = Math.ceil(attachment.base64Data.length * 3 / 4);
-      const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB
+      const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10MB
       if (rawSizeBytes > MAX_IMAGE_BYTES) {
         const sizeMB = (rawSizeBytes / (1024 * 1024)).toFixed(1);
-        lifecycle(`image "${attachment.name}" too large: ${sizeMB}MB (limit 5MB)`);
+        lifecycle(`image "${attachment.name}" too large: ${sizeMB}MB (limit 10MB)`);
         emit({
           type: "error",
-          message: `Image "${attachment.name}" is ${sizeMB}MB which exceeds the 5MB API limit. Please use a smaller image.`,
+          message: `Image "${attachment.name}" is ${sizeMB}MB which exceeds the 10MB API limit. Please use a smaller image.`,
         });
         continue;
       }

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -1104,7 +1104,7 @@ export function ChatInput({ onMessageSubmit }: ChatInputProps) {
             <Upload className="w-8 h-8 text-muted-foreground mb-2" />
             <span className="font-medium text-foreground">Drop files here</span>
             <span className="text-xs text-muted-foreground mt-1">
-              Images, code, and text files (max 5MB each)
+              Images, code, and text files (max 10MB each)
             </span>
           </div>
         )}

--- a/src/lib/__tests__/attachments.test.ts
+++ b/src/lib/__tests__/attachments.test.ts
@@ -592,8 +592,8 @@ describe('getAttachmentSubtitle', () => {
 
 describe('ATTACHMENT_LIMITS', () => {
   it('has expected limits', () => {
-    expect(ATTACHMENT_LIMITS.MAX_FILE_SIZE).toBe(5 * 1024 * 1024);
-    expect(ATTACHMENT_LIMITS.MAX_TOTAL_SIZE).toBe(20 * 1024 * 1024);
+    expect(ATTACHMENT_LIMITS.MAX_FILE_SIZE).toBe(10 * 1024 * 1024);
+    expect(ATTACHMENT_LIMITS.MAX_TOTAL_SIZE).toBe(40 * 1024 * 1024);
     expect(ATTACHMENT_LIMITS.MAX_ATTACHMENTS).toBe(10);
   });
 });

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -11,8 +11,8 @@ import { toBase64 } from './utils';
 // ============================================================================
 
 export const ATTACHMENT_LIMITS = {
-  MAX_FILE_SIZE: 5 * 1024 * 1024,      // 5MB per file
-  MAX_TOTAL_SIZE: 20 * 1024 * 1024,    // 20MB total per message
+  MAX_FILE_SIZE: 10 * 1024 * 1024,     // 10MB per file
+  MAX_TOTAL_SIZE: 40 * 1024 * 1024,    // 40MB total per message
   MAX_ATTACHMENTS: 10,                  // Max files per message
   PREVIEW_LENGTH: 500,                  // Characters for text preview
 };


### PR DESCRIPTION
## Summary
- Raise per-file attachment limit from 5MB → 10MB and per-message total from 20MB → 40MB so users can drag-drop larger screenshots without rejection.
- Bump the matching guard in `agent-runner` (and its error messages) in lockstep so what the UI accepts the runner won't reject.
- Update the drag-overlay help text and the `ATTACHMENT_LIMITS` test assertions to match the new values.

## Files changed
- `src/lib/attachments.ts` — `MAX_FILE_SIZE` 5MB→10MB, `MAX_TOTAL_SIZE` 20MB→40MB
- `src/components/conversation/ChatInput.tsx` — drop-zone hint now reads "max 10MB each"
- `agent-runner/src/index.ts` — `MAX_IMAGE_BYTES` 5MB→10MB and "5MB" → "10MB" in lifecycle log + error toast
- `src/lib/__tests__/attachments.test.ts` — assertions updated

The paste-image error in `useChatInputAttachments.ts` already reads the constant dynamically, so no edit was needed there.

## Test plan
- [ ] `npm run test:run -- src/lib/__tests__/attachments.test.ts` passes
- [ ] `npm run lint` and `npm run build` clean
- [ ] Drag a ~7MB image into Compose — attaches successfully (previously rejected)
- [ ] Drag a >10MB image — rejected with "10MB" toast
- [ ] Paste (Cmd+V) a >10MB image — error message reads "10MB limit"
- [ ] Send a message with the ~7MB image — agent-runner accepts it (no "exceeds the 10MB API limit" in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)