### PR TITLE
fix(feature-gate): tighten SHOW_UNRELEASED gating

### DIFF
--- a/src/components/conversation/OllamaProgressBlock.tsx
+++ b/src/components/conversation/OllamaProgressBlock.tsx
@@ -3,6 +3,7 @@
 import { useAppStore } from '@/stores/appStore';
 import { Download, HardDrive } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { SHOW_UNRELEASED } from '@/lib/constants';
 
 function formatBytes(bytes: number): string {
   if (bytes <= 0) return '0 B';
@@ -18,6 +19,7 @@ function formatBytes(bytes: number): string {
  */
 export function OllamaProgressBlock() {
   const progress = useAppStore((s) => s.ollamaProgress);
+  if (!SHOW_UNRELEASED) return null;
   if (!progress) return null;
 
   const isDownload = progress.type === 'ollama_download';

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -9,6 +9,7 @@ import {
   WEBSOCKET_RECONNECT_BASE_DELAY_MS,
   WEBSOCKET_RECONNECT_MAX_DELAY_MS,
   WEBSOCKET_RECONNECT_MAX_ATTEMPTS,
+  SHOW_UNRELEASED,
 } from '@/lib/constants';
 import { getAuthToken } from '@/lib/auth-token';
 import { getBackendPort } from '@/lib/backend-port';
@@ -1358,7 +1359,9 @@ export function useWebSocket(enabled: boolean = true) {
           console.warn('Failed to re-sync sessions on reconnect:', err);
         });
         // Refresh scheduled task state (next_run_at, last_run_at may have changed)
-        useScheduledTaskStore.getState().fetchTasks();
+        if (SHOW_UNRELEASED) {
+          useScheduledTaskStore.getState().fetchTasks();
+        }
       } else {
         reconcileInitialStreamingState();
       }
@@ -1388,6 +1391,7 @@ export function useWebSocket(enabled: boolean = true) {
 
         // Handle Ollama progress events (binary download or model pull)
         if (data.type === 'ollama_download' || data.type === 'ollama_pull') {
+          if (!SHOW_UNRELEASED) return;
           const payload = data.payload as Record<string, unknown> | undefined;
           if (payload) {
             // Cancel any pending clear timer so a new operation isn't clobbered
@@ -1492,7 +1496,9 @@ export function useWebSocket(enabled: boolean = true) {
               }
             }).catch(() => {});
             // Refresh scheduled task store
-            useScheduledTaskStore.getState().fetchTasks();
+            if (SHOW_UNRELEASED) {
+              useScheduledTaskStore.getState().fetchTasks();
+            }
           }
           return;
         }

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -11,7 +11,7 @@ import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore, type ContentView } from '@/stores/settingsStore';
 import { useNavigationStore, type NavigationEntry } from '@/stores/navigationStore';
 import { useTabStore } from '@/stores/tabStore';
-import { ENABLE_BROWSER_TABS } from '@/lib/constants';
+import { ENABLE_BROWSER_TABS, SHOW_UNRELEASED } from '@/lib/constants';
 import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 import { useScheduledTaskStore } from '@/stores/scheduledTaskStore';
 
@@ -181,12 +181,14 @@ function isEntryValid(entry: NavigationEntry): boolean {
       }
       return true;
     case 'dashboard':
+    case 'scheduled-tasks':
+      return SHOW_UNRELEASED;
     case 'repositories':
     case 'history':
     case 'skills-store':
-    case 'scheduled-tasks':
       return true;
     case 'scheduled-task-detail':
+      if (!SHOW_UNRELEASED) return false;
       return useScheduledTaskStore.getState().tasks.some((t) => t.id === cv.taskId);
     case 'conversation':
     default:
@@ -477,10 +479,20 @@ export function goForward(tabId?: string): void {
 /** Jump to a specific entry in the back stack (index 0 = most recent) */
 export function goToBackEntry(index: number, tabId?: string): void {
   const navStore = useNavigationStore.getState();
+  const id = tabId ?? navStore.activeTabId;
+  const tab = navStore.tabs[id];
+  if (!tab) return;
+
+  // Peek the target entry without mutating stacks. If it's invalid, bail out
+  // before any state changes — otherwise the click would shuffle history yet
+  // not navigate, leaving the popover in a confusing state.
+  const actualIndex = tab.backStack.length - 1 - index;
+  const candidate = tab.backStack[actualIndex];
+  if (!candidate || !isEntryValid(candidate)) return;
+
   const currentEntry = snapshotCurrent();
   const entry = navStore.goToBackIndex(index, currentEntry, tabId);
-
-  if (!entry || !isEntryValid(entry)) return;
+  if (!entry) return;
 
   navStore.setRestoring(true);
   try {
@@ -493,10 +505,18 @@ export function goToBackEntry(index: number, tabId?: string): void {
 /** Jump to a specific entry in the forward stack (index 0 = most recent) */
 export function goToForwardEntry(index: number, tabId?: string): void {
   const navStore = useNavigationStore.getState();
+  const id = tabId ?? navStore.activeTabId;
+  const tab = navStore.tabs[id];
+  if (!tab) return;
+
+  // Peek before mutating — see goToBackEntry for rationale.
+  const actualIndex = tab.forwardStack.length - 1 - index;
+  const candidate = tab.forwardStack[actualIndex];
+  if (!candidate || !isEntryValid(candidate)) return;
+
   const currentEntry = snapshotCurrent();
   const entry = navStore.goToForwardIndex(index, currentEntry, tabId);
-
-  if (!entry || !isEntryValid(entry)) return;
+  if (!entry) return;
 
   navStore.setRestoring(true);
   try {


### PR DESCRIPTION
## Summary

Fully gate unreleased surfaces behind `SHOW_UNRELEASED` so a `NEXT_PUBLIC_SIMULATE_PROD=1` build doesn't leak partial state, do wasted work, or corrupt navigation history.

- **navigation**: `isEntryValid` now returns `false` for `dashboard`, `scheduled-tasks`, and `scheduled-task-detail` when `!SHOW_UNRELEASED`.
- **navigation**: `goToBackEntry` / `goToForwardEntry` peek the candidate entry and run `isEntryValid` *before* mutating the back/forward stacks. Previously, clicking a gated entry in the history popover would silently abort the navigation while still shuffling stacks (pre-existing latent bug, made more reachable by the new gates).
- **ollama**: `OllamaProgressBlock` returns `null` and the WS event handler now early-returns when `!SHOW_UNRELEASED` — no more store writes, timers, or re-renders for a hidden UI.
- **scheduled tasks**: `useScheduledTaskStore.fetchTasks()` calls in `useWebSocket` (reconnect + `scheduled_task_run`) are skipped when `!SHOW_UNRELEASED`.

## Test plan

- [x] `npx tsc --noEmit` — no new errors in `useWebSocket.ts` / `navigation.ts`
- [x] `vitest run src/lib/__tests__/navigation.test.ts src/lib/__tests__/buildNavigationLabel.test.ts` — 48/48 pass
- [x] `eslint src/hooks/useWebSocket.ts src/lib/navigation.ts` — clean
- [ ] Manual: `NEXT_PUBLIC_SIMULATE_PROD=1 npm run dev` — confirm dashboard/scheduled-tasks nav items are hidden, Ollama progress block doesn't render, and back/forward history popover stays consistent if a gated entry is somehow reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)