### PR TITLE
fix(user-question): track selection by index to fix duplicate/comma labels

### DIFF
--- a/src/components/conversation/UserQuestionPrompt.tsx
+++ b/src/components/conversation/UserQuestionPrompt.tsx
@@ -9,8 +9,7 @@ import { ChevronLeft, ChevronRight, ArrowRight, Loader2, X, Pencil, Check } from
 import { answerConversationQuestion } from '@/lib/api';
 import { useToast } from '@/components/ui/toast';
 import type { UserQuestion } from '@/lib/types';
-
-const OTHER_OPTION_LABEL = '__other__';
+import { isUserQuestionAnswered, serializeUserQuestionAnswers } from '@/lib/userQuestion';
 
 interface UserQuestionPromptProps {
   conversationId: string;
@@ -18,20 +17,26 @@ interface UserQuestionPromptProps {
 
 export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) {
   const pending = usePendingUserQuestion(conversationId);
-  const { updateUserQuestionAnswer, nextUserQuestion, prevUserQuestion, clearPendingUserQuestion } = useUserQuestionActions();
+  const {
+    toggleUserQuestionOption,
+    selectUserQuestionOther,
+    deselectUserQuestionOther,
+    setUserQuestionOtherText,
+    setUserQuestionFreeText,
+    nextUserQuestion,
+    prevUserQuestion,
+    clearPendingUserQuestion,
+  } = useUserQuestionActions();
   const { error: showError } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [freeTextValue, setFreeTextValue] = useState('');
-  const [otherSelected, setOtherSelected] = useState(false);
-  const [otherTextValue, setOtherTextValue] = useState('');
   const autoSubmitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const otherSelectedRef = useRef(otherSelected);
-
-  // Keep ref in sync via effect (react-hooks/refs disallows render-time ref mutation)
+  // Ref-mirror of isSubmitting so the auto-submit timer can bail when a manual
+  // submit/dismiss is already in flight (closures captured `isSubmitting` would be stale).
+  const isSubmittingRef = useRef(false);
   useEffect(() => {
-    otherSelectedRef.current = otherSelected;
-  }, [otherSelected]);
+    isSubmittingRef.current = isSubmitting;
+  }, [isSubmitting]);
 
   // Clear auto-submit timeout on unmount
   useEffect(() => {
@@ -45,111 +50,88 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
   const currentQuestion: UserQuestion | undefined = pending?.questions[pending.currentIndex];
   const totalQuestions = pending?.questions.length ?? 0;
   const currentIndex = pending?.currentIndex ?? 0;
+  const currentHeader = currentQuestion?.header;
 
-  // Get selected values for current question
-  const selectedValues = useMemo(() => {
-    if (!pending || !currentQuestion) return new Set<string>();
-    const answer = pending.answers[currentQuestion.header];
-    if (!answer) return new Set<string>();
-    // For multi-select, answers are comma-separated
-    return new Set(answer.split(',').filter(Boolean));
-  }, [pending, currentQuestion]);
+  // Selected option indices for the current question (Set for fast lookup).
+  const selectedIndexSet = useMemo(() => {
+    if (!pending || !currentHeader) return new Set<number>();
+    return new Set(pending.selectedIndices[currentHeader] ?? []);
+  }, [pending, currentHeader]);
 
-  const handleOptionToggle = useCallback((label: string) => {
+  // Other / free-text state — derived directly from store.
+  const otherSelected = currentHeader ? !!pending?.otherSelected[currentHeader] : false;
+  const otherText = currentHeader ? (pending?.otherText[currentHeader] ?? '') : '';
+  const freeTextValue = currentHeader ? (pending?.freeTextAnswer[currentHeader] ?? '') : '';
+
+  const handleOptionToggle = useCallback((optionIndex: number) => {
     if (!currentQuestion || isSubmitting) return;
-
-    // Handle "Other" option selection
-    if (label === OTHER_OPTION_LABEL) {
-      if (currentQuestion.multiSelect) {
-        if (otherSelectedRef.current) {
-          // Toggle off: remove custom text from answer
-          setOtherSelected(false);
-          setOtherTextValue('');
-          const currentAnswer = useAppStore.getState().pendingUserQuestion[conversationId]?.answers[currentQuestion.header] || '';
-          const optionLabels = new Set(currentQuestion.options.map(o => o.label));
-          const regularOnly = currentAnswer.split(',').filter(v => v && optionLabels.has(v));
-          updateUserQuestionAnswer(conversationId, currentQuestion.header, regularOnly.join(','));
-        } else {
-          setOtherSelected(true);
-        }
-      } else {
-        // Single-select: select "Other", clear any regular selection
-        setOtherSelected(true);
-        setOtherTextValue('');
-        updateUserQuestionAnswer(conversationId, currentQuestion.header, '');
-        // Cancel any pending auto-submit from a previous regular option click
-        if (autoSubmitTimeoutRef.current) {
-          clearTimeout(autoSubmitTimeoutRef.current);
-          autoSubmitTimeoutRef.current = null;
-        }
-      }
-      return;
+    // Cancel any pending auto-submit (e.g. from a previous single-select click).
+    if (autoSubmitTimeoutRef.current) {
+      clearTimeout(autoSubmitTimeoutRef.current);
+      autoSubmitTimeoutRef.current = null;
     }
 
-    // Regular option clicked — clear "Other" state for single-select
-    if (!currentQuestion.multiSelect && otherSelectedRef.current) {
-      setOtherSelected(false);
-      setOtherTextValue('');
-    }
+    toggleUserQuestionOption(conversationId, currentQuestion.header, optionIndex, currentQuestion.multiSelect);
 
-    if (currentQuestion.multiSelect) {
-      // Read current answer directly from store to avoid stale closure
-      const currentAnswer = useAppStore.getState().pendingUserQuestion[conversationId]?.answers[currentQuestion.header] || '';
-      const currentSet = new Set(currentAnswer.split(',').filter(Boolean));
-      if (currentSet.has(label)) {
-        currentSet.delete(label);
-      } else {
-        currentSet.add(label);
-      }
-      updateUserQuestionAnswer(conversationId, currentQuestion.header, [...currentSet].join(','));
-    } else {
-      // Single select - replace and show selection briefly before auto-submit/advance
-      updateUserQuestionAnswer(conversationId, currentQuestion.header, label);
-
-      // Brief delay so user sees the selection highlight before advancing
-      if (autoSubmitTimeoutRef.current) {
-        clearTimeout(autoSubmitTimeoutRef.current);
-      }
+    // Single-select: brief delay so user sees the highlight, then advance/auto-submit.
+    if (!currentQuestion.multiSelect) {
       const clickedIndex = useAppStore.getState().pendingUserQuestion[conversationId]?.currentIndex;
       autoSubmitTimeoutRef.current = setTimeout(() => {
         autoSubmitTimeoutRef.current = null;
-
-        // Read fresh state to avoid stale closures
+        // Bail if a manual submit/dismiss is already in flight — without this we
+        // could fire a duplicate `answerConversationQuestion` for the same requestId.
+        if (isSubmittingRef.current) return;
         const pendingState = useAppStore.getState().pendingUserQuestion[conversationId];
         if (!pendingState) return;
-
-        // Bail if the user navigated away from this question before the timer fired
+        // Bail if user navigated away from this question before the timer fired.
         if (pendingState.currentIndex !== clickedIndex) return;
 
         const freshTotal = pendingState.questions.length;
         const freshIndex = pendingState.currentIndex;
-        const freshQuestion = pendingState.questions[freshIndex];
-        if (!freshQuestion) return;
+        const allAnswered = pendingState.questions.every((q) => isUserQuestionAnswered(pendingState, q));
 
-        const allAnswered = pendingState.questions.every((q) => {
-          if (q.header === freshQuestion.header) return true; // this one is now answered
-          const answer = pendingState.answers[q.header];
-          return answer && answer.length > 0;
-        });
-
-        if (allAnswered && freshTotal <= 1) {
-          // Only question — auto-submit with the updated answers
-          const answers = { ...pendingState.answers, [freshQuestion.header]: label };
+        if (allAnswered) {
           setIsSubmitting(true);
-          answerConversationQuestion(conversationId, pendingState.requestId, answers)
+          answerConversationQuestion(conversationId, pendingState.requestId, serializeUserQuestionAnswers(pendingState))
             .then(() => clearPendingUserQuestion(conversationId))
             .catch((error) => showError(error instanceof Error ? error.message : 'Failed to submit answer'))
             .finally(() => setIsSubmitting(false));
         } else if (freshIndex < freshTotal - 1) {
-          // More questions in wizard — advance to next
           nextUserQuestion(conversationId);
         }
       }, 200);
     }
-  }, [conversationId, currentQuestion, isSubmitting, updateUserQuestionAnswer, nextUserQuestion, clearPendingUserQuestion, showError]);
+  }, [conversationId, currentQuestion, isSubmitting, toggleUserQuestionOption, nextUserQuestion, clearPendingUserQuestion, showError]);
+
+  const handleOtherToggle = useCallback(() => {
+    if (!currentQuestion || isSubmitting) return;
+    if (autoSubmitTimeoutRef.current) {
+      clearTimeout(autoSubmitTimeoutRef.current);
+      autoSubmitTimeoutRef.current = null;
+    }
+    if (otherSelected) {
+      deselectUserQuestionOther(conversationId, currentQuestion.header);
+    } else {
+      selectUserQuestionOther(conversationId, currentQuestion.header, currentQuestion.multiSelect);
+    }
+  }, [conversationId, currentQuestion, isSubmitting, otherSelected, selectUserQuestionOther, deselectUserQuestionOther]);
+
+  const handleOtherTextChange = useCallback((text: string) => {
+    if (!currentQuestion) return;
+    setUserQuestionOtherText(conversationId, currentQuestion.header, text);
+  }, [conversationId, currentQuestion, setUserQuestionOtherText]);
+
+  const handleFreeTextChange = useCallback((text: string) => {
+    if (!currentQuestion) return;
+    setUserQuestionFreeText(conversationId, currentQuestion.header, text);
+  }, [conversationId, currentQuestion, setUserQuestionFreeText]);
 
   const handleDismiss = useCallback(async () => {
     if (!pending || isSubmitting) return;
+    if (autoSubmitTimeoutRef.current) {
+      clearTimeout(autoSubmitTimeoutRef.current);
+      autoSubmitTimeoutRef.current = null;
+    }
     // Send cancellation to the agent so it doesn't wait for timeout
     try {
       await answerConversationQuestion(conversationId, pending.requestId, { __cancelled: 'true' });
@@ -169,10 +151,14 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
 
   const handleSubmit = useCallback(async () => {
     if (!pending || isSubmitting) return;
+    if (autoSubmitTimeoutRef.current) {
+      clearTimeout(autoSubmitTimeoutRef.current);
+      autoSubmitTimeoutRef.current = null;
+    }
 
     setIsSubmitting(true);
     try {
-      await answerConversationQuestion(conversationId, pending.requestId, pending.answers);
+      await answerConversationQuestion(conversationId, pending.requestId, serializeUserQuestionAnswers(pending));
       clearPendingUserQuestion(conversationId);
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Failed to submit answer');
@@ -181,73 +167,20 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
     }
   }, [conversationId, pending, isSubmitting, clearPendingUserQuestion, showError]);
 
-  // Check if all questions have answers
+  // Check if all questions have answers (for final-submit gate)
   const canSubmit = useMemo(() => {
     if (!pending) return false;
-    return pending.questions.every((q) => {
-      const answer = pending.answers[q.header];
-      return answer && answer.length > 0;
-    });
+    return pending.questions.every((q) => isUserQuestionAnswered(pending, q));
   }, [pending]);
 
   // Check if the current question has an answer (for advancing in multi-question flows)
   const currentQuestionAnswered = useMemo(() => {
     if (!pending || !currentQuestion) return false;
-    const answer = pending.answers[currentQuestion.header];
-    return !!answer && answer.length > 0;
+    return isUserQuestionAnswered(pending, currentQuestion);
   }, [pending, currentQuestion]);
 
   const isLastQuestion = currentIndex === totalQuestions - 1;
   const shouldAdvance = !isLastQuestion && currentQuestionAnswered && !canSubmit;
-
-  // Sync free-text state when the current question changes
-  const currentHeader = currentQuestion?.header;
-  const hasFreeText = currentQuestion && currentQuestion.options.length === 0;
-  useEffect(() => {
-    if (hasFreeText && currentHeader && pending) {
-      setFreeTextValue(pending.answers[currentHeader] || '');
-    }
-  }, [currentHeader, hasFreeText, pending]);
-
-  // Restore "Other" state when navigating to a different question.
-  // Only fires on currentHeader change (not on answer updates for the current question).
-  useEffect(() => {
-    if (!currentQuestion || currentQuestion.options.length === 0 || !currentHeader) {
-      setOtherSelected(false);
-      setOtherTextValue('');
-      return;
-    }
-    // Read answer directly from store snapshot (not from `pending` dep)
-    const pendingState = useAppStore.getState().pendingUserQuestion[conversationId];
-    const answer = pendingState?.answers[currentHeader];
-    if (!answer) {
-      setOtherSelected(false);
-      setOtherTextValue('');
-      return;
-    }
-    if (!currentQuestion.multiSelect) {
-      const matchesOption = currentQuestion.options.some(o => o.label === answer);
-      if (!matchesOption) {
-        setOtherSelected(true);
-        setOtherTextValue(answer);
-      } else {
-        setOtherSelected(false);
-        setOtherTextValue('');
-      }
-    } else {
-      const values = answer.split(',').filter(Boolean);
-      const optionLabels = new Set(currentQuestion.options.map(o => o.label));
-      const otherValues = values.filter(v => !optionLabels.has(v));
-      if (otherValues.length > 0) {
-        setOtherSelected(true);
-        setOtherTextValue(otherValues[0]);
-      } else {
-        setOtherSelected(false);
-        setOtherTextValue('');
-      }
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentHeader, conversationId]);
 
   // Total options count including "Other" (for keyboard shortcut numbering)
   const otherNumber = currentQuestion ? currentQuestion.options.length + 1 : 0;
@@ -269,27 +202,32 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
 
       if (num <= currentQuestion.options.length) {
         e.preventDefault();
-        handleOptionToggle(currentQuestion.options[num - 1].label);
+        handleOptionToggle(num - 1);
       } else if (num === otherNumber) {
         e.preventDefault();
-        handleOptionToggle(OTHER_OPTION_LABEL);
+        handleOtherToggle();
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [currentQuestion, isSubmitting, otherNumber, handleOptionToggle]);
+  }, [currentQuestion, isSubmitting, otherNumber, handleOptionToggle, handleOtherToggle]);
 
-  // Whether user is actively typing custom "Other" text
-  const isOtherTextActive = otherSelected && otherTextValue.length > 0;
+  // Whether user is actively typing custom "Other" text (for the dim-non-other rows)
+  const isOtherTextActive = otherSelected && otherText.length > 0;
 
-  // Selected count for multi-select footer
+  // Selected count for multi-select footer. Only counts Other once it has text —
+  // empty Other isn't sent on submit (see serializeUserQuestionAnswers), so it shouldn't pad the count.
   const selectedCount = useMemo(() => {
     if (!currentQuestion?.multiSelect) return 0;
-    return selectedValues.size + (isOtherTextActive ? 1 : 0);
-  }, [currentQuestion?.multiSelect, selectedValues.size, isOtherTextActive]);
+    return selectedIndexSet.size + (isOtherTextActive ? 1 : 0);
+  }, [currentQuestion?.multiSelect, selectedIndexSet.size, isOtherTextActive]);
 
   if (!pending || !currentQuestion) return null;
+
+  const isFreeText = currentQuestion.options.length === 0;
+  // In single-select, regular options become non-interactive while Other is being typed.
+  const optionsDimmed = isOtherTextActive && !currentQuestion.multiSelect;
 
   return (
     <div ref={containerRef} className="pt-1 px-3 pb-3">
@@ -341,23 +279,29 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
 
         {/* Options List or Free-text Input — key forces remount when question changes */}
         <div key={currentQuestion.header} className="px-2 pb-1">
-          {currentQuestion.options.length > 0 ? (
+          {!isFreeText ? (
             <>
-              {/* Option rows with dividers */}
+              {/* Option rows with dividers.
+                  Key combines index + label so duplicate labels remain distinct
+                  rows; the outer wrapper at the top of this block keys on
+                  `currentQuestion.header`, so the option list is remounted on
+                  question change — index is stable for this list's lifetime. */}
               {currentQuestion.options.map((option, index) => {
-                const isSelected = selectedValues.has(option.label);
-                const effectiveSelected = isSelected && (!otherSelected || currentQuestion.multiSelect);
+                const isSelected = selectedIndexSet.has(index);
                 return (
-                  <div key={option.label}>
+                  <div key={`${index}-${option.label}`}>
                     <button
                       type="button"
-                      onClick={() => handleOptionToggle(option.label)}
+                      onClick={() => handleOptionToggle(index)}
                       className={cn(
                         'w-full flex items-center gap-3 px-3 py-3 text-left rounded-lg transition-all duration-150',
-                        effectiveSelected
+                        isSelected
                           ? 'bg-brand/10 text-foreground'
                           : 'text-foreground/80 hover:bg-muted/30 hover:text-foreground',
-                        isOtherTextActive && !currentQuestion.multiSelect && 'opacity-50'
+                        // While the user is typing in "Other" (single-select), regular options
+                        // are de-emphasized but stay clickable — clicking one is the explicit
+                        // signal to switch off Other (handled in the store action).
+                        optionsDimmed && 'opacity-50'
                       )}
                       data-testid={`option-${index}`}
                     >
@@ -365,11 +309,11 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
                       {currentQuestion.multiSelect ? (
                         <div className={cn(
                           'flex items-center justify-center h-5 w-5 rounded border-2 shrink-0 transition-colors',
-                          effectiveSelected
+                          isSelected
                             ? 'border-brand bg-brand'
                             : 'border-muted-foreground/30'
                         )}>
-                          {effectiveSelected && <Check className="h-3 w-3 text-primary-foreground" />}
+                          {isSelected && <Check className="h-3 w-3 text-primary-foreground" />}
                         </div>
                       ) : (
                         <span className="flex items-center justify-center h-7 w-7 rounded-full bg-muted/50 text-xs font-medium text-muted-foreground shrink-0">
@@ -383,7 +327,7 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
                         )}
                       </div>
                       {/* Right arrow for selected single-select option */}
-                      {!currentQuestion.multiSelect && effectiveSelected && (
+                      {!currentQuestion.multiSelect && isSelected && (
                         <ArrowRight className="h-4 w-4 text-foreground/60 shrink-0" />
                       )}
                     </button>
@@ -400,26 +344,51 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
 
               {/* "Something else" row — renders as <button> when collapsed,
                   <div> when expanded to avoid invalid HTML (interactive <input>
-                  nested inside <button>). */}
+                  nested inside <button>).
+                  The expanded row uses brand-tinted bg + filled checkbox only
+                  once there's actual text, matching the footer count and
+                  serialization gates (empty Other isn't counted/submitted). */}
               {otherSelected ? (
                 <div
-                  className="w-full flex items-center gap-3 px-3 py-3 text-left rounded-lg transition-all duration-150 bg-brand/10 cursor-pointer"
+                  className={cn(
+                    'w-full flex items-center gap-3 px-3 py-3 text-left rounded-lg transition-all duration-150 cursor-pointer',
+                    // Subtle highlight while typing; full brand tint once there's content.
+                    isOtherTextActive ? 'bg-brand/10' : 'bg-muted/30',
+                    // Visible focus indicator on the wrapper so keyboard users see where focus lives.
+                    'focus-within:ring-1 focus-within:ring-brand/60'
+                  )}
                   data-testid="other-option"
                   onClick={(e) => {
-                    // Toggle off when clicking anywhere except the text input
-                    if ((e.target as HTMLElement).tagName !== 'INPUT') {
-                      handleOptionToggle(OTHER_OPTION_LABEL);
+                    // Toggle off when clicking anywhere except an interactive
+                    // input (covers nested wrappers around the <input> too).
+                    if (!(e.target as HTMLElement).closest('input, textarea, button')) {
+                      handleOtherToggle();
                     }
                   }}
                 >
-                  {/* Left icon */}
+                  {/* Left icon — single-select uses a number badge (matches
+                      keyboard shortcut); multi-select uses a checkbox. The
+                      checkbox is only filled once Other has text, mirroring
+                      the count/submit gate. */}
                   {currentQuestion.multiSelect ? (
-                    <div className="flex items-center justify-center h-5 w-5 rounded border-2 border-brand bg-brand shrink-0 transition-colors">
-                      <Check className="h-3 w-3 text-primary-foreground" />
+                    <div className={cn(
+                      'flex items-center justify-center h-5 w-5 rounded border-2 shrink-0 transition-colors relative',
+                      isOtherTextActive
+                        ? 'border-brand bg-brand'
+                        : 'border-muted-foreground/30'
+                    )}>
+                      {isOtherTextActive ? (
+                        <Check className="h-3 w-3 text-primary-foreground" />
+                      ) : (
+                        <Pencil className="h-2.5 w-2.5 text-muted-foreground" />
+                      )}
                     </div>
                   ) : (
-                    <span className="flex items-center justify-center h-7 w-7 rounded-full bg-muted/50 shrink-0">
-                      <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span
+                      className="flex items-center justify-center h-7 w-7 rounded-full bg-muted/50 text-xs font-medium text-muted-foreground shrink-0"
+                      aria-hidden="true"
+                    >
+                      {otherNumber}
                     </span>
                   )}
                   <div className="flex-1 min-w-0">
@@ -427,23 +396,10 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
                       type="text"
                       className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
                       placeholder="Something else"
-                      value={otherTextValue}
-                      onChange={(e) => {
-                        setOtherTextValue(e.target.value);
-                        if (!currentQuestion.multiSelect) {
-                          updateUserQuestionAnswer(conversationId, currentQuestion.header, e.target.value);
-                        } else {
-                          const currentAnswer = useAppStore.getState().pendingUserQuestion[conversationId]?.answers[currentQuestion.header] || '';
-                          const optionLabels = new Set(currentQuestion.options.map(o => o.label));
-                          const regularSelections = currentAnswer.split(',').filter(v => v && optionLabels.has(v));
-                          if (e.target.value) {
-                            regularSelections.push(e.target.value);
-                          }
-                          updateUserQuestionAnswer(conversationId, currentQuestion.header, regularSelections.join(','));
-                        }
-                      }}
+                      value={otherText}
+                      onChange={(e) => handleOtherTextChange(e.target.value)}
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter' && otherTextValue.trim() && !isSubmitting) {
+                        if (e.key === 'Enter' && otherText.trim() && !isSubmitting) {
                           e.preventDefault();
                           handleSubmit();
                         }
@@ -456,15 +412,23 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
               ) : (
                 <button
                   type="button"
-                  onClick={() => handleOptionToggle(OTHER_OPTION_LABEL)}
+                  onClick={handleOtherToggle}
                   className="w-full flex items-center gap-3 px-3 py-3 text-left rounded-lg transition-all duration-150 hover:bg-muted/30"
                   data-testid="other-option"
                 >
                   {currentQuestion.multiSelect ? (
-                    <div className="flex items-center justify-center h-5 w-5 rounded border-2 shrink-0 transition-colors border-muted-foreground/30" />
+                    // Empty checkbox + small Pencil glyph so multi-select carries
+                    // the "free-text option" signal that single-select gets from
+                    // its number-vs-pencil styling.
+                    <div className="flex items-center justify-center h-5 w-5 rounded border-2 shrink-0 transition-colors border-muted-foreground/30">
+                      <Pencil className="h-2.5 w-2.5 text-muted-foreground" />
+                    </div>
                   ) : (
-                    <span className="flex items-center justify-center h-7 w-7 rounded-full bg-muted/50 shrink-0">
-                      <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span
+                      className="flex items-center justify-center h-7 w-7 rounded-full bg-muted/50 text-xs font-medium text-muted-foreground shrink-0"
+                      aria-hidden="true"
+                    >
+                      {otherNumber}
                     </span>
                   )}
                   <span className="text-sm text-muted-foreground/50">Something else</span>
@@ -475,13 +439,10 @@ export function UserQuestionPrompt({ conversationId }: UserQuestionPromptProps) 
             <div className="px-3 py-1">
               <input
                 type="text"
-                className="w-full px-3 py-2 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                className="w-full px-3 py-2 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-brand/60"
                 placeholder="Type your answer..."
                 value={freeTextValue}
-                onChange={(e) => {
-                  setFreeTextValue(e.target.value);
-                  updateUserQuestionAnswer(conversationId, currentQuestion.header, e.target.value);
-                }}
+                onChange={(e) => handleFreeTextChange(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && canSubmit && !isSubmitting) {
                     e.preventDefault();

--- a/src/components/conversation/__tests__/UserQuestionPrompt.test.tsx
+++ b/src/components/conversation/__tests__/UserQuestionPrompt.test.tsx
@@ -42,7 +42,10 @@ function makePending(overrides: Partial<PendingUserQuestion> = {}): PendingUserQ
     requestId: 'req-1',
     questions: [makeQuestion()],
     currentIndex: 0,
-    answers: {},
+    selectedIndices: {},
+    otherSelected: {},
+    otherText: {},
+    freeTextAnswer: {},
     ...overrides,
   };
 }
@@ -182,8 +185,8 @@ describe('UserQuestionPrompt', () => {
 
       await user.click(screen.getByText('Vue'));
 
-      // Answer should be in store immediately
-      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.answers['Framework']).toBe('Vue');
+      // Selection lands in store immediately by index
+      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework']).toEqual([1]);
 
       // Auto-submit fires after the 200ms delay
       await waitFor(() => {
@@ -218,7 +221,7 @@ describe('UserQuestionPrompt', () => {
         expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.currentIndex).toBe(1);
       });
       expect(answerConversationQuestion).not.toHaveBeenCalled();
-      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.answers['Framework']).toBe('React');
+      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework']).toEqual([0]);
     });
   });
 
@@ -237,11 +240,9 @@ describe('UserQuestionPrompt', () => {
       await user.click(screen.getByText('React'));
       await user.click(screen.getByText('Svelte'));
 
-      const state = useAppStore.getState();
-      const pending = state.pendingUserQuestion[CONV_ID];
-      const answer = pending?.answers['Framework'] ?? '';
-      expect(answer.split(',')).toContain('React');
-      expect(answer.split(',')).toContain('Svelte');
+      const indices = useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework'] ?? [];
+      expect(indices).toContain(0); // React
+      expect(indices).toContain(2); // Svelte
     });
 
     it('toggles off a selected option on re-click', async () => {
@@ -255,9 +256,8 @@ describe('UserQuestionPrompt', () => {
       await user.click(screen.getByText('Svelte'));
       await user.click(screen.getByText('React'));
 
-      const state = useAppStore.getState();
-      const pending = state.pendingUserQuestion[CONV_ID];
-      expect(pending?.answers['Framework']).toBe('Svelte');
+      const indices = useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework'] ?? [];
+      expect(indices).toEqual([2]);
     });
   });
 
@@ -414,21 +414,21 @@ describe('UserQuestionPrompt', () => {
     it('preserves answers when navigating back', async () => {
       setPending(makeMultiPending());
       const store = useAppStore.getState();
-      store.updateUserQuestionAnswer(CONV_ID, 'Framework', 'React');
+      store.toggleUserQuestionOption(CONV_ID, 'Framework', 0, false); // React
       store.nextUserQuestion(CONV_ID);
-      store.updateUserQuestionAnswer(CONV_ID, 'Database', 'PostgreSQL');
+      store.toggleUserQuestionOption(CONV_ID, 'Database', 0, false); // PostgreSQL
       store.prevUserQuestion(CONV_ID);
 
       const state = useAppStore.getState();
       const pending = state.pendingUserQuestion[CONV_ID];
       expect(pending?.currentIndex).toBe(0);
-      expect(pending?.answers['Framework']).toBe('React');
-      expect(pending?.answers['Database']).toBe('PostgreSQL');
+      expect(pending?.selectedIndices['Framework']).toEqual([0]);
+      expect(pending?.selectedIndices['Database']).toEqual([0]);
     });
 
     it('footer button acts as next when current question answered but not all', () => {
       setPending(makeMultiPending());
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Framework', 'React');
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Framework', 0, false);
 
       render(<UserQuestionPrompt conversationId={CONV_ID} />);
 
@@ -453,9 +453,9 @@ describe('UserQuestionPrompt', () => {
     it('submit is enabled when all questions are answered', () => {
       setPending(makeMultiPending());
       const store = useAppStore.getState();
-      store.updateUserQuestionAnswer(CONV_ID, 'Framework', 'React');
-      store.updateUserQuestionAnswer(CONV_ID, 'Database', 'PostgreSQL');
-      store.updateUserQuestionAnswer(CONV_ID, 'Hosting', 'Vercel');
+      store.toggleUserQuestionOption(CONV_ID, 'Framework', 0, false);
+      store.toggleUserQuestionOption(CONV_ID, 'Database', 0, false);
+      store.toggleUserQuestionOption(CONV_ID, 'Hosting', 0, false);
 
       render(<UserQuestionPrompt conversationId={CONV_ID} />);
 
@@ -476,10 +476,9 @@ describe('UserQuestionPrompt', () => {
       await user.click(screen.getByText('PostgreSQL'));
 
       await waitFor(() => {
-        const state = useAppStore.getState();
-        const pending = state.pendingUserQuestion[CONV_ID];
-        expect(pending?.answers['Database']).toBe('PostgreSQL');
-        expect(pending?.answers['Framework']).toBe('React');
+        const pending = useAppStore.getState().pendingUserQuestion[CONV_ID];
+        expect(pending?.selectedIndices['Database']).toEqual([0]);
+        expect(pending?.selectedIndices['Framework']).toEqual([0]);
       });
     });
 
@@ -487,9 +486,9 @@ describe('UserQuestionPrompt', () => {
       const user = userEvent.setup();
       setPending(makeMultiPending());
       const store = useAppStore.getState();
-      store.updateUserQuestionAnswer(CONV_ID, 'Framework', 'React');
-      store.updateUserQuestionAnswer(CONV_ID, 'Database', 'PostgreSQL');
-      store.updateUserQuestionAnswer(CONV_ID, 'Hosting', 'Vercel');
+      store.toggleUserQuestionOption(CONV_ID, 'Framework', 0, false); // React
+      store.toggleUserQuestionOption(CONV_ID, 'Database', 0, false); // PostgreSQL
+      store.toggleUserQuestionOption(CONV_ID, 'Hosting', 0, false); // Vercel
 
       render(<UserQuestionPrompt conversationId={CONV_ID} />);
 
@@ -571,11 +570,31 @@ describe('UserQuestionPrompt', () => {
       render(<UserQuestionPrompt conversationId={CONV_ID} />);
 
       await user.click(screen.getByTestId('other-option'));
-      expect(screen.getByTestId('other-text-input')).toBeInTheDocument();
+      await user.type(screen.getByTestId('other-text-input'), 'Solid.js');
 
+      // Regular options stay clickable while Other has text — clicking one is the
+      // explicit signal to switch off Other in a single click. The store action
+      // clears otherText on regular-option toggle in single-select mode.
       await user.click(screen.getByText('React'));
 
       expect(screen.queryByTestId('other-text-input')).not.toBeInTheDocument();
+      const pending = useAppStore.getState().pendingUserQuestion[CONV_ID];
+      expect(pending?.selectedIndices['Framework']).toEqual([0]);
+      expect(pending?.otherText['Framework']).toBeUndefined();
+    });
+
+    it('keeps regular options clickable while Other has text (visually de-emphasized)', async () => {
+      const user = userEvent.setup();
+      setPending(makePending());
+      render(<UserQuestionPrompt conversationId={CONV_ID} />);
+
+      await user.click(screen.getByTestId('other-option'));
+      await user.type(screen.getByTestId('other-text-input'), 'Solid.js');
+
+      // Buttons should stay enabled — "dim but clickable" so the user can switch
+      // back to a regular option in one click without losing visual access.
+      expect(screen.getByTestId('option-0')).not.toBeDisabled();
+      expect(screen.getByTestId('option-1')).not.toBeDisabled();
     });
 
     it('submit is disabled when "Other" is selected but no text typed', async () => {
@@ -621,7 +640,8 @@ describe('UserQuestionPrompt', () => {
       expect(screen.queryByTestId('other-text-input')).not.toBeInTheDocument();
 
       const state = useAppStore.getState();
-      expect(state.pendingUserQuestion[CONV_ID]?.answers['Framework']).toBe('React');
+      expect(state.pendingUserQuestion[CONV_ID]?.selectedIndices['Framework']).toEqual([0]);
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Framework']).toBeUndefined();
     });
 
     it('cancels pending auto-submit when "Other" is clicked after a regular option', async () => {
@@ -658,7 +678,7 @@ describe('UserQuestionPrompt', () => {
       fireEvent.keyDown(document, { key: '2' });
 
       // Should select "Vue" (option 2)
-      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.answers['Framework']).toBe('Vue');
+      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework']).toEqual([1]);
     });
 
     it('pressing the "Other" number key activates Other mode', async () => {
@@ -683,9 +703,10 @@ describe('UserQuestionPrompt', () => {
       await user.type(input, '123');
 
       expect(input).toHaveValue('123');
-      // Should NOT have selected options 1, 2, 3
+      // Should NOT have selected option indices — "123" goes into Other text
       const store = useAppStore.getState();
-      expect(store.pendingUserQuestion[CONV_ID]?.answers['Framework']).toBe('123');
+      expect(store.pendingUserQuestion[CONV_ID]?.otherText['Framework']).toBe('123');
+      expect(store.pendingUserQuestion[CONV_ID]?.selectedIndices['Framework']).toBeUndefined();
     });
 
     it('ignores number keys out of range', () => {
@@ -694,8 +715,8 @@ describe('UserQuestionPrompt', () => {
 
       fireEvent.keyDown(document, { key: '9' });
 
-      // No answer should be set
-      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.answers['Framework']).toBeUndefined();
+      // No selection should be set
+      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework']).toBeUndefined();
     });
 
     it('selects option via number key in multi-select mode', () => {
@@ -707,9 +728,9 @@ describe('UserQuestionPrompt', () => {
       fireEvent.keyDown(document, { key: '1' });
       fireEvent.keyDown(document, { key: '3' });
 
-      const answer = useAppStore.getState().pendingUserQuestion[CONV_ID]?.answers['Framework'] ?? '';
-      expect(answer.split(',')).toContain('React');
-      expect(answer.split(',')).toContain('Svelte');
+      const indices = useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework'] ?? [];
+      expect(indices).toContain(0); // React
+      expect(indices).toContain(2); // Svelte
     });
   });
 
@@ -720,7 +741,7 @@ describe('UserQuestionPrompt', () => {
   describe('concurrent questions', () => {
     it('replacing pending question overwrites the previous one', () => {
       setPending(makePending({ requestId: 'req-1' }));
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Framework', 'React');
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Framework', 0, false);
 
       setPending(makePending({
         requestId: 'req-2',
@@ -730,7 +751,69 @@ describe('UserQuestionPrompt', () => {
       const state = useAppStore.getState();
       const pending = state.pendingUserQuestion[CONV_ID];
       expect(pending?.requestId).toBe('req-2');
-      expect(pending?.answers).toEqual({});
+      expect(pending?.selectedIndices).toEqual({});
+      expect(pending?.otherText).toEqual({});
+    });
+  });
+
+  // ==========================================================================
+  // Duplicate / Awkward Labels (regression coverage for the bug this fix targets)
+  // ==========================================================================
+
+  describe('duplicate and awkward labels', () => {
+    it('treats duplicate option labels as independently selectable (multi-select)', async () => {
+      const user = userEvent.setup();
+      setPending(makePending({
+        questions: [makeQuestion({
+          multiSelect: true,
+          options: [
+            { label: 'foo.txt', description: 'in /a' },
+            { label: 'foo.txt', description: 'in /b' },
+            { label: 'bar.txt', description: 'in /c' },
+          ],
+        })],
+      }));
+      render(<UserQuestionPrompt conversationId={CONV_ID} />);
+
+      // Click the first foo.txt row (option-0) only
+      await user.click(screen.getByTestId('option-0'));
+
+      const indices = useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework'] ?? [];
+      expect(indices).toEqual([0]);
+      // The second foo.txt row must NOT also become selected
+      expect(indices).not.toContain(1);
+
+      // Now click the second foo.txt row independently
+      await user.click(screen.getByTestId('option-1'));
+      const indices2 = useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices['Framework'] ?? [];
+      expect(indices2).toContain(0);
+      expect(indices2).toContain(1);
+    });
+
+    it('preserves a comma-containing label through submission round-trip', async () => {
+      const user = userEvent.setup();
+      setPending(makePending({
+        questions: [makeQuestion({
+          multiSelect: true,
+          options: [
+            { label: 'Hello, world', description: '' },
+            { label: 'Other label', description: '' },
+          ],
+        })],
+      }));
+      render(<UserQuestionPrompt conversationId={CONV_ID} />);
+
+      await user.click(screen.getByText('Hello, world'));
+      await user.click(screen.getByTestId('submit-question'));
+
+      // The comma-containing label must survive serialization. The wire format
+      // joins on plain ',' (no space), but a single-label submission carries
+      // the original label untouched regardless of separator.
+      expect(answerConversationQuestion).toHaveBeenCalledWith(
+        CONV_ID,
+        'req-1',
+        { Framework: 'Hello, world' },
+      );
     });
   });
 });

--- a/src/hooks/__tests__/useWebSocket.events.test.ts
+++ b/src/hooks/__tests__/useWebSocket.events.test.ts
@@ -331,7 +331,10 @@ describe('useWebSocket — missing event handling', () => {
             requestId: 'req-1',
             questions: [{ question: 'What?', header: '', options: [], multiSelect: false }],
             currentIndex: 0,
-            answers: {},
+            selectedIndices: {},
+            otherSelected: {},
+            otherText: {},
+            freeTextAnswer: {},
           },
         },
       });

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -703,7 +703,10 @@ export function useWebSocket(enabled: boolean = true) {
             requestId: event.requestId as string,
             questions: event.questions,
             currentIndex: 0,
-            answers: {},
+            selectedIndices: {},
+            otherSelected: {},
+            otherText: {},
+            freeTextAnswer: {},
           });
           notifyBackgroundSession(conversationId);
           notifyDesktop(conversationId, 'Question from AI', 'The AI needs your input');

--- a/src/lib/__tests__/userQuestion.test.ts
+++ b/src/lib/__tests__/userQuestion.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import type { PendingUserQuestion, UserQuestion } from '@/lib/types';
+import { isUserQuestionAnswered, serializeUserQuestionAnswers } from '@/lib/userQuestion';
+
+function makeQuestion(overrides: Partial<UserQuestion> = {}): UserQuestion {
+  return {
+    question: 'Pick one',
+    header: 'H',
+    options: [
+      { label: 'A', description: '' },
+      { label: 'B', description: '' },
+      { label: 'C', description: '' },
+    ],
+    multiSelect: false,
+    ...overrides,
+  };
+}
+
+function makePending(overrides: Partial<PendingUserQuestion> = {}): PendingUserQuestion {
+  return {
+    requestId: 'req-1',
+    questions: [makeQuestion()],
+    currentIndex: 0,
+    selectedIndices: {},
+    otherSelected: {},
+    otherText: {},
+    freeTextAnswer: {},
+    ...overrides,
+  };
+}
+
+describe('serializeUserQuestionAnswers', () => {
+  it('emits the picked label for a single-select option', () => {
+    const out = serializeUserQuestionAnswers(makePending({
+      selectedIndices: { H: [1] },
+    }));
+    expect(out).toEqual({ H: 'B' });
+  });
+
+  it('joins multi-select labels with plain "," (no space)', () => {
+    const out = serializeUserQuestionAnswers(makePending({
+      questions: [makeQuestion({ multiSelect: true })],
+      selectedIndices: { H: [0, 2] },
+    }));
+    expect(out).toEqual({ H: 'A,C' });
+  });
+
+  it('appends Other text when selected and non-empty', () => {
+    const out = serializeUserQuestionAnswers(makePending({
+      questions: [makeQuestion({ multiSelect: true })],
+      selectedIndices: { H: [0] },
+      otherSelected: { H: true },
+      otherText: { H: 'custom' },
+    }));
+    expect(out).toEqual({ H: 'A,custom' });
+  });
+
+  it('skips Other when selected but empty', () => {
+    const out = serializeUserQuestionAnswers(makePending({
+      selectedIndices: { H: [0] },
+      otherSelected: { H: true },
+      otherText: { H: '' },
+    }));
+    expect(out).toEqual({ H: 'A' });
+  });
+
+  it('skips Other when text is present but otherSelected is false', () => {
+    const out = serializeUserQuestionAnswers(makePending({
+      selectedIndices: { H: [0] },
+      otherSelected: {},
+      otherText: { H: 'leftover' },
+    }));
+    expect(out).toEqual({ H: 'A' });
+  });
+
+  it('emits free-text answer for free-text questions', () => {
+    const out = serializeUserQuestionAnswers(makePending({
+      questions: [makeQuestion({ options: [], header: 'Why' })],
+      freeTextAnswer: { Why: 'because' },
+    }));
+    expect(out).toEqual({ Why: 'because' });
+  });
+
+  it('omits unanswered questions from the wire payload', () => {
+    const out = serializeUserQuestionAnswers(makePending({
+      questions: [makeQuestion({ header: 'H1' }), makeQuestion({ header: 'H2' })],
+      selectedIndices: { H1: [0] },
+    }));
+    expect(out).toEqual({ H1: 'A' });
+  });
+
+  it('preserves comma-containing labels (with the documented wire-format caveat)', () => {
+    // The internal state cleanly handles a comma-containing label;
+    // the wire format is intentionally a display string, not round-trippable.
+    const out = serializeUserQuestionAnswers(makePending({
+      questions: [makeQuestion({
+        multiSelect: true,
+        options: [
+          { label: 'Hello, world', description: '' },
+          { label: 'B', description: '' },
+        ],
+      })],
+      selectedIndices: { H: [0] },
+    }));
+    expect(out).toEqual({ H: 'Hello, world' });
+  });
+});
+
+describe('isUserQuestionAnswered', () => {
+  it('returns true when an option is picked', () => {
+    const q = makeQuestion();
+    expect(isUserQuestionAnswered(makePending({ selectedIndices: { H: [0] } }), q)).toBe(true);
+  });
+
+  it('returns true when Other is selected with non-empty text', () => {
+    const q = makeQuestion();
+    expect(isUserQuestionAnswered(makePending({
+      otherSelected: { H: true },
+      otherText: { H: 'x' },
+    }), q)).toBe(true);
+  });
+
+  it('returns false when Other is selected but text is empty', () => {
+    const q = makeQuestion();
+    expect(isUserQuestionAnswered(makePending({
+      otherSelected: { H: true },
+      otherText: { H: '' },
+    }), q)).toBe(false);
+  });
+
+  it('returns false when otherText is present but otherSelected is false', () => {
+    const q = makeQuestion();
+    expect(isUserQuestionAnswered(makePending({
+      otherSelected: {},
+      otherText: { H: 'leftover' },
+    }), q)).toBe(false);
+  });
+
+  it('returns true for free-text question with non-empty answer', () => {
+    const q = makeQuestion({ options: [], header: 'F' });
+    expect(isUserQuestionAnswered(makePending({
+      questions: [q],
+      freeTextAnswer: { F: 'hi' },
+    }), q)).toBe(true);
+  });
+
+  it('returns false for free-text question with empty answer', () => {
+    const q = makeQuestion({ options: [], header: 'F' });
+    expect(isUserQuestionAnswered(makePending({
+      questions: [q],
+      freeTextAnswer: { F: '' },
+    }), q)).toBe(false);
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -692,7 +692,21 @@ export interface PendingUserQuestion {
   requestId: string;
   questions: UserQuestion[];
   currentIndex: number;  // Track which question is being shown
-  answers: Record<string, string>;  // header -> selected label(s)
+  // Selection state is stored by option index (per-question, keyed by header)
+  // so duplicate or comma-containing labels can't collide. The wire-format
+  // answer (Record<string, string>) is built only at submit time.
+  selectedIndices: Record<string, number[]>;
+  // Whether the "Other" / free-text option is selected per question. Independent
+  // of otherText so "selected with empty text" is a legible explicit state, not a
+  // sentinel encoded in undefined-vs-string.
+  otherSelected: Record<string, boolean>;
+  // Custom text typed into the "Other" input (option-based questions).
+  // Kept independent of otherSelected: deselecting Other does NOT clear the
+  // text, but a regular-option pick in single-select does (mutex rule).
+  otherText: Record<string, string>;
+  // Answer for free-text questions (questions with no options). Separate slot
+  // from otherText so the two question shapes never share state semantics.
+  freeTextAnswer: Record<string, string>;
 }
 
 export interface PendingQAHandoff {

--- a/src/lib/userQuestion.ts
+++ b/src/lib/userQuestion.ts
@@ -1,0 +1,57 @@
+import type { PendingUserQuestion, UserQuestion } from '@/lib/types';
+
+/**
+ * Build the API-facing answers map from a PendingUserQuestion's selection state.
+ *
+ * Wire format: `Record<string, string>` keyed by question header. Multiple
+ * selected labels are joined with a plain `,` (no space). This is intentionally
+ * a model-facing display string — the model reads it as text, it is NOT a
+ * structured/round-trippable encoding. Do not `.split(',')` it back into labels:
+ * comma-containing labels would be parsed incorrectly. The internal selection
+ * state (selectedIndices) is the source of truth for round-tripping.
+ *
+ * Empty "Other" (otherSelected with no text) is excluded so it doesn't pad the
+ * answer or count toward "answered" gates.
+ */
+export function serializeUserQuestionAnswers(pending: PendingUserQuestion): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const q of pending.questions) {
+    if (q.options.length === 0) {
+      // Free-text question — single answer slot.
+      const free = pending.freeTextAnswer[q.header];
+      if (free && free.length > 0) out[q.header] = free;
+      continue;
+    }
+    // Option-based question.
+    const indices = pending.selectedIndices[q.header] ?? [];
+    const labels = [...indices]
+      .sort((a, b) => a - b)
+      .map((i) => q.options[i]?.label)
+      .filter((l): l is string => typeof l === 'string');
+    const otherText = pending.otherText[q.header];
+    if (pending.otherSelected[q.header] && otherText && otherText.length > 0) {
+      labels.push(otherText);
+    }
+    if (labels.length > 0) out[q.header] = labels.join(',');
+  }
+  return out;
+}
+
+/**
+ * Whether the user has provided an answer for the given question. Used both
+ * for the per-question "advance" gate and the all-questions submit gate.
+ *
+ * - Option-based: at least one option index OR Other selected with non-empty text.
+ * - Free-text: non-empty freeTextAnswer.
+ */
+export function isUserQuestionAnswered(pending: PendingUserQuestion, q: UserQuestion): boolean {
+  if (q.options.length === 0) {
+    const free = pending.freeTextAnswer[q.header];
+    return typeof free === 'string' && free.length > 0;
+  }
+  const indices = pending.selectedIndices[q.header] ?? [];
+  if (indices.length > 0) return true;
+  if (!pending.otherSelected[q.header]) return false;
+  const otherText = pending.otherText[q.header];
+  return typeof otherText === 'string' && otherText.length > 0;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,6 +19,12 @@ export function toBase64(text: string): string {
   return btoa(binary);
 }
 
+/** Return a shallow copy of `obj` with `key` removed. */
+export function omitKey<V>(obj: Record<string, V>, key: string): Record<string, V> {
+  const { [key]: _removed, ...rest } = obj;
+  return rest;
+}
+
 export function toRelativePath(absolutePath: string, worktreePath: string | undefined | null): string {
   if (!worktreePath || !absolutePath) return absolutePath;
 

--- a/src/stores/__tests__/appStore.userQuestion.test.ts
+++ b/src/stores/__tests__/appStore.userQuestion.test.ts
@@ -24,7 +24,10 @@ function makePending(overrides: Partial<PendingUserQuestion> = {}): PendingUserQ
     requestId: 'req-1',
     questions: [makeQuestion()],
     currentIndex: 0,
-    answers: {},
+    selectedIndices: {},
+    otherSelected: {},
+    otherText: {},
+    freeTextAnswer: {},
     ...overrides,
   };
 }
@@ -77,58 +80,212 @@ describe('appStore — user question actions', () => {
   });
 
   // ==========================================================================
-  // updateUserQuestionAnswer
+  // toggleUserQuestionOption
   // ==========================================================================
 
-  describe('updateUserQuestionAnswer', () => {
-    it('sets an answer for a question header', () => {
+  describe('toggleUserQuestionOption', () => {
+    it('selects an option index in single-select mode', () => {
       useAppStore.getState().setPendingUserQuestion(CONV_ID, makePending());
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Language', 'TypeScript');
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Language', 0, false);
 
       const state = useAppStore.getState();
-      expect(state.pendingUserQuestion[CONV_ID]?.answers['Language']).toBe('TypeScript');
+      expect(state.pendingUserQuestion[CONV_ID]?.selectedIndices['Language']).toEqual([0]);
     });
 
-    it('overwrites an existing answer', () => {
+    it('replaces selection in single-select mode (not toggling off)', () => {
       useAppStore.getState().setPendingUserQuestion(CONV_ID, makePending());
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Language', 'TypeScript');
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Language', 'Python');
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Language', 0, false);
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Language', 2, false);
 
       const state = useAppStore.getState();
-      expect(state.pendingUserQuestion[CONV_ID]?.answers['Language']).toBe('Python');
+      expect(state.pendingUserQuestion[CONV_ID]?.selectedIndices['Language']).toEqual([2]);
     });
 
-    it('preserves other answers when updating one', () => {
+    it('toggles indices on/off in multi-select mode', () => {
+      useAppStore.getState().setPendingUserQuestion(CONV_ID, makePending({
+        questions: [makeQuestion({ multiSelect: true })],
+      }));
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Language', 0, true);
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Language', 2, true);
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Language', 0, true);
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.selectedIndices['Language']).toEqual([2]);
+    });
+
+    it('preserves indices for other questions when toggling one', () => {
       useAppStore.getState().setPendingUserQuestion(CONV_ID, makePending({
         questions: [
           makeQuestion({ header: 'Language' }),
           makeQuestion({ header: 'Database', question: 'Pick a DB' }),
         ],
       }));
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Language', 'Go');
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Database', 'Postgres');
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Language', 1, false);
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Database', 0, false);
 
       const state = useAppStore.getState();
-      const answers = state.pendingUserQuestion[CONV_ID]?.answers;
-      expect(answers?.['Language']).toBe('Go');
-      expect(answers?.['Database']).toBe('Postgres');
+      const indices = state.pendingUserQuestion[CONV_ID]?.selectedIndices;
+      expect(indices?.['Language']).toEqual([1]);
+      expect(indices?.['Database']).toEqual([0]);
+    });
+
+    it('clears Other selection AND text in single-select when a regular option is picked', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending());
+      store.selectUserQuestionOther(CONV_ID, 'Language', false);
+      store.setUserQuestionOtherText(CONV_ID, 'Language', 'Rust');
+      store.toggleUserQuestionOption(CONV_ID, 'Language', 0, false);
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherSelected['Language']).toBeUndefined();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Language']).toBeUndefined();
+      expect(state.pendingUserQuestion[CONV_ID]?.selectedIndices['Language']).toEqual([0]);
+    });
+
+    it('keeps Other selection AND text in multi-select when a regular option is picked', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending({
+        questions: [makeQuestion({ multiSelect: true })],
+      }));
+      store.selectUserQuestionOther(CONV_ID, 'Language', true);
+      store.setUserQuestionOtherText(CONV_ID, 'Language', 'Rust');
+      store.toggleUserQuestionOption(CONV_ID, 'Language', 0, true);
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherSelected['Language']).toBe(true);
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Language']).toBe('Rust');
+      expect(state.pendingUserQuestion[CONV_ID]?.selectedIndices['Language']).toEqual([0]);
     });
 
     it('is a no-op when no pending question exists', () => {
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Language', 'Go');
+      useAppStore.getState().toggleUserQuestionOption(CONV_ID, 'Language', 0, false);
 
       const state = useAppStore.getState();
       expect(state.pendingUserQuestion[CONV_ID]).toBeUndefined();
     });
+  });
 
-    it('stores comma-separated values for multi-select', () => {
-      useAppStore.getState().setPendingUserQuestion(CONV_ID, makePending({
-        questions: [makeQuestion({ multiSelect: true })],
-      }));
-      useAppStore.getState().updateUserQuestionAnswer(CONV_ID, 'Language', 'TypeScript,Go');
+  // ==========================================================================
+  // selectUserQuestionOther / deselectUserQuestionOther
+  // ==========================================================================
+
+  describe('selectUserQuestionOther', () => {
+    it('marks Other as selected without touching otherText', () => {
+      useAppStore.getState().setPendingUserQuestion(CONV_ID, makePending());
+      useAppStore.getState().selectUserQuestionOther(CONV_ID, 'Language', false);
 
       const state = useAppStore.getState();
-      expect(state.pendingUserQuestion[CONV_ID]?.answers['Language']).toBe('TypeScript,Go');
+      expect(state.pendingUserQuestion[CONV_ID]?.otherSelected['Language']).toBe(true);
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Language']).toBeUndefined();
+    });
+
+    it('does not touch existing otherText (callers reset via deselect first)', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending({
+        questions: [makeQuestion({ multiSelect: true })],
+      }));
+      store.selectUserQuestionOther(CONV_ID, 'Language', true);
+      store.setUserQuestionOtherText(CONV_ID, 'Language', 'Rust');
+      // Toggle off (deselect clears text) then re-select — text stays cleared.
+      store.deselectUserQuestionOther(CONV_ID, 'Language');
+      store.selectUserQuestionOther(CONV_ID, 'Language', true);
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherSelected['Language']).toBe(true);
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Language']).toBeUndefined();
+    });
+
+    it('clears selected indices in single-select mode', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending());
+      store.toggleUserQuestionOption(CONV_ID, 'Language', 1, false);
+      store.selectUserQuestionOther(CONV_ID, 'Language', false);
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherSelected['Language']).toBe(true);
+      expect(state.pendingUserQuestion[CONV_ID]?.selectedIndices['Language']).toBeUndefined();
+    });
+
+    it('keeps selected indices in multi-select mode', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending({
+        questions: [makeQuestion({ multiSelect: true })],
+      }));
+      store.toggleUserQuestionOption(CONV_ID, 'Language', 1, true);
+      store.selectUserQuestionOther(CONV_ID, 'Language', true);
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherSelected['Language']).toBe(true);
+      expect(state.pendingUserQuestion[CONV_ID]?.selectedIndices['Language']).toEqual([1]);
+    });
+
+    it('is idempotent when Other is already selected', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending());
+      store.selectUserQuestionOther(CONV_ID, 'Language', false);
+      const before = useAppStore.getState().pendingUserQuestion[CONV_ID];
+      store.selectUserQuestionOther(CONV_ID, 'Language', false);
+      const after = useAppStore.getState().pendingUserQuestion[CONV_ID];
+      expect(after).toBe(before); // same reference, no re-render
+    });
+  });
+
+  describe('deselectUserQuestionOther', () => {
+    it('removes Other selection AND its text', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending());
+      store.selectUserQuestionOther(CONV_ID, 'Language', false);
+      store.setUserQuestionOtherText(CONV_ID, 'Language', 'Rust');
+      store.deselectUserQuestionOther(CONV_ID, 'Language');
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherSelected['Language']).toBeUndefined();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Language']).toBeUndefined();
+    });
+  });
+
+  // ==========================================================================
+  // setUserQuestionOtherText
+  // ==========================================================================
+
+  describe('setUserQuestionOtherText', () => {
+    it('stores text without changing selection state', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending());
+      store.setUserQuestionOtherText(CONV_ID, 'Language', 'Rust');
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Language']).toBe('Rust');
+      // Note: text is independent of selection — caller must select Other separately.
+      expect(state.pendingUserQuestion[CONV_ID]?.otherSelected['Language']).toBeUndefined();
+    });
+
+    it('updates the existing text', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending());
+      store.setUserQuestionOtherText(CONV_ID, 'Language', 'Rust');
+      store.setUserQuestionOtherText(CONV_ID, 'Language', 'Zig');
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Language']).toBe('Zig');
+    });
+  });
+
+  // ==========================================================================
+  // setUserQuestionFreeText
+  // ==========================================================================
+
+  describe('setUserQuestionFreeText', () => {
+    it('stores free-text answer separately from otherText', () => {
+      const store = useAppStore.getState();
+      store.setPendingUserQuestion(CONV_ID, makePending({
+        questions: [makeQuestion({ options: [], header: 'Why' })],
+      }));
+      store.setUserQuestionFreeText(CONV_ID, 'Why', 'because');
+
+      const state = useAppStore.getState();
+      expect(state.pendingUserQuestion[CONV_ID]?.freeTextAnswer['Why']).toBe('because');
+      expect(state.pendingUserQuestion[CONV_ID]?.otherText['Why']).toBeUndefined();
     });
   });
 
@@ -241,34 +398,34 @@ describe('appStore — user question actions', () => {
       }));
 
       // Answer Q1, navigate to Q2
-      store.updateUserQuestionAnswer(CONV_ID, 'Language', 'TypeScript');
+      store.toggleUserQuestionOption(CONV_ID, 'Language', 0, false);
       store.nextUserQuestion(CONV_ID);
       expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.currentIndex).toBe(1);
 
       // Answer Q2, navigate to Q3
-      store.updateUserQuestionAnswer(CONV_ID, 'Framework', 'React');
+      store.toggleUserQuestionOption(CONV_ID, 'Framework', 1, false);
       store.nextUserQuestion(CONV_ID);
       expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.currentIndex).toBe(2);
 
       // Answer Q3
-      store.updateUserQuestionAnswer(CONV_ID, 'Database', 'PostgreSQL');
+      store.toggleUserQuestionOption(CONV_ID, 'Database', 2, false);
 
-      // Verify all answers preserved
+      // Verify all selections preserved
       const pending = useAppStore.getState().pendingUserQuestion[CONV_ID];
-      expect(pending?.answers).toEqual({
-        Language: 'TypeScript',
-        Framework: 'React',
-        Database: 'PostgreSQL',
+      expect(pending?.selectedIndices).toEqual({
+        Language: [0],
+        Framework: [1],
+        Database: [2],
       });
 
-      // Navigate back — answers still preserved
+      // Navigate back — selections still preserved
       store.prevUserQuestion(CONV_ID);
       store.prevUserQuestion(CONV_ID);
       expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.currentIndex).toBe(0);
-      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.answers).toEqual({
-        Language: 'TypeScript',
-        Framework: 'React',
-        Database: 'PostgreSQL',
+      expect(useAppStore.getState().pendingUserQuestion[CONV_ID]?.selectedIndices).toEqual({
+        Language: [0],
+        Framework: [1],
+        Database: [2],
       });
 
       // Clear

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -35,6 +35,7 @@ import type { StreamingSnapshotDTO, SnapshotSubAgent } from '@/lib/api';
 import { useSettingsStore } from './settingsStore';
 import { refreshPRStatus } from '@/lib/api';
 import { buildTurnConfigLabel, supportsExtendedContext } from '@/lib/models';
+import { omitKey } from '@/lib/utils';
 import { cleanupConversationState } from '@/hooks/useWebSocket';
 
 // Throttle on-select PR refresh to avoid excessive API calls.
@@ -623,9 +624,17 @@ interface AppState {
   setLastTurnCompletedAt: (sessionId: string, timestamp: number) => void;
   clearBranchSyncStatus: (sessionId: string) => void;
 
-  // User question actions (AskUserQuestion tool)
+  // User question actions (AskUserQuestion tool).
+  // Mutex rule for single-select: picking a regular option deselects Other AND
+  // clears its text; selecting Other clears any picked indices. The rule lives
+  // entirely in toggleUserQuestionOption / selectUserQuestionOther — no other
+  // action mirrors it.
   setPendingUserQuestion: (conversationId: string, question: PendingUserQuestion | null) => void;
-  updateUserQuestionAnswer: (conversationId: string, header: string, answer: string) => void;
+  toggleUserQuestionOption: (conversationId: string, header: string, optionIndex: number, multiSelect: boolean) => void;
+  selectUserQuestionOther: (conversationId: string, header: string, multiSelect: boolean) => void;
+  deselectUserQuestionOther: (conversationId: string, header: string) => void;
+  setUserQuestionOtherText: (conversationId: string, header: string, text: string) => void;
+  setUserQuestionFreeText: (conversationId: string, header: string, text: string) => void;
   nextUserQuestion: (conversationId: string) => void;
   prevUserQuestion: (conversationId: string) => void;
   clearPendingUserQuestion: (conversationId: string) => void;
@@ -2209,7 +2218,10 @@ updateFileTabContent: (id, content) => set((state) => ({
             requestId: snapshot.pendingUserQuestion.requestId,
             questions: snapshot.pendingUserQuestion.questions,
             currentIndex: 0,
-            answers: {},
+            selectedIndices: {},
+            otherSelected: {},
+            otherText: {},
+            freeTextAnswer: {},
           },
         },
       } : {}),
@@ -2868,7 +2880,99 @@ updateFileTabContent: (id, content) => set((state) => ({
     },
   })),
 
-  updateUserQuestionAnswer: (conversationId, header, answer) => set((state) => {
+  toggleUserQuestionOption: (conversationId, header, optionIndex, multiSelect) => set((state) => {
+    const pending = state.pendingUserQuestion[conversationId];
+    if (!pending) return state;
+    const current = pending.selectedIndices[header] ?? [];
+    let next: number[];
+    if (multiSelect) {
+      next = current.includes(optionIndex)
+        ? current.filter((i) => i !== optionIndex)
+        : [...current, optionIndex];
+    } else {
+      // Idempotent: re-clicking the already-selected option (with Other not
+      // selected) is a no-op — avoids producing a fresh array reference that
+      // would force memoized consumers to recompute.
+      if (
+        current.length === 1 &&
+        current[0] === optionIndex &&
+        !pending.otherSelected[header]
+      ) {
+        return state;
+      }
+      next = [optionIndex];
+    }
+    // Single-select mutex: picking a regular option deselects Other AND
+    // clears its in-progress text. Multi-select leaves Other state alone.
+    const nextOtherSelected = multiSelect ? pending.otherSelected : omitKey(pending.otherSelected, header);
+    const nextOtherText = multiSelect ? pending.otherText : omitKey(pending.otherText, header);
+    return {
+      pendingUserQuestion: {
+        ...state.pendingUserQuestion,
+        [conversationId]: {
+          ...pending,
+          selectedIndices: { ...pending.selectedIndices, [header]: next },
+          otherSelected: nextOtherSelected,
+          otherText: nextOtherText,
+        },
+      },
+    };
+  }),
+
+  selectUserQuestionOther: (conversationId, header, multiSelect) => set((state) => {
+    const pending = state.pendingUserQuestion[conversationId];
+    if (!pending) return state;
+    if (pending.otherSelected[header]) return state; // already selected — idempotent no-op
+    // Single-select mutex: selecting Other clears any picked indices. otherText
+    // is left as-is — callers wanting to reset typing should call deselect first.
+    const nextSelectedIndices = multiSelect
+      ? pending.selectedIndices
+      : omitKey(pending.selectedIndices, header);
+    return {
+      pendingUserQuestion: {
+        ...state.pendingUserQuestion,
+        [conversationId]: {
+          ...pending,
+          selectedIndices: nextSelectedIndices,
+          otherSelected: { ...pending.otherSelected, [header]: true },
+        },
+      },
+    };
+  }),
+
+  deselectUserQuestionOther: (conversationId, header) => set((state) => {
+    const pending = state.pendingUserQuestion[conversationId];
+    if (!pending) return state;
+    if (!pending.otherSelected[header] && pending.otherText[header] === undefined) return state;
+    return {
+      pendingUserQuestion: {
+        ...state.pendingUserQuestion,
+        [conversationId]: {
+          ...pending,
+          otherSelected: omitKey(pending.otherSelected, header),
+          otherText: omitKey(pending.otherText, header),
+        },
+      },
+    };
+  }),
+
+  setUserQuestionOtherText: (conversationId, header, text) => set((state) => {
+    const pending = state.pendingUserQuestion[conversationId];
+    if (!pending) return state;
+    // Pure text update — does NOT change selection state. Callers should
+    // selectUserQuestionOther first if they want to flip the selection flag.
+    return {
+      pendingUserQuestion: {
+        ...state.pendingUserQuestion,
+        [conversationId]: {
+          ...pending,
+          otherText: { ...pending.otherText, [header]: text },
+        },
+      },
+    };
+  }),
+
+  setUserQuestionFreeText: (conversationId, header, text) => set((state) => {
     const pending = state.pendingUserQuestion[conversationId];
     if (!pending) return state;
     return {
@@ -2876,10 +2980,7 @@ updateFileTabContent: (id, content) => set((state) => ({
         ...state.pendingUserQuestion,
         [conversationId]: {
           ...pending,
-          answers: {
-            ...pending.answers,
-            [header]: answer,
-          },
+          freeTextAnswer: { ...pending.freeTextAnswer, [header]: text },
         },
       },
     };

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -787,7 +787,11 @@ export const usePageActions = () =>
 export const useUserQuestionActions = () =>
   useAppStore(
     useShallow((s) => ({
-      updateUserQuestionAnswer: s.updateUserQuestionAnswer,
+      toggleUserQuestionOption: s.toggleUserQuestionOption,
+      selectUserQuestionOther: s.selectUserQuestionOther,
+      deselectUserQuestionOther: s.deselectUserQuestionOther,
+      setUserQuestionOtherText: s.setUserQuestionOtherText,
+      setUserQuestionFreeText: s.setUserQuestionFreeText,
       nextUserQuestion: s.nextUserQuestion,
       prevUserQuestion: s.prevUserQuestion,
       clearPendingUserQuestion: s.clearPendingUserQuestion,


### PR DESCRIPTION
## Summary

Reworks the `AskUserQuestion` tool's selection state so duplicate option labels and labels containing commas are handled correctly, and tightens the architecture around it.

**The bug:** selection state was stored as a comma-joined string per question header. When two options shared a label (e.g. two `foo.txt` rows from different directories), clicking one selected both. When a label contained `,` (e.g. `Hello, world`), it collided with the multi-select separator and could be mis-split.

**The fix:** track selection by option index, not label. Each `PendingUserQuestion` now carries four orthogonal slots, each with a single meaning:

| Slot | Meaning |
|---|---|
| `selectedIndices: Record<string, number[]>` | Picked option indices per question header |
| `otherSelected: Record<string, boolean>` | Explicit "Other" selection flag (no string-vs-undefined sentinel) |
| `otherText: Record<string, string>` | Custom "Other" text — independent of selection |
| `freeTextAnswer: Record<string, string>` | Answer for free-text questions (no options) |

The wire payload sent to the agent is unchanged in shape (`Record<string, string>`); it is now built only at submit time via `serializeUserQuestionAnswers` from the structured state.

## Architectural improvements

- **Store API split into orthogonal primitives** so the single-select mutex rule lives in one place rather than being mirrored across actions:
  - `toggleUserQuestionOption(header, idx, multi)` — pick/unpick an option
  - `selectUserQuestionOther(header, multi)` / `deselectUserQuestionOther(header)` — explicit Other toggle
  - `setUserQuestionOtherText(header, text)` — pure text update (no selection side effect)
  - `setUserQuestionFreeText(header, text)` — free-text answer
- **Wire-format and "answered" semantics extracted from the UI component** into `src/lib/userQuestion.ts` (`serializeUserQuestionAnswers`, `isUserQuestionAnswered`) with their own unit tests.
- **`omitKey()` helper** added to `src/lib/utils.ts` to replace the IIFE destructure-omit idiom that was repeated across store actions.
- **Wire format documented as a display string**: `serializeUserQuestionAnswers` now carries an explicit doc comment that the comma-joined output is intentionally a model-facing display string, NOT a round-trippable encoding. The structured state is the source of truth for round-tripping.

## Test plan

- [x] `npm run lint` — no new errors in touched files
- [x] `npx tsc --noEmit` — no type errors in touched files
- [x] `npm run build` — production build passes
- [x] `npm run test:run` — **1788 / 1788 tests pass** (added 22 new tests covering the new actions and helpers, including duplicate-label and comma-label regression coverage)
- [ ] Manual smoke test: AskUserQuestion tool single-select, multi-select, Other, free-text, multi-question wizard, navigation back/forward, keyboard shortcuts, dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)