### PR TITLE
perf(checks): paginate, parallelize, and add SWR for session switches

### DIFF
--- a/backend/github/actions.go
+++ b/backend/github/actions.go
@@ -7,11 +7,23 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
 // maxLogSize is the maximum size of job logs to download (50MB)
 const maxLogSize = 50 * 1024 * 1024
+
+// Pagination caps. Each page is up to 100 items, so 5 pages = 500 items.
+// Beyond this, the panel UX would be unwieldy and we'd risk runaway responses.
+// The cap is a hard safety net: the loop normally terminates earlier on
+// `len(page) < pagePerPage` or once we've accumulated `total_count` items.
+const (
+	maxWorkflowRunPages = 5
+	maxWorkflowJobPages = 5
+	maxCheckRunPages    = 5
+	pagePerPage         = 100
+)
 
 // WorkflowRun represents a GitHub Actions workflow run
 type WorkflowRun struct {
@@ -97,60 +109,73 @@ type githubStep struct {
 	CompletedAt *time.Time `json:"completed_at"`
 }
 
-// ListWorkflowRuns lists workflow runs for a repository, optionally filtered by branch
+// ListWorkflowRuns lists workflow runs for a repository, optionally filtered by branch.
+// Paginates until total_count is reached or maxWorkflowRunPages is hit, so repos with
+// many recent runs don't silently truncate at the first page.
 func (c *Client) ListWorkflowRuns(ctx context.Context, owner, repo, branch string) ([]WorkflowRun, error) {
 	token, err := c.getValidToken(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	reqURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs?per_page=20", c.apiURL, owner, repo)
-	if branch != "" {
-		reqURL = fmt.Sprintf("%s&branch=%s", reqURL, url.QueryEscape(branch))
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetching workflow runs: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
-	}
-
-	var ghResp githubWorkflowRunsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&ghResp); err != nil {
-		return nil, fmt.Errorf("decoding response: %w", err)
-	}
-
-	runs := make([]WorkflowRun, len(ghResp.WorkflowRuns))
-	for i, run := range ghResp.WorkflowRuns {
-		conclusion := ""
-		if run.Conclusion != nil {
-			conclusion = *run.Conclusion
+	var runs []WorkflowRun
+	for page := 1; page <= maxWorkflowRunPages; page++ {
+		q := url.Values{}
+		q.Set("per_page", strconv.Itoa(pagePerPage))
+		q.Set("page", strconv.Itoa(page))
+		if branch != "" {
+			q.Set("branch", branch)
 		}
-		runs[i] = WorkflowRun{
-			ID:         run.ID,
-			Name:       run.Name,
-			Status:     run.Status,
-			Conclusion: conclusion,
-			HeadSHA:    run.HeadSHA,
-			HeadBranch: run.HeadBranch,
-			HTMLURL:    run.HTMLURL,
-			JobsURL:    run.JobsURL,
-			LogsURL:    run.LogsURL,
-			CreatedAt:  run.CreatedAt,
-			UpdatedAt:  run.UpdatedAt,
+		reqURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs?%s", c.apiURL, owner, repo, q.Encode())
+
+		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching workflow runs: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
+		}
+
+		var ghResp githubWorkflowRunsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&ghResp); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("decoding response: %w", err)
+		}
+		resp.Body.Close()
+
+		for _, run := range ghResp.WorkflowRuns {
+			conclusion := ""
+			if run.Conclusion != nil {
+				conclusion = *run.Conclusion
+			}
+			runs = append(runs, WorkflowRun{
+				ID:         run.ID,
+				Name:       run.Name,
+				Status:     run.Status,
+				Conclusion: conclusion,
+				HeadSHA:    run.HeadSHA,
+				HeadBranch: run.HeadBranch,
+				HTMLURL:    run.HTMLURL,
+				JobsURL:    run.JobsURL,
+				LogsURL:    run.LogsURL,
+				CreatedAt:  run.CreatedAt,
+				UpdatedAt:  run.UpdatedAt,
+			})
+		}
+
+		// Stop when this page returned fewer than per_page items, or we've reached total_count.
+		if len(ghResp.WorkflowRuns) < pagePerPage || len(runs) >= ghResp.TotalCount {
+			break
 		}
 	}
 
@@ -214,85 +239,96 @@ func (c *Client) GetWorkflowRun(ctx context.Context, owner, repo string, runID i
 	}, nil
 }
 
-// ListWorkflowJobs lists jobs for a workflow run
+// ListWorkflowJobs lists jobs for a workflow run.
+// Paginates so large matrix builds (>100 jobs) aren't silently truncated.
 func (c *Client) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]WorkflowJob, error) {
 	token, err := c.getValidToken(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	url := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/jobs?per_page=100", c.apiURL, owner, repo, runID)
+	var jobs []WorkflowJob
+	for page := 1; page <= maxWorkflowJobPages; page++ {
+		q := url.Values{}
+		q.Set("per_page", strconv.Itoa(pagePerPage))
+		q.Set("page", strconv.Itoa(page))
+		reqURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/jobs?%s", c.apiURL, owner, repo, runID, q.Encode())
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
+		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/vnd.github+json")
 
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetching jobs: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
-	}
-
-	var ghResp githubJobsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&ghResp); err != nil {
-		return nil, fmt.Errorf("decoding response: %w", err)
-	}
-
-	jobs := make([]WorkflowJob, len(ghResp.Jobs))
-	for i, job := range ghResp.Jobs {
-		conclusion := ""
-		if job.Conclusion != nil {
-			conclusion = *job.Conclusion
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching jobs: %w", err)
 		}
 
-		completedAt := time.Time{}
-		if job.CompletedAt != nil {
-			completedAt = *job.CompletedAt
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("GitHub returned %d: %s", resp.StatusCode, body)
 		}
 
-		steps := make([]JobStep, len(job.Steps))
-		for j, step := range job.Steps {
-			stepConclusion := ""
-			if step.Conclusion != nil {
-				stepConclusion = *step.Conclusion
+		var ghResp githubJobsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&ghResp); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("decoding response: %w", err)
+		}
+		resp.Body.Close()
+
+		for _, job := range ghResp.Jobs {
+			conclusion := ""
+			if job.Conclusion != nil {
+				conclusion = *job.Conclusion
 			}
-			startedAt := time.Time{}
-			if step.StartedAt != nil {
-				startedAt = *step.StartedAt
+
+			completedAt := time.Time{}
+			if job.CompletedAt != nil {
+				completedAt = *job.CompletedAt
 			}
-			stepCompletedAt := time.Time{}
-			if step.CompletedAt != nil {
-				stepCompletedAt = *step.CompletedAt
+
+			steps := make([]JobStep, len(job.Steps))
+			for j, step := range job.Steps {
+				stepConclusion := ""
+				if step.Conclusion != nil {
+					stepConclusion = *step.Conclusion
+				}
+				startedAt := time.Time{}
+				if step.StartedAt != nil {
+					startedAt = *step.StartedAt
+				}
+				stepCompletedAt := time.Time{}
+				if step.CompletedAt != nil {
+					stepCompletedAt = *step.CompletedAt
+				}
+				steps[j] = JobStep{
+					Name:        step.Name,
+					Status:      step.Status,
+					Conclusion:  stepConclusion,
+					Number:      step.Number,
+					StartedAt:   startedAt,
+					CompletedAt: stepCompletedAt,
+				}
 			}
-			steps[j] = JobStep{
-				Name:        step.Name,
-				Status:      step.Status,
-				Conclusion:  stepConclusion,
-				Number:      step.Number,
-				StartedAt:   startedAt,
-				CompletedAt: stepCompletedAt,
-			}
+
+			jobs = append(jobs, WorkflowJob{
+				ID:          job.ID,
+				RunID:       job.RunID,
+				Name:        job.Name,
+				Status:      job.Status,
+				Conclusion:  conclusion,
+				StartedAt:   job.StartedAt,
+				CompletedAt: completedAt,
+				HTMLURL:     job.HTMLURL,
+				Steps:       steps,
+			})
 		}
 
-		jobs[i] = WorkflowJob{
-			ID:          job.ID,
-			RunID:       job.RunID,
-			Name:        job.Name,
-			Status:      job.Status,
-			Conclusion:  conclusion,
-			StartedAt:   job.StartedAt,
-			CompletedAt: completedAt,
-			HTMLURL:     job.HTMLURL,
-			Steps:       steps,
+		if len(ghResp.Jobs) < pagePerPage || len(jobs) >= ghResp.TotalCount {
+			break
 		}
 	}
 

--- a/backend/github/actions_test.go
+++ b/backend/github/actions_test.go
@@ -15,7 +15,8 @@ func TestListWorkflowRuns_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/repos/owner/repo/actions/runs", r.URL.Path)
 		require.Equal(t, "Bearer test_token", r.Header.Get("Authorization"))
-		require.Contains(t, r.URL.RawQuery, "per_page=20")
+		require.Contains(t, r.URL.RawQuery, "per_page=100")
+		require.Contains(t, r.URL.RawQuery, "page=1")
 
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"total_count": 2,

--- a/backend/github/client.go
+++ b/backend/github/client.go
@@ -628,7 +628,10 @@ func (c *Client) GetCombinedStatus(ctx context.Context, owner, repo, ref string)
 		return nil, err
 	}
 
-	statusURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/status", c.apiURL, owner, repo, ref)
+	// Request per_page=100 (max). GitHub defaults to 30, which silently
+	// truncates legacy /statuses contexts on PRs with many environments
+	// (e.g. multi-region Vercel previews).
+	statusURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/status?per_page=100", c.apiURL, owner, repo, ref)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", statusURL, nil)
 	if err != nil {

--- a/backend/github/pr_status.go
+++ b/backend/github/pr_status.go
@@ -187,73 +187,146 @@ func (c *Client) GetPRDetails(ctx context.Context, owner, repo string, prNumber 
 		RequestedReviewers: len(pr.RequestedReviewers),
 	}
 
-	// Fetch check runs for the PR's head commit
-	checksURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs", c.apiURL, owner, repo, pr.Head.SHA)
-	checksReq, err := http.NewRequestWithContext(ctx, "GET", checksURL, nil)
-	if err != nil {
-		// Don't fail completely if we can't get checks
-		return details, nil
+	// Fetch combined Statuses (legacy API) concurrently with check-runs so
+	// total latency is max(checks, status) instead of checks + status.
+	// Always drained below to avoid leaking the goroutine.
+	type combinedResult struct {
+		combined *CombinedStatus
+		err      error
 	}
+	combinedCh := make(chan combinedResult, 1)
+	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				logger.GitHub.Errorf("panic in GetCombinedStatus for %s/%s@%s: %v", owner, repo, pr.Head.SHA, rec)
+				combinedCh <- combinedResult{nil, fmt.Errorf("panic: %v", rec)}
+			}
+		}()
+		combined, statusErr := c.GetCombinedStatus(ctx, owner, repo, pr.Head.SHA)
+		combinedCh <- combinedResult{combined, statusErr}
+	}()
 
-	checksReq.Header.Set("Authorization", "Bearer "+token)
-	checksReq.Header.Set("Accept", "application/vnd.github+json")
+	// Fetch check runs for the PR's head commit. Paginates so PRs with many
+	// checks (>30 — GitHub's default page size) aren't silently truncated.
+	hasFailure := false
+	hasPending := false
 
-	checksResp, err := c.httpClient.Do(checksReq)
-	if err != nil {
-		return details, nil
-	}
-	defer checksResp.Body.Close()
+	for page := 1; page <= maxCheckRunPages; page++ {
+		checksURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs?per_page=%d&page=%d", c.apiURL, owner, repo, pr.Head.SHA, pagePerPage, page)
+		checksReq, reqErr := http.NewRequestWithContext(ctx, "GET", checksURL, nil)
+		if reqErr != nil {
+			logger.GitHub.Warnf("check-runs request build failed (page %d) for %s/%s@%s: %v", page, owner, repo, pr.Head.SHA, reqErr)
+			break
+		}
+		checksReq.Header.Set("Authorization", "Bearer "+token)
+		checksReq.Header.Set("Accept", "application/vnd.github+json")
 
-	if checksResp.StatusCode == http.StatusOK {
+		checksResp, doErr := c.httpClient.Do(checksReq)
+		if doErr != nil {
+			logger.GitHub.Warnf("check-runs fetch failed (page %d) for %s/%s@%s: %v", page, owner, repo, pr.Head.SHA, doErr)
+			break
+		}
+
+		if checksResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(checksResp.Body)
+			checksResp.Body.Close()
+			logger.GitHub.Warnf("check-runs returned %d (page %d) for %s/%s@%s: %s", checksResp.StatusCode, page, owner, repo, pr.Head.SHA, body)
+			break
+		}
+
 		var checkRuns githubCheckRuns
-		if err := json.NewDecoder(checksResp.Body).Decode(&checkRuns); err == nil {
-			details.CheckDetails = make([]CheckDetail, 0, len(checkRuns.CheckRuns))
-			hasFailure := false
-			hasPending := false
+		if decodeErr := json.NewDecoder(checksResp.Body).Decode(&checkRuns); decodeErr != nil {
+			checksResp.Body.Close()
+			logger.GitHub.Warnf("check-runs decode failed (page %d) for %s/%s@%s: %v", page, owner, repo, pr.Head.SHA, decodeErr)
+			break
+		}
+		checksResp.Body.Close()
 
-			for _, run := range checkRuns.CheckRuns {
-				conclusion := ""
-				if run.Conclusion != nil {
-					conclusion = *run.Conclusion
-				}
+		for _, run := range checkRuns.CheckRuns {
+			conclusion := ""
+			if run.Conclusion != nil {
+				conclusion = *run.Conclusion
+			}
 
-				// Calculate duration for completed checks
-				var durationSeconds *int
-				if run.Status == "completed" && run.StartedAt != nil && run.CompletedAt != nil {
-					startTime, err1 := time.Parse(time.RFC3339, *run.StartedAt)
-					endTime, err2 := time.Parse(time.RFC3339, *run.CompletedAt)
-					if err1 == nil && err2 == nil {
-						duration := int(endTime.Sub(startTime).Seconds())
-						durationSeconds = &duration
-					}
-				}
-
-				details.CheckDetails = append(details.CheckDetails, CheckDetail{
-					Name:            run.Name,
-					Status:          run.Status,
-					Conclusion:      conclusion,
-					DurationSeconds: durationSeconds,
-				})
-
-				// Determine overall check status
-				if run.Status != "completed" {
-					hasPending = true
-				} else if conclusion == "failure" || conclusion == "timed_out" || conclusion == "action_required" {
-					hasFailure = true
+			// Calculate duration for completed checks
+			var durationSeconds *int
+			if run.Status == "completed" && run.StartedAt != nil && run.CompletedAt != nil {
+				startTime, err1 := time.Parse(time.RFC3339, *run.StartedAt)
+				endTime, err2 := time.Parse(time.RFC3339, *run.CompletedAt)
+				if err1 == nil && err2 == nil {
+					duration := int(endTime.Sub(startTime).Seconds())
+					durationSeconds = &duration
 				}
 			}
 
-			// Set aggregated status
-			if len(checkRuns.CheckRuns) == 0 {
-				details.CheckStatus = CheckStatusNone
-			} else if hasFailure {
-				details.CheckStatus = CheckStatusFailure
-			} else if hasPending {
-				details.CheckStatus = CheckStatusPending
-			} else {
-				details.CheckStatus = CheckStatusSuccess
+			details.CheckDetails = append(details.CheckDetails, CheckDetail{
+				Name:            run.Name,
+				Status:          run.Status,
+				Conclusion:      conclusion,
+				DurationSeconds: durationSeconds,
+			})
+
+			if run.Status != "completed" {
+				hasPending = true
+			} else if conclusion == "failure" || conclusion == "timed_out" || conclusion == "action_required" {
+				hasFailure = true
 			}
 		}
+
+		if len(checkRuns.CheckRuns) < pagePerPage || len(details.CheckDetails) >= checkRuns.TotalCount {
+			break
+		}
+	}
+
+	// Always drain the combined-status goroutine, even if check-runs failed,
+	// so we don't leak it.
+	combinedRes := <-combinedCh
+
+	// Merge legacy Combined Status API (e.g. Vercel previews, custom webhooks,
+	// older CIs that post via /statuses). check-runs is the modern API but
+	// many tools still use the legacy Statuses API; without merging, those
+	// checks are invisible in the panel. Always merge — even if check-runs
+	// failed entirely, legacy statuses may be the only signal we have.
+	if combinedRes.err == nil && combinedRes.combined != nil {
+		existing := make(map[string]bool, len(details.CheckDetails))
+		for _, cd := range details.CheckDetails {
+			existing[cd.Name] = true
+		}
+		for _, st := range combinedRes.combined.Statuses {
+			if existing[st.Context] {
+				continue // check-runs entry wins on name collision (richer data)
+			}
+			var status, conclusion string
+			switch st.State {
+			case "success":
+				status, conclusion = "completed", "success"
+			case "failure", "error":
+				status, conclusion = "completed", "failure"
+				hasFailure = true
+			case "pending":
+				status, conclusion = "in_progress", ""
+				hasPending = true
+			default:
+				status, conclusion = st.State, ""
+			}
+			details.CheckDetails = append(details.CheckDetails, CheckDetail{
+				Name:       st.Context,
+				Status:     status,
+				Conclusion: conclusion,
+			})
+		}
+	}
+
+	// Set aggregated status — empty -> None, otherwise based on flags.
+	switch {
+	case len(details.CheckDetails) == 0:
+		details.CheckStatus = CheckStatusNone
+	case hasFailure:
+		details.CheckStatus = CheckStatusFailure
+	case hasPending:
+		details.CheckStatus = CheckStatusPending
+	default:
+		details.CheckStatus = CheckStatusSuccess
 	}
 
 	// Fetch PR reviews to determine review decision
@@ -397,7 +470,7 @@ func (c *Client) GetPRFullDetails(ctx context.Context, owner, repo string, prNum
 // Uses goroutines with a semaphore to avoid overwhelming the GitHub API (default maxConcurrent is 5).
 func (c *Client) GetPRDetailsBatch(ctx context.Context, owner, repo string, prNumbers []int, maxConcurrent int) (map[int]*PRDetails, []int) {
 	if maxConcurrent <= 0 {
-		maxConcurrent = 5 // default concurrent limit
+		maxConcurrent = 3 // default concurrent limit
 	}
 
 	results := make(map[int]*PRDetails)

--- a/backend/server/ci_handlers.go
+++ b/backend/server/ci_handlers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/chatml/chatml-backend/github"
 	"github.com/chatml/chatml-backend/models"
 	"github.com/go-chi/chi/v5"
 )
@@ -368,33 +369,54 @@ func (h *Handlers) GetCIFailureContext(w http.ResponseWriter, r *http.Request) {
 	// Include both fully-completed failed runs and in-progress runs (their
 	// individual jobs may already be completed with a failure conclusion).
 	// Skip runs that are still queued/waiting and have no jobs to inspect yet.
+	var eligibleRuns []github.WorkflowRun
+	for _, run := range runs {
+		if run.HeadSHA != latestSHA {
+			continue
+		}
+		if run.Status == "queued" || run.Status == "waiting" || run.Status == "pending" || run.Status == "requested" {
+			continue
+		}
+		if run.Status == "completed" && run.Conclusion != "failure" && run.Conclusion != "timed_out" {
+			continue
+		}
+		eligibleRuns = append(eligibleRuns, run)
+	}
+
+	// Fetch jobs for all eligible runs concurrently. Each ListWorkflowJobs call
+	// can paginate up to 5 pages, so serializing them across runs would
+	// linearly inflate p99 latency.
+	type runJobsResult struct {
+		jobs []github.WorkflowJob
+		err  error
+	}
+	jobResults := make([]runJobsResult, len(eligibleRuns))
+	var fetchWg sync.WaitGroup
+	for i, run := range eligibleRuns {
+		fetchWg.Add(1)
+		go func(idx int, runID int64) {
+			defer fetchWg.Done()
+			jobs, err := h.ghClient.ListWorkflowJobs(ctx, ghCtx.owner, ghCtx.repo, runID)
+			jobResults[idx] = runJobsResult{jobs: jobs, err: err}
+		}(i, run.ID)
+	}
+	fetchWg.Wait()
+
+	// Process results serially so jobCount cap and truncation flag are
+	// applied deterministically (matches GitHub's newest-first ordering).
 	var failedRuns []FailedRunContext
 	totalFailed := 0
 	truncatedOverall := false
 	jobCount := 0
 
-	for _, run := range runs {
-		if run.HeadSHA != latestSHA {
-			continue
-		}
-		// Skip runs that haven't started — no jobs to inspect yet
-		if run.Status == "queued" || run.Status == "waiting" || run.Status == "pending" || run.Status == "requested" {
-			continue
-		}
-		// Skip completed runs that succeeded or were otherwise non-failing
-		if run.Status == "completed" && run.Conclusion != "failure" && run.Conclusion != "timed_out" {
-			continue
-		}
-
-		// Fetch jobs for this failed run
-		jobs, err := h.ghClient.ListWorkflowJobs(ctx, ghCtx.owner, ghCtx.repo, run.ID)
-		if err != nil {
-			log.Printf("Failed to fetch jobs for run %d: %v", run.ID, err)
+	for i, run := range eligibleRuns {
+		if jobResults[i].err != nil {
+			log.Printf("Failed to fetch jobs for run %d: %v", run.ID, jobResults[i].err)
 			continue
 		}
 
 		var failedJobs []FailedJobContext
-		for _, job := range jobs {
+		for _, job := range jobResults[i].jobs {
 			if job.Conclusion != "failure" && job.Conclusion != "timed_out" {
 				continue
 			}

--- a/backend/server/pr_handlers.go
+++ b/backend/server/pr_handlers.go
@@ -495,7 +495,7 @@ func (h *Handlers) ListPRs(w http.ResponseWriter, r *http.Request) {
 				prNumbers[i] = pr.Number
 			}
 			var failedPRs []int
-			prDetailsMap, failedPRs = h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 5)
+			prDetailsMap, failedPRs = h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 3)
 			if len(failedPRs) > 0 {
 				logger.Handlers.Warnf("Failed to fetch details for PRs %v in %s/%s", failedPRs, owner, repoName)
 			}
@@ -612,7 +612,7 @@ func (h *Handlers) refreshPRCache(owner, repoName string) {
 			for i, pr := range entry.PRs {
 				prNumbers[i] = pr.Number
 			}
-			detailsMap, failedPRs := h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 5)
+			detailsMap, failedPRs := h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 3)
 			if len(failedPRs) > 0 {
 				logger.Handlers.Warnf("Background PR detail fetch: failed for PRs %v in %s/%s", failedPRs, owner, repoName)
 			}
@@ -634,7 +634,7 @@ func (h *Handlers) refreshPRCache(owner, repoName string) {
 	for i, pr := range result.PRs {
 		prNumbers[i] = pr.Number
 	}
-	prDetailsMap, failedPRs := h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 5)
+	prDetailsMap, failedPRs := h.ghClient.GetPRDetailsBatch(ctx, owner, repoName, prNumbers, 3)
 	if len(failedPRs) > 0 {
 		logger.Handlers.Warnf("Background PR refresh for %s/%s: failed to fetch details for PRs %v", owner, repoName, failedPRs)
 	}

--- a/src/components/panels/ChecksPanel.tsx
+++ b/src/components/panels/ChecksPanel.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from '@/stores/appStore';
 import { usePRStatus } from '@/hooks/usePRStatus';
 import { useCIRuns } from '@/hooks/useCIRuns';
 import { useGitStatus } from '@/hooks/useGitStatus';
+import { useMinSpinDuration } from '@/hooks/useMinSpinDuration';
 import { getCheckStatusInfo, formatDuration, computeJobDuration } from '@/lib/check-utils';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
@@ -209,6 +210,7 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
   );
 
   const isLoading = prLoading || ciLoading || gitLoading;
+  const gitSpinning = useMinSpinDuration(gitLoading);
 
   const handleRefreshAll = useCallback(() => {
     refetchPR();
@@ -307,9 +309,9 @@ export const ChecksPanel = forwardRef<ChecksPanelHandle, ChecksPanelProps>(funct
               size="icon"
               className="h-5 w-5 shrink-0"
               onClick={refetchGit}
-              disabled={gitLoading}
+              disabled={gitSpinning}
             >
-              <RefreshCw className={cn('h-3 w-3', gitLoading && 'animate-spin')} />
+              <RefreshCw className={cn('h-3 w-3', gitSpinning && 'animate-spin')} />
             </Button>
           </div>
           <div className="px-1.5 pb-2">
@@ -381,6 +383,7 @@ function MergeReadinessBanner({
   onRefresh: () => void;
 }) {
   const { ready, blockers, pendingCount } = readiness;
+  const spinning = useMinSpinDuration(isLoading);
 
   let bgClass: string;
   let borderClass: string;
@@ -436,9 +439,9 @@ function MergeReadinessBanner({
           size="icon"
           className="h-5 w-5 shrink-0"
           onClick={onRefresh}
-          disabled={isLoading}
+          disabled={spinning}
         >
-          <RefreshCw className={cn('h-3 w-3', isLoading && 'animate-spin')} />
+          <RefreshCw className={cn('h-3 w-3', spinning && 'animate-spin')} />
         </Button>
       </div>
       {blockers.length > 0 && (

--- a/src/hooks/__tests__/useCIRuns.test.ts
+++ b/src/hooks/__tests__/useCIRuns.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useCIRuns } from '../useCIRuns';
+import { clearChecksDataCache } from '@/lib/checksDataCache';
 
 // vi.mock is hoisted above imports by Vitest's transform, so the import
 // below always receives the mocked module regardless of source order.
@@ -101,6 +102,7 @@ describe('useCIRuns', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    clearChecksDataCache();
     mockedGetCIRuns.mockResolvedValue([makeRun()]);
   });
 
@@ -259,28 +261,32 @@ describe('useCIRuns', () => {
 
       expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
 
-      // Advance past two poll intervals — no additional calls expected
+      // No in-progress runs → no polling. New-run detection comes from the
+      // prWatcher signal and visibility-change refetch instead.
+      await flushAndAdvance(30_000);
+      expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
+
       await flushAndAdvance(60_000);
       expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
     });
 
-    it('stops polling when in-progress runs complete', async () => {
+    it('stops polling once in-progress runs complete', async () => {
       // First fetch returns in-progress, second returns completed
       mockedGetCIRuns
         .mockResolvedValueOnce([makeRun({ status: 'in_progress', conclusion: '' })])
-        .mockResolvedValueOnce([makeRun({ status: 'completed', conclusion: 'success' })]);
+        .mockResolvedValue([makeRun({ status: 'completed', conclusion: 'success' })]);
 
       renderHook(() => useCIRuns('ws-1', 'session-1'));
       await flushAndAdvance();
 
       expect(mockedGetCIRuns).toHaveBeenCalledTimes(1);
 
-      // First poll fires — returns completed
+      // First fast poll fires at 30s — returns completed
       await flushAndAdvance(30_000);
       expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
 
-      // Next interval — polling should have stopped
-      await flushAndAdvance(30_000);
+      // No more in-progress runs → polling stops.
+      await flushAndAdvance(60_000);
       expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
     });
 

--- a/src/hooks/useCIRuns.ts
+++ b/src/hooks/useCIRuns.ts
@@ -12,8 +12,10 @@ import {
   type WorkflowJobDTO,
   type CIAnalysisResult,
 } from '@/lib/api';
+import { getChecksData, setChecksData } from '@/lib/checksDataCache';
+import { useAppStore } from '@/stores/appStore';
 
-const CI_POLL_INTERVAL_MS = 30000; // 30 seconds
+const CI_POLL_INTERVAL_MS = 30000; // Polled while runs are in-progress
 const AUTH_RETRY_DELAY_MS = 3000; // Retry delay when GitHub auth is pending
 
 interface UseCIRunsResult {
@@ -64,7 +66,7 @@ export function useCIRuns(
     (run) => run.status === 'in_progress' || run.status === 'queued'
   );
 
-  // Fetch workflow runs (stable — reads from refs)
+  // Fetch workflow runs (stable — reads from refs).
   const fetchRuns = useCallback(async (signal?: AbortSignal) => {
     const wsId = workspaceIdRef.current;
     const sessId = sessionIdRef.current;
@@ -80,6 +82,7 @@ export function useCIRuns(
       if (!signal?.aborted) {
         setRuns(data);
         setError(null);
+        setChecksData(wsId, sessId, { runs: data });
       }
     } catch (err) {
       if (signal?.aborted) return;
@@ -154,35 +157,75 @@ export function useCIRuns(
     [workspaceId, sessionId]
   );
 
+  // Stale-while-revalidate on session change: restore cached runs immediately
+  // so switching sessions doesn't blank-flicker, and decide whether to flip
+  // loading=true here (cold start) or skip it (cache hit, revalidate silently).
+  // Apply synchronously — cache restore is itself the urgent update.
+  useEffect(() => {
+    if (!workspaceId || !sessionId) {
+      setRuns([]);
+      setLoading(false);
+      return;
+    }
+    const cached = getChecksData(workspaceId, sessionId);
+    if (cached?.runs) {
+      setRuns(cached.runs);
+      setLoading(false);
+      setError(null);
+    } else {
+      setLoading(true);
+    }
+  }, [workspaceId, sessionId]);
+
   // Initial fetch and fetch on session change.
   // Deferred: skip fetch until the Checks tab has been opened at least once.
   useEffect(() => {
     if (!hasBeenActiveRef.current) return;
+    if (!workspaceId || !sessionId) return;
 
     const abortController = new AbortController();
-
-    if (workspaceId && sessionId) {
-      setLoading(true);
-      fetchRuns(abortController.signal);
-    } else {
-      setRuns([]);
-    }
+    fetchRuns(abortController.signal);
 
     return () => {
       abortController.abort();
     };
   }, [fetchRuns, workspaceId, sessionId, active]);
 
-  // Periodic polling when there are in-progress runs
+  // Periodic polling — only while runs are in-progress.
+  // New-run detection is handled by the prWatcher signal (below) and the
+  // visibility-change refetch, so an idle baseline poll would just burn rate.
+  // Skips the fetch when the document is hidden.
   useEffect(() => {
     if (!active || !workspaceId || !sessionId || !hasInProgressRuns) return;
 
     const interval = setInterval(() => {
+      if (typeof document !== 'undefined' && document.hidden) return;
       fetchRuns();
     }, CI_POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
   }, [active, workspaceId, sessionId, hasInProgressRuns, fetchRuns]);
+
+  // Refetch immediately when the document becomes visible (handles long sleep / tab switch)
+  useEffect(() => {
+    if (!active || !workspaceId || !sessionId) return;
+    const onVisible = () => {
+      if (!document.hidden) fetchRuns();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, [active, workspaceId, sessionId, fetchRuns]);
+
+  // Refetch when the backend prWatcher signals a PR change for this session.
+  // Closes the 30–90s gap between a check transition on GitHub and the panel
+  // reflecting it. Debounced so a burst of WS messages collapses into one fetch.
+  const lastPRRefresh = useAppStore((s) => s.lastPRRefresh);
+  useEffect(() => {
+    if (!active || !workspaceId || !sessionId) return;
+    if (!lastPRRefresh || lastPRRefresh.sessionId !== sessionId) return;
+    const timer = setTimeout(() => fetchRuns(), 400);
+    return () => clearTimeout(timer);
+  }, [active, workspaceId, sessionId, lastPRRefresh, fetchRuns]);
 
   return {
     runs,

--- a/src/hooks/useMinSpinDuration.ts
+++ b/src/hooks/useMinSpinDuration.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState, useLayoutEffect, useRef } from 'react';
+
+export const MIN_SPIN_MS = 500;
+
+/**
+ * Stretch a transient `loading` true into a visible spin so users see feedback
+ * when a refresh is fast (or a no-op because data didn't change).
+ *
+ * Uses useLayoutEffect to flip `holding` to true synchronously *before* the
+ * browser paints the loading→idle transition. This avoids the one-frame gap
+ * where `loading=false` and `holding=false` would render the spinner off.
+ */
+export function useMinSpinDuration(
+  loading: boolean,
+  minMs: number = MIN_SPIN_MS,
+): boolean {
+  const [holding, setHolding] = useState(false);
+  const startRef = useRef<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevLoadingRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (loading) {
+      startRef.current = Date.now();
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    } else if (prevLoadingRef.current) {
+      // Just transitioned from loading to idle.
+      const elapsed = startRef.current ? Date.now() - startRef.current : minMs;
+      startRef.current = null;
+      const remaining = Math.max(0, minMs - elapsed);
+      if (remaining > 0) {
+        // Sync setState in useLayoutEffect is deliberate: flip holding=true
+        // before paint so the spinner doesn't blink off between frames.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setHolding(true);
+        timerRef.current = setTimeout(() => {
+          setHolding(false);
+          timerRef.current = null;
+        }, remaining);
+      } else {
+        // Load took longer than minMs — release any leftover holding.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setHolding(false);
+      }
+    }
+    prevLoadingRef.current = loading;
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [loading, minMs]);
+
+  return loading || holding;
+}

--- a/src/hooks/usePRStatus.ts
+++ b/src/hooks/usePRStatus.ts
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getPRStatus, refreshPRStatus, ApiError, type PRDetails } from '@/lib/api';
+import { getChecksData, setChecksData } from '@/lib/checksDataCache';
+import { useAppStore } from '@/stores/appStore';
 
 const PR_STATUS_FALLBACK_POLL_MS = 90_000; // 90 seconds (fallback, WebSocket is primary)
 
@@ -53,6 +55,7 @@ export function usePRStatus(
       if (isMountedRef.current) {
         setPRDetails(data);
         setError(null);
+        setChecksData(workspaceId, sessionId, { prDetails: data });
       }
     } catch (err) {
       if (isMountedRef.current) {
@@ -76,25 +79,39 @@ export function usePRStatus(
     }
   }, [workspaceId, sessionId, prStatus]);
 
-  // Exposed refetch function
+  // Fire POST force-check alongside GET; without it, the backend serves cached/eventual
+  // data and the refresh button appears to do nothing. Mirrors the session-change effect.
   const refetch = useCallback(async () => {
     setLoading(true);
+    if (workspaceId && sessionId) {
+      refreshPRStatus(workspaceId, sessionId).catch(() => {});
+    }
     await fetchStatus();
-  }, [fetchStatus]);
+  }, [fetchStatus, workspaceId, sessionId]);
 
-  // Clear stale data immediately when session identity changes.
-  // Without this, the previous session's PR details linger in state
-  // while the new fetch is in-flight, causing downstream consumers
-  // (e.g. PrimaryActionButton) to briefly render stale actions.
-  // Uses setTimeout to satisfy react-hooks/set-state-in-effect.
+  // Stale-while-revalidate on session change: restore cached details for the
+  // new session immediately so downstream consumers (e.g. PrimaryActionButton)
+  // never see another session's stale data, and the panel doesn't blank-flicker.
+  // Also decides whether to flip loading=true (cold start) or revalidate silently.
+  // Apply synchronously — cache restore is itself the urgent update.
   useEffect(() => {
-    const id = setTimeout(() => {
+    if (!workspaceId || !sessionId) {
       setPRDetails(null);
-      setLoading(true);
+      setLoading(false);
       setError(null);
-    }, 0);
-    return () => clearTimeout(id);
-  }, [workspaceId, sessionId]);
+      return;
+    }
+    const cached = getChecksData(workspaceId, sessionId);
+    if (cached?.prDetails !== undefined) {
+      setPRDetails(cached.prDetails ?? null);
+      setLoading(false);
+      setError(null);
+    } else {
+      setPRDetails(null);
+      setLoading(prStatus !== undefined && prStatus !== 'none');
+      setError(null);
+    }
+  }, [workspaceId, sessionId, prStatus]);
 
   // Initial fetch and fetch on session change.
   // Deferred: skip fetch until the caller has been active at least once.
@@ -106,16 +123,11 @@ export function usePRStatus(
     }
 
     if (prStatus && prStatus !== 'none') {
-      setLoading(true);
       fetchStatus();
-
-      // Trigger a backend force-check so we get fresh data from GitHub
-      if (workspaceId && sessionId) {
-        refreshPRStatus(workspaceId, sessionId).catch(() => {
-          // Silently ignore — the force-check is best-effort;
-          // the GET above already returns cached data for immediate display
-        });
-      }
+      // No POST force-check here. The backend prWatcher already pushes
+      // updates over WebSocket (see useWebSocket setLastPRRefresh), and the
+      // manual refetch path explicitly POSTs. Firing it on every session
+      // switch would burn ~5 GitHub calls per click for stale-by-seconds data.
     } else {
       setPRDetails(null);
       setLoading(false);
@@ -126,16 +138,39 @@ export function usePRStatus(
     };
   }, [fetchStatus, prStatus, workspaceId, sessionId, active]);
 
-  // Slow fallback poll when PR is open (WebSocket is the primary update mechanism)
+  // Slow fallback poll when PR is open (WebSocket is the primary update mechanism).
+  // Skips when the document is hidden so backgrounded windows don't keep hitting GitHub.
   useEffect(() => {
     if (!active || !workspaceId || !sessionId || prStatus !== 'open') return;
 
     const interval = setInterval(() => {
+      if (typeof document !== 'undefined' && document.hidden) return;
       fetchStatus();
     }, PR_STATUS_FALLBACK_POLL_MS);
 
     return () => clearInterval(interval);
   }, [active, workspaceId, sessionId, prStatus, fetchStatus]);
+
+  // Refetch immediately when the document becomes visible (covers long sleep / tab return)
+  useEffect(() => {
+    if (!active || !workspaceId || !sessionId || prStatus !== 'open') return;
+    const onVisible = () => {
+      if (!document.hidden) fetchStatus();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, [active, workspaceId, sessionId, prStatus, fetchStatus]);
+
+  // Refetch when the backend prWatcher signals a PR change for this session.
+  // Eliminates the 30–90s gap between a check transition and the panel reflecting it.
+  // Debounced so a burst of WS messages collapses into one fetch.
+  const lastPRRefresh = useAppStore((s) => s.lastPRRefresh);
+  useEffect(() => {
+    if (!active || !workspaceId || !sessionId) return;
+    if (!lastPRRefresh || lastPRRefresh.sessionId !== sessionId) return;
+    const timer = setTimeout(() => fetchStatus(), 400);
+    return () => clearTimeout(timer);
+  }, [active, workspaceId, sessionId, lastPRRefresh, fetchStatus]);
 
   return { prDetails, loading, error, refetch };
 }

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1594,6 +1594,11 @@ export function useWebSocket(enabled: boolean = true) {
             )?.prStatus;
             getStore().updateSession(data.sessionId, updates);
 
+            // Signal to ChecksPanel hooks (usePRStatus, useCIRuns) that they
+            // should refetch detailed data — sidebar badges are already in sync,
+            // but the panel's checkDetails / runs need a fresh GET to update.
+            getStore().setLastPRRefresh(data.sessionId);
+
             if (updates.prStatus === 'open' && prevPrStatus !== 'open') {
               trackEvent('pr_created');
             } else if (updates.prStatus === 'merged' && prevPrStatus !== 'merged') {

--- a/src/lib/checksDataCache.ts
+++ b/src/lib/checksDataCache.ts
@@ -1,0 +1,60 @@
+/**
+ * Per-session cache for Checks panel data (PR details + CI runs).
+ *
+ * Mirrors sessionDataCache.ts: stale-while-revalidate placeholder so switching
+ * sessions doesn't flash empty UI while the background fetch is in flight.
+ *
+ * No TTL — callers always revalidate; cached data is just a render hint.
+ */
+
+import type { PRDetails, WorkflowRunDTO } from '@/lib/api';
+
+export interface ChecksCacheEntry {
+  prDetails?: PRDetails | null;
+  runs?: WorkflowRunDTO[];
+}
+
+const cache = new Map<string, ChecksCacheEntry>();
+const MAX_SESSIONS = 10;
+
+function makeKey(workspaceId: string, sessionId: string): string {
+  return `${workspaceId}:${sessionId}`;
+}
+
+export function getChecksData(
+  workspaceId: string,
+  sessionId: string,
+): ChecksCacheEntry | null {
+  const key = makeKey(workspaceId, sessionId);
+  const entry = cache.get(key);
+  if (!entry) return null;
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry;
+}
+
+export function setChecksData(
+  workspaceId: string,
+  sessionId: string,
+  patch: Partial<ChecksCacheEntry>,
+): void {
+  const key = makeKey(workspaceId, sessionId);
+  const existing = cache.get(key) ?? {};
+  cache.delete(key);
+  cache.set(key, { ...existing, ...patch });
+  if (cache.size > MAX_SESSIONS) {
+    const firstKey = cache.keys().next().value;
+    if (firstKey) cache.delete(firstKey);
+  }
+}
+
+export function invalidateChecksData(
+  workspaceId: string,
+  sessionId: string,
+): void {
+  cache.delete(makeKey(workspaceId, sessionId));
+}
+
+export function clearChecksDataCache(): void {
+  cache.clear();
+}

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -350,6 +350,11 @@ interface AppState {
   // Git index change signal from branch watcher (via WebSocket session_stats_update)
   lastStatsInvalidation: { sessionId: string; timestamp: number } | null;
 
+  // PR/check change signal from backend prWatcher (via WebSocket session_pr_update).
+  // Used by usePRStatus / useCIRuns to refetch detailed data without waiting for
+  // the next poll cycle.
+  lastPRRefresh: { sessionId: string; timestamp: number } | null;
+
   // Query responses from agent (dynamic model info from SDK)
   supportedModels: Array<{
     value: string;
@@ -642,6 +647,7 @@ interface AppState {
   // File watcher actions
   setLastFileChange: (event: { workspaceId: string; path: string; fullPath: string }) => void;
   setLastStatsInvalidation: (sessionId: string) => void;
+  setLastPRRefresh: (sessionId: string) => void;
 }
 
 /** Build a sessionId → Conversation[] lookup from a flat conversations array. */
@@ -710,6 +716,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   summaries: {},
   lastFileChange: null,
   lastStatsInvalidation: null,
+  lastPRRefresh: null,
   messagePagination: {},
 
   // Query responses
@@ -2996,6 +3003,9 @@ updateFileTabContent: (id, content) => set((state) => ({
   }),
   setLastStatsInvalidation: (sessionId) => set({
     lastStatsInvalidation: { sessionId, timestamp: Date.now() },
+  }),
+  setLastPRRefresh: (sessionId) => set({
+    lastPRRefresh: { sessionId, timestamp: Date.now() },
   }),
 
 }));


### PR DESCRIPTION
## Summary

Reworks the Checks panel data flow for correctness and snappiness.

**Backend**
- Paginate workflow runs, jobs, and check-runs (5 × 100) so multi-environment PRs (e.g. multi-region Vercel previews) and matrix builds aren't silently truncated at the first page.
- Fetch legacy `/statuses` combined-status concurrently with `check-runs` in `GetPRDetails` and merge the contexts into `CheckDetails` — restores visibility for older CIs / Vercel previews that don't post check-runs. Total latency is now `max(checks, status)` instead of `checks + status`.
- Parallelize per-run job fetches in `GetCIFailureContext`; serial result processing keeps the job-cap truncation deterministic.
- Drop `GetPRDetailsBatch` default concurrency from 5 → 3 to ease GitHub rate-limit pressure during background refresh.
- `defer/recover` on the new goroutine, matching the pattern in `pr_handlers.refreshPRCache`.

**Frontend**
- New `checksDataCache` (LRU, no TTL) mirroring `sessionDataCache`: switching sessions restores cached PR details + CI runs instantly while the fetch effect revalidates silently — no more blank-flicker or briefly-stale `PrimaryActionButton` rendering.
- New `lastPRRefresh` signal in `appStore` set by the WebSocket `session_pr_update` handler; `usePRStatus` and `useCIRuns` debounce-subscribe (400ms) so a burst of WS messages collapses into one refetch. Closes the 30–90s gap between a check transition and the panel reflecting it.
- `visibilitychange` refetch + skip polling while document is hidden, so backgrounded windows don't keep hitting GitHub.
- Drop the per-session-switch `POST /pr-refresh` (`prWatcher` already pushes updates over WS); manual refetch still fires both `POST` + `GET`.
- Extract `useMinSpinDuration` to `src/hooks/` and reuse for the git-status + merge-readiness refresh buttons — sub-500ms loads (or no-op refreshes) now show a visible spin.

## Test plan
- [x] `go test ./github/... ./server/...` — passes
- [x] `npm run test:run` — 1760/1760 pass
- [x] `npm run build` — clean
- [x] `npm run lint` — no new errors (one intentional `eslint-disable` on `useMinSpinDuration`'s sync-setState in `useLayoutEffect`, justified inline)
- [ ] Manual: switch between sessions on the Checks panel — no blank-flicker
- [ ] Manual: open a PR with >30 checks (e.g. multi-region preview) — all rows render
- [ ] Manual: trigger a check transition on a watched PR — panel updates within ~1s of WS message
- [ ] Manual: tab away while a CI run is in-progress, return after a minute — runs refetch on visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)