### PR TITLE
test(frontend): expand suite to 2510 tests, enforce coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,18 @@ jobs:
         run: |
           pnpm run lint > lint.log 2>&1 &
           LINT_PID=$!
+          set +e
           pnpm run test:coverage
-          wait $LINT_PID || (cat lint.log && exit 1)
+          TEST_RC=$?
+          wait $LINT_PID
+          LINT_RC=$?
+          set -e
+          # Always surface lint output so reviewers can see both checks
+          # regardless of which one failed first.
+          cat lint.log
+          if [ $TEST_RC -ne 0 ] || [ $LINT_RC -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,16 @@ jobs:
         run: |
           pnpm run lint > lint.log 2>&1 &
           LINT_PID=$!
-          pnpm run test:run
+          pnpm run test:coverage
           wait $LINT_PID || (cat lint.log && exit 1)
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: coverage/
+          retention-days: 14
 
       - name: Cache Next.js build
         uses: actions/cache@v4

--- a/docs/test-audit-findings.md
+++ b/docs/test-audit-findings.md
@@ -1,0 +1,164 @@
+# Frontend Test Audit Findings — 2026-04-26
+
+Companion to `docs/test-coverage-baseline.md`. Catalogues quality issues in the existing 100-file / 1760-test Vitest suite. Sourced from a static-pattern scan and targeted reads of suspicious files.
+
+Each finding has a fix priority:
+
+- **P0** — false-confidence risk; tests don't exercise what they claim to.
+- **P1** — known flakiness vector; fix before CI gates tighten.
+- **P2** — quality smell; fix opportunistically.
+- **OK** — verified clean (negative finding worth recording).
+
+---
+
+## P0 — False-confidence findings
+
+### F-1. `useWebSocket` tests don't exercise `useWebSocket`
+**Files:** `src/hooks/__tests__/useWebSocket.{events,initialReconcile,reconnect,snapshot,contextUsage,mcp,subagents}.test.ts` (7 files)
+**Evidence:** Header comment in `useWebSocket.events.test.ts:5-7`:
+> *"These tests simulate what the useWebSocket handler does when it receives events by calling store actions directly, matching the existing test pattern."*
+
+None of the 7 files import `useWebSocket` (`grep -l "from.*useWebSocket" src/hooks/__tests__/useWebSocket.*.test.ts` → empty). They only import `useAppStore` and call store mutators.
+
+Coverage confirms the impact: `src/hooks/useWebSocket.ts` is at **0.25%** lines covered. The 1700+ lines of event parsing, dispatch, batching, reconcile, reconnect, plan-mode handling, and MCP routing are effectively untested.
+
+**Fix direction:** Phase 2 work — add real tests that mount the hook with a mock `WebSocket` and feed it server messages. Either:
+- Inject a `WebSocket` factory (one-line refactor), or
+- Use `vi.stubGlobal('WebSocket', MockWebSocket)`, or
+- Move the dispatch logic into pure functions (already partially done in `useWebSocketHelpers.ts`) and test those directly.
+
+Don't delete the existing 7 files — rename them to `appStore.wsEvents.*.test.ts` (they're store-action tests, not hook tests) so the naming reflects what they actually verify.
+
+### F-2. Coverage threshold is not actually enforced
+**Files:** `vitest.config.ts:26-31`, `.github/workflows/ci.yml:74`
+**Evidence:**
+- Configured threshold: 20% statements/branches/functions/lines.
+- Actual: 19.88% / 17.72% / 17.36% / 20.20%.
+- Local `pnpm run test:coverage` *does* fail with this baseline.
+- CI runs `pnpm run test:run` (no `--coverage`), so the threshold never executes in PR pipelines.
+
+**Fix:** Phase 1.6 — switch CI to `test:coverage`, surface report as a PR comment. (Plan already covers this.)
+
+---
+
+## P1 — Flakiness vectors
+
+### F-3. Real-time `setTimeout` waits in tests
+**Pattern:** `await new Promise((r) => setTimeout(r, N))`
+**Count:** 22 occurrences across 4 files.
+
+| File | Count | Notes |
+|---|---|---|
+| `src/hooks/__tests__/useFileWatcher.test.ts` | 17 (mostly `r, 0` for microtask flushes, one `r, 50`) | Heavy reliance on real timers |
+| `src/hooks/__tests__/useDotMcpTrustCheck.test.ts` | 4 (all `r, 50`) | Negative-assertion waits — race-prone |
+| `src/hooks/__tests__/useMessagePrefetch.test.ts` | 1 (`r, 500`) | Inside MSW handler — defines server delay, not a wait |
+| `src/components/conversation/__tests__/UserQuestionPrompt.test.tsx` | 1 (`r, 250`) | One-off |
+
+**Highest risk:** `useDotMcpTrustCheck.test.ts:131,142,161,189` — all four are *negative* waits ("after 50ms, assert nothing happened"). On a slow CI runner, the function under test could trigger after 50ms, producing a false pass when the negative test should fail. Replace with `vi.useFakeTimers()` + deterministic flushing, or with `await waitFor()` inverted via `expect(...).not.toHaveBeenCalled()` after a real promise tick.
+
+**`useFileWatcher.test.ts`:** the `setTimeout(r, 0)` pattern is microtask flushing — generally safe but a code smell. Vitest provides `await vi.dynamicImportSettled()` and `await Promise.resolve()` for explicit microtask boundaries; the file already uses `vi.dynamicImportSettled?.() ?? new Promise(r => setTimeout(r, 0))` at line 103 — a hint someone knew the right tool but didn't apply it consistently.
+
+**Fix:** Phase 1.3 — standardize on fake timers + `vi.advanceTimersByTimeAsync` for any test that asserts "X happens after delay" or "X does not happen within delay."
+
+### F-4. Mock theater in `useMenuHandlers.paste.test.ts`
+**File:** `src/hooks/__tests__/useMenuHandlers.paste.test.ts`
+**Evidence:** 12 `vi.mock()` calls (lines 9, 21, 25, 29, 36, 45, 51, 57, 63, 67, 71). Mocks include `@/lib/tauri`, `next-themes`, `@/components/ui/toast`, **all five Zustand stores**, `@/lib/constants`, `@/components/navigation/BrowserTabBar`, and `@/hooks/useClaudeAuthStatus`.
+
+When every collaborator is mocked, the test runs against a synthetic environment that the real app never inhabits. Bugs in any of those mocked surfaces (renamed exports, behavior changes) silently pass. The hook itself shows **40.83%** coverage despite this file existing — the test is exercising a narrow path through a mock garden.
+
+**Fix:** Phase 2 — when adding the rest of `useMenuHandlers` coverage, prefer real Zustand stores (mock factories already exist in `src/test-utils/store-utils.ts`) and only mock the platform boundary (Tauri APIs).
+
+### F-5. Console error/warn suppression — verify scoping
+**Pattern:** `vi.spyOn(console, 'error').mockImplementation(() => {})`
+**Count:** 17 occurrences across 8 files.
+
+| File | Count |
+|---|---|
+| `src/lib/__tests__/linearAuth.test.ts` | 4 |
+| `src/hooks/__tests__/useTabPersistence.test.ts` | 2 |
+| `src/hooks/__tests__/useFileMentions.test.ts` | 3 |
+| `src/hooks/__tests__/useReviewTrigger.test.ts` | 2 |
+| `src/stores/__tests__/updateStore.test.ts` | 2 |
+| `src/lib/__tests__/auth-token.test.ts` | 1 |
+| `src/hooks/__tests__/useWebSocket.events.test.ts` | 2 (`console.warn`) |
+
+Spot-reading: most are local to a single negative-path test (catching a logged error in error-handling code). That's acceptable. **Verify** during Phase 1.3 that none are at top-of-file scope (which would suppress unrelated `act()` warnings, hiding real React bugs).
+
+### F-6. `--localstorage-file` warning during test runs
+**Evidence:** `(node:69158) Warning: '--localstorage-file' was provided without a valid path` fires multiple times in every run.
+
+`vitest.setup.ts` already provides a localStorage polyfill (lines 7-18). This warning is from Node's built-in localStorage flag being forwarded by Vitest 4. Cosmetic but obscures real warnings in logs. Worth filing a small fix.
+
+**Fix:** Phase 1, low-priority polish — investigate and silence at the Vitest invocation or via `--no-localstorage-file` if available.
+
+---
+
+## P2 — Quality smells
+
+### F-7. Async-test discipline
+**Pattern:** 533 `it(..., async () => ...)` declarations across 45 files.
+
+Many are valid. But async test bodies that never `await` anything are landmines (no failure raises until the next test cleanup). A file-by-file pass during Phase 2 should grep for `async (` paired with no `await` in the body — automate this if feasible.
+
+### F-8. `vi.mock()` density
+**Pattern:** 56 `vi.mock()` declarations across 29 files.
+
+Distribution looks reasonable. The outlier is `useMenuHandlers.paste.test.ts` (12 mocks, see F-4). Anything with >5 mocks per file deserves a second look in Phase 2.
+
+### F-9. `runInAct` underused
+**File:** `src/test-utils/store-utils.ts` exports a `runInAct` helper to wrap Zustand mutations in React's `act()`. Coverage shows `test-utils/` at 0% — not because the helpers don't work, but because they're underused (or used directly without coverage instrumentation).
+
+When new store tests are added in Phase 2, prefer `runInAct(() => store.setState(...))` over bare `store.setState(...)` to avoid React testing warnings on consumers that re-render.
+
+### F-10. `expect()` density looks healthy
+**Counts:** 3171 `expect()` across 1760 tests = ~1.8 per test. No obvious assertion-less `it` blocks; would need AST parsing to be sure. Spot-reading didn't surface any.
+
+---
+
+## OK — Negative findings (verified clean)
+
+| Check | Result |
+|---|---|
+| Snapshot test usage (`toMatchSnapshot`/`toMatchInlineSnapshot`) | **0 occurrences** — no snapshot abuse. |
+| Skipped tests (`.skip`/`.only`/`.todo`/`.fit`/`.xit`) | **0 occurrences** — no abandoned/forgotten tests. |
+| Fake-timer / real-timer balance | 50 calls across 21 files; spot-checked `appStore.contextUsage.test.ts` (3 fake / 1 real-in-`afterEach`) and `useDesktopNotifications.test.ts` (2/2) — proper cleanup pattern via `afterEach`. No leak detected. |
+| Test failures | **0** — 1760/1760 pass deterministically across the runs in this audit. |
+| Slowest spec | 5 ms (`useMessagePrefetch > polls at 200ms intervals`). No spec exceeds 200 ms. |
+| Custom render patterns | Single `src/test-utils/render.tsx` with `ThemeProvider`. Consistent. |
+
+---
+
+## Action priority for Phase 1
+
+1. **F-2** — wire `test:coverage` into CI, publish PR comment. *(Phase 1.6 of the master plan.)*
+2. **F-1** — write real `useWebSocket.ts` tests that drive the hook through a `WebSocket` mock; rename the existing 7 files to reflect their actual scope. *(Promote into Phase 1.3 instead of Phase 2 — false confidence here is too high to leave for later.)*
+3. **F-3** — replace `setTimeout(r, 50)` negative waits in `useDotMcpTrustCheck.test.ts` with fake timers. *(Phase 1.3.)*
+4. **F-6** — silence the `--localstorage-file` warning. *(Cosmetic.)*
+5. **F-4, F-5, F-7, F-8, F-9** — review/cleanup as part of Phase 2 gap-filling work; not a blocker.
+
+---
+
+## Reproduction
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run test:coverage          # baseline numbers
+pnpm exec vitest run --reporter=verbose 2>&1 | tee /tmp/verbose.log
+grep -E '\b[0-9]{3,}ms\b' /tmp/verbose.log    # slow specs (none today)
+```
+
+Pattern grep recipes used in this audit:
+
+```bash
+# Real-time setTimeout waits
+rg 'new Promise\s*\(\s*\(?\s*(resolve|r)\s*\)?\s*=>\s*setTimeout' --type ts -g '**/*.{test,spec}.{ts,tsx}'
+
+# vi.mock density
+rg 'vi\.mock\(' --type ts -g '**/*.{test,spec}.{ts,tsx}' -c
+
+# Skipped tests
+rg '\.(skip|todo|only)\(|fit\(|xit\(|xdescribe\(' --type ts -g '**/*.{test,spec}.{ts,tsx}'
+
+# Snapshot usage
+rg 'toMatchSnapshot|toMatchInlineSnapshot' --type ts -g '**/*.{test,spec}.{ts,tsx}'
+```

--- a/docs/test-coverage-baseline.md
+++ b/docs/test-coverage-baseline.md
@@ -109,7 +109,7 @@ Directories sorted by `% Lines`:
 | Metric | Day 0 | Now | Δ |
 |---|---|---|---|
 | Test files | 100 | 132 | +32 |
-| Tests | 1760 | 2310 | +550 |
+| Tests | 1760 | 2510 | +750 |
 | Wall-clock | ~7s | ~7s | (no regression) |
 
 **Overall coverage**
@@ -134,4 +134,4 @@ All four metrics now exceed the 20% gate. The configured threshold has been rais
 
 - `pnpm run test:coverage` now runs in the `frontend` job (was `pnpm run test:run`), gated by the configured thresholds.
 - Coverage report uploaded as an artifact (`frontend-coverage`, 14-day retention).
-- Per-directory thresholds added in `vitest.config.ts` for `src/lib/api/**` (85/68/85/85) and `src/stores/**` (60/51/53/61) so well-tested directories cannot silently regress while the global average stays acceptable.
+- Per-directory thresholds added in `vitest.config.ts` for `src/lib/api/**` (85/68/85/85), `src/lib/**` (55/55/55/58), and `src/stores/**` (60/51/53/61) so well-tested directories cannot silently regress while the global average stays acceptable.

--- a/docs/test-coverage-baseline.md
+++ b/docs/test-coverage-baseline.md
@@ -1,0 +1,137 @@
+# Frontend Test Coverage Baseline — 2026-04-26
+
+Snapshot of the Vitest unit test suite at the start of the test-improvement initiative (`mcastilho/analyze-frontend-unit-test-gaps`). Reproduce with:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run test:coverage
+```
+
+> **Status:** This file is the Day 0 baseline. Current coverage is tracked at the bottom under "Progress log".
+
+## Suite size & speed
+
+| Metric | Value |
+|---|---|
+| Test files | 100 |
+| Tests | 1760 (all passing) |
+| `expect()` calls | 3171 (~1.8 per test) |
+| Wall-clock duration | ~6.7s (verbose run), ~8.8s (with coverage) |
+| Slowest individual test | 5ms (`useMessagePrefetch > polls at 200ms intervals`) — no specs above 200ms |
+| Setup time (parallel) | ~27s — dominated by jsdom + module imports |
+
+The suite is fast. Slow-spec triage is **not** a priority; setup-time reduction is the only meaningful runtime lever.
+
+## Overall coverage
+
+| | % Stmts | % Branch | % Funcs | % Lines |
+|---|---|---|---|---|
+| **All files** | **19.88** | **17.72** | **17.36** | **20.20** |
+
+The configured threshold (`vitest.config.ts:26-31`) is 20% across all metrics. **Statements, branches, and functions are below threshold** — the gate is symbolic and CI does not run with `--coverage`, so this does not fail the build today.
+
+## Per-directory coverage
+
+Directories sorted by `% Lines`:
+
+| Directory | % Stmts | % Branch | % Funcs | % Lines | Notes |
+|---|---|---|---|---|---|
+| `lib/` | 59.78 | 58.08 | 57.86 | 61.12 | Strongest area — pure utilities well-tested |
+| `__mocks__/` (handlers + tauri) | 79.41 | 65.00 | 66.66 | 77.41 | MSW + Tauri mocks |
+| `stores/` | 40.44 | 36.49 | 35.08 | 42.12 | Mixed; appStore drags average down |
+| `components/ui/` | 34.43 | 30.66 | 34.04 | 34.85 | shadcn primitives, partial coverage |
+| `hooks/` | 25.26 | 17.02 | 26.85 | 25.20 | Many high-value hooks at 0% |
+| `lib/api/` | 21.80 | 23.74 | 18.68 | 22.01 | Most endpoint clients at 0% |
+| `components/conversation/` | 16.61 | 21.44 | 14.48 | 17.19 | Critical area — ChatInput/PlateInput at 0% |
+| `components/shared/` | 15.55 | 12.73 | 15.10 | 15.01 | |
+| `components/panels/` | 14.02 | 13.77 | 13.78 | 14.25 | |
+| `components/dialogs/` | 11.92 | 16.78 | 10.76 | 10.88 | CommandPalette/FilePicker at 0% |
+| `components/settings/sections/` | 7.46 | 12.73 | 7.63 | 7.11 | |
+| `components/session-manager/` | 6.75 | 17.14 | 4.00 | 7.07 | |
+| `components/files/` | 3.20 | 0.00 | 0.99 | 3.62 | |
+| `components/layout/` | 3.46 | 4.13 | 2.66 | 2.75 | |
+| `components/conversation/tool-details/` | 0.34 | 0 | 0 | 0.39 | |
+| `components/navigation/` | 0.22 | 0 | 0 | 0.25 | |
+| `app/` | 0 | 0 | 0 | 0 | `page.tsx` 0% |
+| `components/` (root) | 0 | 0 | 0 | 0 | `BranchSyncBanner`, `ConflictDialog` |
+| `components/ci/` | 0 | 0 | 0 | 0 | |
+| `components/dashboards/` | 0 | 0 | 0 | 0 | PRDashboard, etc. |
+| `components/data-table/` | 0 | 0 | 0 | 0 | |
+| `components/icons/` | 0 | 0 | 0 | 0 | |
+| `components/mission-control/` | 0 | 0 | 0 | 0 | |
+| `components/onboarding/`, `onboarding/steps/` | 0 | 0 | 0 | 0 | |
+| `components/scheduled/` | 0 | 0 | 0 | 0 | |
+| `components/skills/` | 0 | 0 | 0 | 0 | |
+| `components/tabs/` | 0 | 0 | 0 | 0 | |
+| `components/branch-cleanup/` | 0 | 0 | 0 | 0 | |
+| `components/comments/` | 4.34 | 0 | 0 | 4.68 | |
+| `lib/permission/` | 0 | 0 | 0 | 0 | |
+| `test-utils/` | 0 | 100 | 0 | 0 | Test helpers themselves |
+
+## Notable per-file outliers
+
+### Strong (≥ 90% lines)
+`lib/`: action-templates, auth-token, check-utils, clone-errors, conversationMarkers, diffCache, fileContentCache, formatReviewFeedback, linearAuth, markdownCache, menuContext, models, pierre, pkce, pr-utils, slashCommands, thinkingLevels, workspace-colors. `lib/api/`: review-comments. `stores/`: authStore, branchCacheStore (97%), linearAuthStore, recentlyClosedStore, skillsStore, uiStore. `hooks/`: useBranchSync (96%), useCIRuns (95%), useDotMcpTrustCheck (95%), useFileMentions (99%), useGitStatus (100%), useMessagePrefetch (94%), useReviewTrigger (98%), useSessionSnapshot (95%), useStreamingBatcher (97%), useTabPersistence (98%). `components/conversation/`: ChangesBlock (100%), ContextMeter (94%), ThinkingNode (100%), UserBubble (100%), VerificationBlock (100%).
+
+### Critical 0% — load-bearing files with no exercise
+| File | Why this matters |
+|---|---|
+| `src/hooks/useWebSocket.ts` | **0.25%** — 1700+ lines of event dispatch. Despite 7 `useWebSocket.*.test.ts` files, those tests bypass the hook and call store actions directly. See audit doc. |
+| `src/hooks/useTerminal.ts` | 0% — terminal lifecycle, large surface |
+| `src/hooks/usePRStatus.ts` | 1.61% — PR polling/state |
+| `src/hooks/useMenuHandlers.ts` | 40.83% — only paste paths covered |
+| `src/components/conversation/ChatInput.tsx` | 0% — main user input (1284 lines) |
+| `src/components/conversation/PlateInput.tsx` | 0% — Plate.js editor + content extraction |
+| `src/components/conversation/ConversationArea.tsx` | 0% — 1200+ lines |
+| `src/components/conversation/StreamingMessage.tsx` | 0% — 600+ lines |
+| `src/components/dialogs/CommandPalette.tsx` | 0% — keyboard + search |
+| `src/components/dialogs/FilePicker.tsx` | 0% — fuzzy match + picker |
+| `src/components/navigation/WorkspaceSidebar.tsx` | 0% — 2500 lines |
+| `src/lib/api/git.ts`, `branches.ts`, `ci.ts`, `files.ts`, `file-operations.ts`, `github.ts`, `health.ts`, `repositories.ts`, `scheduled-tasks.ts`, `scripts.ts`, `skills.ts`, `stats.ts`, `summaries.ts` | 0% — full API endpoints uncovered |
+| `src/stores/dismissedAttentionStore.ts` | 0% |
+| `src/stores/scheduledTaskStore.ts` | 5% |
+| `src/stores/settingsStore.ts` | 18% |
+
+## Coverage outputs
+
+- HTML report: `coverage/index.html` (gitignored)
+- LCOV: `coverage/lcov.info` (gitignored)
+- CI: `frontend-coverage` artifact (14-day retention, see `.github/workflows/ci.yml`)
+
+---
+
+## Progress log
+
+### 2026-04-26 — Initial sweep
+
+**Suite**
+
+| Metric | Day 0 | Now | Δ |
+|---|---|---|---|
+| Test files | 100 | 132 | +32 |
+| Tests | 1760 | 2310 | +550 |
+| Wall-clock | ~7s | ~7s | (no regression) |
+
+**Overall coverage**
+
+| | Day 0 | Now | Δ |
+|---|---|---|---|
+| Statements | 19.88% | **24.50%** | +4.62 |
+| Branches | 17.72% | **20.78%** | +3.06 |
+| Functions | 17.36% | **23.70%** | +6.34 |
+| Lines | 20.20% | **24.90%** | +4.70 |
+
+All four metrics now exceed the 20% gate. The configured threshold has been raised to 22/19/22/22 (~2 pts of headroom over current values).
+
+**Top moves**
+
+- `lib/api/`: 21.80% → **97.29% statements** (23 new test files, 396 tests). Every API client function is now exercised through MSW handlers.
+- `useWebSocketHelpers.ts` / `useWebSocketPlanMode.ts` / `useWebSocketReconciliation.ts`: ~15% → **94%–100%**. Pure-function tests for type guards, status mappers, cooldown timers, ref-counted reconciliation.
+- `useWebSocket.ts` itself: 0.25% → **13.92%**. Real integration tests with a `MockWebSocket` harness that exercises the actual hook code path (connection lifecycle, reconnect backoff, event dispatch, returned `reconnect()` callback). Mitigates the audit's P0 false-confidence finding (existing 7 `useWebSocket.*.test.ts` files claim to test the hook but only drive store actions).
+- `appStore.ts`: 29.17% → **73%** statements (5 new test files, 167 tests). Workspaces, sessions, conversations, file tabs, active tools, sub-agents, background tasks all covered through CRUD + cascade tests.
+
+**CI integration**
+
+- `pnpm run test:coverage` now runs in the `frontend` job (was `pnpm run test:run`), gated by the configured thresholds.
+- Coverage report uploaded as an artifact (`frontend-coverage`, 14-day retention).
+- Per-directory thresholds added in `vitest.config.ts` for `src/lib/api/**` (85/68/85/85) and `src/stores/**` (60/51/53/61) so well-tested directories cannot silently regress while the global average stays acceptable.

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -40,92 +40,14 @@ import { ToolApprovalPrompt, BatchToolApprovalPrompt } from './ToolApprovalPromp
 import { ChatInputToolbar, type PermissionMode } from './ChatInputToolbar';
 import { DictationWaveform } from './DictationWaveform';
 import { useDictation } from '@/hooks/useDictation';
+import {
+  parseDictationShortcut,
+  formatShortcutHint,
+  flattenFileTree,
+  resolveBackend,
+  getAvailableThinkingLevels,
+} from './chatInputUtils';
 
-import type { Shortcut, ModifierKey } from '@/lib/shortcuts';
-import type { DictationShortcutPreset } from '@/stores/settingsStore';
-
-/** Convert a dictation shortcut preset + custom string into a Shortcut definition. */
-function parseDictationShortcut(preset: DictationShortcutPreset, custom: string): Shortcut {
-  const base = { id: 'toggleDictation', label: 'Toggle dictation', category: 'Chat' as const };
-  switch (preset) {
-    case 'capslock':
-      return { ...base, key: 'CapsLock', modifiers: [] };
-    case 'cmd-shift-d':
-      return { ...base, key: 'd', modifiers: ['meta', 'shift'] };
-    case 'custom': {
-      if (!custom) return { ...base, key: 'd', modifiers: ['meta', 'shift'] };
-      const parts = custom.split('+');
-      const key = parts[parts.length - 1];
-      const modifiers = parts.slice(0, -1) as ModifierKey[];
-      return { ...base, key, modifiers };
-    }
-  }
-}
-
-/** Format a Shortcut into a human-readable hint string (e.g. "⌘⇧D"). */
-function formatShortcutHint(shortcut: Shortcut): string {
-  const parts: string[] = [];
-  for (const mod of shortcut.modifiers) {
-    switch (mod) {
-      case 'meta': parts.push('\u2318'); break;
-      case 'ctrl': parts.push('Ctrl'); break;
-      case 'alt': parts.push('\u2325'); break;
-      case 'shift': parts.push('\u21E7'); break;
-    }
-  }
-  const key = shortcut.key.length === 1 ? shortcut.key.toUpperCase() : shortcut.key;
-  parts.push(key);
-  return parts.join('');
-}
-
-// Flat file type for mention items
-interface FlatFile {
-  path: string;
-  name: string;
-  directory: string;
-}
-
-// Helper to flatten file tree for mentions (excludes hidden directories)
-function flattenFileTree(nodes: FileNodeDTO[], parentPath: string = '', depth: number = 0): FlatFile[] {
-  if (depth >= 15) return [];
-  const result: FlatFile[] = [];
-  for (const node of nodes) {
-    // Skip hidden files and directories (starting with .)
-    if (node.name.startsWith('.')) continue;
-
-    if (node.isDir) {
-      if (node.children) {
-        result.push(...flattenFileTree(node.children, node.path, depth + 1));
-      }
-    } else {
-      const directory = parentPath || node.path.split('/').slice(0, -1).join('/');
-      result.push({ path: node.path, name: node.name, directory });
-    }
-  }
-  return result;
-}
-
-
-/** Resolve the backend type. Called from event handlers (not render), so getState() is correct. */
-function resolveBackend(modelId: string): 'native' | undefined {
-  if (isLocalModel(modelId)) return 'native';
-  return useSettingsStore.getState().defaultBackend === 'native' ? 'native' : undefined;
-}
-
-
-
-/** Get available thinking level IDs for a model, respecting SDK-reported supported levels. */
-function getAvailableThinkingLevels(model: ModelEntry): ThinkingLevel[] {
-  const allLevels = THINKING_LEVELS.map(l => l.id);
-  const allowOff = canDisableThinking(model);
-  let available = allowOff ? allLevels : allLevels.filter(l => l !== 'off');
-  // Filter by SDK-reported supported effort levels when available
-  if (model.supportsEffort && model.supportedEffortLevels) {
-    const supported = new Set(model.supportedEffortLevels);
-    available = available.filter(l => l === 'off' || supported.has(l as 'low' | 'medium' | 'high' | 'max'));
-  }
-  return available;
-}
 
 interface ChatInputProps {
   onMessageSubmit?: () => void;

--- a/src/components/conversation/ChatInput.tsx
+++ b/src/components/conversation/ChatInput.tsx
@@ -18,17 +18,17 @@ import { loadAllAttachmentContents } from '@/lib/attachments';
 import { UserQuestionPrompt } from './UserQuestionPrompt';
 import { usePendingUserQuestion, useStreamingChatInput, useSelectedIds, useConversationState, useChatInputActions, useConversationHasMessages } from '@/stores/selectors';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { THINKING_LEVELS, type ThinkingLevel, resolveThinkingParams, clampThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
+import { type ThinkingLevel, resolveThinkingParams, clampThinkingLevel } from '@/lib/thinkingLevels';
 import { useSlashCommandStore, type UnifiedSlashCommand } from '@/stores/slashCommandStore';
 import { LinearIssuePicker } from './LinearIssuePicker';
 import { WorkspacePicker } from './WorkspacePicker';
 import type { LinearIssueDTO } from '@/lib/api';
 import { PlateInput, type PlateInputHandle } from './PlateInput';
-import { type ModelEntry, buildStaticModelList, isLocalModel } from '@/lib/models';
+import { type ModelEntry, buildStaticModelList } from '@/lib/models';
 import type { MentionItem } from '@/components/ui/mention-node';
 import { trackEvent } from '@/lib/telemetry';
 import { playSound } from '@/lib/sounds';
-import { listSessionFiles, type FileNodeDTO } from '@/lib/api';
+import { listSessionFiles } from '@/lib/api';
 
 // Extracted modules
 import { useChatInputDrafts } from './useChatInputDrafts';

--- a/src/components/conversation/PlateInput.tsx
+++ b/src/components/conversation/PlateInput.tsx
@@ -10,6 +10,7 @@ import { SlashPlugin, SlashInputPlugin } from '@platejs/slash-command/react';
 import { Plate, usePlateEditor } from 'platejs/react';
 
 import { cn } from '@/lib/utils';
+import { extractContent } from '@/lib/plate-content';
 import { Editor, EditorContainer } from '@/components/ui/editor';
 import {
   MentionElement,
@@ -43,38 +44,6 @@ interface PlateInputProps {
   onPaste?: (e: React.ClipboardEvent) => void;
   onFocus?: () => void;
   onBlur?: () => void;
-}
-
-// Extract text and mentioned files from Plate value in a single pass.
-// Uses array-join instead of string concatenation for better performance
-// on large pastes where the node tree can be deep.
-function extractContent(value: Value): { text: string; mentionedFiles: string[] } {
-  const parts: string[] = [];
-  const mentionedFiles: string[] = [];
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plate nodes have dynamic structure
-  const processNode = (node: any) => {
-    if (node.text !== undefined) {
-      parts.push(node.text);
-    } else if (node.type === 'mention') {
-      parts.push(`@${node.value}`);
-      if (node.value) {
-        mentionedFiles.push(node.value);
-      }
-    } else if (node.children) {
-      node.children.forEach(processNode);
-    }
-  };
-
-  value.forEach((node, index) => {
-    processNode(node);
-    // Add newline between paragraphs (except after last one)
-    if (index < value.length - 1) {
-      parts.push('\n');
-    }
-  });
-
-  return { text: parts.join('').trim(), mentionedFiles };
 }
 
 const emptyValue: Value = [{ type: 'p', children: [{ text: '' }] }];

--- a/src/components/conversation/__tests__/PlateInput.test.tsx
+++ b/src/components/conversation/__tests__/PlateInput.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Smoke tests for the PlateInput wrapper.
+ *
+ * Plate.js editors are heavy in jsdom (canvas measurements, complex DOM ops),
+ * so we verify just the high-level orchestration:
+ *   - The editor renders with the provided placeholder
+ *   - The imperative handle exposes focus/clear/getText/getContent/setText
+ *   - getText/getContent delegate to the extracted extractContent function
+ *
+ * Deeper editor interaction (typing, mentions, slash commands) is covered
+ * indirectly via the extractContent unit tests in lib/__tests__/plate-content.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRef } from 'react';
+import { render } from '@/test-utils/render';
+import { PlateInput, type PlateInputHandle } from '../PlateInput';
+
+describe('PlateInput', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<PlateInput />);
+    expect(container.querySelector('[data-slate-editor]')).toBeInTheDocument();
+  });
+
+  it('renders the placeholder text', () => {
+    const { container } = render(<PlateInput placeholder="Type a message..." />);
+    // Plate uses data attributes for placeholders
+    const editor = container.querySelector('[data-slate-editor]');
+    expect(editor).toBeInTheDocument();
+  });
+
+  it('exposes the imperative handle (focus/clear/getText/getContent/setText)', () => {
+    const ref = createRef<PlateInputHandle>();
+    render(<PlateInput ref={ref} />);
+
+    expect(ref.current).not.toBeNull();
+    expect(typeof ref.current?.focus).toBe('function');
+    expect(typeof ref.current?.clear).toBe('function');
+    expect(typeof ref.current?.getText).toBe('function');
+    expect(typeof ref.current?.getContent).toBe('function');
+    expect(typeof ref.current?.setText).toBe('function');
+  });
+
+  it('getText() returns empty string for an empty editor', () => {
+    const ref = createRef<PlateInputHandle>();
+    render(<PlateInput ref={ref} />);
+    expect(ref.current?.getText()).toBe('');
+  });
+
+  it('getContent() returns empty text and no mentions for an empty editor', () => {
+    const ref = createRef<PlateInputHandle>();
+    render(<PlateInput ref={ref} />);
+    const content = ref.current?.getContent();
+    expect(content?.text).toBe('');
+    expect(content?.mentionedFiles).toEqual([]);
+  });
+
+  it('setText() updates the editor content (next getText reflects it)', () => {
+    const ref = createRef<PlateInputHandle>();
+    render(<PlateInput ref={ref} />);
+
+    ref.current?.setText('hello world');
+    expect(ref.current?.getText()).toBe('hello world');
+  });
+
+  it('clear() empties the editor', () => {
+    const ref = createRef<PlateInputHandle>();
+    render(<PlateInput ref={ref} />);
+
+    ref.current?.setText('something');
+    expect(ref.current?.getText()).toBe('something');
+
+    ref.current?.clear();
+    expect(ref.current?.getText()).toBe('');
+  });
+
+  it('accepts mentionItems / slashCommands / callbacks without throwing', () => {
+    const cb = () => {};
+    expect(() =>
+      render(
+        <PlateInput
+          mentionItems={[]}
+          mentionItemsLoading={false}
+          slashCommands={[]}
+          onSlashCommandExecute={cb}
+          onInput={cb}
+          onKeyDown={cb}
+          onPaste={cb}
+          onFocus={cb}
+          onBlur={cb}
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('multiple instances coexist with independent state', () => {
+    const ref1 = createRef<PlateInputHandle>();
+    const ref2 = createRef<PlateInputHandle>();
+
+    render(
+      <>
+        <PlateInput ref={ref1} />
+        <PlateInput ref={ref2} />
+      </>,
+    );
+
+    ref1.current?.setText('one');
+    ref2.current?.setText('two');
+
+    expect(ref1.current?.getText()).toBe('one');
+    expect(ref2.current?.getText()).toBe('two');
+  });
+});

--- a/src/components/conversation/__tests__/PlateInput.test.tsx
+++ b/src/components/conversation/__tests__/PlateInput.test.tsx
@@ -21,9 +21,13 @@ describe('PlateInput', () => {
     expect(container.querySelector('[data-slate-editor]')).toBeInTheDocument();
   });
 
-  it('renders the placeholder text', () => {
+  it('renders when given a placeholder prop', () => {
+    // Plate.js renders the placeholder via internal slots / attributes that
+    // jsdom doesn't expose reliably across versions. We assert the editor
+    // mounts and accepts the prop without throwing; verifying that the
+    // placeholder text is actually visible to the user belongs in an e2e
+    // test rather than jsdom.
     const { container } = render(<PlateInput placeholder="Type a message..." />);
-    // Plate uses data attributes for placeholders
     const editor = container.querySelector('[data-slate-editor]');
     expect(editor).toBeInTheDocument();
   });

--- a/src/components/conversation/__tests__/chatInputUtils.test.ts
+++ b/src/components/conversation/__tests__/chatInputUtils.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  parseDictationShortcut,
+  formatShortcutHint,
+  flattenFileTree,
+  resolveBackend,
+  getAvailableThinkingLevels,
+  type FlatFile,
+} from '../chatInputUtils';
+import { useSettingsStore } from '@/stores/settingsStore';
+import type { FileNodeDTO } from '@/lib/api';
+import type { ModelEntry } from '@/lib/models';
+
+describe('parseDictationShortcut', () => {
+  it("returns CapsLock with no modifiers for 'capslock' preset", () => {
+    expect(parseDictationShortcut('capslock', '')).toMatchObject({
+      key: 'CapsLock',
+      modifiers: [],
+    });
+  });
+
+  it("returns Cmd+Shift+D for 'cmd-shift-d' preset", () => {
+    expect(parseDictationShortcut('cmd-shift-d', '')).toMatchObject({
+      key: 'd',
+      modifiers: ['meta', 'shift'],
+    });
+  });
+
+  it("parses a custom shortcut like 'ctrl+shift+x'", () => {
+    expect(parseDictationShortcut('custom', 'ctrl+shift+x')).toMatchObject({
+      key: 'x',
+      modifiers: ['ctrl', 'shift'],
+    });
+  });
+
+  it("falls back to Cmd+Shift+D when 'custom' preset has empty string", () => {
+    expect(parseDictationShortcut('custom', '')).toMatchObject({
+      key: 'd',
+      modifiers: ['meta', 'shift'],
+    });
+  });
+
+  it('always sets id, label, category', () => {
+    const result = parseDictationShortcut('capslock', '');
+    expect(result.id).toBe('toggleDictation');
+    expect(result.label).toBe('Toggle dictation');
+    expect(result.category).toBe('Chat');
+  });
+});
+
+describe('formatShortcutHint', () => {
+  it('formats a single key', () => {
+    expect(formatShortcutHint({
+      id: 'x', label: 'X', category: 'Chat',
+      key: 'a', modifiers: [],
+    })).toBe('A');
+  });
+
+  it('uppercases single-char keys', () => {
+    expect(formatShortcutHint({
+      id: 'x', label: 'X', category: 'Chat',
+      key: 'd', modifiers: ['meta'],
+    })).toBe('⌘D');
+  });
+
+  it('preserves multi-char keys verbatim (e.g. CapsLock)', () => {
+    expect(formatShortcutHint({
+      id: 'x', label: 'X', category: 'Chat',
+      key: 'CapsLock', modifiers: [],
+    })).toBe('CapsLock');
+  });
+
+  it('renders all four modifier glyphs', () => {
+    expect(formatShortcutHint({
+      id: 'x', label: 'X', category: 'Chat',
+      key: 'a', modifiers: ['meta', 'ctrl', 'alt', 'shift'],
+    })).toBe('⌘Ctrl⌥⇧A');
+  });
+});
+
+describe('flattenFileTree', () => {
+  it('returns empty array for empty input', () => {
+    expect(flattenFileTree([])).toEqual([]);
+  });
+
+  it('flattens a single file', () => {
+    const nodes: FileNodeDTO[] = [
+      { name: 'app.tsx', path: 'src/app.tsx', isDir: false },
+    ];
+    const result = flattenFileTree(nodes);
+    expect(result).toEqual<FlatFile[]>([
+      { path: 'src/app.tsx', name: 'app.tsx', directory: 'src' },
+    ]);
+  });
+
+  it('flattens nested directories', () => {
+    const nodes: FileNodeDTO[] = [
+      {
+        name: 'src',
+        path: 'src',
+        isDir: true,
+        children: [
+          { name: 'app.tsx', path: 'src/app.tsx', isDir: false },
+          { name: 'utils.ts', path: 'src/utils.ts', isDir: false },
+        ],
+      },
+    ];
+    const result = flattenFileTree(nodes);
+    expect(result).toHaveLength(2);
+    expect(result.map((f) => f.path).sort()).toEqual(['src/app.tsx', 'src/utils.ts']);
+  });
+
+  it('skips hidden files and directories (starting with .)', () => {
+    const nodes: FileNodeDTO[] = [
+      { name: '.env', path: '.env', isDir: false },
+      { name: '.git', path: '.git', isDir: true, children: [
+        { name: 'HEAD', path: '.git/HEAD', isDir: false },
+      ]},
+      { name: 'README.md', path: 'README.md', isDir: false },
+    ];
+    const result = flattenFileTree(nodes);
+    expect(result.map((f) => f.name)).toEqual(['README.md']);
+  });
+
+  it('captures the parent directory in each result', () => {
+    const nodes: FileNodeDTO[] = [
+      {
+        name: 'lib',
+        path: 'lib',
+        isDir: true,
+        children: [
+          {
+            name: 'api',
+            path: 'lib/api',
+            isDir: true,
+            children: [
+              { name: 'git.ts', path: 'lib/api/git.ts', isDir: false },
+            ],
+          },
+        ],
+      },
+    ];
+    const result = flattenFileTree(nodes);
+    expect(result[0].directory).toBe('lib/api');
+  });
+
+  it('caps recursion at depth 15 (defensive against pathological trees)', () => {
+    // Build a 20-deep nested directory
+    let nested: FileNodeDTO = {
+      name: 'leaf',
+      path: '/'.repeat(20) + 'leaf',
+      isDir: false,
+    };
+    for (let i = 19; i >= 0; i--) {
+      nested = {
+        name: `d${i}`,
+        path: `d${i}`,
+        isDir: true,
+        children: [nested],
+      };
+    }
+    const result = flattenFileTree([nested]);
+    // Cap means the leaf at depth 20 is unreachable
+    expect(result).toEqual([]);
+  });
+
+  it('handles directories with no children gracefully', () => {
+    const nodes: FileNodeDTO[] = [
+      { name: 'empty', path: 'empty', isDir: true },
+    ];
+    expect(flattenFileTree(nodes)).toEqual([]);
+  });
+});
+
+describe('resolveBackend', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ defaultBackend: 'agent-runner' } as never);
+  });
+
+  it("returns 'native' for local models regardless of settings", () => {
+    useSettingsStore.setState({ defaultBackend: 'agent-runner' } as never);
+    // isLocalModel matches the 'ollama/' prefix
+    expect(resolveBackend('ollama/llama3')).toBe('native');
+  });
+
+  it("returns 'native' when defaultBackend is 'native'", () => {
+    useSettingsStore.setState({ defaultBackend: 'native' } as never);
+    expect(resolveBackend('claude-sonnet-4-6')).toBe('native');
+  });
+
+  it('returns undefined when defaultBackend is agent-runner and model is non-local', () => {
+    useSettingsStore.setState({ defaultBackend: 'agent-runner' } as never);
+    expect(resolveBackend('claude-sonnet-4-6')).toBeUndefined();
+  });
+});
+
+describe('getAvailableThinkingLevels', () => {
+  // canDisableThinking returns !model.supportsEffort. So:
+  //   supportsEffort: true  → "off" is NOT allowed (excluded from levels)
+  //   supportsEffort: false → "off" IS allowed (included in levels)
+
+  it('excludes "off" when the model uses effort-based thinking (supportsEffort=true)', () => {
+    const model: ModelEntry = {
+      id: 'gpt-5',
+      name: 'GPT-5',
+      description: '',
+      supportsThinking: true,
+      supportsEffort: true,
+      contextWindow: 200000,
+    } as never;
+    const levels = getAvailableThinkingLevels(model);
+    expect(levels).not.toContain('off');
+  });
+
+  it('includes "off" when the model does not use effort levels (supportsEffort=false)', () => {
+    const model: ModelEntry = {
+      id: 'claude-haiku-4-5',
+      name: 'Haiku 4.5',
+      description: '',
+      supportsThinking: true,
+      supportsEffort: false,
+      contextWindow: 200000,
+    } as never;
+    const levels = getAvailableThinkingLevels(model);
+    expect(levels).toContain('off');
+  });
+
+  it('filters by SDK-reported supportedEffortLevels (without "off")', () => {
+    const model: ModelEntry = {
+      id: 'gpt-5',
+      name: 'GPT-5',
+      description: '',
+      supportsThinking: true,
+      supportsEffort: true,
+      supportedEffortLevels: ['low', 'medium'],
+      contextWindow: 200000,
+    } as never;
+    const levels = getAvailableThinkingLevels(model);
+    // 'off' excluded because supportsEffort=true; only allowed effort levels remain
+    expect(levels).not.toContain('off');
+    expect(levels).toContain('low');
+    expect(levels).toContain('medium');
+    expect(levels).not.toContain('high');
+    expect(levels).not.toContain('max');
+  });
+
+  it('returns all levels (including "off") when supportsEffort is false', () => {
+    const model: ModelEntry = {
+      id: 'claude-sonnet-4-6',
+      name: 'Sonnet 4.6',
+      description: '',
+      supportsThinking: true,
+      supportsEffort: false,
+      contextWindow: 200000,
+    } as never;
+    const levels = getAvailableThinkingLevels(model);
+    expect(levels.length).toBeGreaterThan(2);
+    expect(levels).toContain('off');
+  });
+});

--- a/src/components/conversation/__tests__/chatInputUtils.test.ts
+++ b/src/components/conversation/__tests__/chatInputUtils.test.ts
@@ -145,23 +145,30 @@ describe('flattenFileTree', () => {
   });
 
   it('caps recursion at depth 15 (defensive against pathological trees)', () => {
-    // Build a 20-deep nested directory
-    let nested: FileNodeDTO = {
-      name: 'leaf',
-      path: '/'.repeat(20) + 'leaf',
-      isDir: false,
-    };
+    // Build a 20-deep nested directory using realistic, monotonically growing
+    // paths (`d0`, `d0/d1`, `d0/d1/d2`, ...) — same structure a real backend
+    // would emit, just deeper than the cap allows.
+    const leafPath = Array.from({ length: 20 }, (_, j) => `d${j}`).join('/') + '/leaf';
+    let nested: FileNodeDTO = { name: 'leaf', path: leafPath, isDir: false };
     for (let i = 19; i >= 0; i--) {
-      nested = {
-        name: `d${i}`,
-        path: `d${i}`,
-        isDir: true,
-        children: [nested],
-      };
+      const dirPath = Array.from({ length: i + 1 }, (_, j) => `d${j}`).join('/');
+      nested = { name: `d${i}`, path: dirPath, isDir: true, children: [nested] };
     }
     const result = flattenFileTree([nested]);
     // Cap means the leaf at depth 20 is unreachable
     expect(result).toEqual([]);
+  });
+
+  it('handles top-level files with no parent directory', () => {
+    const nodes: FileNodeDTO[] = [
+      { name: 'README.md', path: 'README.md', isDir: false },
+    ];
+    // Pinned: a root-level file (path with no slash) yields directory=''.
+    // The mention-search ranker uses this as the "no parent" sentinel — keep
+    // an eye on this if the ranker ever distinguishes empty vs. undefined.
+    expect(flattenFileTree(nodes)).toEqual([
+      { path: 'README.md', name: 'README.md', directory: '' },
+    ]);
   });
 
   it('handles directories with no children gracefully', () => {

--- a/src/components/conversation/chatInputUtils.ts
+++ b/src/components/conversation/chatInputUtils.ts
@@ -73,7 +73,14 @@ export function flattenFileTree(
   return result;
 }
 
-/** Resolve the backend type. Reads from settingsStore. */
+/**
+ * Resolve the backend type from the current settings.
+ *
+ * Must be called from event handlers / async callbacks, **not** from a render
+ * path: `useSettingsStore.getState()` reads a snapshot and won't subscribe the
+ * caller to subsequent setting changes. Inside components use the
+ * `useSettingsStore(...)` hook variant instead.
+ */
 export function resolveBackend(modelId: string): 'native' | undefined {
   if (isLocalModel(modelId)) return 'native';
   return useSettingsStore.getState().defaultBackend === 'native' ? 'native' : undefined;

--- a/src/components/conversation/chatInputUtils.ts
+++ b/src/components/conversation/chatInputUtils.ts
@@ -1,0 +1,94 @@
+import type { Shortcut, ModifierKey } from '@/lib/shortcuts';
+import type { DictationShortcutPreset } from '@/stores/settingsStore';
+import type { FileNodeDTO } from '@/lib/api';
+import type { ModelEntry } from '@/lib/models';
+import { isLocalModel } from '@/lib/models';
+import { THINKING_LEVELS, type ThinkingLevel, canDisableThinking } from '@/lib/thinkingLevels';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+/** Convert a dictation shortcut preset + custom string into a Shortcut definition. */
+export function parseDictationShortcut(
+  preset: DictationShortcutPreset,
+  custom: string,
+): Shortcut {
+  const base = { id: 'toggleDictation', label: 'Toggle dictation', category: 'Chat' as const };
+  switch (preset) {
+    case 'capslock':
+      return { ...base, key: 'CapsLock', modifiers: [] };
+    case 'cmd-shift-d':
+      return { ...base, key: 'd', modifiers: ['meta', 'shift'] };
+    case 'custom': {
+      if (!custom) return { ...base, key: 'd', modifiers: ['meta', 'shift'] };
+      const parts = custom.split('+');
+      const key = parts[parts.length - 1];
+      const modifiers = parts.slice(0, -1) as ModifierKey[];
+      return { ...base, key, modifiers };
+    }
+  }
+}
+
+/** Format a Shortcut into a human-readable hint string (e.g. "⌘⇧D"). */
+export function formatShortcutHint(shortcut: Shortcut): string {
+  const parts: string[] = [];
+  for (const mod of shortcut.modifiers) {
+    switch (mod) {
+      case 'meta': parts.push('⌘'); break;
+      case 'ctrl': parts.push('Ctrl'); break;
+      case 'alt': parts.push('⌥'); break;
+      case 'shift': parts.push('⇧'); break;
+    }
+  }
+  const key = shortcut.key.length === 1 ? shortcut.key.toUpperCase() : shortcut.key;
+  parts.push(key);
+  return parts.join('');
+}
+
+/** Flat file shape used by ChatInput's mention-search ranking. */
+export interface FlatFile {
+  path: string;
+  name: string;
+  directory: string;
+}
+
+/** Flatten a Plate file tree into a flat list, skipping hidden files/directories. */
+export function flattenFileTree(
+  nodes: FileNodeDTO[],
+  parentPath: string = '',
+  depth: number = 0,
+): FlatFile[] {
+  if (depth >= 15) return [];
+  const result: FlatFile[] = [];
+  for (const node of nodes) {
+    if (node.name.startsWith('.')) continue;
+
+    if (node.isDir) {
+      if (node.children) {
+        result.push(...flattenFileTree(node.children, node.path, depth + 1));
+      }
+    } else {
+      const directory = parentPath || node.path.split('/').slice(0, -1).join('/');
+      result.push({ path: node.path, name: node.name, directory });
+    }
+  }
+  return result;
+}
+
+/** Resolve the backend type. Reads from settingsStore. */
+export function resolveBackend(modelId: string): 'native' | undefined {
+  if (isLocalModel(modelId)) return 'native';
+  return useSettingsStore.getState().defaultBackend === 'native' ? 'native' : undefined;
+}
+
+/** Get available thinking level IDs for a model, respecting SDK-reported supported levels. */
+export function getAvailableThinkingLevels(model: ModelEntry): ThinkingLevel[] {
+  const allLevels = THINKING_LEVELS.map((l) => l.id);
+  const allowOff = canDisableThinking(model);
+  let available = allowOff ? allLevels : allLevels.filter((l) => l !== 'off');
+  if (model.supportsEffort && model.supportedEffortLevels) {
+    const supported = new Set(model.supportedEffortLevels);
+    available = available.filter(
+      (l) => l === 'off' || supported.has(l as 'low' | 'medium' | 'high' | 'max'),
+    );
+  }
+  return available;
+}

--- a/src/components/dialogs/__tests__/CommandPalette.test.tsx
+++ b/src/components/dialogs/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Smoke tests for the CommandPalette dialog.
+ *
+ * Verifies the high-traffic paths: open/close events, search filtering,
+ * command execution, and submenu navigation. The COMMANDS array is large
+ * (~30+ items) so we don't try to assert on every command — just the
+ * orchestration surface.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@/test-utils/render';
+import { CommandPalette } from '../CommandPalette';
+import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useNavigationStore } from '@/stores/navigationStore';
+
+// Boundary mocks: clipboard/Tauri, API, toast
+vi.mock('@/lib/tauri', () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  unlinkPR: vi.fn(),
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  }),
+}));
+
+// useShortcut from @/hooks: stub so it doesn't try to wire keyboard handlers
+vi.mock('@/hooks/useShortcut', () => ({
+  useShortcut: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigate: vi.fn(),
+}));
+
+function openPalette() {
+  act(() => {
+    window.dispatchEvent(new CustomEvent('open-command-palette'));
+  });
+}
+
+function closePalette() {
+  act(() => {
+    window.dispatchEvent(new CustomEvent('close-command-palette'));
+  });
+}
+
+describe('CommandPalette', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [],
+      sessions: [],
+      conversations: [],
+      selectedWorkspaceId: null,
+      selectedSessionId: null,
+      selectedConversationId: null,
+    });
+    useSettingsStore.setState({
+      recentCommands: [],
+      addRecentCommand: vi.fn(),
+      setContentView: vi.fn(),
+    } as never);
+    useNavigationStore.setState({
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render the dialog when closed initially', () => {
+    render(<CommandPalette />);
+    expect(screen.queryByPlaceholderText(/Type a command or search/i)).toBeNull();
+  });
+
+  it('opens via the open-command-palette event', () => {
+    render(<CommandPalette />);
+    openPalette();
+    expect(screen.getByPlaceholderText(/Type a command or search/i)).toBeInTheDocument();
+  });
+
+  it('renders Settings navigation command in the visible list', () => {
+    render(<CommandPalette />);
+    openPalette();
+    expect(screen.getByText('Open Settings')).toBeInTheDocument();
+  });
+
+  it('filters commands by search query', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+
+    const input = screen.getByPlaceholderText(/Type a command or search/i);
+    await user.type(input, 'history');
+
+    // History command remains visible
+    expect(screen.getByText('Open History')).toBeInTheDocument();
+    // A non-matching command is hidden
+    expect(screen.queryByText('Open Settings')).toBeNull();
+  });
+
+  it('closes via the close-command-palette event', () => {
+    render(<CommandPalette />);
+    openPalette();
+    expect(screen.getByPlaceholderText(/Type a command or search/i)).toBeInTheDocument();
+
+    closePalette();
+    expect(screen.queryByPlaceholderText(/Type a command or search/i)).toBeNull();
+  });
+
+  it('executes a command on selection and closes the dialog', async () => {
+    const setContentView = vi.fn();
+    useSettingsStore.setState({
+      recentCommands: [],
+      addRecentCommand: vi.fn(),
+      setContentView,
+    } as never);
+
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+
+    const item = screen.getByText('Open History');
+    await user.click(item);
+
+    expect(setContentView).toHaveBeenCalledWith({ type: 'history' });
+    // Dialog closes after navigation
+    expect(screen.queryByPlaceholderText(/Type a command or search/i)).toBeNull();
+  });
+
+  it('records executed command in recent list', async () => {
+    const addRecentCommand = vi.fn();
+    useSettingsStore.setState({
+      recentCommands: [],
+      addRecentCommand,
+      setContentView: vi.fn(),
+    } as never);
+
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+
+    const item = screen.getByText('Open History');
+    await user.click(item);
+
+    expect(addRecentCommand).toHaveBeenCalledWith('open-history');
+  });
+
+  it('navigate-back command calls navigationStore.goBack', async () => {
+    const goBack = vi.fn();
+    useNavigationStore.setState({ goBack, goForward: vi.fn() } as never);
+
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+
+    const input = screen.getByPlaceholderText(/Type a command or search/i);
+    await user.type(input, 'Navigate Back');
+    const item = screen.getByText('Navigate Back');
+    await user.click(item);
+
+    expect(goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides commands whose available() returns false', () => {
+    // No workspaces → 'go-to-workspace' is unavailable
+    useAppStore.setState({
+      workspaces: [],
+      sessions: [],
+      conversations: [],
+    });
+    render(<CommandPalette />);
+    openPalette();
+
+    expect(screen.queryByText('Go to Workspace...')).toBeNull();
+  });
+
+  it('shows submenu commands when entries exist', () => {
+    useAppStore.setState({
+      workspaces: [{ id: 'ws-1', name: 'My Project', path: '/x' } as never],
+      sessions: [],
+      conversations: [],
+    });
+    render(<CommandPalette />);
+    openPalette();
+
+    expect(screen.getByText('Go to Workspace...')).toBeInTheDocument();
+  });
+
+  it('Backspace with empty search and no submenu page is a no-op (does not break)', () => {
+    render(<CommandPalette />);
+    openPalette();
+
+    const input = screen.getByPlaceholderText(/Type a command or search/i);
+    fireEvent.keyDown(input, { key: 'Backspace' });
+    // Dialog still open
+    expect(screen.getByPlaceholderText(/Type a command or search/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/dialogs/__tests__/CommandPalette.test.tsx
+++ b/src/components/dialogs/__tests__/CommandPalette.test.tsx
@@ -33,9 +33,14 @@ vi.mock('@/components/ui/toast', () => ({
   }),
 }));
 
-// useShortcut from @/hooks: stub so it doesn't try to wire keyboard handlers
+// useShortcut from @/hooks: capture the registered shortcut callbacks per
+// id so we can simulate keyboard-triggered behavior without wiring the real
+// keyboard surface (that's covered by useShortcut.test.ts directly).
+const shortcutHandlers: Record<string, () => void> = {};
 vi.mock('@/hooks/useShortcut', () => ({
-  useShortcut: vi.fn(),
+  useShortcut: vi.fn((id: string, cb: () => void) => {
+    shortcutHandlers[id] = cb;
+  }),
 }));
 
 vi.mock('@/lib/navigation', () => ({
@@ -76,6 +81,7 @@ describe('CommandPalette', () => {
   });
 
   afterEach(() => {
+    for (const key of Object.keys(shortcutHandlers)) delete shortcutHandlers[key];
     vi.clearAllMocks();
   });
 
@@ -87,6 +93,19 @@ describe('CommandPalette', () => {
   it('opens via the open-command-palette event', () => {
     render(<CommandPalette />);
     openPalette();
+    expect(screen.getByPlaceholderText(/Type a command or search/i)).toBeInTheDocument();
+  });
+
+  it("registers the 'commandPalette' shortcut and opening it shows the dialog", () => {
+    // Verifies the keyboard binding wiring without depending on the global
+    // shortcut module's internals: when useShortcut is invoked with id
+    // 'commandPalette', firing its captured callback opens the palette.
+    render(<CommandPalette />);
+    expect(typeof shortcutHandlers.commandPalette).toBe('function');
+
+    act(() => {
+      shortcutHandlers.commandPalette();
+    });
     expect(screen.getByPlaceholderText(/Type a command or search/i)).toBeInTheDocument();
   });
 

--- a/src/hooks/__tests__/terminal-utils.test.ts
+++ b/src/hooks/__tests__/terminal-utils.test.ts
@@ -134,7 +134,18 @@ describe('getShellFallbackChain', () => {
     });
   });
 
-  it("returns unix defaults when not in Tauri (invoke fails) on unix", async () => {
+  // The unix fallback chain probes both /bin/* and /usr/bin/* variants so
+  // distros (NixOS, Alpine, containers) without /bin/zsh still resolve.
+  const UNIX_DEFAULTS = [
+    '/bin/zsh',
+    '/usr/bin/zsh',
+    '/bin/bash',
+    '/usr/bin/bash',
+    '/bin/sh',
+    '/usr/bin/sh',
+  ];
+
+  it('returns unix defaults when not in Tauri (invoke fails) on unix', async () => {
     Object.defineProperty(navigator, 'platform', {
       value: 'MacIntel',
       configurable: true,
@@ -142,7 +153,7 @@ describe('getShellFallbackChain', () => {
     mockedInvoke.mockRejectedValueOnce(new Error('not in Tauri'));
 
     const chain = await getShellFallbackChain();
-    expect(chain).toEqual(['/bin/zsh', '/bin/bash', '/bin/sh']);
+    expect(chain).toEqual(UNIX_DEFAULTS);
   });
 
   it("returns windows defaults when not in Tauri on windows", async () => {
@@ -179,12 +190,7 @@ describe('getShellFallbackChain', () => {
     mockedInvoke.mockResolvedValueOnce('/usr/local/bin/fish');
 
     const chain = await getShellFallbackChain();
-    expect(chain).toEqual([
-      '/usr/local/bin/fish',
-      '/bin/zsh',
-      '/bin/bash',
-      '/bin/sh',
-    ]);
+    expect(chain).toEqual(['/usr/local/bin/fish', ...UNIX_DEFAULTS]);
   });
 
   it('falls back to defaults when invoke returns null', async () => {
@@ -195,7 +201,7 @@ describe('getShellFallbackChain', () => {
     mockedInvoke.mockResolvedValueOnce(null);
 
     const chain = await getShellFallbackChain();
-    expect(chain).toEqual(['/bin/zsh', '/bin/bash', '/bin/sh']);
+    expect(chain).toEqual(UNIX_DEFAULTS);
   });
 });
 

--- a/src/hooks/__tests__/terminal-utils.test.ts
+++ b/src/hooks/__tests__/terminal-utils.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  detectPlatform,
+  getShellFallbackChain,
+  getShellArgs,
+  getTerminalTheme,
+  darkTerminalTheme,
+  lightTerminalTheme,
+  TERMINAL_FONT_FAMILY,
+} from '../terminal-utils';
+
+// Mock Tauri's invoke — terminal utils use it to query the user's $SHELL.
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from '@tauri-apps/api/core';
+const mockedInvoke = vi.mocked(invoke);
+
+describe('detectPlatform', () => {
+  let originalUserAgentData: unknown;
+  let originalPlatform: string;
+
+  beforeEach(() => {
+    originalUserAgentData = (navigator as Navigator & {
+      userAgentData?: { platform?: string };
+    }).userAgentData;
+    originalPlatform = navigator.platform;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: originalUserAgentData,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'platform', {
+      value: originalPlatform,
+      configurable: true,
+    });
+  });
+
+  it("returns 'windows' when userAgentData reports a Windows platform", () => {
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: { platform: 'Windows' },
+      configurable: true,
+    });
+    expect(detectPlatform()).toBe('windows');
+  });
+
+  it('falls back to navigator.platform when userAgentData is unavailable', () => {
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Win32',
+      configurable: true,
+    });
+    expect(detectPlatform()).toBe('windows');
+  });
+
+  it("returns 'unix' for non-Windows platforms (default in jsdom)", () => {
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: { platform: 'macOS' },
+      configurable: true,
+    });
+    expect(detectPlatform()).toBe('unix');
+  });
+
+  it("returns 'unix' when userAgentData.platform is empty", () => {
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: { platform: '' },
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Linux x86_64',
+      configurable: true,
+    });
+    expect(detectPlatform()).toBe('unix');
+  });
+});
+
+describe('getShellArgs', () => {
+  let originalPlatform: string;
+
+  beforeEach(() => {
+    originalPlatform = navigator.platform;
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: originalPlatform,
+      configurable: true,
+    });
+  });
+
+  it('returns ["-l"] (login shell) on unix', () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    });
+    expect(getShellArgs()).toEqual(['-l']);
+  });
+
+  it('returns [] on windows', () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Win32',
+      configurable: true,
+    });
+    expect(getShellArgs()).toEqual([]);
+  });
+});
+
+describe('getShellFallbackChain', () => {
+  let originalPlatform: string;
+
+  beforeEach(() => {
+    originalPlatform = navigator.platform;
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: undefined,
+      configurable: true,
+    });
+    mockedInvoke.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: originalPlatform,
+      configurable: true,
+    });
+  });
+
+  it("returns unix defaults when not in Tauri (invoke fails) on unix", async () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    });
+    mockedInvoke.mockRejectedValueOnce(new Error('not in Tauri'));
+
+    const chain = await getShellFallbackChain();
+    expect(chain).toEqual(['/bin/zsh', '/bin/bash', '/bin/sh']);
+  });
+
+  it("returns windows defaults when not in Tauri on windows", async () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Win32',
+      configurable: true,
+    });
+    mockedInvoke.mockRejectedValueOnce(new Error('not in Tauri'));
+
+    const chain = await getShellFallbackChain();
+    expect(chain).toEqual(['powershell.exe', 'pwsh.exe', 'cmd.exe']);
+  });
+
+  it("prepends user's $SHELL when invoke succeeds (and dedupes)", async () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    });
+    mockedInvoke.mockResolvedValueOnce('/bin/zsh');
+
+    const chain = await getShellFallbackChain();
+    // Dedupes: zsh appears at the front, removed from defaults
+    expect(chain[0]).toBe('/bin/zsh');
+    expect(chain.filter((s) => s === '/bin/zsh')).toHaveLength(1);
+    expect(chain).toContain('/bin/bash');
+    expect(chain).toContain('/bin/sh');
+  });
+
+  it("prepends a non-default user shell (e.g. /usr/local/bin/fish)", async () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    });
+    mockedInvoke.mockResolvedValueOnce('/usr/local/bin/fish');
+
+    const chain = await getShellFallbackChain();
+    expect(chain).toEqual([
+      '/usr/local/bin/fish',
+      '/bin/zsh',
+      '/bin/bash',
+      '/bin/sh',
+    ]);
+  });
+
+  it('falls back to defaults when invoke returns null', async () => {
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    });
+    mockedInvoke.mockResolvedValueOnce(null);
+
+    const chain = await getShellFallbackChain();
+    expect(chain).toEqual(['/bin/zsh', '/bin/bash', '/bin/sh']);
+  });
+});
+
+describe('getTerminalTheme', () => {
+  it('returns dark theme for "dark"', () => {
+    expect(getTerminalTheme('dark')).toBe(darkTerminalTheme);
+  });
+
+  it('returns light theme for "light"', () => {
+    expect(getTerminalTheme('light')).toBe(lightTerminalTheme);
+  });
+
+  it('dark theme has the project background and green-400 foreground', () => {
+    expect(darkTerminalTheme.background).toBe('#0f1111');
+    expect(darkTerminalTheme.foreground).toBe('#4ade80');
+  });
+
+  it('light theme has white background and dark foreground', () => {
+    expect(lightTerminalTheme.background).toBe('#ffffff');
+    expect(lightTerminalTheme.foreground).toBe('#1a1a1a');
+  });
+
+  it('both themes share the same shape (key set)', () => {
+    expect(Object.keys(darkTerminalTheme).sort()).toEqual(
+      Object.keys(lightTerminalTheme).sort()
+    );
+  });
+});
+
+describe('TERMINAL_FONT_FAMILY', () => {
+  it('starts with the MesloLGS Nerd Font and falls back to monospace', () => {
+    expect(TERMINAL_FONT_FAMILY).toMatch(/^"MesloLGS NF"/);
+    expect(TERMINAL_FONT_FAMILY).toMatch(/monospace$/);
+  });
+});

--- a/src/hooks/__tests__/use-mounted.test.ts
+++ b/src/hooks/__tests__/use-mounted.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMounted } from '../use-mounted';
+
+describe('useMounted', () => {
+  it('returns true after mount', () => {
+    const { result } = renderHook(() => useMounted());
+    // After the first render + effect, mounted is true
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true on subsequent renders', () => {
+    const { result, rerender } = renderHook(() => useMounted());
+    rerender();
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true across multiple instances', () => {
+    const a = renderHook(() => useMounted());
+    const b = renderHook(() => useMounted());
+    expect(a.result.current).toBe(true);
+    expect(b.result.current).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useApprovalPrompt.test.ts
+++ b/src/hooks/__tests__/useApprovalPrompt.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useApprovalTimer,
+  useApprovalKeyboard,
+  TIMEOUT_MS,
+  type ApprovalAction,
+} from '../useApprovalPrompt';
+
+describe('useApprovalTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns initial state when no requestId is provided', () => {
+    const { result } = renderHook(() => useApprovalTimer(undefined, vi.fn()));
+    expect(result.current.elapsed).toBe(0);
+    expect(result.current.progressPct).toBe(0);
+    expect(result.current.submitting).toBe(false);
+  });
+
+  it('updates elapsed on the 200ms tick when requestId is set', () => {
+    const onAction = vi.fn();
+    const { result } = renderHook(() => useApprovalTimer('req-1', onAction));
+
+    expect(result.current.elapsed).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(result.current.elapsed).toBeGreaterThanOrEqual(400);
+    expect(result.current.progressPct).toBeGreaterThan(0);
+  });
+
+  it('auto-denies after TIMEOUT_MS elapses', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalTimer('req-1', onAction));
+
+    act(() => {
+      vi.advanceTimersByTime(TIMEOUT_MS + 200);
+    });
+
+    expect(onAction).toHaveBeenCalledWith('deny_once');
+  });
+
+  it('only auto-denies once per request even if more time passes', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalTimer('req-1', onAction));
+
+    act(() => {
+      vi.advanceTimersByTime(TIMEOUT_MS + 1000);
+    });
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets elapsed and submitting when requestId changes', () => {
+    const onAction = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ rid }: { rid: string | undefined }) => useApprovalTimer(rid, onAction),
+      { initialProps: { rid: 'req-1' as string | undefined } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.elapsed).toBeGreaterThanOrEqual(2000);
+
+    rerender({ rid: 'req-2' });
+    // After requestId change, elapsed resets to 0
+    expect(result.current.elapsed).toBe(0);
+  });
+
+  it('clears the timer on unmount', () => {
+    const onAction = vi.fn();
+    const { unmount } = renderHook(() => useApprovalTimer('req-1', onAction));
+
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(TIMEOUT_MS + 1000);
+    });
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('progressPct caps at 100', () => {
+    const { result } = renderHook(() => useApprovalTimer('req-1', vi.fn()));
+    act(() => {
+      vi.advanceTimersByTime(TIMEOUT_MS * 2);
+    });
+    expect(result.current.progressPct).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('useApprovalKeyboard', () => {
+  function dispatchKey(opts: KeyboardEventInit & { target?: EventTarget }) {
+    act(() => {
+      const event = new KeyboardEvent('keydown', { ...opts, cancelable: true, bubbles: true });
+      if (opts.target) {
+        Object.defineProperty(event, 'target', { value: opts.target });
+      }
+      window.dispatchEvent(event);
+    });
+  }
+
+  it('Escape sends deny_once', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalKeyboard(true, onAction));
+
+    dispatchKey({ key: 'Escape' });
+    expect(onAction).toHaveBeenCalledWith('deny_once');
+  });
+
+  it('Cmd+Enter sends allow_always by default', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalKeyboard(true, onAction));
+
+    dispatchKey({ key: 'Enter', metaKey: true });
+    expect(onAction).toHaveBeenCalledWith('allow_always');
+  });
+
+  it('Cmd+Enter respects custom cmdEnterAction', () => {
+    const onAction = vi.fn();
+    renderHook(() =>
+      useApprovalKeyboard(true, onAction, { cmdEnterAction: 'allow_session' as ApprovalAction })
+    );
+
+    dispatchKey({ key: 'Enter', metaKey: true });
+    expect(onAction).toHaveBeenCalledWith('allow_session');
+  });
+
+  it('Ctrl+Enter also triggers cmdEnterAction (cross-platform)', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalKeyboard(true, onAction));
+
+    dispatchKey({ key: 'Enter', ctrlKey: true });
+    expect(onAction).toHaveBeenCalledWith('allow_always');
+  });
+
+  it('plain Enter sends allow_once when not inside a textarea', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalKeyboard(true, onAction));
+
+    dispatchKey({ key: 'Enter' });
+    expect(onAction).toHaveBeenCalledWith('allow_once');
+  });
+
+  it('plain Enter inside a textarea is suppressed by default', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalKeyboard(true, onAction));
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    dispatchKey({ key: 'Enter', target: textarea });
+    document.body.removeChild(textarea);
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('plain Enter inside a textarea fires when skipEnterInTextarea=false', () => {
+    const onAction = vi.fn();
+    renderHook(() =>
+      useApprovalKeyboard(true, onAction, { skipEnterInTextarea: false })
+    );
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    dispatchKey({ key: 'Enter', target: textarea });
+    document.body.removeChild(textarea);
+
+    expect(onAction).toHaveBeenCalledWith('allow_once');
+  });
+
+  it('Shift+Enter does not trigger', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalKeyboard(true, onAction));
+
+    dispatchKey({ key: 'Enter', shiftKey: true });
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when active=false', () => {
+    const onAction = vi.fn();
+    renderHook(() => useApprovalKeyboard(false, onAction));
+
+    dispatchKey({ key: 'Escape' });
+    dispatchKey({ key: 'Enter', metaKey: true });
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('cleans up listener on unmount', () => {
+    const onAction = vi.fn();
+    const { unmount } = renderHook(() => useApprovalKeyboard(true, onAction));
+
+    unmount();
+    dispatchKey({ key: 'Escape' });
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useApprovalPrompt.test.ts
+++ b/src/hooks/__tests__/useApprovalPrompt.test.ts
@@ -98,6 +98,14 @@ describe('useApprovalTimer', () => {
 });
 
 describe('useApprovalKeyboard', () => {
+  // CAVEAT: when `opts.target` is supplied we override `event.target` via
+  // `Object.defineProperty`, but the event is still dispatched on `window`,
+  // so it does NOT bubble through the supplied target's DOM ancestry. This
+  // works for the production hook because it only inspects `e.target.tagName`
+  // (cheap shallow read). If the hook is ever changed to walk ancestors —
+  // e.g. `e.target.closest('textarea, input, [contenteditable]')` — this
+  // helper will silently stop matching reality. Append a real DOM dispatch
+  // path here if that day comes.
   function dispatchKey(opts: KeyboardEventInit & { target?: EventTarget }) {
     act(() => {
       const event = new KeyboardEvent('keydown', { ...opts, cancelable: true, bubbles: true });

--- a/src/hooks/__tests__/useAttentionCount.test.ts
+++ b/src/hooks/__tests__/useAttentionCount.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAttentionCount } from '../useAttentionCount';
+import { useAppStore } from '@/stores/appStore';
+import { useDismissedAttentionStore, attentionId } from '@/stores/dismissedAttentionStore';
+import type { WorktreeSession } from '@/lib/types';
+
+function makeSession(overrides: Partial<WorktreeSession> = {}): WorktreeSession {
+  return {
+    id: `s-${Math.random().toString(36).slice(2, 8)}`,
+    workspaceId: 'ws-1',
+    name: 'Test',
+    branch: 'main',
+    worktreePath: '/wt',
+    status: 'idle',
+    archived: false,
+    ...overrides,
+  } as WorktreeSession;
+}
+
+describe('useAttentionCount', () => {
+  beforeEach(() => {
+    useAppStore.setState({ sessions: [] });
+    useDismissedAttentionStore.setState({ entries: [] } as never);
+  });
+
+  it('returns 0 when there are no sessions', () => {
+    const { result } = renderHook(() => useAttentionCount());
+    expect(result.current).toBe(0);
+  });
+
+  it('counts sessions with status=error', () => {
+    useAppStore.setState({
+      sessions: [
+        makeSession({ id: 's1', status: 'error' }),
+        makeSession({ id: 's2', status: 'idle' }),
+      ],
+    });
+    const { result } = renderHook(() => useAttentionCount());
+    expect(result.current).toBe(1);
+  });
+
+  it('counts sessions with hasMergeConflict', () => {
+    useAppStore.setState({
+      sessions: [
+        makeSession({ id: 's1', hasMergeConflict: true }),
+        makeSession({ id: 's2' }),
+      ],
+    });
+    const { result } = renderHook(() => useAttentionCount());
+    expect(result.current).toBe(1);
+  });
+
+  it('counts CI failures only when PR is open', () => {
+    useAppStore.setState({
+      sessions: [
+        makeSession({ id: 's1', checkStatus: 'failure', prStatus: 'open' }),
+        // CI failure but no open PR — does not count
+        makeSession({ id: 's2', checkStatus: 'failure', prStatus: 'merged' }),
+      ],
+    });
+    const { result } = renderHook(() => useAttentionCount());
+    expect(result.current).toBe(1);
+  });
+
+  it('skips archived sessions entirely', () => {
+    useAppStore.setState({
+      sessions: [
+        makeSession({ id: 's1', status: 'error', archived: true }),
+        makeSession({ id: 's2', hasMergeConflict: true, archived: true }),
+      ],
+    });
+    const { result } = renderHook(() => useAttentionCount());
+    expect(result.current).toBe(0);
+  });
+
+  it('respects dismissed attention items', () => {
+    useAppStore.setState({
+      sessions: [makeSession({ id: 's1', status: 'error' })],
+    });
+    useDismissedAttentionStore.setState({
+      entries: [{ id: attentionId.error('s1'), at: Date.now() }],
+    } as never);
+
+    const { result } = renderHook(() => useAttentionCount());
+    expect(result.current).toBe(0);
+  });
+
+  it('sums multiple attention reasons across sessions', () => {
+    useAppStore.setState({
+      sessions: [
+        makeSession({ id: 's1', status: 'error' }),
+        makeSession({ id: 's2', hasMergeConflict: true }),
+        makeSession({ id: 's3', checkStatus: 'failure', prStatus: 'open' }),
+      ],
+    });
+    const { result } = renderHook(() => useAttentionCount());
+    expect(result.current).toBe(3);
+  });
+
+  it('counts a session with multiple attention reasons multiple times', () => {
+    useAppStore.setState({
+      sessions: [
+        makeSession({
+          id: 's1',
+          status: 'error',
+          hasMergeConflict: true,
+          checkStatus: 'failure',
+          prStatus: 'open',
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useAttentionCount());
+    expect(result.current).toBe(3);
+  });
+});

--- a/src/hooks/__tests__/useAvatars.test.ts
+++ b/src/hooks/__tests__/useAvatars.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/__mocks__/server';
+import { flushAsync } from '@/test-utils/async';
 import { useAvatars, getCachedAvatar, clearAvatarCache } from '../useAvatars';
 
 const API_BASE = 'http://localhost:9876';
@@ -83,9 +84,12 @@ describe('useAvatars', () => {
     await waitFor(() => expect(result.current['x@example.com']).toBeDefined());
     const initial = getCount;
 
-    // Re-render with the same email — should hit cache, not refetch
+    // Re-render with the same email — should hit cache, not refetch.
+    // The cache lookup is synchronous, so we don't wait "no fetch within N ms"
+    // (a flaky negative-timer pattern); we just flush queued microtasks and
+    // assert no additional GET fired.
     rerender({ emails: ['x@example.com'] });
-    await new Promise((r) => setTimeout(r, 100));
+    await flushAsync();
 
     expect(getCount).toBe(initial);
     expect(result.current['x@example.com']).toBe('https://avatars/x@example.com');

--- a/src/hooks/__tests__/useAvatars.test.ts
+++ b/src/hooks/__tests__/useAvatars.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { useAvatars, getCachedAvatar, clearAvatarCache } from '../useAvatars';
+
+const API_BASE = 'http://localhost:9876';
+
+describe('useAvatars', () => {
+  beforeEach(() => {
+    clearAvatarCache();
+    server.use(
+      http.get(`${API_BASE}/api/avatars`, ({ request }) => {
+        const emails = new URL(request.url).searchParams.get('emails') ?? '';
+        const list = emails.split(',').filter(Boolean);
+        const avatars: Record<string, string> = {};
+        for (const e of list) avatars[e] = `https://avatars/${e}`;
+        return HttpResponse.json({ avatars });
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('getCachedAvatar / clearAvatarCache', () => {
+    it('returns undefined for an uncached email', () => {
+      expect(getCachedAvatar('nobody@example.com')).toBeUndefined();
+    });
+
+    it('clears all entries', async () => {
+      const { result, unmount } = renderHook(() => useAvatars(['alice@example.com']));
+      await waitFor(() => {
+        expect(result.current['alice@example.com']).toBe('https://avatars/alice@example.com');
+      });
+      expect(getCachedAvatar('alice@example.com')).toBeDefined();
+
+      clearAvatarCache();
+      expect(getCachedAvatar('alice@example.com')).toBeUndefined();
+      unmount();
+    });
+  });
+
+  it('returns empty object for an empty email list', () => {
+    const { result } = renderHook(() => useAvatars([]));
+    expect(result.current).toEqual({});
+  });
+
+  it('fetches avatars for new emails (after debounce)', async () => {
+    const { result } = renderHook(() => useAvatars(['alice@example.com']));
+
+    await waitFor(() => {
+      expect(result.current['alice@example.com']).toBe('https://avatars/alice@example.com');
+    });
+  });
+
+  it('lowercases email keys when caching', async () => {
+    const { result } = renderHook(() => useAvatars(['Alice@Example.com']));
+    await waitFor(() => {
+      expect(result.current['alice@example.com']).toBeDefined();
+    });
+    expect(getCachedAvatar('ALICE@EXAMPLE.COM')).toBeDefined();
+  });
+
+  it('serves cached avatars synchronously without re-fetching', async () => {
+    let getCount = 0;
+    server.use(
+      http.get(`${API_BASE}/api/avatars`, ({ request }) => {
+        getCount++;
+        const emails = new URL(request.url).searchParams.get('emails') ?? '';
+        const list = emails.split(',').filter(Boolean);
+        const avatars: Record<string, string> = {};
+        for (const e of list) avatars[e] = `https://avatars/${e}`;
+        return HttpResponse.json({ avatars });
+      })
+    );
+
+    const { result, rerender } = renderHook(({ emails }) => useAvatars(emails), {
+      initialProps: { emails: ['x@example.com'] },
+    });
+
+    await waitFor(() => expect(result.current['x@example.com']).toBeDefined());
+    const initial = getCount;
+
+    // Re-render with the same email — should hit cache, not refetch
+    rerender({ emails: ['x@example.com'] });
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(getCount).toBe(initial);
+    expect(result.current['x@example.com']).toBe('https://avatars/x@example.com');
+  });
+
+  it('deduplicates emails before fetching', async () => {
+    let capturedSearch = '';
+    server.use(
+      http.get(`${API_BASE}/api/avatars`, ({ request }) => {
+        capturedSearch = new URL(request.url).search;
+        return HttpResponse.json({
+          avatars: { 'a@example.com': 'https://avatars/a@example.com' },
+        });
+      })
+    );
+
+    renderHook(() => useAvatars(['a@example.com', 'A@Example.com', 'a@example.com']));
+    await waitFor(() => {
+      expect(capturedSearch).toContain('a%40example.com');
+    });
+
+    // Only one comma-joined email should appear (no duplicates)
+    const emails = new URLSearchParams(capturedSearch).get('emails') ?? '';
+    expect(emails.split(',').length).toBe(1);
+  });
+
+  it('skips empty/whitespace emails', async () => {
+    let capturedSearch = '';
+    server.use(
+      http.get(`${API_BASE}/api/avatars`, ({ request }) => {
+        capturedSearch = new URL(request.url).search;
+        return HttpResponse.json({
+          avatars: { 'real@example.com': 'https://avatars/real@example.com' },
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useAvatars(['', '  ', 'real@example.com']));
+    await waitFor(() => expect(result.current['real@example.com']).toBeDefined());
+
+    const emails = new URLSearchParams(capturedSearch).get('emails') ?? '';
+    expect(emails).toBe('real@example.com');
+  });
+
+  it('marks emails as fetched (with empty value) on API error', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    server.use(
+      http.get(`${API_BASE}/api/avatars`, () =>
+        HttpResponse.text('boom', { status: 500 })
+      )
+    );
+
+    renderHook(() => useAvatars(['failing@example.com']));
+
+    await waitFor(() => {
+      expect(getCachedAvatar('failing@example.com')).toBe('');
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/src/hooks/__tests__/useDotMcpTrustCheck.test.ts
+++ b/src/hooks/__tests__/useDotMcpTrustCheck.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useSettingsStore } from '@/stores/settingsStore';
 
+// Flush pending microtasks deterministically (replaces audit F-3 negative-wait
+// `setTimeout(r, 50)` patterns that race against the hook's async callbacks).
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 // ---- Mocks ----
 
 const mockGetDotMcpInfo = vi.fn();
@@ -128,7 +136,7 @@ describe('useDotMcpTrustCheck', () => {
     );
 
     // Give time for any async operations
-    await new Promise((r) => setTimeout(r, 50));
+    await flushAsync();
 
     expect(mockGetDotMcpInfo).not.toHaveBeenCalled();
     expect(mockShowDotMcpTrust).not.toHaveBeenCalled();
@@ -139,7 +147,7 @@ describe('useDotMcpTrustCheck', () => {
       useDotMcpTrustCheck(mockWorkspaces, null, mockDialogRef)
     );
 
-    await new Promise((r) => setTimeout(r, 50));
+    await flushAsync();
 
     expect(mockGetDotMcpInfo).not.toHaveBeenCalled();
   });
@@ -158,7 +166,7 @@ describe('useDotMcpTrustCheck', () => {
 
     // Re-render with same workspace — should not check again
     rerender({ wsId: 'ws-1' });
-    await new Promise((r) => setTimeout(r, 50));
+    await flushAsync();
 
     expect(mockGetDotMcpInfo).toHaveBeenCalledTimes(1);
   });
@@ -186,7 +194,7 @@ describe('useDotMcpTrustCheck', () => {
     );
 
     // Should not throw or show dialog
-    await new Promise((r) => setTimeout(r, 50));
+    await flushAsync();
 
     expect(mockShowDotMcpTrust).not.toHaveBeenCalled();
   });

--- a/src/hooks/__tests__/useDotMcpTrustCheck.test.ts
+++ b/src/hooks/__tests__/useDotMcpTrustCheck.test.ts
@@ -1,14 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useSettingsStore } from '@/stores/settingsStore';
-
-// Flush pending microtasks deterministically (replaces audit F-3 negative-wait
-// `setTimeout(r, 50)` patterns that race against the hook's async callbacks).
-async function flushAsync() {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-}
+import { flushAsync } from '@/test-utils/async';
 
 // ---- Mocks ----
 

--- a/src/hooks/__tests__/useExternalLinkGuard.test.ts
+++ b/src/hooks/__tests__/useExternalLinkGuard.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useExternalLinkGuard } from '../useExternalLinkGuard';
+
+vi.mock('@/lib/tauri', () => ({
+  openUrlInBrowser: vi.fn(),
+}));
+
+import { openUrlInBrowser } from '@/lib/tauri';
+
+function clickAnchor(anchor: HTMLAnchorElement) {
+  let prevented = false;
+  let stopped = false;
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'preventDefault', {
+    value: () => {
+      prevented = true;
+    },
+  });
+  Object.defineProperty(event, 'stopPropagation', {
+    value: () => {
+      stopped = true;
+    },
+  });
+  act(() => {
+    anchor.dispatchEvent(event);
+  });
+  return { prevented, stopped };
+}
+
+describe('useExternalLinkGuard', () => {
+  beforeEach(() => {
+    vi.mocked(openUrlInBrowser).mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('opens external https links in the system browser', () => {
+    renderHook(() => useExternalLinkGuard());
+    const a = document.createElement('a');
+    a.href = 'https://example.com';
+    document.body.appendChild(a);
+
+    const { prevented } = clickAnchor(a);
+
+    expect(prevented).toBe(true);
+    expect(openUrlInBrowser).toHaveBeenCalledWith(expect.stringMatching(/^https:\/\/example\.com\/?$/));
+  });
+
+  it('opens external http links in the system browser', () => {
+    renderHook(() => useExternalLinkGuard());
+    const a = document.createElement('a');
+    a.href = 'http://example.com';
+    document.body.appendChild(a);
+
+    clickAnchor(a);
+    expect(openUrlInBrowser).toHaveBeenCalled();
+  });
+
+  it('does not intercept relative links', () => {
+    renderHook(() => useExternalLinkGuard());
+    const a = document.createElement('a');
+    a.setAttribute('href', '/internal/path');
+    document.body.appendChild(a);
+
+    clickAnchor(a);
+    expect(openUrlInBrowser).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept empty href', () => {
+    renderHook(() => useExternalLinkGuard());
+    const a = document.createElement('a');
+    document.body.appendChild(a);
+
+    clickAnchor(a);
+    expect(openUrlInBrowser).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept clicks not on an anchor', () => {
+    renderHook(() => useExternalLinkGuard());
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    act(() => {
+      div.dispatchEvent(event);
+    });
+
+    expect(openUrlInBrowser).not.toHaveBeenCalled();
+  });
+
+  it('skips intercept when URL hash matches an in-page element', () => {
+    renderHook(() => useExternalLinkGuard());
+    const target = document.createElement('div');
+    target.id = 'section-1';
+    document.body.appendChild(target);
+
+    const a = document.createElement('a');
+    a.href = 'https://example.com/#section-1';
+    document.body.appendChild(a);
+
+    clickAnchor(a);
+    // The in-page anchor matches → external open is skipped
+    expect(openUrlInBrowser).not.toHaveBeenCalled();
+  });
+
+  it('still intercepts when URL hash does not match any element', () => {
+    renderHook(() => useExternalLinkGuard());
+    const a = document.createElement('a');
+    a.href = 'https://example.com/#missing-anchor';
+    document.body.appendChild(a);
+
+    clickAnchor(a);
+    expect(openUrlInBrowser).toHaveBeenCalled();
+  });
+
+  it('handles bubbled clicks from inside an anchor (e.g. a span child)', () => {
+    renderHook(() => useExternalLinkGuard());
+    const a = document.createElement('a');
+    a.href = 'https://example.com';
+    const span = document.createElement('span');
+    a.appendChild(span);
+    document.body.appendChild(a);
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    act(() => {
+      span.dispatchEvent(event);
+    });
+
+    expect(openUrlInBrowser).toHaveBeenCalled();
+  });
+
+  it('cleans up the listener on unmount', () => {
+    const { unmount } = renderHook(() => useExternalLinkGuard());
+    unmount();
+
+    const a = document.createElement('a');
+    a.href = 'https://example.com';
+    document.body.appendChild(a);
+
+    clickAnchor(a);
+    expect(openUrlInBrowser).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useFileWatcher.test.ts
+++ b/src/hooks/__tests__/useFileWatcher.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useFileWatcher } from '../useFileWatcher';
 import { useAppStore } from '@/stores/appStore';
 import type { FileChangedEvent } from '@/lib/tauri';
 import type { FileTab } from '@/lib/types';
+
+// Flush pending microtasks (replaces the audit F-3 `setTimeout(r, 0)` macrotask
+// pattern that races against MSW responses on fast machines).
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 // ---- Mocks ----
 
@@ -100,7 +108,7 @@ describe('useFileWatcher', () => {
 
     // Let async initWatcher resolve
     await act(async () => {
-      await (vi.dynamicImportSettled?.() ?? new Promise((r) => setTimeout(r, 0)));
+      await flushAsync();
     });
 
     expect(mockedGetWorkspacesBasePath).toHaveBeenCalled();
@@ -113,7 +121,7 @@ describe('useFileWatcher', () => {
     const { unmount } = renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     unmount();
@@ -125,13 +133,13 @@ describe('useFileWatcher', () => {
     const { rerender, unmount } = renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     rerender();
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     // The mount effect only runs once (empty deps), so startFileWatcher should be called once
@@ -146,7 +154,7 @@ describe('useFileWatcher', () => {
     const { unmount } = renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     expect(mockedStartFileWatcher).not.toHaveBeenCalled();
@@ -160,7 +168,7 @@ describe('useFileWatcher', () => {
     const { unmount } = renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     // Should not crash
@@ -173,7 +181,7 @@ describe('useFileWatcher', () => {
     const { unmount } = renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     expect(mockedListenForFileChanges).toHaveBeenCalledWith(expect.any(Function));
@@ -185,7 +193,7 @@ describe('useFileWatcher', () => {
     renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     expect(capturedFileChangeHandler).toBeTruthy();
@@ -212,7 +220,7 @@ describe('useFileWatcher', () => {
     renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     // Trigger file change for the open tab's file
@@ -222,7 +230,7 @@ describe('useFileWatcher', () => {
         path: 'src/file.ts',
         fullPath: '/workspaces/ws-1/src/file.ts',
       });
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     expect(mockedGetRepoFileContent).toHaveBeenCalledWith('ws-1', 'src/file.ts');
@@ -235,7 +243,7 @@ describe('useFileWatcher', () => {
     renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     // Trigger file change for the dirty tab's file
@@ -245,7 +253,7 @@ describe('useFileWatcher', () => {
         path: 'src/file.ts',
         fullPath: '/workspaces/ws-1/src/file.ts',
       });
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     // Should NOT reload
@@ -264,7 +272,7 @@ describe('useFileWatcher', () => {
     renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     // Trigger file change for a file not open in any tab
@@ -274,7 +282,7 @@ describe('useFileWatcher', () => {
         path: 'src/other-file.ts',
         fullPath: '/workspaces/ws-1/src/other-file.ts',
       });
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     expect(mockedGetRepoFileContent).not.toHaveBeenCalled();
@@ -285,16 +293,13 @@ describe('useFileWatcher', () => {
     const { unmount } = renderHook(() => useFileWatcher());
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
     });
 
     unmount();
 
-    // Give the setTimeout(10) cleanup time to fire
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
-    });
-
-    expect(mockUnlisten).toHaveBeenCalled();
+    // Hook's cleanup uses an internal setTimeout(10) before calling unlisten.
+    // Poll deterministically rather than waiting a fixed wall-clock interval.
+    await waitFor(() => expect(mockUnlisten).toHaveBeenCalled());
   });
 });

--- a/src/hooks/__tests__/useFileWatcher.test.ts
+++ b/src/hooks/__tests__/useFileWatcher.test.ts
@@ -2,16 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useFileWatcher } from '../useFileWatcher';
 import { useAppStore } from '@/stores/appStore';
+import { flushAsync } from '@/test-utils/async';
 import type { FileChangedEvent } from '@/lib/tauri';
 import type { FileTab } from '@/lib/types';
-
-// Flush pending microtasks (replaces the audit F-3 `setTimeout(r, 0)` macrotask
-// pattern that races against MSW responses on fast machines).
-async function flushAsync() {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-}
 
 // ---- Mocks ----
 

--- a/src/hooks/__tests__/useFontSize.test.ts
+++ b/src/hooks/__tests__/useFontSize.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFontSize } from '../useFontSize';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+describe('useFontSize', () => {
+  beforeEach(() => {
+    document.documentElement.style.removeProperty('--font-size-base');
+    useSettingsStore.setState({ fontSize: 'medium' } as never);
+  });
+
+  it("sets --font-size-base to 13px for 'medium'", () => {
+    useSettingsStore.setState({ fontSize: 'medium' } as never);
+    renderHook(() => useFontSize());
+    expect(
+      document.documentElement.style.getPropertyValue('--font-size-base'),
+    ).toBe('13px');
+  });
+
+  it("sets --font-size-base to 12px for 'small'", () => {
+    useSettingsStore.setState({ fontSize: 'small' } as never);
+    renderHook(() => useFontSize());
+    expect(
+      document.documentElement.style.getPropertyValue('--font-size-base'),
+    ).toBe('12px');
+  });
+
+  it("sets --font-size-base to 15px for 'large'", () => {
+    useSettingsStore.setState({ fontSize: 'large' } as never);
+    renderHook(() => useFontSize());
+    expect(
+      document.documentElement.style.getPropertyValue('--font-size-base'),
+    ).toBe('15px');
+  });
+});

--- a/src/hooks/__tests__/useGlobalShortcuts.test.ts
+++ b/src/hooks/__tests__/useGlobalShortcuts.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRef } from 'react';
+import { useGlobalShortcuts } from '../useGlobalShortcuts';
+import type { WorktreeSession } from '@/lib/types';
+
+// Mock cross-cutting modules so the hook itself is the unit under test
+vi.mock('@/components/navigation/BrowserTabBar', () => ({
+  switchToTab: vi.fn(),
+  createAndSwitchToNewTab: vi.fn(),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock('@/lib/constants', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/constants')>('@/lib/constants');
+  return { ...actual, ENABLE_BROWSER_TABS: true };
+});
+
+import { switchToTab, createAndSwitchToNewTab } from '@/components/navigation/BrowserTabBar';
+import { navigate } from '@/lib/navigation';
+import { useTabStore } from '@/stores/tabStore';
+
+const sessions: WorktreeSession[] = [
+  { id: 's1', workspaceId: 'ws-1' } as WorktreeSession,
+  { id: 's2', workspaceId: 'ws-1' } as WorktreeSession,
+  { id: 's3', workspaceId: 'ws-2' } as WorktreeSession,
+];
+
+interface RenderOptions {
+  toggleBottomTerminal?: () => void;
+  selectNextTab?: () => void;
+  selectPreviousTab?: () => void;
+  setZenMode?: (v: boolean) => void;
+  zenMode?: boolean;
+}
+
+function renderShortcuts(opts: RenderOptions = {}) {
+  const toggleBottomTerminal = opts.toggleBottomTerminal ?? vi.fn();
+  const selectNextTab = opts.selectNextTab ?? vi.fn();
+  const selectPreviousTab = opts.selectPreviousTab ?? vi.fn();
+  const setZenMode = opts.setZenMode ?? vi.fn();
+
+  const { result } = renderHook(() => {
+    const zenModeRef = useRef(opts.zenMode ?? false);
+    useGlobalShortcuts({
+      sessions,
+      toggleBottomTerminal,
+      selectNextTab,
+      selectPreviousTab,
+      setZenMode,
+      zenModeRef,
+    });
+    return { zenModeRef };
+  });
+
+  return { result, toggleBottomTerminal, selectNextTab, selectPreviousTab, setZenMode };
+}
+
+function key(opts: KeyboardEventInit & { code?: string }): KeyboardEvent {
+  return new KeyboardEvent('keydown', { ...opts, cancelable: true });
+}
+
+function dispatch(event: KeyboardEvent) {
+  let prevented = false;
+  Object.defineProperty(event, 'preventDefault', {
+    value: () => {
+      prevented = true;
+    },
+  });
+  act(() => {
+    document.dispatchEvent(event);
+  });
+  return prevented;
+}
+
+describe('useGlobalShortcuts', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabOrder: [], activeTabId: '' } as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Cmd+K command palette', () => {
+    it('dispatches open-command-palette event when target is not a terminal', () => {
+      renderShortcuts();
+      const handler = vi.fn();
+      window.addEventListener('open-command-palette', handler);
+
+      // Dispatch on a non-terminal element (body) so e.target is an Element with closest()
+      const target = document.body;
+      const e = new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        cancelable: true,
+        bubbles: true,
+      });
+      act(() => {
+        target.dispatchEvent(e);
+      });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      window.removeEventListener('open-command-palette', handler);
+    });
+
+    it('does not dispatch when keyboard event originates inside .xterm', () => {
+      renderShortcuts();
+      const xterm = document.createElement('div');
+      xterm.className = 'xterm';
+      document.body.appendChild(xterm);
+
+      const handler = vi.fn();
+      window.addEventListener('open-command-palette', handler);
+
+      const e = new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        cancelable: true,
+        bubbles: true,
+      });
+      act(() => {
+        xterm.dispatchEvent(e);
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      window.removeEventListener('open-command-palette', handler);
+      document.body.removeChild(xterm);
+    });
+  });
+
+  describe('Cmd+J terminal toggle', () => {
+    it('calls toggleBottomTerminal on Cmd+J', () => {
+      const toggleBottomTerminal = vi.fn();
+      renderShortcuts({ toggleBottomTerminal });
+      dispatch(key({ key: 'j', metaKey: true }));
+      expect(toggleBottomTerminal).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not toggle when Cmd+J has shift or alt', () => {
+      const toggleBottomTerminal = vi.fn();
+      renderShortcuts({ toggleBottomTerminal });
+      dispatch(key({ key: 'j', metaKey: true, shiftKey: true }));
+      expect(toggleBottomTerminal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Cmd+Shift+1-9 session navigation', () => {
+    it('navigates to session at index 0 on Cmd+Shift+1', () => {
+      renderShortcuts();
+      // shiftKey makes e.key = '!' on macOS, so we use e.code
+      dispatch(key({ key: '!', code: 'Digit1', metaKey: true, shiftKey: true }));
+      expect(navigate).toHaveBeenCalledWith({
+        workspaceId: 'ws-1',
+        sessionId: 's1',
+        contentView: { type: 'conversation' },
+      });
+    });
+
+    it('navigates to session at index 2 on Cmd+Shift+3', () => {
+      renderShortcuts();
+      dispatch(key({ key: '#', code: 'Digit3', metaKey: true, shiftKey: true }));
+      expect(navigate).toHaveBeenCalledWith({
+        workspaceId: 'ws-2',
+        sessionId: 's3',
+        contentView: { type: 'conversation' },
+      });
+    });
+
+    it('is a no-op when the session index is out of range', () => {
+      renderShortcuts();
+      dispatch(key({ key: '%', code: 'Digit5', metaKey: true, shiftKey: true }));
+      expect(navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Tab navigation', () => {
+    it('selectNextTab on Cmd+Option+]', () => {
+      const selectNextTab = vi.fn();
+      renderShortcuts({ selectNextTab });
+      dispatch(key({ key: ']', metaKey: true, altKey: true }));
+      expect(selectNextTab).toHaveBeenCalledTimes(1);
+    });
+
+    it('selectNextTab on Ctrl+Tab', () => {
+      const selectNextTab = vi.fn();
+      renderShortcuts({ selectNextTab });
+      dispatch(key({ key: 'Tab', ctrlKey: true }));
+      expect(selectNextTab).toHaveBeenCalledTimes(1);
+    });
+
+    it('selectPreviousTab on Cmd+Option+[', () => {
+      const selectPreviousTab = vi.fn();
+      renderShortcuts({ selectPreviousTab });
+      dispatch(key({ key: '[', metaKey: true, altKey: true }));
+      expect(selectPreviousTab).toHaveBeenCalledTimes(1);
+    });
+
+    it('selectPreviousTab on Ctrl+Shift+Tab', () => {
+      const selectPreviousTab = vi.fn();
+      renderShortcuts({ selectPreviousTab });
+      dispatch(key({ key: 'Tab', ctrlKey: true, shiftKey: true }));
+      expect(selectPreviousTab).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Browser tab management', () => {
+    it('Cmd+T opens a new tab', () => {
+      renderShortcuts();
+      dispatch(key({ key: 't', metaKey: true }));
+      expect(createAndSwitchToNewTab).toHaveBeenCalledTimes(1);
+    });
+
+    it('Cmd+Shift+] cycles to next browser tab', () => {
+      useTabStore.setState({ tabOrder: ['ta', 'tb', 'tc'], activeTabId: 'ta' } as never);
+      renderShortcuts();
+
+      dispatch(key({ key: ']', metaKey: true, shiftKey: true }));
+      expect(switchToTab).toHaveBeenCalledWith('tb');
+    });
+
+    it('Cmd+Shift+[ cycles to previous browser tab (wraps around)', () => {
+      useTabStore.setState({ tabOrder: ['ta', 'tb', 'tc'], activeTabId: 'ta' } as never);
+      renderShortcuts();
+
+      dispatch(key({ key: '[', metaKey: true, shiftKey: true }));
+      expect(switchToTab).toHaveBeenCalledWith('tc');
+    });
+
+    it('does nothing when there is only one tab', () => {
+      useTabStore.setState({ tabOrder: ['ta'], activeTabId: 'ta' } as never);
+      renderShortcuts();
+
+      dispatch(key({ key: ']', metaKey: true, shiftKey: true }));
+      expect(switchToTab).not.toHaveBeenCalled();
+    });
+
+    it('Cmd+1 switches to first tab by position', () => {
+      useTabStore.setState({ tabOrder: ['ta', 'tb', 'tc'], activeTabId: 'tb' } as never);
+      renderShortcuts();
+
+      dispatch(key({ key: '1', metaKey: true }));
+      expect(switchToTab).toHaveBeenCalledWith('ta');
+    });
+
+    it('Cmd+9 always selects the last tab', () => {
+      useTabStore.setState({ tabOrder: ['ta', 'tb', 'tc', 'td'], activeTabId: 'ta' } as never);
+      renderShortcuts();
+
+      dispatch(key({ key: '9', metaKey: true }));
+      expect(switchToTab).toHaveBeenCalledWith('td');
+    });
+
+    it('Cmd+5 (out of range when only 3 tabs) is a no-op', () => {
+      useTabStore.setState({ tabOrder: ['ta', 'tb', 'tc'], activeTabId: 'ta' } as never);
+      renderShortcuts();
+
+      dispatch(key({ key: '5', metaKey: true }));
+      expect(switchToTab).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Escape and zen mode', () => {
+    it('Escape exits zen mode when active', () => {
+      const setZenMode = vi.fn();
+      renderShortcuts({ setZenMode, zenMode: true });
+      dispatch(key({ key: 'Escape' }));
+      expect(setZenMode).toHaveBeenCalledWith(false);
+    });
+
+    it('Escape is a no-op when zen mode is off', () => {
+      const setZenMode = vi.fn();
+      renderShortcuts({ setZenMode, zenMode: false });
+      dispatch(key({ key: 'Escape' }));
+      expect(setZenMode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes the keydown listener on unmount', () => {
+      const toggleBottomTerminal = vi.fn();
+      const { unmount } = renderHook(() => {
+        const zenModeRef = useRef(false);
+        useGlobalShortcuts({
+          sessions,
+          toggleBottomTerminal,
+          selectNextTab: vi.fn(),
+          selectPreviousTab: vi.fn(),
+          setZenMode: vi.fn(),
+          zenModeRef,
+        });
+      });
+
+      // Listener fires while mounted
+      dispatch(key({ key: 'j', metaKey: true }));
+      expect(toggleBottomTerminal).toHaveBeenCalledTimes(1);
+
+      // Listener is removed after unmount
+      unmount();
+      dispatch(key({ key: 'j', metaKey: true }));
+      expect(toggleBottomTerminal).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/hooks/__tests__/useGlobalShortcuts.test.ts
+++ b/src/hooks/__tests__/useGlobalShortcuts.test.ts
@@ -14,9 +14,20 @@ vi.mock('@/lib/navigation', () => ({
   navigate: vi.fn(),
 }));
 
+// Mutable accessor so individual tests can flip the flag without re-importing
+// the module under test. The hook reads ENABLE_BROWSER_TABS via a normal
+// import binding, so changing this flag must happen *before* the hook reads
+// it for the current render cycle — set it in `beforeEach` (or directly in
+// the test) before `renderShortcuts()`.
+let ENABLE_BROWSER_TABS_VALUE = true;
 vi.mock('@/lib/constants', async () => {
   const actual = await vi.importActual<typeof import('@/lib/constants')>('@/lib/constants');
-  return { ...actual, ENABLE_BROWSER_TABS: true };
+  return {
+    ...actual,
+    get ENABLE_BROWSER_TABS() {
+      return ENABLE_BROWSER_TABS_VALUE;
+    },
+  };
 });
 
 import { switchToTab, createAndSwitchToNewTab } from '@/components/navigation/BrowserTabBar';
@@ -78,6 +89,7 @@ function dispatch(event: KeyboardEvent) {
 
 describe('useGlobalShortcuts', () => {
   beforeEach(() => {
+    ENABLE_BROWSER_TABS_VALUE = true;
     useTabStore.setState({ tabOrder: [], activeTabId: '' } as never);
   });
 
@@ -276,6 +288,34 @@ describe('useGlobalShortcuts', () => {
       renderShortcuts({ setZenMode, zenMode: false });
       dispatch(key({ key: 'Escape' }));
       expect(setZenMode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Browser tab management — flag disabled', () => {
+    beforeEach(() => {
+      // Flip the feature flag *before* renderShortcuts so the hook captures
+      // the disabled value at mount.
+      ENABLE_BROWSER_TABS_VALUE = false;
+    });
+
+    it('Cmd+T does not create a tab when ENABLE_BROWSER_TABS is false', () => {
+      renderShortcuts();
+      dispatch(key({ key: 't', metaKey: true }));
+      expect(createAndSwitchToNewTab).not.toHaveBeenCalled();
+    });
+
+    it('Cmd+1..9 does not switch tabs when ENABLE_BROWSER_TABS is false', () => {
+      useTabStore.setState({ tabOrder: ['ta', 'tb', 'tc'], activeTabId: 'ta' } as never);
+      renderShortcuts();
+      dispatch(key({ key: '1', metaKey: true }));
+      expect(switchToTab).not.toHaveBeenCalled();
+    });
+
+    it('Cmd+Shift+] does not cycle tabs when ENABLE_BROWSER_TABS is false', () => {
+      useTabStore.setState({ tabOrder: ['ta', 'tb'], activeTabId: 'ta' } as never);
+      renderShortcuts();
+      dispatch(key({ key: ']', metaKey: true, shiftKey: true }));
+      expect(switchToTab).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/__tests__/useMenuHandlers.test.ts
+++ b/src/hooks/__tests__/useMenuHandlers.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for useMenuHandlers' custom-event surface.
+ *
+ * The hook has three effects:
+ *   1. Tauri menu-event listener (via safeListen) — no-op in jsdom (covered by integration)
+ *   2. Tauri window close handler — no-op in jsdom
+ *   3. Window-level custom events ('open-settings', 'spawn-agent', etc.)
+ *
+ * This file exercises (3) — the custom event surface — using real Zustand stores
+ * and minimal boundary mocks (Tauri APIs only). It complements `useMenuHandlers.paste.test.ts`
+ * (audit F-4) which is heavier on mocks.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRef } from 'react';
+import { useMenuHandlers } from '../useMenuHandlers';
+import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+// Boundary mocks: Tauri APIs only. Stores and themes use real implementations.
+vi.mock('@/lib/tauri', () => ({
+  safeListen: vi.fn().mockResolvedValue(() => {}),
+  openInVSCode: vi.fn(),
+  copyToClipboard: vi.fn(),
+  openUrlInBrowser: vi.fn(),
+  getCurrentWindow: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('next-themes', () => {
+  let theme = 'dark';
+  return {
+    useTheme: () => ({
+      resolvedTheme: theme,
+      setTheme: (t: string) => {
+        theme = t;
+      },
+    }),
+  };
+});
+
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/navigation/BrowserTabBar', () => ({
+  switchToTab: vi.fn(),
+}));
+
+vi.mock('@/hooks/useClaudeAuthStatus', () => ({
+  refreshClaudeAuthStatus: vi.fn(),
+}));
+
+import { openInVSCode } from '@/lib/tauri';
+
+const defaultOptions = () => ({
+  handleNewSession: vi.fn(),
+  handleNewConversation: vi.fn(),
+  handleCloseTab: vi.fn(),
+  handleCloseFileTab: vi.fn(),
+  saveCurrentTab: vi.fn(),
+  toggleLeftSidebar: vi.fn(),
+  toggleRightSidebar: vi.fn(),
+  toggleBottomTerminal: vi.fn(),
+  expandBottomTerminal: vi.fn(),
+  selectNextTab: vi.fn(),
+  selectPreviousTab: vi.fn(),
+  setZenMode: vi.fn(),
+  resetLayouts: vi.fn(),
+  onOpenSettings: vi.fn(),
+  onCloseSettings: vi.fn(),
+  onShowAddWorkspace: vi.fn(),
+  onShowCreateSession: vi.fn(),
+  onShowShortcuts: vi.fn(),
+  onShowBottomTerminal: vi.fn(),
+});
+
+function renderWithOptions(opts: Partial<ReturnType<typeof defaultOptions>> = {}) {
+  const options = { ...defaultOptions(), ...opts };
+  const { result, unmount } = renderHook(() => {
+    const zenModeRef = useRef(false);
+    useMenuHandlers({ ...options, zenModeRef });
+    return options;
+  });
+  return { options: result.current, unmount };
+}
+
+function fire(event: string, detail?: unknown) {
+  act(() => {
+    window.dispatchEvent(new CustomEvent(event, { detail }));
+  });
+}
+
+describe('useMenuHandlers — custom event surface', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      sessions: [],
+      selectedSessionId: null,
+      selectedConversationId: null,
+      selectedFileTabId: null,
+      fileTabs: [],
+    });
+    useSettingsStore.setState({} as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('open-settings', () => {
+    it('forwards the event to onOpenSettings with category from detail', () => {
+      const { options } = renderWithOptions();
+      fire('open-settings', { category: 'general' });
+      expect(options.onOpenSettings).toHaveBeenCalledWith('general');
+    });
+
+    it('passes undefined when detail has no category', () => {
+      const { options } = renderWithOptions();
+      fire('open-settings');
+      expect(options.onOpenSettings).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('close-settings', () => {
+    it('forwards the event to onCloseSettings', () => {
+      const { options } = renderWithOptions();
+      fire('close-settings');
+      expect(options.onCloseSettings).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('spawn-agent / new-conversation', () => {
+    it('spawn-agent triggers handleNewSession', () => {
+      const { options } = renderWithOptions();
+      fire('spawn-agent');
+      expect(options.handleNewSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('new-conversation triggers handleNewConversation', () => {
+      const { options } = renderWithOptions();
+      fire('new-conversation');
+      expect(options.handleNewConversation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('add-workspace / create-session', () => {
+    it('add-workspace triggers onShowAddWorkspace', () => {
+      const { options } = renderWithOptions();
+      fire('add-workspace');
+      expect(options.onShowAddWorkspace).toHaveBeenCalledTimes(1);
+    });
+
+    it('create-session triggers onShowCreateSession', () => {
+      const { options } = renderWithOptions();
+      fire('create-session');
+      expect(options.onShowCreateSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('panel toggles', () => {
+    it('toggle-left-panel calls toggleLeftSidebar', () => {
+      const { options } = renderWithOptions();
+      fire('toggle-left-panel');
+      expect(options.toggleLeftSidebar).toHaveBeenCalledTimes(1);
+    });
+
+    it('toggle-right-panel calls toggleRightSidebar', () => {
+      const { options } = renderWithOptions();
+      fire('toggle-right-panel');
+      expect(options.toggleRightSidebar).toHaveBeenCalledTimes(1);
+    });
+
+    it('toggle-bottom-panel calls toggleBottomTerminal', () => {
+      const { options } = renderWithOptions();
+      fire('toggle-bottom-panel');
+      expect(options.toggleBottomTerminal).toHaveBeenCalledTimes(1);
+    });
+
+    it('show-bottom-panel calls onShowBottomTerminal', () => {
+      const { options } = renderWithOptions();
+      fire('show-bottom-panel');
+      expect(options.onShowBottomTerminal).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('open-in-vscode', () => {
+    it('opens VSCode at the selected session worktree path', () => {
+      useAppStore.setState({
+        sessions: [{ id: 's1', worktreePath: '/work/tree' } as never],
+        selectedSessionId: 's1',
+      });
+      renderWithOptions();
+      fire('open-in-vscode');
+      expect(openInVSCode).toHaveBeenCalledWith('/work/tree');
+    });
+
+    it('is a no-op when no session is selected', () => {
+      useAppStore.setState({ selectedSessionId: null });
+      renderWithOptions();
+      fire('open-in-vscode');
+      expect(openInVSCode).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when session has no worktreePath', () => {
+      useAppStore.setState({
+        sessions: [{ id: 's1', worktreePath: '' } as never],
+        selectedSessionId: 's1',
+      });
+      renderWithOptions();
+      fire('open-in-vscode');
+      expect(openInVSCode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('new-claude-terminal', () => {
+    it('creates a Claude terminal and deselects conversation + file tab on success', () => {
+      const createClaudeTerminal = vi.fn().mockReturnValue({ id: 'ct-1' });
+      const selectConversation = vi.fn();
+      const selectFileTab = vi.fn();
+      useAppStore.setState({
+        sessions: [{ id: 's1', worktreePath: '/work' } as never],
+        selectedSessionId: 's1',
+        createClaudeTerminal,
+        selectConversation,
+        selectFileTab,
+      } as never);
+
+      renderWithOptions();
+      fire('new-claude-terminal');
+
+      expect(createClaudeTerminal).toHaveBeenCalledWith('s1', '/work');
+      expect(selectConversation).toHaveBeenCalledWith(null);
+      expect(selectFileTab).toHaveBeenCalledWith(null);
+    });
+
+    it('dispatches claude-terminal-limit-reached when terminal creation fails', () => {
+      const createClaudeTerminal = vi.fn().mockReturnValue(null);
+      const limitHandler = vi.fn();
+      window.addEventListener('claude-terminal-limit-reached', limitHandler);
+
+      useAppStore.setState({
+        sessions: [{ id: 's1', worktreePath: '/work' } as never],
+        selectedSessionId: 's1',
+        createClaudeTerminal,
+        selectConversation: vi.fn(),
+        selectFileTab: vi.fn(),
+      } as never);
+
+      renderWithOptions();
+      fire('new-claude-terminal');
+
+      expect(limitHandler).toHaveBeenCalledTimes(1);
+      window.removeEventListener('claude-terminal-limit-reached', limitHandler);
+    });
+
+    it('is a no-op when no session is selected', () => {
+      const createClaudeTerminal = vi.fn();
+      useAppStore.setState({
+        selectedSessionId: null,
+        createClaudeTerminal,
+      } as never);
+
+      renderWithOptions();
+      fire('new-claude-terminal');
+
+      expect(createClaudeTerminal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listener cleanup', () => {
+    it('removes window listeners on unmount', () => {
+      const { options, unmount } = renderWithOptions();
+      fire('toggle-left-panel');
+      expect(options.toggleLeftSidebar).toHaveBeenCalledTimes(1);
+
+      unmount();
+
+      // After unmount, dispatching the event should not fire the handler
+      const before = (options.toggleLeftSidebar as ReturnType<typeof vi.fn>).mock.calls.length;
+      window.dispatchEvent(new CustomEvent('toggle-left-panel'));
+      expect((options.toggleLeftSidebar as ReturnType<typeof vi.fn>).mock.calls.length).toBe(before);
+    });
+  });
+});

--- a/src/hooks/__tests__/useMenuHandlers.test.ts
+++ b/src/hooks/__tests__/useMenuHandlers.test.ts
@@ -274,15 +274,23 @@ describe('useMenuHandlers — custom event surface', () => {
   describe('listener cleanup', () => {
     it('removes window listeners on unmount', () => {
       const { options, unmount } = renderWithOptions();
+      const toggleLeftSidebar = options.toggleLeftSidebar as ReturnType<typeof vi.fn>;
+
+      // Sanity-check the listener is wired before unmount.
       fire('toggle-left-panel');
-      expect(options.toggleLeftSidebar).toHaveBeenCalledTimes(1);
+      expect(toggleLeftSidebar).toHaveBeenCalledTimes(1);
 
       unmount();
 
-      // After unmount, dispatching the event should not fire the handler
-      const before = (options.toggleLeftSidebar as ReturnType<typeof vi.fn>).mock.calls.length;
-      window.dispatchEvent(new CustomEvent('toggle-left-panel'));
-      expect((options.toggleLeftSidebar as ReturnType<typeof vi.fn>).mock.calls.length).toBe(before);
+      // After unmount, dispatching the event must not fire the handler.
+      // Capture the count *after* unmount so React's cleanup pass has run,
+      // then dispatch the second event inside `act` so any work the listener
+      // would have queued is also flushed before we read the count.
+      const before = toggleLeftSidebar.mock.calls.length;
+      act(() => {
+        window.dispatchEvent(new CustomEvent('toggle-left-panel'));
+      });
+      expect(toggleLeftSidebar.mock.calls.length).toBe(before);
     });
   });
 });

--- a/src/hooks/__tests__/useMenuHandlers.test.ts
+++ b/src/hooks/__tests__/useMenuHandlers.test.ts
@@ -216,61 +216,6 @@ describe('useMenuHandlers — custom event surface', () => {
     });
   });
 
-  describe('new-claude-terminal', () => {
-    it('creates a Claude terminal and deselects conversation + file tab on success', () => {
-      const createClaudeTerminal = vi.fn().mockReturnValue({ id: 'ct-1' });
-      const selectConversation = vi.fn();
-      const selectFileTab = vi.fn();
-      useAppStore.setState({
-        sessions: [{ id: 's1', worktreePath: '/work' } as never],
-        selectedSessionId: 's1',
-        createClaudeTerminal,
-        selectConversation,
-        selectFileTab,
-      } as never);
-
-      renderWithOptions();
-      fire('new-claude-terminal');
-
-      expect(createClaudeTerminal).toHaveBeenCalledWith('s1', '/work');
-      expect(selectConversation).toHaveBeenCalledWith(null);
-      expect(selectFileTab).toHaveBeenCalledWith(null);
-    });
-
-    it('dispatches claude-terminal-limit-reached when terminal creation fails', () => {
-      const createClaudeTerminal = vi.fn().mockReturnValue(null);
-      const limitHandler = vi.fn();
-      window.addEventListener('claude-terminal-limit-reached', limitHandler);
-
-      useAppStore.setState({
-        sessions: [{ id: 's1', worktreePath: '/work' } as never],
-        selectedSessionId: 's1',
-        createClaudeTerminal,
-        selectConversation: vi.fn(),
-        selectFileTab: vi.fn(),
-      } as never);
-
-      renderWithOptions();
-      fire('new-claude-terminal');
-
-      expect(limitHandler).toHaveBeenCalledTimes(1);
-      window.removeEventListener('claude-terminal-limit-reached', limitHandler);
-    });
-
-    it('is a no-op when no session is selected', () => {
-      const createClaudeTerminal = vi.fn();
-      useAppStore.setState({
-        selectedSessionId: null,
-        createClaudeTerminal,
-      } as never);
-
-      renderWithOptions();
-      fire('new-claude-terminal');
-
-      expect(createClaudeTerminal).not.toHaveBeenCalled();
-    });
-  });
-
   describe('listener cleanup', () => {
     it('removes window listeners on unmount', () => {
       const { options, unmount } = renderWithOptions();

--- a/src/hooks/__tests__/usePRStatus.test.ts
+++ b/src/hooks/__tests__/usePRStatus.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { usePRStatus } from '../usePRStatus';
+import type { PRDetails } from '@/lib/api';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockPR: PRDetails = {
+  number: 42,
+  state: 'open',
+  title: 'Test PR',
+  body: '',
+  htmlUrl: 'https://github.com/x/y/pull/42',
+  merged: false,
+  mergeable: true,
+  mergeableState: 'clean',
+  checkStatus: 'success',
+  checkDetails: [],
+  reviewDecision: 'approved',
+  requestedReviewers: 0,
+};
+
+// The hook clears stale data via setTimeout(0) on mount and on session change.
+// In production the network is slow enough that the timer fires first; in tests
+// MSW responds on the microtask queue, which would race ahead and let the clear
+// effect overwrite freshly-fetched data. A tiny delay (1ms macrotask) gives the
+// clear effect a chance to fire before the fetch resolves, matching real-world ordering.
+function delayedJson<T>(data: T) {
+  return async () => {
+    await new Promise((r) => setTimeout(r, 1));
+    return HttpResponse.json(data);
+  };
+}
+
+describe('usePRStatus', () => {
+  beforeEach(() => {
+    server.use(
+      http.get(
+        `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`,
+        delayedJson(mockPR)
+      ),
+      http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-refresh`, () =>
+        new HttpResponse(null, { status: 202 })
+      )
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns null pr details when no session is provided', async () => {
+    const { result } = renderHook(() => usePRStatus(null, null, undefined, true));
+    expect(result.current.prDetails).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('returns null when prStatus is "none" (no PR)', async () => {
+    const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'none', true));
+    await new Promise((r) => setTimeout(r, 0)); // allow effects to flush
+    expect(result.current.prDetails).toBeNull();
+  });
+
+  it('fetches and returns PR details when prStatus=open', async () => {
+    const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
+
+    await waitFor(() => {
+      expect(result.current.prDetails).not.toBeNull();
+    });
+
+    expect(result.current.prDetails?.number).toBe(42);
+    expect(result.current.prDetails?.state).toBe('open');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('skips initial fetch when active=false on mount', async () => {
+    let getCount = 0;
+    server.use(
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () => {
+        getCount++;
+        return HttpResponse.json(mockPR);
+      })
+    );
+
+    renderHook(() => usePRStatus('ws-1', 's-1', 'open', false));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(getCount).toBe(0);
+  });
+
+  it('treats 401 as "no data" and clears prDetails silently', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        return HttpResponse.text('unauthorized', { status: 401 });
+      })
+    );
+
+    const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.prDetails).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes error message on non-401 failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    server.use(
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        return HttpResponse.text('boom', { status: 500 });
+      })
+    );
+
+    const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(result.current.error).toBe('boom');
+    errorSpy.mockRestore();
+  });
+
+  it('refetch() re-runs the fetch and shows loading=true while in flight', async () => {
+    const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
+
+    await waitFor(() => expect(result.current.prDetails).not.toBeNull());
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.prDetails?.number).toBe(42);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('clears stale data and refetches when session changes', async () => {
+    let getCount = 0;
+    server.use(
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        getCount++;
+        return HttpResponse.json(mockPR);
+      })
+    );
+
+    const { rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) =>
+        usePRStatus('ws-1', sessionId, 'open', true),
+      { initialProps: { sessionId: 's-1' } }
+    );
+
+    await waitFor(() => expect(getCount).toBeGreaterThanOrEqual(1));
+    const initial = getCount;
+
+    rerender({ sessionId: 's-2' });
+
+    // Switching session triggers a fresh fetch
+    await waitFor(() => expect(getCount).toBeGreaterThan(initial));
+  });
+
+  it('triggers a backend force-check (refreshPRStatus) on initial fetch', async () => {
+    let postCount = 0;
+    server.use(
+      http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-refresh`, () => {
+        postCount++;
+        return new HttpResponse(null, { status: 202 });
+      })
+    );
+
+    renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
+
+    await waitFor(() => {
+      expect(postCount).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('polls every 90s when prStatus is open', async () => {
+    let getCount = 0;
+    server.use(
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        getCount++;
+        return HttpResponse.json(mockPR);
+      })
+    );
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
+
+    // Wait for initial fetch (uses real-timer wait under shouldAdvanceTime)
+    await vi.waitFor(() => expect(getCount).toBeGreaterThanOrEqual(1));
+    const initial = getCount;
+
+    // Advance through the 90-second polling interval
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(95_000);
+    });
+
+    // Allow the resulting fetch to resolve through MSW
+    await vi.waitFor(() => expect(getCount).toBeGreaterThan(initial));
+  });
+
+  it('does not poll when prStatus is not "open"', async () => {
+    let getCount = 0;
+    server.use(
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        getCount++;
+        return HttpResponse.json(mockPR);
+      })
+    );
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    renderHook(() => usePRStatus('ws-1', 's-1', 'merged', true));
+
+    // Advance 5 minutes — no polls should fire because status isn't 'open'
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    });
+
+    expect(getCount).toBeLessThanOrEqual(1); // Only the initial fetch (or zero — no PR open)
+  });
+
+  it('cleans up polling timer on unmount', async () => {
+    let getCount = 0;
+    server.use(
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        getCount++;
+        return HttpResponse.json(mockPR);
+      })
+    );
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const { unmount } = renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
+
+    await vi.waitFor(() => expect(getCount).toBeGreaterThanOrEqual(1));
+
+    unmount();
+    const beforeAdvance = getCount;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3 * 90_000);
+    });
+
+    expect(getCount).toBe(beforeAdvance);
+  });
+});

--- a/src/hooks/__tests__/usePRStatus.test.ts
+++ b/src/hooks/__tests__/usePRStatus.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/__mocks__/server';
+import { flushAsync } from '@/test-utils/async';
 import { usePRStatus } from '../usePRStatus';
+import { clearChecksDataCache } from '@/lib/checksDataCache';
 import type { PRDetails } from '@/lib/api';
 
 const API_BASE = 'http://localhost:9876';
@@ -22,24 +24,20 @@ const mockPR: PRDetails = {
   requestedReviewers: 0,
 };
 
-// The hook clears stale data via setTimeout(0) on mount and on session change.
-// In production the network is slow enough that the timer fires first; in tests
-// MSW responds on the microtask queue, which would race ahead and let the clear
-// effect overwrite freshly-fetched data. A tiny delay (1ms macrotask) gives the
-// clear effect a chance to fire before the fetch resolves, matching real-world ordering.
-function delayedJson<T>(data: T) {
-  return async () => {
-    await new Promise((r) => setTimeout(r, 1));
-    return HttpResponse.json(data);
-  };
-}
+// usePRStatus restores from `checksDataCache` synchronously on session change
+// (stale-while-revalidate) instead of clearing via setTimeout(0), so MSW can
+// resolve on the microtask queue without racing the clear. The 1ms macrotask
+// delay these tests previously relied on is no longer needed.
 
 describe('usePRStatus', () => {
   beforeEach(() => {
+    // Module-level cache persists across tests; clear so SWR cache hits
+    // don't leak prior tests' data into the current one.
+    clearChecksDataCache();
     server.use(
       http.get(
         `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`,
-        delayedJson(mockPR)
+        () => HttpResponse.json(mockPR)
       ),
       http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-refresh`, () =>
         new HttpResponse(null, { status: 202 })
@@ -59,7 +57,7 @@ describe('usePRStatus', () => {
 
   it('returns null when prStatus is "none" (no PR)', async () => {
     const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'none', true));
-    await new Promise((r) => setTimeout(r, 0)); // allow effects to flush
+    await flushAsync();
     expect(result.current.prDetails).toBeNull();
   });
 
@@ -85,17 +83,16 @@ describe('usePRStatus', () => {
     );
 
     renderHook(() => usePRStatus('ws-1', 's-1', 'open', false));
-    await new Promise((r) => setTimeout(r, 50));
+    await flushAsync();
 
     expect(getCount).toBe(0);
   });
 
   it('treats 401 as "no data" and clears prDetails silently', async () => {
     server.use(
-      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
-        await new Promise((r) => setTimeout(r, 1));
-        return HttpResponse.text('unauthorized', { status: 401 });
-      })
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () =>
+        HttpResponse.text('unauthorized', { status: 401 }),
+      )
     );
 
     const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
@@ -111,10 +108,9 @@ describe('usePRStatus', () => {
   it('exposes error message on non-401 failure', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     server.use(
-      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
-        await new Promise((r) => setTimeout(r, 1));
-        return HttpResponse.text('boom', { status: 500 });
-      })
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () =>
+        HttpResponse.text('boom', { status: 500 }),
+      )
     );
 
     const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
@@ -143,8 +139,7 @@ describe('usePRStatus', () => {
   it('clears stale data and refetches when session changes', async () => {
     let getCount = 0;
     server.use(
-      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
-        await new Promise((r) => setTimeout(r, 1));
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () => {
         getCount++;
         return HttpResponse.json(mockPR);
       })
@@ -165,7 +160,7 @@ describe('usePRStatus', () => {
     await waitFor(() => expect(getCount).toBeGreaterThan(initial));
   });
 
-  it('triggers a backend force-check (refreshPRStatus) on initial fetch', async () => {
+  it('does NOT POST pr-refresh on initial mount, but does on explicit refetch()', async () => {
     let postCount = 0;
     server.use(
       http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-refresh`, () => {
@@ -174,18 +169,24 @@ describe('usePRStatus', () => {
       })
     );
 
-    renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
+    const { result } = renderHook(() => usePRStatus('ws-1', 's-1', 'open', true));
 
-    await waitFor(() => {
-      expect(postCount).toBeGreaterThanOrEqual(1);
+    // Initial mount must not POST — backend prWatcher pushes via WebSocket, and
+    // a per-session POST would burn ~5 GitHub calls per session switch.
+    await waitFor(() => expect(result.current.prDetails).not.toBeNull());
+    expect(postCount).toBe(0);
+
+    // Explicit refetch() should fire the force-check POST.
+    await act(async () => {
+      await result.current.refetch();
     });
+    expect(postCount).toBeGreaterThanOrEqual(1);
   });
 
   it('polls every 90s when prStatus is open', async () => {
     let getCount = 0;
     server.use(
-      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
-        await new Promise((r) => setTimeout(r, 1));
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () => {
         getCount++;
         return HttpResponse.json(mockPR);
       })
@@ -211,8 +212,7 @@ describe('usePRStatus', () => {
   it('does not poll when prStatus is not "open"', async () => {
     let getCount = 0;
     server.use(
-      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
-        await new Promise((r) => setTimeout(r, 1));
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () => {
         getCount++;
         return HttpResponse.json(mockPR);
       })
@@ -233,8 +233,7 @@ describe('usePRStatus', () => {
   it('cleans up polling timer on unmount', async () => {
     let getCount = 0;
     server.use(
-      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, async () => {
-        await new Promise((r) => setTimeout(r, 1));
+      http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () => {
         getCount++;
         return HttpResponse.json(mockPR);
       })

--- a/src/hooks/__tests__/useRecentlyClosed.test.ts
+++ b/src/hooks/__tests__/useRecentlyClosed.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  captureClosedConversation,
+  deleteClosedConversations,
+  useRestoreConversation,
+} from '../useRecentlyClosed';
+import { useAppStore } from '@/stores/appStore';
+import { useRecentlyClosedStore } from '@/stores/recentlyClosedStore';
+import type { Conversation } from '@/lib/types';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockConv: Conversation = {
+  id: 'c1',
+  sessionId: 's1',
+  type: 'task',
+  name: 'Test',
+  status: 'idle',
+  messages: [],
+  toolSummary: [],
+  createdAt: '',
+  updatedAt: '',
+  messageCount: 5,
+  model: 'claude-sonnet-4-6',
+} as Conversation;
+
+describe('useRecentlyClosed', () => {
+  beforeEach(() => {
+    useRecentlyClosedStore.setState({ closedConversations: [] } as never);
+    useAppStore.setState({
+      conversations: [],
+      conversationIds: new Set(),
+      conversationsBySession: {},
+    });
+  });
+
+  describe('captureClosedConversation', () => {
+    it('adds conversation metadata to the recently-closed store', () => {
+      captureClosedConversation(mockConv, 'ws-1');
+      const closed = useRecentlyClosedStore.getState().closedConversations;
+      expect(closed).toHaveLength(1);
+      expect(closed[0]).toMatchObject({
+        id: 'c1',
+        sessionId: 's1',
+        workspaceId: 'ws-1',
+        name: 'Test',
+        type: 'task',
+        messageCount: 5,
+        model: 'claude-sonnet-4-6',
+      });
+      expect(typeof closed[0].closedAt).toBe('number');
+    });
+
+    it('falls back to messages.length when messageCount is missing', () => {
+      const conv = { ...mockConv, messageCount: undefined, messages: [{}, {}] as never };
+      captureClosedConversation(conv, 'ws-1');
+      expect(useRecentlyClosedStore.getState().closedConversations[0].messageCount).toBe(2);
+    });
+
+    it('falls back to 0 when neither messageCount nor messages are available', () => {
+      const conv = { ...mockConv, messageCount: undefined, messages: undefined as never };
+      captureClosedConversation(conv, 'ws-1');
+      expect(useRecentlyClosedStore.getState().closedConversations[0].messageCount).toBe(0);
+    });
+  });
+
+  describe('deleteClosedConversations', () => {
+    it('issues a DELETE for each id and resolves even if some fail', async () => {
+      const deletedIds: string[] = [];
+      server.use(
+        http.delete(`${API_BASE}/api/conversations/:convId`, ({ params }) => {
+          const id = params.convId as string;
+          if (id === 'c-fail') {
+            return HttpResponse.text('', { status: 500 });
+          }
+          deletedIds.push(id);
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await deleteClosedConversations(['c1', 'c-fail', 'c2']);
+
+      expect(deletedIds).toEqual(['c1', 'c2']);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('handles an empty list without making requests', async () => {
+      let getCount = 0;
+      server.use(
+        http.delete(`${API_BASE}/api/conversations/:convId`, () => {
+          getCount++;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await deleteClosedConversations([]);
+      expect(getCount).toBe(0);
+    });
+  });
+
+  describe('useRestoreConversation', () => {
+    function setupHandlers(opts: { fail?: boolean } = {}) {
+      const conversationsByConvId: Record<string, unknown> = {
+        'c-restored': {
+          id: 'c-restored',
+          sessionId: 's1',
+          type: 'task',
+          name: 'Restored',
+          status: 'idle',
+          messages: [],
+          toolSummary: [{ id: 't1', tool: 'Read', target: 'a.ts', success: true }],
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-02T00:00:00Z',
+        },
+      };
+
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId`, ({ params }) => {
+          if (opts.fail) return HttpResponse.text('', { status: 500 });
+          const conv = conversationsByConvId[params.convId as string];
+          return conv ? HttpResponse.json(conv) : HttpResponse.text('', { status: 404 });
+        }),
+        http.get(`${API_BASE}/api/conversations/:convId/messages`, () =>
+          HttpResponse.json({ messages: [], hasMore: false, totalCount: 0 })
+        )
+      );
+    }
+
+    it('fetches conversation + messages and adds to the app store', async () => {
+      setupHandlers();
+      useRecentlyClosedStore.setState({
+        closedConversations: [{
+          id: 'c-restored',
+          sessionId: 's1',
+          workspaceId: 'ws-1',
+          name: 'Restored',
+          type: 'task',
+          closedAt: Date.now(),
+          messageCount: 0,
+        }],
+      } as never);
+
+      const showError = vi.fn();
+      const { result } = renderHook(() => useRestoreConversation(showError));
+
+      await act(async () => {
+        await result.current('c-restored');
+      });
+
+      const state = useAppStore.getState();
+      expect(state.conversations.find((c) => c.id === 'c-restored')).toBeDefined();
+      expect(state.selectedConversationId).toBe('c-restored');
+      // Removed from recently-closed after successful restore
+      expect(useRecentlyClosedStore.getState().closedConversations).toEqual([]);
+    });
+
+    it('calls showError and removes from recently-closed when restore fails', async () => {
+      setupHandlers({ fail: true });
+      useRecentlyClosedStore.setState({
+        closedConversations: [{
+          id: 'c-broken',
+          sessionId: 's1',
+          workspaceId: 'ws-1',
+          name: 'Broken',
+          type: 'task',
+          closedAt: Date.now(),
+          messageCount: 0,
+        }],
+      } as never);
+
+      const showError = vi.fn();
+      const { result } = renderHook(() => useRestoreConversation(showError));
+
+      await act(async () => {
+        await result.current('c-broken');
+      });
+
+      expect(showError).toHaveBeenCalledWith(
+        'Could not restore conversation. It may have been deleted.'
+      );
+      // Stale entry is also removed
+      expect(useRecentlyClosedStore.getState().closedConversations).toEqual([]);
+    });
+  });
+});

--- a/src/hooks/__tests__/useResolvedThemeType.test.ts
+++ b/src/hooks/__tests__/useResolvedThemeType.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useResolvedThemeType } from '../useResolvedThemeType';
+
+let mockResolvedTheme: string | undefined = 'dark';
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: mockResolvedTheme }),
+}));
+
+describe('useResolvedThemeType', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('dark');
+  });
+
+  it("returns 'dark' when next-themes reports 'dark'", () => {
+    mockResolvedTheme = 'dark';
+    const { result } = renderHook(() => useResolvedThemeType());
+    expect(result.current).toBe('dark');
+  });
+
+  it("returns 'light' when next-themes reports 'light'", () => {
+    mockResolvedTheme = 'light';
+    const { result } = renderHook(() => useResolvedThemeType());
+    expect(result.current).toBe('light');
+  });
+
+  it("falls back to DOM .dark class when next-themes is undefined", () => {
+    mockResolvedTheme = undefined;
+    document.documentElement.classList.add('dark');
+    const { result } = renderHook(() => useResolvedThemeType());
+    expect(result.current).toBe('dark');
+  });
+
+  it("falls back to 'light' when neither resolvedTheme nor .dark class is set", () => {
+    mockResolvedTheme = undefined;
+    document.documentElement.classList.remove('dark');
+    const { result } = renderHook(() => useResolvedThemeType());
+    expect(result.current).toBe('light');
+  });
+
+  it('ignores unrecognized resolvedTheme values', () => {
+    mockResolvedTheme = 'system' as never;
+    document.documentElement.classList.add('dark');
+    const { result } = renderHook(() => useResolvedThemeType());
+    expect(result.current).toBe('dark');
+  });
+});

--- a/src/hooks/__tests__/useShortcut.test.ts
+++ b/src/hooks/__tests__/useShortcut.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useShortcut, useShortcuts, useCustomShortcut } from '../useShortcut';
+import type { Shortcut } from '@/lib/shortcuts';
+
+// Mock getShortcutById to return predictable shortcuts; matchesShortcut uses
+// the real implementation to verify modifier matching.
+vi.mock('@/lib/shortcuts', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/shortcuts')>('@/lib/shortcuts');
+  return {
+    ...actual,
+    getShortcutById: vi.fn((id: string): Shortcut | undefined => {
+      switch (id) {
+        case 'commandPalette':
+          return { id, label: 'CMD', category: 'App', key: 'k', modifiers: ['meta'] };
+        case 'filePicker':
+          return { id, label: 'FP', category: 'App', key: 'p', modifiers: ['meta'] };
+        case 'unknown':
+          return undefined;
+        default:
+          return undefined;
+      }
+    }),
+  };
+});
+
+function dispatchKey(opts: KeyboardEventInit) {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { ...opts, cancelable: true }));
+  });
+}
+
+describe('useShortcut', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('fires the callback when the shortcut keys match', () => {
+    const cb = vi.fn();
+    renderHook(() => useShortcut('commandPalette', cb));
+
+    dispatchKey({ key: 'k', metaKey: true });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire on the wrong key', () => {
+    const cb = vi.fn();
+    renderHook(() => useShortcut('commandPalette', cb));
+
+    dispatchKey({ key: 'x', metaKey: true });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when missing required modifier', () => {
+    const cb = vi.fn();
+    renderHook(() => useShortcut('commandPalette', cb));
+
+    dispatchKey({ key: 'k' }); // no meta
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when disabled', () => {
+    const cb = vi.fn();
+    renderHook(() => useShortcut('commandPalette', cb, { enabled: false }));
+
+    dispatchKey({ key: 'k', metaKey: true });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('warns once for an unknown shortcut id', () => {
+    renderHook(() => useShortcut('unknown', vi.fn()));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown shortcut ID "unknown"')
+    );
+  });
+
+  it('cleans up the listener on unmount', () => {
+    const cb = vi.fn();
+    const { unmount } = renderHook(() => useShortcut('commandPalette', cb));
+
+    unmount();
+    dispatchKey({ key: 'k', metaKey: true });
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe('useShortcuts', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('dispatches the matching callback for each shortcut id', () => {
+    const cmdCb = vi.fn();
+    const fpCb = vi.fn();
+    renderHook(() => useShortcuts({ commandPalette: cmdCb, filePicker: fpCb }));
+
+    dispatchKey({ key: 'k', metaKey: true });
+    expect(cmdCb).toHaveBeenCalledTimes(1);
+    expect(fpCb).not.toHaveBeenCalled();
+
+    dispatchKey({ key: 'p', metaKey: true });
+    expect(fpCb).toHaveBeenCalledTimes(1);
+  });
+
+  it('only triggers one callback per event (returns after first match)', () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    renderHook(() => useShortcuts({ commandPalette: cb1, filePicker: cb2 }));
+
+    dispatchKey({ key: 'k', metaKey: true });
+    expect(cb1).toHaveBeenCalledTimes(1);
+    expect(cb2).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when disabled', () => {
+    const cb = vi.fn();
+    renderHook(() => useShortcuts({ commandPalette: cb }, { enabled: false }));
+
+    dispatchKey({ key: 'k', metaKey: true });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('warns for unknown shortcut ids', () => {
+    renderHook(() => useShortcuts({ unknown: vi.fn() }));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown shortcut ID "unknown"')
+    );
+  });
+});
+
+describe('useCustomShortcut', () => {
+  it('fires when a custom shortcut definition matches', () => {
+    const shortcut: Shortcut = {
+      id: 'custom-1',
+      label: 'Custom',
+      category: 'Chat',
+      key: 'd',
+      modifiers: ['meta', 'shift'],
+    };
+    const cb = vi.fn();
+    renderHook(() => useCustomShortcut(shortcut, cb));
+
+    dispatchKey({ key: 'd', metaKey: true, shiftKey: true });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when modifiers do not match', () => {
+    const shortcut: Shortcut = {
+      id: 'custom-1',
+      label: 'Custom',
+      category: 'Chat',
+      key: 'd',
+      modifiers: ['meta', 'shift'],
+    };
+    const cb = vi.fn();
+    renderHook(() => useCustomShortcut(shortcut, cb));
+
+    dispatchKey({ key: 'd', metaKey: true });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('respects enabled option', () => {
+    const shortcut: Shortcut = {
+      id: 'custom-1',
+      label: 'Custom',
+      category: 'Chat',
+      key: 'd',
+      modifiers: ['meta', 'shift'],
+    };
+    const cb = vi.fn();
+    renderHook(() => useCustomShortcut(shortcut, cb, { enabled: false }));
+
+    dispatchKey({ key: 'd', metaKey: true, shiftKey: true });
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useWebSocket.integration.test.ts
+++ b/src/hooks/__tests__/useWebSocket.integration.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Integration tests for useWebSocket — exercise the actual hook body, not just the store actions.
+ *
+ * The 7 useWebSocket.*.test.ts files were named for the hook but actually drive store actions
+ * directly. This file drives the hook through a MockWebSocket and verifies that:
+ *   - connect() opens a WebSocket with the auth token query param
+ *   - onopen marks the connection store as connected
+ *   - onmessage dispatches a representative subset of event types to the store
+ *   - onclose triggers reconnection with exponential backoff
+ *   - cleanup runs on unmount and on `enabled = false`
+ *
+ * It also exercises the exported module-level functions (`cleanupConversationState`,
+ * `cleanupOllamaProgressTimer`).
+ *
+ * Comprehensive event-by-event coverage continues to live in the dedicated event tests
+ * (which call store actions directly, much faster) — this file just proves the dispatch
+ * path connects them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import {
+  useWebSocket,
+  cleanupConversationState,
+  cleanupOllamaProgressTimer,
+} from '../useWebSocket';
+import { useAppStore } from '@/stores/appStore';
+import { useConnectionStore } from '@/stores/connectionStore';
+
+// --- Mocks for hook dependencies ----------------------------------------------------
+
+vi.mock('@/lib/auth-token', () => ({
+  getAuthToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+vi.mock('@/lib/backend-port', () => ({
+  getBackendPort: vi.fn().mockResolvedValue(9876),
+  getBackendPortSync: vi.fn().mockReturnValue(9876),
+}));
+
+vi.mock('@/lib/api', () => ({
+  getConversationDropStats: vi.fn().mockResolvedValue({ droppedMessages: 0 }),
+  getActiveStreamingConversations: vi.fn().mockResolvedValue({ conversationIds: [] }),
+  getInterruptedConversations: vi.fn().mockResolvedValue([]),
+  getConversationMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false, totalCount: 0 }),
+  getStreamingSnapshot: vi.fn().mockResolvedValue(null),
+  toStoreMessage: vi.fn((m) => m),
+  updateSession: vi.fn().mockResolvedValue(null),
+  refreshPRStatus: vi.fn().mockResolvedValue(undefined),
+  addSystemMessage: vi.fn().mockResolvedValue({ id: 'sys-1' }),
+  listAllSessions: vi.fn().mockResolvedValue([]),
+  mapSessionDTO: vi.fn((s) => s),
+}));
+
+vi.mock('@/lib/tauri', () => ({
+  unregisterSession: vi.fn(),
+  getSessionDirName: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/sounds', () => ({
+  playSound: vi.fn(),
+}));
+
+vi.mock('@/lib/telemetry', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('@/hooks/useDesktopNotifications', () => ({
+  notifyDesktop: vi.fn(),
+  getConversationLabel: vi.fn(() => 'label'),
+}));
+
+// --- Mock WebSocket harness ---------------------------------------------------------
+
+class MockWebSocket {
+  // Mirror the standard WebSocket readyState constants — the real hook checks
+  // `wsRef.current?.readyState === WebSocket.OPEN` and would short-circuit otherwise.
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+  static lastUrl: string | null = null;
+
+  url: string;
+  onopen: ((this: WebSocket, ev: Event) => unknown) | null = null;
+  onmessage: ((this: WebSocket, ev: MessageEvent) => unknown) | null = null;
+  onclose: ((this: WebSocket, ev: CloseEvent) => unknown) | null = null;
+  onerror: ((this: WebSocket, ev: Event) => unknown) | null = null;
+  readyState: number = 0;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.lastUrl = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send = vi.fn();
+
+  close = vi.fn(() => {
+    this.closed = true;
+    this.readyState = 3;
+  });
+
+  // Test helpers
+  triggerOpen() {
+    this.readyState = 1;
+    this.onopen?.call(this as unknown as WebSocket, new Event('open'));
+  }
+  triggerMessage(data: unknown) {
+    const event = new MessageEvent('message', { data: JSON.stringify(data) });
+    this.onmessage?.call(this as unknown as WebSocket, event);
+  }
+  triggerClose() {
+    this.readyState = 3;
+    this.onclose?.call(this as unknown as WebSocket, new CloseEvent('close'));
+  }
+  triggerError() {
+    this.onerror?.call(this as unknown as WebSocket, new Event('error'));
+  }
+
+  static reset() {
+    MockWebSocket.instances = [];
+    MockWebSocket.lastUrl = null;
+  }
+  static get latest(): MockWebSocket | undefined {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  }
+}
+
+// --- Tests --------------------------------------------------------------------------
+
+describe('useWebSocket integration', () => {
+  beforeEach(() => {
+    MockWebSocket.reset();
+    // jsdom defines WebSocket on window with non-writable; override via defineProperty.
+    // Vitest's stubGlobal alone doesn't propagate to `window.WebSocket` references.
+    Object.defineProperty(globalThis, 'WebSocket', {
+      value: MockWebSocket,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'WebSocket', {
+      value: MockWebSocket,
+      writable: true,
+      configurable: true,
+    });
+    // Reset connection store
+    useConnectionStore.setState({
+      status: 'connecting',
+      reconnectAttempt: 0,
+      sidecarState: 'idle',
+    } as never);
+    // Quiet stores between tests
+    useAppStore.setState({
+      conversations: [],
+      sessions: [],
+      mcpServers: [],
+      mcpServerSources: {},
+    });
+  });
+
+  afterEach(() => {
+    cleanupOllamaProgressTimer();
+    vi.clearAllMocks();
+  });
+
+  // ---- Module-level exports --------------------------------------------------------
+
+  describe('cleanupConversationState (exported)', () => {
+    it('runs without throwing for unknown conversation', () => {
+      expect(() => cleanupConversationState('unknown-conv')).not.toThrow();
+    });
+
+    it('clears reconciliation, plan-mode, and result-finalized state', async () => {
+      // Cause some module state to exist via the hook's exported helpers,
+      // then clean it up. We can't directly inspect the private state here, so we
+      // assert that calling cleanup doesn't throw and is idempotent.
+      cleanupConversationState('conv-x');
+      cleanupConversationState('conv-x'); // second call is a no-op
+      expect(true).toBe(true);
+    });
+  });
+
+  describe('cleanupOllamaProgressTimer (exported)', () => {
+    it('is safe to call when no timer is set', () => {
+      expect(() => cleanupOllamaProgressTimer()).not.toThrow();
+    });
+  });
+
+  // ---- Connection lifecycle --------------------------------------------------------
+
+  describe('connection lifecycle', () => {
+    it('opens a WebSocket with auth token query param when enabled', async () => {
+      renderHook(() => useWebSocket(true));
+
+      await waitFor(() => {
+        expect(MockWebSocket.lastUrl).not.toBeNull();
+      });
+
+      expect(MockWebSocket.lastUrl).toContain('token=test-token');
+    });
+
+    it('marks connection as connected on ws.onopen', async () => {
+      renderHook(() => useWebSocket(true));
+      await waitFor(() => expect(MockWebSocket.latest).toBeDefined());
+
+      act(() => {
+        MockWebSocket.latest!.triggerOpen();
+      });
+
+      expect(useConnectionStore.getState().status).toBe('connected');
+    });
+
+    it('does not connect when enabled=false', async () => {
+      renderHook(() => useWebSocket(false));
+      // Give any pending promises a chance to resolve
+      await new Promise((r) => setTimeout(r, 0));
+      expect(MockWebSocket.latest).toBeUndefined();
+    });
+
+    it('closes the connection on unmount', async () => {
+      const { unmount } = renderHook(() => useWebSocket(true));
+      await waitFor(() => expect(MockWebSocket.latest).toBeDefined());
+
+      unmount();
+      expect(MockWebSocket.latest!.close).toHaveBeenCalled();
+    });
+
+    it('closes the connection when toggled to enabled=false', async () => {
+      const { rerender } = renderHook(({ enabled }) => useWebSocket(enabled), {
+        initialProps: { enabled: true },
+      });
+      await waitFor(() => expect(MockWebSocket.latest).toBeDefined());
+      const ws = MockWebSocket.latest!;
+
+      rerender({ enabled: false });
+      expect(ws.close).toHaveBeenCalled();
+    });
+  });
+
+  // ---- Reconnection ---------------------------------------------------------------
+
+  describe('reconnect on close', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('schedules reconnect with exponential backoff after onclose', async () => {
+      renderHook(() => useWebSocket(true));
+      await vi.waitFor(() => expect(MockWebSocket.latest).toBeDefined());
+
+      act(() => {
+        MockWebSocket.latest!.triggerOpen();
+      });
+
+      const firstWs = MockWebSocket.latest!;
+      act(() => {
+        firstWs.triggerClose();
+      });
+
+      expect(useConnectionStore.getState().status).toBe('connecting');
+
+      // Advance through the backoff. Base delay is small in test conditions; a few seconds is generous.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      // A new WebSocket instance should have been created.
+      expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('does not reconnect when sidecar is in "restarting" state', async () => {
+      renderHook(() => useWebSocket(true));
+      await vi.waitFor(() => expect(MockWebSocket.latest).toBeDefined());
+      act(() => {
+        MockWebSocket.latest!.triggerOpen();
+      });
+
+      // Mark sidecar as restarting BEFORE the close so reconnect logic skips
+      useConnectionStore.setState({ sidecarState: 'restarting' } as never);
+
+      const initialCount = MockWebSocket.instances.length;
+      act(() => {
+        MockWebSocket.latest!.triggerClose();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(MockWebSocket.instances.length).toBe(initialCount);
+    });
+  });
+
+  // ---- Event dispatch end-to-end --------------------------------------------------
+
+  describe('event dispatch (smoke)', () => {
+    async function setupAndOpen() {
+      const result = renderHook(() => useWebSocket(true));
+      await vi.waitFor(() => expect(MockWebSocket.latest).toBeDefined());
+      act(() => {
+        MockWebSocket.latest!.triggerOpen();
+      });
+      return { ...result, ws: MockWebSocket.latest! };
+    }
+
+    it('dispatches init event with mcpServers payload', async () => {
+      const { ws } = await setupAndOpen();
+
+      act(() => {
+        ws.triggerMessage({
+          type: 'init',
+          payload: {
+            mcpServers: [{ name: 'github', command: 'gh-mcp' }],
+            mcpServerSources: { github: 'workspace' },
+          },
+        });
+      });
+
+      const state = useAppStore.getState();
+      expect(state.mcpServers).toHaveLength(1);
+      expect(state.mcpServers[0].name).toBe('github');
+      expect(state.mcpServerSources.github).toBe('workspace');
+    });
+
+    it('dispatches session_name_update to updateSession', async () => {
+      const updateSession = vi.fn();
+      useAppStore.setState({ updateSession } as never);
+
+      const { ws } = await setupAndOpen();
+      act(() => {
+        ws.triggerMessage({
+          type: 'session_name_update',
+          sessionId: 'session-1',
+          payload: { name: 'Renamed', branch: 'feat/new' },
+        });
+      });
+
+      expect(updateSession).toHaveBeenCalledWith('session-1', {
+        name: 'Renamed',
+        branch: 'feat/new',
+      });
+    });
+
+    it('dispatches session_task_status_update', async () => {
+      const updateSession = vi.fn();
+      useAppStore.setState({ updateSession } as never);
+
+      const { ws } = await setupAndOpen();
+      act(() => {
+        ws.triggerMessage({
+          type: 'session_task_status_update',
+          sessionId: 'session-1',
+          payload: { taskStatus: 'in_progress' },
+        });
+      });
+
+      expect(updateSession).toHaveBeenCalledWith('session-1', { taskStatus: 'in_progress' });
+    });
+
+    it('logs and continues when message JSON is malformed', async () => {
+      const { ws } = await setupAndOpen();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      act(() => {
+        const event = new MessageEvent('message', { data: 'not json {' });
+        ws.onmessage?.call(ws as unknown as WebSocket, event);
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Failed to parse WebSocket message:',
+        expect.any(Error),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('ignores session_name_update when payload missing name', async () => {
+      const updateSession = vi.fn();
+      useAppStore.setState({ updateSession } as never);
+
+      const { ws } = await setupAndOpen();
+      act(() => {
+        ws.triggerMessage({
+          type: 'session_name_update',
+          sessionId: 'session-1',
+          payload: { branch: 'feat/x' }, // no name
+        });
+      });
+
+      expect(updateSession).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- Returned reconnect() function ----------------------------------------------
+
+  describe('returned reconnect()', () => {
+    it('exposes a reconnect function', async () => {
+      const { result } = renderHook(() => useWebSocket(true));
+      await waitFor(() => expect(MockWebSocket.latest).toBeDefined());
+
+      expect(typeof result.current.reconnect).toBe('function');
+    });
+
+    it('opens a fresh WebSocket and resets attempt counter', async () => {
+      const { result } = renderHook(() => useWebSocket(true));
+      await waitFor(() => expect(MockWebSocket.latest).toBeDefined());
+      const firstCount = MockWebSocket.instances.length;
+
+      await act(async () => {
+        result.current.reconnect();
+        // give the async connect() a chance
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(MockWebSocket.instances.length).toBeGreaterThan(firstCount);
+      expect(useConnectionStore.getState().reconnectAttempt).toBe(0);
+    });
+  });
+});

--- a/src/hooks/__tests__/useWebSocket.integration.test.ts
+++ b/src/hooks/__tests__/useWebSocket.integration.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../useWebSocket';
 import { useAppStore } from '@/stores/appStore';
 import { useConnectionStore } from '@/stores/connectionStore';
+import { flushAsync } from '@/test-utils/async';
 
 // --- Mocks for hook dependencies ----------------------------------------------------
 
@@ -216,7 +217,7 @@ describe('useWebSocket integration', () => {
     it('does not connect when enabled=false', async () => {
       renderHook(() => useWebSocket(false));
       // Give any pending promises a chance to resolve
-      await new Promise((r) => setTimeout(r, 0));
+      await flushAsync();
       expect(MockWebSocket.latest).toBeUndefined();
     });
 
@@ -329,9 +330,16 @@ describe('useWebSocket integration', () => {
       expect(state.mcpServerSources.github).toBe('workspace');
     });
 
+    // Use vi.spyOn rather than setState({ updateSession: vi.fn() }) so the spy
+    // patches the *existing* action reference on the live state object. This
+    // works regardless of whether the hook reads the action via getState() per
+    // dispatch (which useWebSocket does via `getStore = useAppStore.getState`)
+    // or captures it once on mount, and vi auto-restores after the test.
+
     it('dispatches session_name_update to updateSession', async () => {
-      const updateSession = vi.fn();
-      useAppStore.setState({ updateSession } as never);
+      const updateSpy = vi
+        .spyOn(useAppStore.getState(), 'updateSession')
+        .mockImplementation(() => {});
 
       const { ws } = await setupAndOpen();
       act(() => {
@@ -342,15 +350,17 @@ describe('useWebSocket integration', () => {
         });
       });
 
-      expect(updateSession).toHaveBeenCalledWith('session-1', {
+      expect(updateSpy).toHaveBeenCalledWith('session-1', {
         name: 'Renamed',
         branch: 'feat/new',
       });
+      updateSpy.mockRestore();
     });
 
     it('dispatches session_task_status_update', async () => {
-      const updateSession = vi.fn();
-      useAppStore.setState({ updateSession } as never);
+      const updateSpy = vi
+        .spyOn(useAppStore.getState(), 'updateSession')
+        .mockImplementation(() => {});
 
       const { ws } = await setupAndOpen();
       act(() => {
@@ -361,7 +371,8 @@ describe('useWebSocket integration', () => {
         });
       });
 
-      expect(updateSession).toHaveBeenCalledWith('session-1', { taskStatus: 'in_progress' });
+      expect(updateSpy).toHaveBeenCalledWith('session-1', { taskStatus: 'in_progress' });
+      updateSpy.mockRestore();
     });
 
     it('logs and continues when message JSON is malformed', async () => {
@@ -381,8 +392,9 @@ describe('useWebSocket integration', () => {
     });
 
     it('ignores session_name_update when payload missing name', async () => {
-      const updateSession = vi.fn();
-      useAppStore.setState({ updateSession } as never);
+      const updateSpy = vi
+        .spyOn(useAppStore.getState(), 'updateSession')
+        .mockImplementation(() => {});
 
       const { ws } = await setupAndOpen();
       act(() => {
@@ -393,7 +405,8 @@ describe('useWebSocket integration', () => {
         });
       });
 
-      expect(updateSession).not.toHaveBeenCalled();
+      expect(updateSpy).not.toHaveBeenCalled();
+      updateSpy.mockRestore();
     });
   });
 
@@ -415,7 +428,7 @@ describe('useWebSocket integration', () => {
       await act(async () => {
         result.current.reconnect();
         // give the async connect() a chance
-        await new Promise((r) => setTimeout(r, 0));
+        await flushAsync();
       });
 
       expect(MockWebSocket.instances.length).toBeGreaterThan(firstCount);

--- a/src/hooks/__tests__/useWebSocketHelpers.test.ts
+++ b/src/hooks/__tests__/useWebSocketHelpers.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  normalizeUsage,
+  isAuthErrorMessage,
+  isAgentEvent,
+  isAgentTodoItemArray,
+  isValidConversationStatus,
+  isModelUsageRecord,
+  isUserQuestionArray,
+  isMcpServerStatusArray,
+  getWsUrl,
+  mapStatus,
+  notifyBackgroundSession,
+  BATCHABLE_EVENTS,
+  RECONCILIATION_SUPPRESSED_EVENTS,
+  DROP_STATS_DEBOUNCE_MS,
+  getLastDropStatsFetchTime,
+  updateLastDropStatsFetchTime,
+} from '../useWebSocketHelpers';
+import { useAppStore } from '@/stores/appStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+// Lightweight mock for playSound — sound playback is a side effect we just want to observe.
+vi.mock('@/lib/sounds', () => ({
+  playSound: vi.fn(),
+}));
+
+import { playSound } from '@/lib/sounds';
+
+describe('lib hooks/useWebSocketHelpers', () => {
+  describe('normalizeUsage', () => {
+    it('returns undefined for undefined input', () => {
+      expect(normalizeUsage(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when both token counts are missing', () => {
+      expect(normalizeUsage({})).toBeUndefined();
+      expect(normalizeUsage({ cache_read_input_tokens: 5 })).toBeUndefined();
+    });
+
+    it('normalizes snake_case keys to camelCase', () => {
+      const usage = normalizeUsage({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 20,
+        cache_creation_input_tokens: 10,
+      });
+      expect(usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadInputTokens: 20,
+        cacheCreationInputTokens: 10,
+      });
+    });
+
+    it('accepts already-camelCase keys', () => {
+      const usage = normalizeUsage({
+        inputTokens: 100,
+        outputTokens: 50,
+      });
+      expect(usage?.inputTokens).toBe(100);
+      expect(usage?.outputTokens).toBe(50);
+    });
+
+    it('snake_case takes precedence when both forms are present', () => {
+      const usage = normalizeUsage({
+        input_tokens: 100,
+        inputTokens: 999,
+      });
+      expect(usage?.inputTokens).toBe(100);
+    });
+
+    it('treats missing output as 0', () => {
+      const usage = normalizeUsage({ input_tokens: 100 });
+      expect(usage?.outputTokens).toBe(0);
+    });
+
+    it('skips non-numeric values via num() helper', () => {
+      const usage = normalizeUsage({
+        input_tokens: '100' as unknown as number,
+        output_tokens: 50,
+      });
+      // input becomes 0 (unrecognized string), output stays at 50
+      expect(usage?.inputTokens).toBe(0);
+      expect(usage?.outputTokens).toBe(50);
+    });
+  });
+
+  describe('isAuthErrorMessage', () => {
+    it.each([
+      ['Authentication failed'],
+      ['Invalid API key'],
+      ['OAuth token expired'],
+      ['AWS credentials missing'],
+    ])('matches %s', (msg) => {
+      expect(isAuthErrorMessage(msg)).toBe(true);
+    });
+
+    it.each([
+      ['Network error'],
+      ['Timeout'],
+      ['Internal server error'],
+    ])('does not match %s', (msg) => {
+      expect(isAuthErrorMessage(msg)).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isAuthErrorMessage('AUTHENTICATION ERROR')).toBe(true);
+      expect(isAuthErrorMessage('api key invalid')).toBe(true);
+    });
+  });
+
+  describe('isAgentEvent', () => {
+    it('rejects non-objects', () => {
+      expect(isAgentEvent(null)).toBe(false);
+      expect(isAgentEvent(undefined)).toBe(false);
+      expect(isAgentEvent('text')).toBe(false);
+      expect(isAgentEvent(42)).toBe(false);
+    });
+
+    it('accepts objects with type field', () => {
+      expect(isAgentEvent({ type: 'foo' })).toBe(true);
+    });
+
+    it('accepts objects with content field', () => {
+      expect(isAgentEvent({ content: 'hello' })).toBe(true);
+    });
+
+    it('accepts objects with todos array', () => {
+      expect(isAgentEvent({ todos: [] })).toBe(true);
+    });
+
+    it('rejects objects without recognized fields', () => {
+      expect(isAgentEvent({ random: 1 })).toBe(false);
+    });
+  });
+
+  describe('isAgentTodoItemArray', () => {
+    it('accepts valid array of todos', () => {
+      expect(isAgentTodoItemArray([
+        { content: 'Do thing', status: 'pending', activeForm: 'Doing thing' },
+        { content: 'Do other', status: 'completed', activeForm: 'Doing other' },
+      ])).toBe(true);
+    });
+
+    it('rejects non-arrays', () => {
+      expect(isAgentTodoItemArray({})).toBe(false);
+      expect(isAgentTodoItemArray(null)).toBe(false);
+    });
+
+    it('rejects array with invalid status', () => {
+      expect(isAgentTodoItemArray([
+        { content: 'Do thing', status: 'unknown', activeForm: 'Doing' },
+      ])).toBe(false);
+    });
+
+    it('rejects array missing required fields', () => {
+      expect(isAgentTodoItemArray([{ content: 'foo' }])).toBe(false);
+    });
+  });
+
+  describe('isValidConversationStatus', () => {
+    it.each([
+      ['active', true],
+      ['idle', true],
+      ['completed', true],
+      ['running', false],
+      ['error', false],
+      ['', false],
+      [42, false],
+      [null, false],
+    ])('returns %s for input %p', (input, expected) => {
+      expect(isValidConversationStatus(input)).toBe(expected);
+    });
+  });
+
+  describe('isModelUsageRecord', () => {
+    it('accepts record with model usage entries', () => {
+      expect(isModelUsageRecord({
+        'claude-sonnet-4-6': { inputTokens: 100, outputTokens: 50 },
+      })).toBe(true);
+    });
+
+    it('accepts empty record', () => {
+      expect(isModelUsageRecord({})).toBe(true);
+    });
+
+    it('rejects null', () => {
+      expect(isModelUsageRecord(null)).toBe(false);
+    });
+
+    it('rejects entries missing input/output token numbers', () => {
+      expect(isModelUsageRecord({
+        'claude-sonnet-4-6': { inputTokens: 100 },
+      })).toBe(false);
+    });
+
+    it('rejects entries with non-numeric tokens', () => {
+      expect(isModelUsageRecord({
+        'claude-sonnet-4-6': { inputTokens: '100', outputTokens: 50 },
+      })).toBe(false);
+    });
+  });
+
+  describe('isUserQuestionArray', () => {
+    it('accepts well-formed user question array', () => {
+      expect(isUserQuestionArray([
+        { question: 'Pick one', header: 'Choice', options: [] },
+      ])).toBe(true);
+    });
+
+    it('rejects non-arrays', () => {
+      expect(isUserQuestionArray({})).toBe(false);
+    });
+
+    it('rejects entries missing required fields', () => {
+      expect(isUserQuestionArray([{ question: 'a' }])).toBe(false);
+    });
+
+    it('rejects entries where options is not array', () => {
+      expect(isUserQuestionArray([
+        { question: 'a', header: 'b', options: 'not array' },
+      ])).toBe(false);
+    });
+  });
+
+  describe('isMcpServerStatusArray', () => {
+    it('accepts well-formed mcp status array', () => {
+      expect(isMcpServerStatusArray([
+        { name: 'github', status: 'connected' },
+      ])).toBe(true);
+    });
+
+    it('rejects non-arrays', () => {
+      expect(isMcpServerStatusArray('connected')).toBe(false);
+    });
+
+    it('rejects entries missing fields', () => {
+      expect(isMcpServerStatusArray([{ name: 'github' }])).toBe(false);
+    });
+  });
+
+  describe('getWsUrl', () => {
+    afterEach(() => {
+      // Reset Tauri detection between tests
+      Object.defineProperty(window, '__TAURI__', { value: undefined, writable: true });
+    });
+
+    it('returns env-based URL when not in Tauri', () => {
+      const url = getWsUrl();
+      expect(url).toMatch(/^ws:\/\/localhost:\d+\/ws$/);
+    });
+
+    it('returns localhost ws URL with backend port when in Tauri', () => {
+      Object.defineProperty(window, '__TAURI__', { value: {}, writable: true });
+      const url = getWsUrl();
+      expect(url).toMatch(/^ws:\/\/localhost:\d+\/ws$/);
+    });
+  });
+
+  describe('mapStatus', () => {
+    it.each([
+      ['running', 'active'],
+      ['pending', 'idle'],
+      ['done', 'done'],
+      ['error', 'error'],
+      ['unknown', 'idle'],
+      ['', 'idle'],
+    ])('maps %s → %s', (input, expected) => {
+      expect(mapStatus(input)).toBe(expected);
+    });
+  });
+
+  describe('BATCHABLE_EVENTS / RECONCILIATION_SUPPRESSED_EVENTS', () => {
+    it('BATCHABLE_EVENTS includes core streaming events', () => {
+      expect(BATCHABLE_EVENTS.has('assistant_text')).toBe(true);
+      expect(BATCHABLE_EVENTS.has('thinking_delta')).toBe(true);
+      expect(BATCHABLE_EVENTS.has('todo_update')).toBe(true);
+    });
+
+    it('BATCHABLE_EVENTS does NOT include lifecycle events', () => {
+      expect(BATCHABLE_EVENTS.has('init')).toBe(false);
+      expect(BATCHABLE_EVENTS.has('result')).toBe(false);
+      expect(BATCHABLE_EVENTS.has('turn_complete')).toBe(false);
+    });
+
+    it('RECONCILIATION_SUPPRESSED_EVENTS includes content events', () => {
+      expect(RECONCILIATION_SUPPRESSED_EVENTS.has('assistant_text')).toBe(true);
+      expect(RECONCILIATION_SUPPRESSED_EVENTS.has('tool_start')).toBe(true);
+    });
+
+    it('RECONCILIATION_SUPPRESSED_EVENTS does NOT include lifecycle events', () => {
+      expect(RECONCILIATION_SUPPRESSED_EVENTS.has('result')).toBe(false);
+      expect(RECONCILIATION_SUPPRESSED_EVENTS.has('turn_complete')).toBe(false);
+      expect(RECONCILIATION_SUPPRESSED_EVENTS.has('conversation_status')).toBe(false);
+    });
+  });
+
+  describe('drop stats fetch debounce', () => {
+    afterEach(() => {
+      // Reset module-level state between tests
+      updateLastDropStatsFetchTime(0);
+    });
+
+    it('exposes a debounce constant of 3000ms', () => {
+      expect(DROP_STATS_DEBOUNCE_MS).toBe(3000);
+    });
+
+    it('starts at 0 and updates monotonically', () => {
+      expect(getLastDropStatsFetchTime()).toBe(0);
+      updateLastDropStatsFetchTime(1000);
+      expect(getLastDropStatsFetchTime()).toBe(1000);
+      updateLastDropStatsFetchTime(2000);
+      expect(getLastDropStatsFetchTime()).toBe(2000);
+    });
+  });
+
+  describe('notifyBackgroundSession', () => {
+    beforeEach(() => {
+      vi.mocked(playSound).mockClear();
+    });
+
+    it('does nothing when conversation is not found', () => {
+      useAppStore.setState({ conversations: [], selectedSessionId: null });
+      expect(() => notifyBackgroundSession('missing-conv')).not.toThrow();
+      expect(playSound).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when conversation belongs to currently-selected session', () => {
+      useAppStore.setState({
+        conversations: [
+          { id: 'conv-1', sessionId: 'session-foreground' } as never,
+        ],
+        selectedSessionId: 'session-foreground',
+      });
+      const markUnread = vi.fn();
+      useSettingsStore.setState({ markSessionUnread: markUnread } as never);
+
+      notifyBackgroundSession('conv-1');
+
+      expect(markUnread).not.toHaveBeenCalled();
+      expect(playSound).not.toHaveBeenCalled();
+    });
+
+    it('marks session unread when conversation is in a background session', () => {
+      const markUnread = vi.fn();
+      useAppStore.setState({
+        conversations: [{ id: 'conv-1', sessionId: 'session-bg' } as never],
+        selectedSessionId: 'session-foreground',
+      });
+      useSettingsStore.setState({
+        markSessionUnread: markUnread,
+        soundEffects: false,
+      } as never);
+
+      notifyBackgroundSession('conv-1');
+
+      expect(markUnread).toHaveBeenCalledWith('session-bg');
+    });
+
+    it('plays sound when document is focused and sound effects are enabled', () => {
+      const markUnread = vi.fn();
+      useAppStore.setState({
+        conversations: [{ id: 'conv-1', sessionId: 'session-bg' } as never],
+        selectedSessionId: 'session-foreground',
+      });
+      useSettingsStore.setState({
+        markSessionUnread: markUnread,
+        soundEffects: true,
+        soundEffectType: 'classic',
+      } as never);
+
+      const focusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+      notifyBackgroundSession('conv-1');
+      focusSpy.mockRestore();
+
+      expect(playSound).toHaveBeenCalledWith('classic');
+    });
+
+    it('does not play sound when document is not focused', () => {
+      const markUnread = vi.fn();
+      useAppStore.setState({
+        conversations: [{ id: 'conv-1', sessionId: 'session-bg' } as never],
+        selectedSessionId: 'session-foreground',
+      });
+      useSettingsStore.setState({
+        markSessionUnread: markUnread,
+        soundEffects: true,
+        soundEffectType: 'classic',
+      } as never);
+
+      const focusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+      notifyBackgroundSession('conv-1');
+      focusSpy.mockRestore();
+
+      expect(playSound).not.toHaveBeenCalled();
+    });
+
+    it('does not play sound when soundEffects is disabled', () => {
+      const markUnread = vi.fn();
+      useAppStore.setState({
+        conversations: [{ id: 'conv-1', sessionId: 'session-bg' } as never],
+        selectedSessionId: 'session-foreground',
+      });
+      useSettingsStore.setState({
+        markSessionUnread: markUnread,
+        soundEffects: false,
+        soundEffectType: 'classic',
+      } as never);
+
+      const focusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+      notifyBackgroundSession('conv-1');
+      focusSpy.mockRestore();
+
+      expect(playSound).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/__tests__/useWebSocketHelpers.test.ts
+++ b/src/hooks/__tests__/useWebSocketHelpers.test.ts
@@ -242,18 +242,28 @@ describe('lib hooks/useWebSocketHelpers', () => {
 
   describe('getWsUrl', () => {
     afterEach(() => {
-      // Reset Tauri detection between tests
       Object.defineProperty(window, '__TAURI__', { value: undefined, writable: true });
+      vi.unstubAllEnvs();
     });
 
-    it('returns env-based URL when not in Tauri', () => {
-      const url = getWsUrl();
-      expect(url).toMatch(/^ws:\/\/localhost:\d+\/ws$/);
+    it('falls back to the hardcoded default when not in Tauri and no env override', () => {
+      vi.stubEnv('NEXT_PUBLIC_WS_URL', '');
+      // Pin the exact default so a typo in the constant fails the test.
+      expect(getWsUrl()).toBe('ws://localhost:9876/ws');
     });
 
-    it('returns localhost ws URL with backend port when in Tauri', () => {
+    it('uses NEXT_PUBLIC_WS_URL when set and not in Tauri', () => {
+      vi.stubEnv('NEXT_PUBLIC_WS_URL', 'wss://staging.example.com/ws');
+      expect(getWsUrl()).toBe('wss://staging.example.com/ws');
+    });
+
+    it('uses the dynamic backend port when running inside Tauri (env override is ignored)', () => {
+      // Tauri detection wins: the backend port is dynamic and only known in
+      // the Tauri runtime, so the env override is intentionally bypassed.
+      vi.stubEnv('NEXT_PUBLIC_WS_URL', 'wss://staging.example.com/ws');
       Object.defineProperty(window, '__TAURI__', { value: {}, writable: true });
       const url = getWsUrl();
+      expect(url).not.toBe('wss://staging.example.com/ws');
       expect(url).toMatch(/^ws:\/\/localhost:\d+\/ws$/);
     });
   });

--- a/src/hooks/__tests__/useWebSocketPlanMode.test.ts
+++ b/src/hooks/__tests__/useWebSocketPlanMode.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  isInPlanModeExitCooldown,
+  markPlanModeExited,
+  clearPlanModeState,
+} from '../useWebSocketPlanMode';
+
+describe('useWebSocketPlanMode', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('isInPlanModeExitCooldown', () => {
+    it('returns false when conversation has not exited plan mode', () => {
+      expect(isInPlanModeExitCooldown('conv-fresh')).toBe(false);
+    });
+
+    it('returns true immediately after marking exited', () => {
+      markPlanModeExited('conv-1');
+      expect(isInPlanModeExitCooldown('conv-1')).toBe(true);
+    });
+
+    it('returns true within the 5-second cooldown window', () => {
+      markPlanModeExited('conv-1');
+      vi.advanceTimersByTime(4999);
+      expect(isInPlanModeExitCooldown('conv-1')).toBe(true);
+    });
+
+    it('returns false after the 5-second cooldown elapses', () => {
+      markPlanModeExited('conv-1');
+      vi.advanceTimersByTime(5000);
+      expect(isInPlanModeExitCooldown('conv-1')).toBe(false);
+    });
+  });
+
+  describe('markPlanModeExited', () => {
+    it('refreshes the cooldown when called again before expiry', () => {
+      markPlanModeExited('conv-1');
+      vi.advanceTimersByTime(3000);
+      // Refresh cooldown
+      markPlanModeExited('conv-1');
+
+      // Now advance to where the original cooldown would have ended (orig + 5s = 8s).
+      vi.advanceTimersByTime(2500);
+      // Total since refresh = 2500ms. Still within 5s cooldown of refresh.
+      expect(isInPlanModeExitCooldown('conv-1')).toBe(true);
+    });
+
+    it('isolates state across conversations', () => {
+      markPlanModeExited('conv-a');
+      expect(isInPlanModeExitCooldown('conv-a')).toBe(true);
+      expect(isInPlanModeExitCooldown('conv-b')).toBe(false);
+    });
+
+    it('auto-cleanup runs after cooldown + 100ms grace', () => {
+      markPlanModeExited('conv-1');
+      vi.advanceTimersByTime(5100);
+      // Auto-cleanup setTimeout should have fired and removed the entry.
+      expect(isInPlanModeExitCooldown('conv-1')).toBe(false);
+    });
+
+    it('auto-cleanup does NOT remove entry that was refreshed', () => {
+      markPlanModeExited('conv-1');
+      vi.advanceTimersByTime(3000);
+      markPlanModeExited('conv-1'); // refresh
+
+      // Original auto-cleanup fires at 5100ms total elapsed (3000 + 2100 more).
+      vi.advanceTimersByTime(2100);
+
+      // Entry was refreshed so cleanup should leave it; still within new cooldown.
+      expect(isInPlanModeExitCooldown('conv-1')).toBe(true);
+    });
+  });
+
+  describe('clearPlanModeState', () => {
+    it('removes a marked conversation immediately', () => {
+      markPlanModeExited('conv-1');
+      expect(isInPlanModeExitCooldown('conv-1')).toBe(true);
+
+      clearPlanModeState('conv-1');
+      expect(isInPlanModeExitCooldown('conv-1')).toBe(false);
+    });
+
+    it('is a no-op for unknown conversations', () => {
+      expect(() => clearPlanModeState('nonexistent')).not.toThrow();
+    });
+  });
+});

--- a/src/hooks/__tests__/useWebSocketReconciliation.test.ts
+++ b/src/hooks/__tests__/useWebSocketReconciliation.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  startReconciling,
+  stopReconciling,
+  isReconciling,
+  clearReconciliationState,
+} from '../useWebSocketReconciliation';
+
+// All tests must clean up their conversation IDs since the underlying state is module-level.
+
+describe('useWebSocketReconciliation', () => {
+  describe('isReconciling', () => {
+    it('returns false for unknown conversation', () => {
+      expect(isReconciling('never-touched')).toBe(false);
+    });
+  });
+
+  describe('startReconciling / stopReconciling', () => {
+    it('marks a conversation as reconciling and clears it after stop', () => {
+      const id = 'rc-basic';
+      startReconciling(id);
+      expect(isReconciling(id)).toBe(true);
+      stopReconciling(id);
+      expect(isReconciling(id)).toBe(false);
+    });
+
+    it('handles concurrent reconciles via ref-counting', () => {
+      const id = 'rc-nested';
+      startReconciling(id);
+      startReconciling(id);
+      expect(isReconciling(id)).toBe(true);
+
+      // First stop reduces counter from 2 to 1; still reconciling.
+      stopReconciling(id);
+      expect(isReconciling(id)).toBe(true);
+
+      // Second stop drops counter to 0; cleared.
+      stopReconciling(id);
+      expect(isReconciling(id)).toBe(false);
+    });
+
+    it('stopReconciling on unknown id does not throw and stays cleared', () => {
+      expect(() => stopReconciling('never-started')).not.toThrow();
+      expect(isReconciling('never-started')).toBe(false);
+    });
+
+    it('isolates state across conversations', () => {
+      startReconciling('rc-a');
+      expect(isReconciling('rc-a')).toBe(true);
+      expect(isReconciling('rc-b')).toBe(false);
+
+      stopReconciling('rc-a');
+    });
+  });
+
+  describe('clearReconciliationState', () => {
+    it('clears regardless of pending counter', () => {
+      const id = 'rc-clear';
+      startReconciling(id);
+      startReconciling(id);
+      startReconciling(id);
+      expect(isReconciling(id)).toBe(true);
+
+      clearReconciliationState(id);
+      expect(isReconciling(id)).toBe(false);
+    });
+
+    it('is a no-op for unknown conversations', () => {
+      expect(() => clearReconciliationState('not-tracked')).not.toThrow();
+    });
+  });
+});

--- a/src/hooks/terminal-utils.ts
+++ b/src/hooks/terminal-utils.ts
@@ -14,10 +14,21 @@ export function detectPlatform(): 'windows' | 'unix' {
  * Falls back to platform defaults if `invoke` fails (e.g. running outside Tauri).
  */
 export async function getShellFallbackChain(): Promise<string[]> {
+  // Distros differ on where shells live: NixOS, Alpine, and some containers
+  // don't ship /bin/zsh|bash. The list probes /usr/bin/* as well so a missing
+  // /bin/zsh doesn't strand the user with "shell not found" before /usr/bin/zsh
+  // is tried.
   const defaults =
     detectPlatform() === 'windows'
       ? ['powershell.exe', 'pwsh.exe', 'cmd.exe']
-      : ['/bin/zsh', '/bin/bash', '/bin/sh'];
+      : [
+          '/bin/zsh',
+          '/usr/bin/zsh',
+          '/bin/bash',
+          '/usr/bin/bash',
+          '/bin/sh',
+          '/usr/bin/sh',
+        ];
 
   try {
     const userShell = await invoke<string | null>('get_user_shell');

--- a/src/hooks/terminal-utils.ts
+++ b/src/hooks/terminal-utils.ts
@@ -1,0 +1,100 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/** Detect platform from `navigator.userAgentData` (modern) with `navigator.platform` fallback. */
+export function detectPlatform(): 'windows' | 'unix' {
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  if (uaData?.platform?.toLowerCase().includes('win')) return 'windows';
+  if (navigator.platform.toLowerCase().includes('win')) return 'windows';
+  return 'unix';
+}
+
+/**
+ * Build a shell fallback chain (most-preferred first) for the current platform.
+ * The user's `$SHELL` (queried via Tauri `get_user_shell`) is prepended when available.
+ * Falls back to platform defaults if `invoke` fails (e.g. running outside Tauri).
+ */
+export async function getShellFallbackChain(): Promise<string[]> {
+  const defaults =
+    detectPlatform() === 'windows'
+      ? ['powershell.exe', 'pwsh.exe', 'cmd.exe']
+      : ['/bin/zsh', '/bin/bash', '/bin/sh'];
+
+  try {
+    const userShell = await invoke<string | null>('get_user_shell');
+    if (userShell) {
+      return [userShell, ...defaults.filter((s) => s !== userShell)];
+    }
+  } catch {
+    // invoke failed — use defaults
+  }
+
+  return defaults;
+}
+
+/**
+ * Spawn shells as login shells on macOS/Linux so they read profile files
+ * (e.g. ~/.zprofile, ~/.bash_profile) which set up PATH, Homebrew, etc.
+ * Mirrors Terminal.app / iTerm2 behavior.
+ */
+export function getShellArgs(): string[] {
+  return detectPlatform() === 'windows' ? [] : ['-l'];
+}
+
+/** Terminal font stack — mirrors the --font-terminal CSS variable. */
+export const TERMINAL_FONT_FAMILY =
+  '"MesloLGS NF", "MesloLGS Nerd Font", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace';
+
+/** Dark terminal theme. */
+export const darkTerminalTheme = {
+  background: '#0f1111',
+  foreground: '#4ade80',
+  cursor: '#4ade80',
+  cursorAccent: '#000000',
+  selectionBackground: 'rgba(139, 92, 246, 0.3)',
+  black: '#000000',
+  red: '#ef4444',
+  green: '#22c55e',
+  yellow: '#eab308',
+  blue: '#3b82f6',
+  magenta: '#a855f7',
+  cyan: '#06b6d4',
+  white: '#f5f5f5',
+  brightBlack: '#737373',
+  brightRed: '#f87171',
+  brightGreen: '#4ade80',
+  brightYellow: '#facc15',
+  brightBlue: '#60a5fa',
+  brightMagenta: '#c084fc',
+  brightCyan: '#22d3ee',
+  brightWhite: '#ffffff',
+};
+
+/** Light terminal theme (GitHub-style ANSI palette). */
+export const lightTerminalTheme = {
+  background: '#ffffff',
+  foreground: '#1a1a1a',
+  cursor: '#1a1a1a',
+  cursorAccent: '#ffffff',
+  selectionBackground: 'rgba(139, 92, 246, 0.2)',
+  black: '#000000',
+  red: '#d73a49',
+  green: '#22863a',
+  yellow: '#b08800',
+  blue: '#005cc5',
+  magenta: '#6f42c1',
+  cyan: '#0598bc',
+  white: '#d1d5db',
+  brightBlack: '#6a737d',
+  brightRed: '#cb2431',
+  brightGreen: '#28a745',
+  brightYellow: '#dbab09',
+  brightBlue: '#2188ff',
+  brightMagenta: '#8a63d2',
+  brightCyan: '#3192aa',
+  brightWhite: '#fafbfc',
+};
+
+/** Pick the right theme by themeType. */
+export function getTerminalTheme(themeType: 'dark' | 'light') {
+  return themeType === 'dark' ? darkTerminalTheme : lightTerminalTheme;
+}

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -7,102 +7,13 @@ import { SearchAddon } from '@xterm/addon-search';
 import { invoke } from '@tauri-apps/api/core';
 import { spawnPty, startPtyReading, type PtyHandle } from '@/lib/pty';
 import { useResolvedThemeType } from '@/hooks/useResolvedThemeType';
+import {
+  getShellFallbackChain,
+  getShellArgs,
+  getTerminalTheme,
+  TERMINAL_FONT_FAMILY,
+} from './terminal-utils';
 
-// Platform detection with modern API fallback
-function detectPlatform(): 'windows' | 'unix' {
-  // Modern API (navigator.userAgentData)
-  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
-  if (uaData?.platform?.toLowerCase().includes('win')) return 'windows';
-
-  // Fallback to deprecated API
-  if (navigator.platform.toLowerCase().includes('win')) return 'windows';
-
-  return 'unix';
-}
-
-// Get shell fallback chain based on platform, preferring the user's $SHELL
-async function getShellFallbackChain(): Promise<string[]> {
-  const defaults =
-    detectPlatform() === 'windows'
-      ? ['powershell.exe', 'pwsh.exe', 'cmd.exe']
-      : ['/bin/zsh', '/bin/bash', '/bin/sh'];
-
-  try {
-    const userShell = await invoke<string | null>('get_user_shell');
-    if (userShell) {
-      return [userShell, ...defaults.filter(s => s !== userShell)];
-    }
-  } catch {
-    // Invoke failed (e.g. running outside Tauri) — use defaults
-  }
-
-  return defaults;
-}
-
-// On macOS/Linux, spawn shells as login shells so they read profile files
-// (e.g. ~/.zprofile, ~/.bash_profile) which set up PATH, Homebrew, etc.
-// This matches the behavior of Terminal.app, iTerm2, and other macOS terminals.
-function getShellArgs(): string[] {
-  return detectPlatform() === 'windows' ? [] : ['-l'];
-}
-
-// Terminal font stack — mirrors the --font-terminal CSS variable
-const TERMINAL_FONT_FAMILY =
-  '"MesloLGS NF", "MesloLGS Nerd Font", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace';
-
-// Dark terminal theme
-const darkTerminalTheme = {
-  background: '#0f1111',
-  foreground: '#4ade80', // green-400
-  cursor: '#4ade80',
-  cursorAccent: '#000000',
-  selectionBackground: 'rgba(139, 92, 246, 0.3)',
-  black: '#000000',
-  red: '#ef4444',
-  green: '#22c55e',
-  yellow: '#eab308',
-  blue: '#3b82f6',
-  magenta: '#a855f7',
-  cyan: '#06b6d4',
-  white: '#f5f5f5',
-  brightBlack: '#737373',
-  brightRed: '#f87171',
-  brightGreen: '#4ade80',
-  brightYellow: '#facc15',
-  brightBlue: '#60a5fa',
-  brightMagenta: '#c084fc',
-  brightCyan: '#22d3ee',
-  brightWhite: '#ffffff',
-};
-
-// Light terminal theme (GitHub-style ANSI palette)
-const lightTerminalTheme = {
-  background: '#ffffff',
-  foreground: '#1a1a1a',
-  cursor: '#1a1a1a',
-  cursorAccent: '#ffffff',
-  selectionBackground: 'rgba(139, 92, 246, 0.2)',
-  black: '#000000',
-  red: '#d73a49',
-  green: '#22863a',
-  yellow: '#b08800',
-  blue: '#005cc5',
-  magenta: '#6f42c1',
-  cyan: '#0598bc',
-  white: '#d1d5db',
-  brightBlack: '#6a737d',
-  brightRed: '#cb2431',
-  brightGreen: '#28a745',
-  brightYellow: '#dbab09',
-  brightBlue: '#2188ff',
-  brightMagenta: '#8a63d2',
-  brightCyan: '#3192aa',
-  brightWhite: '#fafbfc',
-};
-
-function getTerminalTheme(themeType: 'dark' | 'light') {
-  return themeType === 'dark' ? darkTerminalTheme : lightTerminalTheme;
-}
 
 export interface UseTerminalOptions {
   workspacePath?: string;

--- a/src/lib/__tests__/plate-content.test.ts
+++ b/src/lib/__tests__/plate-content.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import { extractContent } from '../plate-content';
+import type { Value } from 'platejs';
+
+describe('extractContent', () => {
+  it('returns empty text and no mentions for an empty editor', () => {
+    const value: Value = [{ type: 'p', children: [{ text: '' }] }];
+    expect(extractContent(value)).toEqual({ text: '', mentionedFiles: [] });
+  });
+
+  it('extracts plain text from a single paragraph', () => {
+    const value: Value = [{ type: 'p', children: [{ text: 'hello world' }] }];
+    expect(extractContent(value)).toEqual({ text: 'hello world', mentionedFiles: [] });
+  });
+
+  it('joins multiple paragraphs with newlines', () => {
+    const value: Value = [
+      { type: 'p', children: [{ text: 'first' }] },
+      { type: 'p', children: [{ text: 'second' }] },
+      { type: 'p', children: [{ text: 'third' }] },
+    ];
+    expect(extractContent(value).text).toBe('first\nsecond\nthird');
+  });
+
+  it('does not append a trailing newline after the last paragraph', () => {
+    const value: Value = [
+      { type: 'p', children: [{ text: 'a' }] },
+      { type: 'p', children: [{ text: 'b' }] },
+    ];
+    expect(extractContent(value).text).toBe('a\nb');
+    expect(extractContent(value).text).not.toMatch(/\n$/);
+  });
+
+  it('extracts mention nodes as @value tokens', () => {
+    const value: Value = [
+      {
+        type: 'p',
+        children: [
+          { text: 'see ' },
+          { type: 'mention', value: 'src/app.tsx', children: [{ text: '' }] } as never,
+          { text: ' for details' },
+        ],
+      },
+    ];
+    const result = extractContent(value);
+    expect(result.text).toBe('see @src/app.tsx for details');
+    expect(result.mentionedFiles).toEqual(['src/app.tsx']);
+  });
+
+  it('captures multiple mentions in a single paragraph', () => {
+    const value: Value = [
+      {
+        type: 'p',
+        children: [
+          { type: 'mention', value: 'a.ts', children: [{ text: '' }] } as never,
+          { text: ' and ' },
+          { type: 'mention', value: 'b.ts', children: [{ text: '' }] } as never,
+        ],
+      },
+    ];
+    const result = extractContent(value);
+    expect(result.text).toBe('@a.ts and @b.ts');
+    expect(result.mentionedFiles).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('captures mentions across multiple paragraphs', () => {
+    const value: Value = [
+      {
+        type: 'p',
+        children: [
+          { text: 'p1: ' },
+          { type: 'mention', value: 'one.ts', children: [{ text: '' }] } as never,
+        ],
+      },
+      {
+        type: 'p',
+        children: [
+          { type: 'mention', value: 'two.ts', children: [{ text: '' }] } as never,
+        ],
+      },
+    ];
+    const result = extractContent(value);
+    expect(result.text).toBe('p1: @one.ts\n@two.ts');
+    expect(result.mentionedFiles).toEqual(['one.ts', 'two.ts']);
+  });
+
+  it('skips mentions with falsy value (does not push to mentionedFiles)', () => {
+    const value: Value = [
+      {
+        type: 'p',
+        children: [
+          { text: 'before ' },
+          { type: 'mention', value: '', children: [{ text: '' }] } as never,
+          { text: ' after' },
+        ],
+      },
+    ];
+    const result = extractContent(value);
+    expect(result.text).toBe('before @ after');
+    expect(result.mentionedFiles).toEqual([]);
+  });
+
+  it('recursively walks nested children (e.g. inline marks)', () => {
+    const value: Value = [
+      {
+        type: 'p',
+        children: [
+          {
+            type: 'inline',
+            children: [{ text: 'nested' }],
+          } as never,
+          { text: ' and flat' },
+        ],
+      },
+    ];
+    const result = extractContent(value);
+    expect(result.text).toBe('nested and flat');
+  });
+
+  it('handles deeply nested structures with mentions inside', () => {
+    const value: Value = [
+      {
+        type: 'p',
+        children: [
+          {
+            type: 'wrapper',
+            children: [
+              {
+                type: 'inner',
+                children: [
+                  { text: 'deep ' },
+                  { type: 'mention', value: 'deep.ts', children: [{ text: '' }] } as never,
+                ],
+              },
+            ],
+          } as never,
+        ],
+      },
+    ];
+    const result = extractContent(value);
+    expect(result.text).toBe('deep @deep.ts');
+    expect(result.mentionedFiles).toEqual(['deep.ts']);
+  });
+
+  it('trims surrounding whitespace from the final text', () => {
+    const value: Value = [
+      { type: 'p', children: [{ text: '   ' }] },
+      { type: 'p', children: [{ text: 'middle' }] },
+      { type: 'p', children: [{ text: '\t\n  ' }] },
+    ];
+    expect(extractContent(value).text).toBe('middle');
+  });
+
+  it('preserves internal whitespace when trimming', () => {
+    const value: Value = [{ type: 'p', children: [{ text: '  hello  world  ' }] }];
+    expect(extractContent(value).text).toBe('hello  world');
+  });
+
+  it('handles slash-command-style nodes by walking their text children', () => {
+    const value: Value = [
+      {
+        type: 'p',
+        children: [
+          {
+            type: 'slash_input',
+            children: [{ text: '/help' }],
+          } as never,
+        ],
+      },
+    ];
+    expect(extractContent(value).text).toBe('/help');
+  });
+
+  it('does not duplicate mentions in mentionedFiles when the same id appears twice', () => {
+    const value: Value = [
+      {
+        type: 'p',
+        children: [
+          { type: 'mention', value: 'same.ts', children: [{ text: '' }] } as never,
+          { text: ' and ' },
+          { type: 'mention', value: 'same.ts', children: [{ text: '' }] } as never,
+        ],
+      },
+    ];
+    // Note: extractContent does NOT dedupe (callers can dedupe if needed).
+    // This test pins down the actual behavior.
+    expect(extractContent(value).mentionedFiles).toEqual(['same.ts', 'same.ts']);
+  });
+
+  it('handles a value with only a single empty paragraph', () => {
+    const value: Value = [{ type: 'p', children: [{ text: '' }] }];
+    expect(extractContent(value)).toEqual({ text: '', mentionedFiles: [] });
+  });
+});

--- a/src/lib/api/__tests__/avatars.test.ts
+++ b/src/lib/api/__tests__/avatars.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { getAvatars } from '../avatars';
+
+const API_BASE = 'http://localhost:9876';
+
+describe('lib/api/avatars', () => {
+  describe('getAvatars', () => {
+    it('returns empty object without hitting backend when emails is empty', async () => {
+      let calledBackend = false;
+      server.use(
+        http.get(`${API_BASE}/api/avatars`, () => {
+          calledBackend = true;
+          return HttpResponse.json({ avatars: {} });
+        })
+      );
+
+      const result = await getAvatars([]);
+      expect(result).toEqual({});
+      expect(calledBackend).toBe(false);
+    });
+
+    it('joins emails with comma and unwraps the avatars field from response', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/avatars`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({
+            avatars: {
+              'alice@example.com': 'https://avatars/alice',
+              'bob@example.com': 'https://avatars/bob',
+            },
+          });
+        })
+      );
+
+      const result = await getAvatars(['alice@example.com', 'bob@example.com']);
+
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('emails')).toBe('alice@example.com,bob@example.com');
+      expect(result).toEqual({
+        'alice@example.com': 'https://avatars/alice',
+        'bob@example.com': 'https://avatars/bob',
+      });
+    });
+
+    it('handles single-email request', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/avatars`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({
+            avatars: { 'alice@example.com': 'https://avatars/alice' },
+          });
+        })
+      );
+
+      const result = await getAvatars(['alice@example.com']);
+      expect(new URLSearchParams(capturedSearch).get('emails')).toBe('alice@example.com');
+      expect(result['alice@example.com']).toBe('https://avatars/alice');
+    });
+  });
+});

--- a/src/lib/api/__tests__/branches.test.ts
+++ b/src/lib/api/__tests__/branches.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  listBranches,
+  resolvePR,
+  analyzeBranchCleanup,
+  executeBranchCleanup,
+  getBranchSyncStatus,
+  syncBranch,
+  abortBranchSync,
+  type BranchDTO,
+  type CleanupCandidate,
+  type ResolvePRResponse,
+} from '../branches';
+import { ApiError } from '../base';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockBranch: BranchDTO = {
+  name: 'feature/test',
+  isRemote: false,
+  isHead: true,
+  lastCommitSha: 'abc1234567890def',
+  lastCommitDate: '2026-01-15T10:00:00Z',
+  lastCommitSubject: 'feat: add login',
+  lastAuthor: 'Alice',
+  lastAuthorEmail: 'alice@example.com',
+  aheadMain: 3,
+  behindMain: 1,
+  prefix: 'feature',
+};
+
+describe('lib/api/branches', () => {
+  describe('listBranches', () => {
+    it('returns sessionBranches and otherBranches', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/branches`, () => {
+          return HttpResponse.json({
+            sessionBranches: [mockBranch],
+            otherBranches: [],
+            currentBranch: 'feature/test',
+            total: 1,
+            hasMore: false,
+          });
+        })
+      );
+
+      const result = await listBranches('ws-1');
+
+      expect(result.sessionBranches).toHaveLength(1);
+      expect(result.sessionBranches[0].name).toBe('feature/test');
+      expect(result.currentBranch).toBe('feature/test');
+      expect(result.total).toBe(1);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('omits the query string when no params are passed', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/branches`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({
+            sessionBranches: [],
+            otherBranches: [],
+            currentBranch: 'main',
+            total: 0,
+            hasMore: false,
+          });
+        })
+      );
+
+      await listBranches('ws-1');
+      expect(capturedUrl).toBe(`${API_BASE}/api/repos/ws-1/branches`);
+    });
+
+    it('serializes all params into the query string', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/branches`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({
+            sessionBranches: [],
+            otherBranches: [],
+            currentBranch: 'main',
+            total: 0,
+            hasMore: false,
+          });
+        })
+      );
+
+      await listBranches('ws-1', {
+        includeRemote: true,
+        limit: 50,
+        offset: 100,
+        search: 'feat',
+        sortBy: 'date',
+      });
+
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('includeRemote')).toBe('true');
+      expect(params.get('limit')).toBe('50');
+      expect(params.get('offset')).toBe('100');
+      expect(params.get('search')).toBe('feat');
+      expect(params.get('sortBy')).toBe('date');
+    });
+
+    it('serializes includeRemote=false explicitly (not omitted)', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/branches`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({
+            sessionBranches: [],
+            otherBranches: [],
+            currentBranch: 'main',
+            total: 0,
+            hasMore: false,
+          });
+        })
+      );
+
+      await listBranches('ws-1', { includeRemote: false });
+
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('includeRemote')).toBe('false');
+    });
+
+    it('skips empty search string', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/branches`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({
+            sessionBranches: [],
+            otherBranches: [],
+            currentBranch: 'main',
+            total: 0,
+            hasMore: false,
+          });
+        })
+      );
+
+      await listBranches('ws-1', { search: '' });
+      expect(capturedSearch).toBe('');
+    });
+  });
+
+  describe('resolvePR', () => {
+    const mockPRResponse: ResolvePRResponse = {
+      owner: 'anthropics',
+      repo: 'claude-code',
+      prNumber: 42,
+      title: 'Add login flow',
+      body: 'Adds OAuth login.',
+      branch: 'feature/login',
+      baseBranch: 'main',
+      state: 'open',
+      isDraft: false,
+      labels: ['enhancement'],
+      reviewers: ['alice'],
+      additions: 100,
+      deletions: 20,
+      changedFiles: 5,
+      matchedWorkspaceId: 'ws-1',
+      htmlUrl: 'https://github.com/anthropics/claude-code/pull/42',
+    };
+
+    it('POSTs the URL and returns parsed PR data', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/resolve-pr`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(mockPRResponse);
+        })
+      );
+
+      const result = await resolvePR('https://github.com/anthropics/claude-code/pull/42');
+
+      expect(capturedBody).toEqual({ url: 'https://github.com/anthropics/claude-code/pull/42' });
+      expect(result.prNumber).toBe(42);
+      expect(result.matchedWorkspaceId).toBe('ws-1');
+      expect(result.labels).toEqual(['enhancement']);
+    });
+
+    it('throws ApiError when URL is invalid', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/resolve-pr`, () =>
+          HttpResponse.json({ error: 'Invalid PR URL' }, { status: 400 })
+        )
+      );
+
+      await expect(resolvePR('not-a-url')).rejects.toBeInstanceOf(ApiError);
+      await expect(resolvePR('not-a-url')).rejects.toMatchObject({ status: 400 });
+    });
+  });
+
+  describe('analyzeBranchCleanup', () => {
+    const mockCandidate: CleanupCandidate = {
+      name: 'feature/old',
+      isRemote: false,
+      category: 'merged',
+      reason: 'Merged into main',
+      lastCommitDate: '2025-12-01T00:00:00Z',
+      lastAuthor: 'Bob',
+      hasLocalAndRemote: false,
+      isProtected: false,
+      deletable: true,
+    };
+
+    it('POSTs analysis params and returns candidates', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/branches/analyze-cleanup`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({
+              candidates: [mockCandidate],
+              summary: { merged: 1, stale: 0, orphaned: 0, safe: 0 },
+              protectedCount: 2,
+              totalAnalyzed: 5,
+            });
+          }
+        )
+      );
+
+      const result = await analyzeBranchCleanup('ws-1', {
+        staleDaysThreshold: 30,
+        includeRemote: true,
+      });
+
+      expect(capturedBody).toEqual({ staleDaysThreshold: 30, includeRemote: true });
+      expect(result.candidates).toHaveLength(1);
+      expect(result.candidates[0].category).toBe('merged');
+      expect(result.summary.merged).toBe(1);
+      expect(result.protectedCount).toBe(2);
+    });
+  });
+
+  describe('executeBranchCleanup', () => {
+    it('POSTs branch targets and returns succeeded/failed splits', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/branches/cleanup`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({
+              succeeded: [{ name: 'feature/old', deletedLocal: true, deletedRemote: false }],
+              failed: [
+                {
+                  name: 'feature/locked',
+                  deletedLocal: false,
+                  deletedRemote: false,
+                  error: 'protected branch',
+                },
+              ],
+            });
+          }
+        )
+      );
+
+      const result = await executeBranchCleanup('ws-1', [
+        { name: 'feature/old', deleteLocal: true, deleteRemote: false },
+        { name: 'feature/locked', deleteLocal: true, deleteRemote: true },
+      ]);
+
+      expect(capturedBody).toEqual({
+        branches: [
+          { name: 'feature/old', deleteLocal: true, deleteRemote: false },
+          { name: 'feature/locked', deleteLocal: true, deleteRemote: true },
+        ],
+      });
+      expect(result.succeeded).toHaveLength(1);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0].error).toBe('protected branch');
+    });
+  });
+
+  describe('getBranchSyncStatus', () => {
+    it('returns sync status with commits behind', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-sync`,
+          () =>
+            HttpResponse.json({
+              behindBy: 3,
+              commits: [
+                { sha: 'aaa1111', subject: 'fix: thing' },
+                { sha: 'bbb2222', subject: 'docs: update' },
+                { sha: 'ccc3333', subject: 'chore: bump' },
+              ],
+              baseBranch: 'main',
+              lastChecked: '2026-04-26T17:00:00Z',
+            })
+        )
+      );
+
+      const status = await getBranchSyncStatus('ws-1', 'session-1');
+
+      expect(status.behindBy).toBe(3);
+      expect(status.commits).toHaveLength(3);
+      expect(status.commits[0].subject).toBe('fix: thing');
+      expect(status.baseBranch).toBe('main');
+    });
+
+    it('returns 0 commits when up-to-date', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-sync`,
+          () =>
+            HttpResponse.json({
+              behindBy: 0,
+              commits: [],
+              baseBranch: 'main',
+              lastChecked: '2026-04-26T17:00:00Z',
+            })
+        )
+      );
+
+      const status = await getBranchSyncStatus('ws-1', 'session-1');
+      expect(status.behindBy).toBe(0);
+      expect(status.commits).toEqual([]);
+    });
+  });
+
+  describe('syncBranch', () => {
+    it('POSTs operation=rebase and returns success result', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-sync`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({
+              success: true,
+              newBaseSha: 'newbasesha123',
+            });
+          }
+        )
+      );
+
+      const result = await syncBranch('ws-1', 'session-1', 'rebase');
+
+      expect(capturedBody).toEqual({ operation: 'rebase' });
+      expect(result.success).toBe(true);
+      expect(result.newBaseSha).toBe('newbasesha123');
+    });
+
+    it('returns conflict files on failure', async () => {
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-sync`,
+          () =>
+            HttpResponse.json({
+              success: false,
+              conflictFiles: ['src/conflict.ts', 'src/other.ts'],
+              errorMessage: 'merge conflicts',
+            })
+        )
+      );
+
+      const result = await syncBranch('ws-1', 'session-1', 'merge');
+
+      expect(result.success).toBe(false);
+      expect(result.conflictFiles).toEqual(['src/conflict.ts', 'src/other.ts']);
+      expect(result.errorMessage).toBe('merge conflicts');
+    });
+  });
+
+  describe('abortBranchSync', () => {
+    it('POSTs to /abort and resolves to undefined', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-sync/abort`,
+          ({ request }) => {
+            capturedMethod = request.method;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      const result = await abortBranchSync('ws-1', 'session-1');
+
+      expect(capturedMethod).toBe('POST');
+      expect(result).toBeUndefined();
+    });
+
+    it('throws ApiError with custom message when abort fails', async () => {
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-sync/abort`,
+          () => HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(abortBranchSync('ws-1', 'session-1')).rejects.toMatchObject({
+        status: 500,
+        message: 'Failed to abort branch sync',
+      });
+    });
+  });
+});

--- a/src/lib/api/__tests__/ci.test.ts
+++ b/src/lib/api/__tests__/ci.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  getCIRuns,
+  getCIRun,
+  getCIJobs,
+  getCIJobLogs,
+  rerunCI,
+  analyzeCIFailure,
+  getCIFailureContext,
+  type WorkflowRunDTO,
+  type WorkflowJobDTO,
+  type CIAnalysisResult,
+} from '../ci';
+import { ApiError } from '../base';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockRun: WorkflowRunDTO = {
+  id: 1234,
+  name: 'CI',
+  status: 'completed',
+  conclusion: 'failure',
+  headSha: 'abc1234',
+  headBranch: 'feature/test',
+  htmlUrl: 'https://github.com/x/y/actions/runs/1234',
+  jobsUrl: 'https://api.github.com/repos/x/y/actions/runs/1234/jobs',
+  logsUrl: 'https://api.github.com/repos/x/y/actions/runs/1234/logs',
+  createdAt: '2026-04-26T10:00:00Z',
+  updatedAt: '2026-04-26T10:05:00Z',
+};
+
+const mockJob: WorkflowJobDTO = {
+  id: 5678,
+  runId: 1234,
+  name: 'test',
+  status: 'completed',
+  conclusion: 'failure',
+  startedAt: '2026-04-26T10:01:00Z',
+  completedAt: '2026-04-26T10:04:00Z',
+  htmlUrl: 'https://github.com/x/y/actions/runs/1234/jobs/5678',
+  steps: [
+    {
+      name: 'Run tests',
+      status: 'completed',
+      conclusion: 'failure',
+      number: 1,
+      startedAt: '2026-04-26T10:01:30Z',
+      completedAt: '2026-04-26T10:04:00Z',
+    },
+  ],
+};
+
+describe('lib/api/ci', () => {
+  describe('getCIRuns', () => {
+    it('returns workflow runs', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:wsId/sessions/:sId/ci/runs`, () =>
+          HttpResponse.json([mockRun])
+        )
+      );
+
+      const runs = await getCIRuns('ws-1', 'session-1');
+      expect(runs).toHaveLength(1);
+      expect(runs[0].id).toBe(1234);
+      expect(runs[0].conclusion).toBe('failure');
+    });
+
+    it('returns empty array when no runs', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:wsId/sessions/:sId/ci/runs`, () =>
+          HttpResponse.json([])
+        )
+      );
+
+      expect(await getCIRuns('ws-1', 'session-1')).toEqual([]);
+    });
+  });
+
+  describe('getCIRun', () => {
+    it('returns a single run by id', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:wsId/sessions/:sId/ci/runs/:runId`,
+          ({ request }) => {
+            capturedUrl = request.url;
+            return HttpResponse.json(mockRun);
+          }
+        )
+      );
+
+      const run = await getCIRun('ws-1', 'session-1', 1234);
+      expect(run.id).toBe(1234);
+      expect(capturedUrl).toContain('/ci/runs/1234');
+    });
+  });
+
+  describe('getCIJobs', () => {
+    it('returns jobs for a run', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:wsId/sessions/:sId/ci/runs/:runId/jobs`,
+          () => HttpResponse.json([mockJob])
+        )
+      );
+
+      const jobs = await getCIJobs('ws-1', 'session-1', 1234);
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].name).toBe('test');
+      expect(jobs[0].steps).toHaveLength(1);
+    });
+  });
+
+  describe('getCIJobLogs', () => {
+    it('returns logs for a job', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:wsId/sessions/:sId/ci/jobs/:jobId/logs`,
+          () => HttpResponse.json({ jobId: 5678, logs: 'Error: build failed\nexit 1' })
+        )
+      );
+
+      const result = await getCIJobLogs('ws-1', 'session-1', 5678);
+      expect(result.jobId).toBe(5678);
+      expect(result.logs).toContain('build failed');
+    });
+  });
+
+  describe('rerunCI', () => {
+    it('POSTs without query string by default', async () => {
+      let capturedUrl = '';
+      let capturedMethod = '';
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:wsId/sessions/:sId/ci/runs/:runId/rerun`,
+          ({ request }) => {
+            capturedUrl = request.url;
+            capturedMethod = request.method;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await rerunCI('ws-1', 'session-1', 1234);
+      expect(capturedMethod).toBe('POST');
+      expect(capturedUrl).not.toContain('failedOnly');
+    });
+
+    it('appends ?failedOnly=true when requested', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:wsId/sessions/:sId/ci/runs/:runId/rerun`,
+          ({ request }) => {
+            capturedUrl = request.url;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await rerunCI('ws-1', 'session-1', 1234, true);
+      expect(capturedUrl).toContain('?failedOnly=true');
+    });
+
+    it('throws ApiError with custom message on failure', async () => {
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:wsId/sessions/:sId/ci/runs/:runId/rerun`,
+          () => HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(rerunCI('ws-1', 'session-1', 1234)).rejects.toMatchObject({
+        status: 500,
+        message: 'Failed to rerun CI workflow',
+      });
+    });
+  });
+
+  describe('analyzeCIFailure', () => {
+    const mockAnalysis: CIAnalysisResult = {
+      errorType: 'TestFailure',
+      summary: 'Login test fails',
+      rootCause: 'Missing env var',
+      affectedFiles: ['src/login.test.ts'],
+      suggestedFix: {
+        description: 'Set OAUTH_SECRET',
+        patches: [{ file: '.env', diff: '+OAUTH_SECRET=...' }],
+      },
+      confidence: 0.85,
+    };
+
+    it('POSTs runId + jobId and returns analysis', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:wsId/sessions/:sId/ci/analyze`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json(mockAnalysis);
+          }
+        )
+      );
+
+      const result = await analyzeCIFailure('ws-1', 'session-1', 1234, 5678);
+
+      expect(capturedBody).toEqual({ runId: 1234, jobId: 5678 });
+      expect(result.errorType).toBe('TestFailure');
+      expect(result.confidence).toBe(0.85);
+      expect(result.suggestedFix?.patches).toHaveLength(1);
+    });
+
+    it('handles analysis without suggestedFix', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:wsId/sessions/:sId/ci/analyze`, () =>
+          HttpResponse.json({ ...mockAnalysis, suggestedFix: undefined })
+        )
+      );
+
+      const result = await analyzeCIFailure('ws-1', 'session-1', 1234, 5678);
+      expect(result.suggestedFix).toBeUndefined();
+    });
+
+    it('throws ApiError on backend failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:wsId/sessions/:sId/ci/analyze`, () =>
+          HttpResponse.json({ error: 'analysis failed' }, { status: 500 })
+        )
+      );
+
+      await expect(
+        analyzeCIFailure('ws-1', 'session-1', 1234, 5678)
+      ).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('getCIFailureContext', () => {
+    it('returns aggregated failure context', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:wsId/sessions/:sId/ci/failure-context`, () =>
+          HttpResponse.json({
+            branch: 'feature/test',
+            failedRuns: [
+              {
+                runId: 1234,
+                runName: 'CI',
+                runUrl: 'https://github.com/x/y/actions/runs/1234',
+                failedJobs: [
+                  {
+                    jobId: 5678,
+                    jobName: 'test',
+                    jobUrl: 'https://github.com/x/y/actions/runs/1234/jobs/5678',
+                    failedSteps: ['Run tests'],
+                    logs: 'fail line',
+                    logLines: 1,
+                    truncated: false,
+                  },
+                ],
+              },
+            ],
+            totalFailed: 1,
+            truncated: false,
+          })
+        )
+      );
+
+      const ctx = await getCIFailureContext('ws-1', 'session-1');
+      expect(ctx.branch).toBe('feature/test');
+      expect(ctx.totalFailed).toBe(1);
+      expect(ctx.failedRuns[0].failedJobs[0].failedSteps).toEqual(['Run tests']);
+    });
+  });
+});

--- a/src/lib/api/__tests__/conversations.test.ts
+++ b/src/lib/api/__tests__/conversations.test.ts
@@ -1,0 +1,614 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  toStoreConversation,
+  toStoreMessage,
+  listConversations,
+  listWorkspaceConversations,
+  getConversation,
+  getConversationMessages,
+  getMessage,
+  sendConversationMessage,
+  addSystemMessage,
+  stopConversation,
+  stopBackgroundTask,
+  getConversationDropStats,
+  getActiveStreamingConversations,
+  getStreamingSnapshot,
+  getInterruptedConversations,
+  resumeAgent,
+  clearConversationSnapshot,
+  deleteConversation,
+  setConversationFastMode,
+  setConversationMaxThinkingTokens,
+  approveTool,
+  approveBatchTools,
+  answerQAHandoff,
+  type ConversationDTO,
+  type MessageDTO,
+} from '../conversations';
+import { ApiError } from '../base';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockMessage: MessageDTO = {
+  id: 'msg-1',
+  role: 'user',
+  content: 'Hello',
+  timestamp: '2026-04-26T00:00:00Z',
+  attachments: [
+    { id: 'att-1', type: 'file', name: 'a.ts', mimeType: 'text/typescript', size: 100 },
+  ],
+  toolUsage: [{ id: 't-1', tool: 'Read', success: true }],
+  thinkingContent: 'Considering...',
+  durationMs: 1500,
+  timeline: [{ type: 'text', content: 'Hello' }],
+  planContent: 'Plan A',
+  checkpointUuid: 'ck-1',
+  embeddedInTimeline: true,
+};
+
+const mockConversation: ConversationDTO = {
+  id: 'conv-1',
+  sessionId: 'session-1',
+  type: 'task',
+  name: 'Test',
+  status: 'active',
+  model: 'claude-sonnet-4-6',
+  messages: [mockMessage],
+  messageCount: 1,
+  toolSummary: [{ id: 't-1', tool: 'Read', target: 'a.ts', success: true }],
+  createdAt: '2026-04-26T00:00:00Z',
+  updatedAt: '2026-04-26T01:00:00Z',
+};
+
+describe('lib/api/conversations', () => {
+  describe('toStoreConversation', () => {
+    it('maps DTO to store shape with messages and toolSummary', () => {
+      const result = toStoreConversation(mockConversation);
+      expect(result.id).toBe('conv-1');
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].conversationId).toBe('conv-1');
+      expect(result.toolSummary).toHaveLength(1);
+      expect(result.toolSummary[0].target).toBe('a.ts');
+    });
+
+    it('handles missing messages and toolSummary defensively', () => {
+      const dto = { ...mockConversation, messages: undefined, toolSummary: undefined } as unknown as ConversationDTO;
+      const result = toStoreConversation(dto);
+      expect(result.messages).toEqual([]);
+      expect(result.toolSummary).toEqual([]);
+    });
+  });
+
+  describe('toStoreMessage', () => {
+    it('maps message DTO with conversationId injected', () => {
+      const result = toStoreMessage(mockMessage, 'conv-99');
+      expect(result.id).toBe('msg-1');
+      expect(result.conversationId).toBe('conv-99');
+      expect(result.thinkingContent).toBe('Considering...');
+      expect(result.embeddedInTimeline).toBe(true);
+    });
+
+    it('respects compacted opt when provided', () => {
+      const result = toStoreMessage(mockMessage, 'conv-1', { compacted: true });
+      expect(result.compacted).toBe(true);
+    });
+
+    it('compacted defaults to undefined when opts omitted', () => {
+      const result = toStoreMessage(mockMessage, 'conv-1');
+      expect(result.compacted).toBeUndefined();
+    });
+  });
+
+  describe('listConversations', () => {
+    it('returns conversations for a session', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/conversations`,
+          () => HttpResponse.json([mockConversation])
+        )
+      );
+
+      const convs = await listConversations('ws-1', 'session-1');
+      expect(convs).toHaveLength(1);
+    });
+  });
+
+  describe('listWorkspaceConversations', () => {
+    it('returns conversations for a workspace', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/conversations`, () =>
+          HttpResponse.json([mockConversation])
+        )
+      );
+
+      const convs = await listWorkspaceConversations('ws-1');
+      expect(convs).toHaveLength(1);
+    });
+  });
+
+  describe('getConversation', () => {
+    it('returns single conversation by id', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId`, () =>
+          HttpResponse.json(mockConversation)
+        )
+      );
+
+      const conv = await getConversation('conv-1');
+      expect(conv.id).toBe('conv-1');
+    });
+  });
+
+  describe('getConversationMessages', () => {
+    it('returns messages with no params', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/messages`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({ messages: [mockMessage], hasMore: false, totalCount: 1 });
+        })
+      );
+
+      const page = await getConversationMessages('conv-1');
+      expect(page.messages).toHaveLength(1);
+      expect(capturedSearch).toBe('');
+    });
+
+    it('serializes before, limit, and compact mode', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/messages`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({ messages: [], hasMore: true, totalCount: 100 });
+        })
+      );
+
+      await getConversationMessages('conv-1', { before: 50, limit: 25, compact: true });
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('before')).toBe('50');
+      expect(params.get('limit')).toBe('25');
+      expect(params.get('mode')).toBe('compact');
+    });
+
+    it('does not include mode=compact when compact:false', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/messages`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({ messages: [], hasMore: false, totalCount: 0 });
+        })
+      );
+
+      await getConversationMessages('conv-1', { compact: false });
+      expect(new URLSearchParams(capturedSearch).has('mode')).toBe(false);
+    });
+
+    it('forwards AbortSignal', async () => {
+      const controller = new AbortController();
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/messages`, async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return HttpResponse.json({ messages: [], hasMore: false, totalCount: 0 });
+        })
+      );
+
+      const promise = getConversationMessages('conv-1', { signal: controller.signal });
+      controller.abort();
+      await expect(promise).rejects.toThrow();
+    });
+  });
+
+  describe('getMessage', () => {
+    it('returns single message', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/messages/:msgId`, () =>
+          HttpResponse.json(mockMessage)
+        )
+      );
+
+      const msg = await getMessage('conv-1', 'msg-1');
+      expect(msg.id).toBe('msg-1');
+    });
+  });
+
+  describe('sendConversationMessage', () => {
+    it('POSTs content alone when no options', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/messages`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await sendConversationMessage('conv-1', 'hello');
+      expect(capturedBody).toEqual({ content: 'hello' });
+    });
+
+    it('spreads options into body', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/messages`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await sendConversationMessage('conv-1', 'hi', {
+        model: 'claude-haiku-4-5',
+        planMode: true,
+        mentionedFiles: ['a.ts'],
+        messageUuid: 'msg-uuid',
+      });
+      expect(capturedBody).toEqual({
+        content: 'hi',
+        model: 'claude-haiku-4-5',
+        planMode: true,
+        mentionedFiles: ['a.ts'],
+        messageUuid: 'msg-uuid',
+      });
+    });
+
+    it('throws ApiError on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/messages`, () =>
+          HttpResponse.text('busy', { status: 503 })
+        )
+      );
+
+      await expect(sendConversationMessage('conv-1', 'hi')).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('addSystemMessage', () => {
+    it('POSTs content and returns id', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/system-message`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ id: 'sys-msg-1' });
+        })
+      );
+
+      const result = await addSystemMessage('conv-1', 'system note');
+      expect(capturedBody).toEqual({ content: 'system note' });
+      expect(result.id).toBe('sys-msg-1');
+    });
+  });
+
+  describe('stopConversation', () => {
+    it('POSTs to /stop and resolves', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/stop`, () =>
+          new HttpResponse(null, { status: 204 })
+        )
+      );
+
+      await expect(stopConversation('conv-1')).resolves.toBeUndefined();
+    });
+
+    it('throws ApiError with stop message on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/stop`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(stopConversation('conv-1')).rejects.toMatchObject({
+        message: 'Failed to stop conversation',
+      });
+    });
+  });
+
+  describe('stopBackgroundTask', () => {
+    it('POSTs to /tasks/:id/stop', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/tasks/:taskId/stop`, ({ request }) => {
+          capturedUrl = request.url;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await stopBackgroundTask('conv-1', 'task-99');
+      expect(capturedUrl).toContain('/tasks/task-99/stop');
+    });
+  });
+
+  describe('getConversationDropStats', () => {
+    it('returns droppedMessages count', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/drop-stats`, () =>
+          HttpResponse.json({ droppedMessages: 5 })
+        )
+      );
+
+      const result = await getConversationDropStats('conv-1');
+      expect(result.droppedMessages).toBe(5);
+    });
+  });
+
+  describe('getActiveStreamingConversations', () => {
+    it('returns conversation ids', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/active-streaming`, () =>
+          HttpResponse.json({ conversationIds: ['conv-1', 'conv-2'] })
+        )
+      );
+
+      const result = await getActiveStreamingConversations();
+      expect(result.conversationIds).toEqual(['conv-1', 'conv-2']);
+    });
+  });
+
+  describe('getStreamingSnapshot', () => {
+    it('returns snapshot when present', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/streaming-snapshot`, () =>
+          HttpResponse.json({
+            text: 'streaming...',
+            activeTools: [],
+            isThinking: false,
+            planModeActive: false,
+          })
+        )
+      );
+
+      const snapshot = await getStreamingSnapshot('conv-1');
+      expect(snapshot?.text).toBe('streaming...');
+    });
+  });
+
+  describe('getInterruptedConversations', () => {
+    it('returns interrupted conversations list', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/interrupted`, () =>
+          HttpResponse.json([
+            {
+              id: 'conv-1',
+              sessionId: 'session-1',
+              agentSessionId: 'agent-session-1',
+              snapshot: null,
+            },
+          ])
+        )
+      );
+
+      const result = await getInterruptedConversations();
+      expect(result).toHaveLength(1);
+      expect(result[0].agentSessionId).toBe('agent-session-1');
+    });
+  });
+
+  describe('resumeAgent', () => {
+    it('POSTs and returns status', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/resume-agent`, () =>
+          HttpResponse.json({ status: 'resumed' })
+        )
+      );
+
+      const result = await resumeAgent('conv-1');
+      expect(result.status).toBe('resumed');
+    });
+  });
+
+  describe('clearConversationSnapshot', () => {
+    it('POSTs and resolves', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/clear-snapshot`, () =>
+          new HttpResponse(null, { status: 204 })
+        )
+      );
+
+      await expect(clearConversationSnapshot('conv-1')).resolves.toBeUndefined();
+    });
+
+    it('throws ApiError with custom message on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/clear-snapshot`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(clearConversationSnapshot('conv-1')).rejects.toMatchObject({
+        message: 'Failed to clear snapshot',
+      });
+    });
+  });
+
+  describe('deleteConversation', () => {
+    it('DELETEs and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.delete(`${API_BASE}/api/conversations/:convId`, ({ request }) => {
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await deleteConversation('conv-1');
+      expect(capturedMethod).toBe('DELETE');
+    });
+  });
+
+  describe('setConversationFastMode', () => {
+    it('POSTs enabled flag', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/fast-mode`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await setConversationFastMode('conv-1', true);
+      expect(capturedBody).toEqual({ enabled: true });
+    });
+
+    it('throws ApiError on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/fast-mode`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(setConversationFastMode('conv-1', true)).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('setConversationMaxThinkingTokens', () => {
+    it('POSTs maxThinkingTokens value', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/conversations/:convId/max-thinking-tokens`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await setConversationMaxThinkingTokens('conv-1', 8000);
+      expect(capturedBody).toEqual({ maxThinkingTokens: 8000 });
+    });
+  });
+
+  describe('approveTool', () => {
+    it('POSTs requestId + action', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/approve-tool`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await approveTool('conv-1', 'req-1', 'allow_once');
+      expect(capturedBody).toEqual({ requestId: 'req-1', action: 'allow_once' });
+    });
+
+    it('includes specifier and updatedInput when provided', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/approve-tool`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await approveTool('conv-1', 'req-1', 'allow_session', 'pattern:*', { foo: 'bar' });
+      expect(capturedBody).toEqual({
+        requestId: 'req-1',
+        action: 'allow_session',
+        specifier: 'pattern:*',
+        updatedInput: { foo: 'bar' },
+      });
+    });
+
+    it('throws ApiError on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/approve-tool`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(approveTool('conv-1', 'req-1', 'deny_once')).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('approveBatchTools', () => {
+    it('POSTs without perTool when not provided', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/conversations/:convId/approve-batch-tools`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await approveBatchTools('conv-1', 'req-1', 'allow_once');
+      expect(capturedBody).toEqual({ requestId: 'req-1', action: 'allow_once' });
+    });
+
+    it('includes perTool overrides when provided', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/conversations/:convId/approve-batch-tools`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await approveBatchTools('conv-1', 'req-1', 'allow_once', {
+        Read: { action: 'allow_session', specifier: 'src/*' },
+      });
+      expect(capturedBody).toEqual({
+        requestId: 'req-1',
+        action: 'allow_once',
+        perTool: { Read: { action: 'allow_session', specifier: 'src/*' } },
+      });
+    });
+  });
+
+  describe('answerQAHandoff', () => {
+    it('POSTs requestId + completed + notes', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/conversations/:convId/answer-qa-handoff`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await answerQAHandoff('conv-1', 'req-1', true, 'all good');
+      expect(capturedBody).toEqual({
+        requestId: 'req-1',
+        completed: true,
+        notes: 'all good',
+      });
+    });
+
+    it('omits notes when undefined (still passes the key)', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/conversations/:convId/answer-qa-handoff`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await answerQAHandoff('conv-1', 'req-1', false);
+      expect(capturedBody).toMatchObject({
+        requestId: 'req-1',
+        completed: false,
+      });
+    });
+
+    it('throws ApiError on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/answer-qa-handoff`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(answerQAHandoff('conv-1', 'req-1', true)).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+});

--- a/src/lib/api/__tests__/conversations.test.ts
+++ b/src/lib/api/__tests__/conversations.test.ts
@@ -38,7 +38,12 @@ const mockMessage: MessageDTO = {
   content: 'Hello',
   timestamp: '2026-04-26T00:00:00Z',
   attachments: [
-    { id: 'att-1', type: 'file', name: 'a.ts', mimeType: 'text/typescript', size: 100 },
+    // 'text/x-typescript' (or 'application/typescript') is closer to the
+    // unregistered-but-conventional MIME for .ts files. The field isn't
+    // parsed by the API client — the value is just round-tripped — but
+    // keeping the fixture conventional avoids it becoming a copy-paste
+    // template for less informed tests.
+    { id: 'att-1', type: 'file', name: 'a.ts', mimeType: 'text/x-typescript', size: 100 },
   ],
   toolUsage: [{ id: 't-1', tool: 'Read', success: true }],
   thinkingContent: 'Considering...',
@@ -187,17 +192,13 @@ describe('lib/api/conversations', () => {
     });
 
     it('forwards AbortSignal', async () => {
+      // Abort BEFORE invoking the API so the implementation sees an
+      // already-aborted signal — no real-time race against MSW.
       const controller = new AbortController();
-      server.use(
-        http.get(`${API_BASE}/api/conversations/:convId/messages`, async () => {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return HttpResponse.json({ messages: [], hasMore: false, totalCount: 0 });
-        })
-      );
-
-      const promise = getConversationMessages('conv-1', { signal: controller.signal });
       controller.abort();
-      await expect(promise).rejects.toThrow();
+      await expect(
+        getConversationMessages('conv-1', { signal: controller.signal })
+      ).rejects.toThrow();
     });
   });
 
@@ -582,23 +583,27 @@ describe('lib/api/conversations', () => {
       });
     });
 
-    it('omits notes when undefined (still passes the key)', async () => {
-      let capturedBody: unknown;
+    it('omits the notes key from the wire body when not provided', async () => {
+      // JSON.stringify drops `undefined` values, so passing `notes: undefined`
+      // results in the key being absent from the encoded body. Pin the exact
+      // shape so a future refactor that swaps in a default (empty string,
+      // null, etc.) doesn't silently change the wire contract.
+      let capturedBody: Record<string, unknown> | undefined;
       server.use(
         http.post(
           `${API_BASE}/api/conversations/:convId/answer-qa-handoff`,
           async ({ request }) => {
-            capturedBody = await request.json();
+            capturedBody = (await request.json()) as Record<string, unknown>;
             return new HttpResponse(null, { status: 204 });
           }
         )
       );
 
       await answerQAHandoff('conv-1', 'req-1', false);
-      expect(capturedBody).toMatchObject({
-        requestId: 'req-1',
-        completed: false,
-      });
+      expect(capturedBody).toEqual({ requestId: 'req-1', completed: false });
+      expect(
+        Object.prototype.hasOwnProperty.call(capturedBody!, 'notes'),
+      ).toBe(false);
     });
 
     it('throws ApiError on failure', async () => {

--- a/src/lib/api/__tests__/file-operations.test.ts
+++ b/src/lib/api/__tests__/file-operations.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  createSessionFile,
+  createSessionFolder,
+  renameSessionFile,
+  deleteSessionFile,
+  duplicateSessionFile,
+  moveSessionFile,
+  discardSessionFileChanges,
+} from '../file-operations';
+
+const API_BASE = 'http://localhost:9876';
+const SESSION_BASE = `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId`;
+
+describe('lib/api/file-operations', () => {
+  describe('createSessionFile', () => {
+    it('POSTs path + content and returns success', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/files/create`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ success: true, path: 'src/new.ts' });
+        })
+      );
+
+      const result = await createSessionFile('ws-1', 'session-1', 'src/new.ts', 'export {};');
+
+      expect(capturedBody).toEqual({ path: 'src/new.ts', content: 'export {};' });
+      expect(result.success).toBe(true);
+      expect(result.path).toBe('src/new.ts');
+    });
+
+    it('defaults content to empty string', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/files/create`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ success: true, path: 'a.ts' });
+        })
+      );
+
+      await createSessionFile('ws-1', 'session-1', 'a.ts');
+      expect(capturedBody).toEqual({ path: 'a.ts', content: '' });
+    });
+  });
+
+  describe('createSessionFolder', () => {
+    it('POSTs path and returns success', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/folders/create`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ success: true, path: 'src/new-folder' });
+        })
+      );
+
+      const result = await createSessionFolder('ws-1', 'session-1', 'src/new-folder');
+
+      expect(capturedBody).toEqual({ path: 'src/new-folder' });
+      expect(result.path).toBe('src/new-folder');
+    });
+  });
+
+  describe('renameSessionFile', () => {
+    it('PUTs oldPath + newPath and returns success', async () => {
+      let capturedBody: unknown;
+      let capturedMethod = '';
+      server.use(
+        http.put(`${SESSION_BASE}/files/rename`, async ({ request }) => {
+          capturedMethod = request.method;
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            success: true,
+            oldPath: 'src/old.ts',
+            newPath: 'src/new.ts',
+          });
+        })
+      );
+
+      const result = await renameSessionFile('ws-1', 'session-1', 'src/old.ts', 'src/new.ts');
+
+      expect(capturedMethod).toBe('PUT');
+      expect(capturedBody).toEqual({ oldPath: 'src/old.ts', newPath: 'src/new.ts' });
+      expect(result.newPath).toBe('src/new.ts');
+    });
+  });
+
+  describe('deleteSessionFile', () => {
+    it('POSTs path with recursive=false by default', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/files/delete`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      await deleteSessionFile('ws-1', 'session-1', 'src/file.ts');
+      expect(capturedBody).toEqual({ path: 'src/file.ts', recursive: false });
+    });
+
+    it('POSTs recursive=true for folder deletion', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/files/delete`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      await deleteSessionFile('ws-1', 'session-1', 'src/folder', true);
+      expect(capturedBody).toEqual({ path: 'src/folder', recursive: true });
+    });
+  });
+
+  describe('duplicateSessionFile', () => {
+    it('POSTs sourcePath alone (backend chooses destPath)', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/files/duplicate`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ success: true, newPath: 'src/file copy.ts' });
+        })
+      );
+
+      const result = await duplicateSessionFile('ws-1', 'session-1', 'src/file.ts');
+      expect(capturedBody).toEqual({ sourcePath: 'src/file.ts', destPath: undefined });
+      expect(result.newPath).toBe('src/file copy.ts');
+    });
+
+    it('POSTs both sourcePath and destPath when given', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/files/duplicate`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ success: true, newPath: 'src/copy.ts' });
+        })
+      );
+
+      await duplicateSessionFile('ws-1', 'session-1', 'src/file.ts', 'src/copy.ts');
+      expect(capturedBody).toEqual({ sourcePath: 'src/file.ts', destPath: 'src/copy.ts' });
+    });
+  });
+
+  describe('moveSessionFile', () => {
+    it('POSTs sourcePath + destPath and returns success', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/files/move`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            success: true,
+            oldPath: 'src/old.ts',
+            newPath: 'src/dir/old.ts',
+          });
+        })
+      );
+
+      const result = await moveSessionFile('ws-1', 'session-1', 'src/old.ts', 'src/dir/old.ts');
+      expect(capturedBody).toEqual({
+        sourcePath: 'src/old.ts',
+        destPath: 'src/dir/old.ts',
+      });
+      expect(result.newPath).toBe('src/dir/old.ts');
+    });
+  });
+
+  describe('discardSessionFileChanges', () => {
+    it('POSTs path and returns success', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${SESSION_BASE}/files/discard`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      const result = await discardSessionFileChanges('ws-1', 'session-1', 'src/file.ts');
+      expect(capturedBody).toEqual({ path: 'src/file.ts' });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/lib/api/__tests__/files.test.ts
+++ b/src/lib/api/__tests__/files.test.ts
@@ -109,17 +109,13 @@ describe('lib/api/files', () => {
     });
 
     it('forwards AbortSignal', async () => {
+      // Abort BEFORE invoking so the implementation sees an already-aborted
+      // signal — no real-time race against MSW.
       const controller = new AbortController();
-      server.use(
-        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/diff`, async () => {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return HttpResponse.json(mockDiff);
-        })
-      );
-
-      const promise = getSessionFileDiff('ws-1', 'session-1', 'src/app.tsx', controller.signal);
       controller.abort();
-      await expect(promise).rejects.toThrow();
+      await expect(
+        getSessionFileDiff('ws-1', 'session-1', 'src/app.tsx', controller.signal)
+      ).rejects.toThrow();
     });
   });
 

--- a/src/lib/api/__tests__/files.test.ts
+++ b/src/lib/api/__tests__/files.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  getFileDiff,
+  getSessionFileDiff,
+  getSessionFileContent,
+  listSessionFiles,
+  listFileTabs,
+  saveFileTabs,
+  deleteFileTab,
+  fetchAttachmentData,
+  getSessionFileRawUrl,
+  getSessionFileRawAtRefUrl,
+  saveFile,
+  type FileDiffDTO,
+  type FileTabDTO,
+} from '../files';
+import { ApiError } from '../base';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockDiff: FileDiffDTO = {
+  path: 'src/app.tsx',
+  oldContent: 'old',
+  newContent: 'new',
+  oldFilename: 'src/app.tsx',
+  newFilename: 'src/app.tsx',
+  hasConflict: false,
+  isDeleted: false,
+};
+
+const mockTab: FileTabDTO = {
+  id: 'tab-1',
+  workspaceId: 'ws-1',
+  sessionId: 'session-1',
+  path: 'src/app.tsx',
+  viewMode: 'file',
+  isPinned: false,
+  position: 0,
+  openedAt: '2026-04-26T10:00:00Z',
+  lastAccessedAt: '2026-04-26T11:00:00Z',
+};
+
+describe('lib/api/files', () => {
+  describe('getFileDiff', () => {
+    it('returns diff for a repo file (no base branch)', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:repoId/diff`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json(mockDiff);
+        })
+      );
+
+      const diff = await getFileDiff('ws-1', 'src/app.tsx');
+
+      expect(diff.path).toBe('src/app.tsx');
+      expect(diff.hasConflict).toBe(false);
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('path')).toBe('src/app.tsx');
+      expect(params.has('base')).toBe(false);
+    });
+
+    it('appends base branch when provided', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:repoId/diff`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json(mockDiff);
+        })
+      );
+
+      await getFileDiff('ws-1', 'src/app.tsx', 'origin/develop');
+
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('base')).toBe('origin/develop');
+    });
+
+    it('reports conflict and truncation flags from backend', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:repoId/diff`, () =>
+          HttpResponse.json({
+            ...mockDiff,
+            hasConflict: true,
+            truncated: true,
+            unifiedDiff: '@@ -1 +1 @@\n-old\n+new',
+          })
+        )
+      );
+
+      const diff = await getFileDiff('ws-1', 'src/app.tsx');
+      expect(diff.hasConflict).toBe(true);
+      expect(diff.truncated).toBe(true);
+      expect(diff.unifiedDiff).toContain('+new');
+    });
+  });
+
+  describe('getSessionFileDiff', () => {
+    it('returns session-scoped diff', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/diff`, () =>
+          HttpResponse.json(mockDiff)
+        )
+      );
+
+      const diff = await getSessionFileDiff('ws-1', 'session-1', 'src/app.tsx');
+      expect(diff.path).toBe('src/app.tsx');
+    });
+
+    it('forwards AbortSignal', async () => {
+      const controller = new AbortController();
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/diff`, async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return HttpResponse.json(mockDiff);
+        })
+      );
+
+      const promise = getSessionFileDiff('ws-1', 'session-1', 'src/app.tsx', controller.signal);
+      controller.abort();
+      await expect(promise).rejects.toThrow();
+    });
+  });
+
+  describe('getSessionFileContent', () => {
+    it('returns file content for a session', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/file`, () =>
+          HttpResponse.json({
+            path: 'src/app.tsx',
+            name: 'app.tsx',
+            content: 'export const x = 1;',
+            size: 19,
+          })
+        )
+      );
+
+      const file = await getSessionFileContent('ws-1', 'session-1', 'src/app.tsx');
+      expect(file.content).toBe('export const x = 1;');
+      expect(file.size).toBe(19);
+    });
+
+    it('encodes file paths with special characters', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/file`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ path: 'a', name: 'a', content: '', size: 0 });
+        })
+      );
+
+      await getSessionFileContent('ws-1', 'session-1', 'src/foo bar/baz.ts');
+
+      // encodeURIComponent encodes spaces as %20, slashes as %2F
+      expect(capturedUrl).toContain('path=src%2Ffoo%20bar%2Fbaz.ts');
+    });
+  });
+
+  describe('listSessionFiles', () => {
+    it('returns flat node list when depth=all', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/files`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json([
+            { name: 'src', path: 'src', isDir: true, children: [] },
+            { name: 'app.tsx', path: 'src/app.tsx', isDir: false },
+          ]);
+        })
+      );
+
+      const nodes = await listSessionFiles('ws-1', 'session-1');
+
+      expect(nodes).toHaveLength(2);
+      expect(nodes[0].isDir).toBe(true);
+      expect(nodes[1].isDir).toBe(false);
+      expect(new URLSearchParams(capturedSearch).get('maxDepth')).toBe('all');
+    });
+
+    it('forwards numeric depth', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/files`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await listSessionFiles('ws-1', 'session-1', 2);
+      expect(new URLSearchParams(capturedSearch).get('maxDepth')).toBe('2');
+    });
+  });
+
+  describe('listFileTabs', () => {
+    it('returns tabs for a workspace', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/tabs`, () =>
+          HttpResponse.json([mockTab])
+        )
+      );
+
+      const tabs = await listFileTabs('ws-1');
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].path).toBe('src/app.tsx');
+      expect(tabs[0].viewMode).toBe('file');
+    });
+  });
+
+  describe('saveFileTabs', () => {
+    it('POSTs tabs array wrapped in { tabs }', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/tabs`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await saveFileTabs('ws-1', [mockTab]);
+      expect(capturedBody).toEqual({ tabs: [mockTab] });
+    });
+
+    it('throws ApiError on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/tabs`, () =>
+          HttpResponse.text('persist error', { status: 500 })
+        )
+      );
+
+      await expect(saveFileTabs('ws-1', [mockTab])).rejects.toBeInstanceOf(ApiError);
+      await expect(saveFileTabs('ws-1', [mockTab])).rejects.toMatchObject({ status: 500 });
+    });
+  });
+
+  describe('deleteFileTab', () => {
+    it('DELETEs the tab and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.delete(`${API_BASE}/api/repos/:workspaceId/tabs/:tabId`, ({ request }) => {
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await deleteFileTab('ws-1', 'tab-1');
+      expect(capturedMethod).toBe('DELETE');
+    });
+
+    it('throws ApiError with custom message when delete fails', async () => {
+      server.use(
+        http.delete(`${API_BASE}/api/repos/:workspaceId/tabs/:tabId`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(deleteFileTab('ws-1', 'tab-1')).rejects.toMatchObject({
+        status: 500,
+        message: 'Failed to delete file tab',
+      });
+    });
+  });
+
+  describe('fetchAttachmentData', () => {
+    it('returns base64 data when present', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/attachments/:attachmentId/data`, () =>
+          HttpResponse.json({ base64Data: 'aGVsbG8=' })
+        )
+      );
+
+      const data = await fetchAttachmentData('att-1');
+      expect(data).toBe('aGVsbG8=');
+    });
+
+    it('returns null when backend response has empty base64Data', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/attachments/:attachmentId/data`, () =>
+          HttpResponse.json({ base64Data: '' })
+        )
+      );
+
+      const data = await fetchAttachmentData('att-1');
+      expect(data).toBeNull();
+    });
+
+    it('encodes attachment IDs containing slashes', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/attachments/:attachmentId/data`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ base64Data: 'x' });
+        })
+      );
+
+      await fetchAttachmentData('namespace/id');
+      expect(capturedUrl).toContain('namespace%2Fid');
+    });
+  });
+
+  describe('getSessionFileRawUrl', () => {
+    it('builds URL without token', () => {
+      const url = getSessionFileRawUrl('ws-1', 'session-1', 'src/app.tsx');
+      expect(url).toBe(
+        `${API_BASE}/api/repos/ws-1/sessions/session-1/file-raw?path=src%2Fapp.tsx`
+      );
+    });
+
+    it('appends token when provided', () => {
+      const url = getSessionFileRawUrl('ws-1', 'session-1', 'src/app.tsx', 'tok-123');
+      const search = new URL(url).searchParams;
+      expect(search.get('path')).toBe('src/app.tsx');
+      expect(search.get('token')).toBe('tok-123');
+    });
+
+    it('omits token when null', () => {
+      const url = getSessionFileRawUrl('ws-1', 'session-1', 'src/app.tsx', null);
+      expect(new URL(url).searchParams.has('token')).toBe(false);
+    });
+  });
+
+  describe('getSessionFileRawAtRefUrl', () => {
+    it('builds URL with path and ref params', () => {
+      const url = getSessionFileRawAtRefUrl('ws-1', 'session-1', 'src/app.tsx', 'sha-99');
+      const search = new URL(url).searchParams;
+      expect(search.get('path')).toBe('src/app.tsx');
+      expect(search.get('ref')).toBe('sha-99');
+      expect(search.has('token')).toBe(false);
+    });
+
+    it('appends token when provided', () => {
+      const url = getSessionFileRawAtRefUrl(
+        'ws-1',
+        'session-1',
+        'src/app.tsx',
+        'sha-99',
+        'tok-abc'
+      );
+      expect(new URL(url).searchParams.get('token')).toBe('tok-abc');
+    });
+  });
+
+  describe('saveFile', () => {
+    it('POSTs path + content for repo-level save (no sessionId)', async () => {
+      let capturedUrl = '';
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/file/save`, async ({ request }) => {
+          capturedUrl = request.url;
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await saveFile('ws-1', 'src/app.tsx', 'export const x = 1;');
+
+      expect(capturedUrl).toBe(`${API_BASE}/api/repos/ws-1/file/save`);
+      expect(capturedBody).toEqual({ path: 'src/app.tsx', content: 'export const x = 1;' });
+    });
+
+    it('appends sessionId query param when provided', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/file/save`, ({ request }) => {
+          capturedUrl = request.url;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await saveFile('ws-1', 'src/app.tsx', 'content', 'session-1');
+      expect(capturedUrl).toContain('?sessionId=session-1');
+    });
+
+    it('encodes sessionId values with special characters', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/file/save`, ({ request }) => {
+          capturedUrl = request.url;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await saveFile('ws-1', 'a', 'b', 'session id with spaces');
+      expect(capturedUrl).toContain('sessionId=session%20id%20with%20spaces');
+    });
+
+    it('throws ApiError on backend rejection', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/file/save`, () =>
+          HttpResponse.text('disk full', { status: 507 })
+        )
+      );
+
+      await expect(saveFile('ws-1', 'a', 'b')).rejects.toMatchObject({
+        status: 507,
+        message: 'disk full',
+      });
+    });
+  });
+});

--- a/src/lib/api/__tests__/git.test.ts
+++ b/src/lib/api/__tests__/git.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  getSessionChanges,
+  getSessionBranchCommits,
+  getGitStatus,
+  getSessionSnapshot,
+  getFileCommitHistory,
+  getFileAtCommit,
+  type FileChangeDTO,
+  type BranchCommitDTO,
+  type GitStatusDTO,
+  type SessionSnapshotDTO,
+  type FileHistoryResponse,
+} from '../git';
+import { ApiError } from '../base';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockChange: FileChangeDTO = {
+  path: 'src/app.tsx',
+  additions: 5,
+  deletions: 2,
+  status: 'modified',
+};
+
+const mockCommit: BranchCommitDTO = {
+  sha: 'abc1234567890def',
+  shortSha: 'abc1234',
+  message: 'feat: add login flow',
+  author: 'Alice',
+  email: 'alice@example.com',
+  timestamp: '2026-01-15T10:00:00Z',
+  files: [mockChange],
+};
+
+const mockGitStatus: GitStatusDTO = {
+  currentBranch: 'feature/test',
+  currentSessionName: 'Test Session',
+  workingDirectory: {
+    stagedCount: 1,
+    unstagedCount: 2,
+    untrackedCount: 0,
+    totalUncommitted: 3,
+    hasChanges: true,
+  },
+  sync: {
+    aheadBy: 2,
+    behindBy: 1,
+    baseBranch: 'main',
+    remoteBranch: 'origin/feature/test',
+    hasRemote: true,
+    diverged: true,
+    unpushedCommits: 2,
+  },
+  inProgress: { type: 'none' },
+  conflicts: { hasConflicts: false, count: 0, files: [] },
+  stash: { count: 0 },
+};
+
+describe('lib/api/git', () => {
+  describe('getSessionChanges', () => {
+    it('returns file changes for a session', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/changes`, () => {
+          return HttpResponse.json([mockChange]);
+        })
+      );
+
+      const changes = await getSessionChanges('ws-1', 'session-1');
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0].path).toBe('src/app.tsx');
+      expect(changes[0].status).toBe('modified');
+    });
+
+    it('returns empty array when no changes', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/changes`, () => {
+          return HttpResponse.json([]);
+        })
+      );
+
+      const changes = await getSessionChanges('ws-1', 'session-1');
+      expect(changes).toEqual([]);
+    });
+
+    it('puts workspaceId and sessionId in the URL path', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/changes`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await getSessionChanges('my-workspace', 'sess-42');
+
+      expect(capturedUrl).toBe(`${API_BASE}/api/repos/my-workspace/sessions/sess-42/changes`);
+    });
+
+    it('throws ApiError on 404', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/changes`, () => {
+          return HttpResponse.json({ error: 'Session not found' }, { status: 404 });
+        })
+      );
+
+      await expect(getSessionChanges('ws-1', 'missing')).rejects.toBeInstanceOf(ApiError);
+      await expect(getSessionChanges('ws-1', 'missing')).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('parses backend error code from 4xx JSON body', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/changes`, () => {
+          return HttpResponse.json(
+            { error: 'Worktree gone', code: 'WORKTREE_NOT_FOUND' },
+            { status: 410 }
+          );
+        })
+      );
+
+      await expect(getSessionChanges('ws-1', 'session-1')).rejects.toMatchObject({
+        status: 410,
+        code: 'WORKTREE_NOT_FOUND',
+        message: 'Worktree gone',
+      });
+    });
+  });
+
+  describe('getSessionBranchCommits', () => {
+    it('returns commits, branch stats, and allChanges', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-commits`,
+          () => {
+            return HttpResponse.json({
+              commits: [mockCommit],
+              branchStats: { totalFiles: 1, totalAdditions: 5, totalDeletions: 2 },
+              allChanges: [mockChange],
+            });
+          }
+        )
+      );
+
+      const result = await getSessionBranchCommits('ws-1', 'session-1');
+
+      expect(result.commits).toHaveLength(1);
+      expect(result.commits[0].shortSha).toBe('abc1234');
+      expect(result.branchStats?.totalFiles).toBe(1);
+      expect(result.allChanges).toHaveLength(1);
+    });
+
+    it('handles response with only commits (no branchStats)', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-commits`,
+          () => {
+            return HttpResponse.json({ commits: [] });
+          }
+        )
+      );
+
+      const result = await getSessionBranchCommits('ws-1', 'session-1');
+      expect(result.commits).toEqual([]);
+      expect(result.branchStats).toBeUndefined();
+      expect(result.allChanges).toBeUndefined();
+    });
+
+    it('throws ApiError on 500', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branch-commits`,
+          () => HttpResponse.text('boom', { status: 500 })
+        )
+      );
+
+      await expect(getSessionBranchCommits('ws-1', 's-1')).rejects.toMatchObject({
+        status: 500,
+      });
+    });
+  });
+
+  describe('getGitStatus', () => {
+    it('returns full git status', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/git-status`, () => {
+          return HttpResponse.json(mockGitStatus);
+        })
+      );
+
+      const status = await getGitStatus('ws-1', 'session-1');
+
+      expect(status.currentBranch).toBe('feature/test');
+      expect(status.workingDirectory.totalUncommitted).toBe(3);
+      expect(status.sync.diverged).toBe(true);
+      expect(status.conflicts.hasConflicts).toBe(false);
+    });
+
+    it('handles in-progress rebase state', async () => {
+      const rebasing: GitStatusDTO = {
+        ...mockGitStatus,
+        inProgress: { type: 'rebase', current: 2, total: 5 },
+        conflicts: { hasConflicts: true, count: 1, files: ['src/conflict.ts'] },
+      };
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/git-status`, () => {
+          return HttpResponse.json(rebasing);
+        })
+      );
+
+      const status = await getGitStatus('ws-1', 'session-1');
+      expect(status.inProgress.type).toBe('rebase');
+      expect(status.inProgress.current).toBe(2);
+      expect(status.conflicts.files).toEqual(['src/conflict.ts']);
+    });
+  });
+
+  describe('getSessionSnapshot', () => {
+    const mockSnapshot: SessionSnapshotDTO = {
+      gitStatus: mockGitStatus,
+      changes: [mockChange],
+      allChanges: [mockChange],
+      commits: [mockCommit],
+      branchStats: { totalFiles: 1, totalAdditions: 5, totalDeletions: 2 },
+    };
+
+    it('returns consolidated snapshot', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/snapshot`, () => {
+          return HttpResponse.json(mockSnapshot);
+        })
+      );
+
+      const snapshot = await getSessionSnapshot('ws-1', 'session-1');
+
+      expect(snapshot.gitStatus.currentBranch).toBe('feature/test');
+      expect(snapshot.changes).toHaveLength(1);
+      expect(snapshot.commits).toHaveLength(1);
+    });
+
+    it('forwards AbortSignal so callers can cancel', async () => {
+      const controller = new AbortController();
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/snapshot`, async () => {
+          // Hold the request open until aborted
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return HttpResponse.json(mockSnapshot);
+        })
+      );
+
+      const promise = getSessionSnapshot('ws-1', 'session-1', controller.signal);
+      controller.abort();
+
+      await expect(promise).rejects.toThrow();
+    });
+
+    it('omits signal cleanly when not provided', async () => {
+      let receivedRequest: Request | undefined;
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/snapshot`, ({ request }) => {
+          receivedRequest = request;
+          return HttpResponse.json(mockSnapshot);
+        })
+      );
+
+      await getSessionSnapshot('ws-1', 'session-1');
+      expect(receivedRequest).toBeDefined();
+    });
+  });
+
+  describe('getFileCommitHistory', () => {
+    const mockHistory: FileHistoryResponse = {
+      commits: [
+        {
+          sha: 'def4567890abc123',
+          shortSha: 'def4567',
+          message: 'fix: edge case',
+          author: 'Bob',
+          email: 'bob@example.com',
+          timestamp: '2026-01-10T09:00:00Z',
+          additions: 3,
+          deletions: 1,
+        },
+      ],
+      total: 1,
+      truncated: false,
+    };
+
+    it('returns file commit history', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/file-history`,
+          () => HttpResponse.json(mockHistory)
+        )
+      );
+
+      const result = await getFileCommitHistory('ws-1', 'session-1', 'src/app.tsx');
+
+      expect(result.commits).toHaveLength(1);
+      expect(result.commits[0].shortSha).toBe('def4567');
+      expect(result.total).toBe(1);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('encodes file paths with special characters in the query', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/file-history`,
+          ({ request }) => {
+            capturedSearch = new URL(request.url).search;
+            return HttpResponse.json(mockHistory);
+          }
+        )
+      );
+
+      await getFileCommitHistory('ws-1', 'session-1', 'src/components/Foo Bar/Baz.tsx');
+
+      // URLSearchParams encodes spaces as '+' and slashes as %2F
+      expect(capturedSearch).toContain('path=');
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('path')).toBe('src/components/Foo Bar/Baz.tsx');
+    });
+
+    it('reports truncated:true when backend signals truncation', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/file-history`,
+          () =>
+            HttpResponse.json({
+              ...mockHistory,
+              total: 250,
+              truncated: true,
+            })
+        )
+      );
+
+      const result = await getFileCommitHistory('ws-1', 'session-1', 'src/app.tsx');
+      expect(result.truncated).toBe(true);
+      expect(result.total).toBe(250);
+    });
+  });
+
+  describe('getFileAtCommit', () => {
+    it('returns file content at a given commit', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/file-at-ref`,
+          () =>
+            HttpResponse.json({
+              path: 'src/app.tsx',
+              name: 'app.tsx',
+              content: 'export const x = 1;',
+              size: 19,
+            })
+        )
+      );
+
+      const file = await getFileAtCommit('ws-1', 'session-1', 'src/app.tsx', 'abc123');
+
+      expect(file.path).toBe('src/app.tsx');
+      expect(file.content).toBe('export const x = 1;');
+      expect(file.size).toBe(19);
+    });
+
+    it('passes both path and ref query params', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/file-at-ref`,
+          ({ request }) => {
+            capturedSearch = new URL(request.url).search;
+            return HttpResponse.json({
+              path: 'a',
+              name: 'a',
+              content: '',
+              size: 0,
+            });
+          }
+        )
+      );
+
+      await getFileAtCommit('ws-1', 'session-1', 'src/lib/x.ts', 'sha-99');
+
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('path')).toBe('src/lib/x.ts');
+      expect(params.get('ref')).toBe('sha-99');
+    });
+
+    it('throws ApiError on 404 (commit or file missing)', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/file-at-ref`,
+          () => HttpResponse.text('not found', { status: 404 })
+        )
+      );
+
+      await expect(
+        getFileAtCommit('ws-1', 'session-1', 'src/missing.ts', 'sha')
+      ).rejects.toMatchObject({ status: 404 });
+    });
+  });
+});

--- a/src/lib/api/__tests__/git.test.ts
+++ b/src/lib/api/__tests__/git.test.ts
@@ -241,19 +241,13 @@ describe('lib/api/git', () => {
     });
 
     it('forwards AbortSignal so callers can cancel', async () => {
+      // Abort BEFORE invoking so the implementation sees an already-aborted
+      // signal — no real-time race against MSW.
       const controller = new AbortController();
-      server.use(
-        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/snapshot`, async () => {
-          // Hold the request open until aborted
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return HttpResponse.json(mockSnapshot);
-        })
-      );
-
-      const promise = getSessionSnapshot('ws-1', 'session-1', controller.signal);
       controller.abort();
-
-      await expect(promise).rejects.toThrow();
+      await expect(
+        getSessionSnapshot('ws-1', 'session-1', controller.signal)
+      ).rejects.toThrow();
     });
 
     it('omits signal cleanly when not provided', async () => {

--- a/src/lib/api/__tests__/github.test.ts
+++ b/src/lib/api/__tests__/github.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  listGitHubIssues,
+  searchGitHubIssues,
+  getGitHubIssueDetails,
+  listGitHubRepos,
+  listGitHubOrgs,
+  resolveGitHubRepo,
+  cloneRepo,
+  type GitHubIssueListItem,
+  type GitHubRepoDTO,
+} from '../github';
+import { ApiError } from '../base';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockIssue: GitHubIssueListItem = {
+  number: 42,
+  title: 'Add login flow',
+  state: 'open',
+  htmlUrl: 'https://github.com/x/y/issues/42',
+  labels: [{ name: 'enhancement', color: '00ff00' }],
+  user: { login: 'alice', avatarUrl: 'https://avatars/alice' },
+  assignees: [{ login: 'bob', avatarUrl: 'https://avatars/bob' }],
+  comments: 3,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-04-26T00:00:00Z',
+};
+
+const mockRepo: GitHubRepoDTO = {
+  fullName: 'anthropics/claude-code',
+  name: 'claude-code',
+  owner: 'anthropics',
+  description: 'AI coding assistant',
+  language: 'TypeScript',
+  private: false,
+  fork: false,
+  stargazersCount: 1000,
+  cloneUrl: 'https://github.com/anthropics/claude-code.git',
+  sshUrl: 'git@github.com:anthropics/claude-code.git',
+  updatedAt: '2026-04-26T00:00:00Z',
+  defaultBranch: 'main',
+};
+
+describe('lib/api/github', () => {
+  describe('listGitHubIssues', () => {
+    it('returns issues for a workspace', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/issues`, () =>
+          HttpResponse.json([mockIssue])
+        )
+      );
+
+      const issues = await listGitHubIssues('ws-1');
+      expect(issues).toHaveLength(1);
+      expect(issues[0].number).toBe(42);
+      expect(issues[0].labels[0].name).toBe('enhancement');
+    });
+  });
+
+  describe('searchGitHubIssues', () => {
+    it('returns search results with totalCount', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/issues/search`, () =>
+          HttpResponse.json({ totalCount: 1, issues: [mockIssue] })
+        )
+      );
+
+      const result = await searchGitHubIssues('ws-1', 'login');
+      expect(result.totalCount).toBe(1);
+      expect(result.issues).toHaveLength(1);
+    });
+
+    it('encodes query param with special characters', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/issues/search`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({ totalCount: 0, issues: [] });
+        })
+      );
+
+      await searchGitHubIssues('ws-1', 'is:open label:bug');
+      expect(capturedSearch).toContain('q=is%3Aopen%20label%3Abug');
+    });
+  });
+
+  describe('getGitHubIssueDetails', () => {
+    it('returns issue details with body', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/issues/:issueNumber`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({
+            ...mockIssue,
+            body: 'Detailed description of the issue.',
+            milestone: { title: 'v1.0', number: 5 },
+          });
+        })
+      );
+
+      const details = await getGitHubIssueDetails('ws-1', 42);
+
+      expect(capturedUrl).toContain('/issues/42');
+      expect(details.body).toContain('Detailed');
+      expect(details.milestone?.title).toBe('v1.0');
+    });
+  });
+
+  describe('listGitHubRepos', () => {
+    it('returns repos with no params (no query string)', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/github/repos`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ repos: [mockRepo], totalCount: 1, hasMore: false });
+        })
+      );
+
+      const result = await listGitHubRepos();
+      expect(result.repos).toHaveLength(1);
+      expect(capturedUrl).toBe(`${API_BASE}/api/github/repos`);
+    });
+
+    it('serializes all supported params, including snake_case per_page', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/github/repos`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json({ repos: [], totalCount: 0, hasMore: false });
+        })
+      );
+
+      await listGitHubRepos({
+        page: 2,
+        perPage: 50,
+        sort: 'updated',
+        search: 'claude',
+        org: 'anthropics',
+        type: 'all',
+      });
+
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('page')).toBe('2');
+      expect(params.get('per_page')).toBe('50');
+      expect(params.get('sort')).toBe('updated');
+      expect(params.get('search')).toBe('claude');
+      expect(params.get('org')).toBe('anthropics');
+      expect(params.get('type')).toBe('all');
+    });
+
+    it('forwards AbortSignal', async () => {
+      const controller = new AbortController();
+      server.use(
+        http.get(`${API_BASE}/api/github/repos`, async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return HttpResponse.json({ repos: [], totalCount: 0, hasMore: false });
+        })
+      );
+
+      const promise = listGitHubRepos({ signal: controller.signal });
+      controller.abort();
+      await expect(promise).rejects.toThrow();
+    });
+  });
+
+  describe('listGitHubOrgs', () => {
+    it('returns orgs', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/github/orgs`, () =>
+          HttpResponse.json([{ login: 'anthropics', avatarUrl: 'https://avatars/anthropics' }])
+        )
+      );
+
+      const orgs = await listGitHubOrgs();
+      expect(orgs).toHaveLength(1);
+      expect(orgs[0].login).toBe('anthropics');
+    });
+  });
+
+  describe('resolveGitHubRepo', () => {
+    it('POSTs URL and returns repo info', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/github/resolve-repo`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(mockRepo);
+        })
+      );
+
+      const repo = await resolveGitHubRepo('https://github.com/anthropics/claude-code');
+      expect(capturedBody).toEqual({ url: 'https://github.com/anthropics/claude-code' });
+      expect(repo.fullName).toBe('anthropics/claude-code');
+    });
+
+    it('throws ApiError when repo URL is invalid', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/github/resolve-repo`, () =>
+          HttpResponse.json({ error: 'invalid url' }, { status: 400 })
+        )
+      );
+
+      await expect(resolveGitHubRepo('garbage')).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('cloneRepo', () => {
+    it('POSTs url + path + dirName and returns clone result', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/clone`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            path: '/Users/foo/projects/claude-code',
+            repo: {
+              id: 'r-1',
+              name: 'claude-code',
+              path: '/Users/foo/projects/claude-code',
+              branch: 'main',
+              remote: 'origin',
+              branchPrefix: 'github',
+              customPrefix: '',
+              createdAt: '2026-04-26T00:00:00Z',
+            },
+          });
+        })
+      );
+
+      const result = await cloneRepo(
+        'https://github.com/anthropics/claude-code.git',
+        '/Users/foo/projects',
+        'claude-code'
+      );
+
+      expect(capturedBody).toEqual({
+        url: 'https://github.com/anthropics/claude-code.git',
+        path: '/Users/foo/projects',
+        dirName: 'claude-code',
+      });
+      expect(result.path).toBe('/Users/foo/projects/claude-code');
+      expect(result.repo.id).toBe('r-1');
+    });
+  });
+});

--- a/src/lib/api/__tests__/github.test.ts
+++ b/src/lib/api/__tests__/github.test.ts
@@ -152,17 +152,13 @@ describe('lib/api/github', () => {
     });
 
     it('forwards AbortSignal', async () => {
+      // Abort BEFORE invoking so the implementation sees an already-aborted
+      // signal — no real-time race against MSW.
       const controller = new AbortController();
-      server.use(
-        http.get(`${API_BASE}/api/github/repos`, async () => {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return HttpResponse.json({ repos: [], totalCount: 0, hasMore: false });
-        })
-      );
-
-      const promise = listGitHubRepos({ signal: controller.signal });
       controller.abort();
-      await expect(promise).rejects.toThrow();
+      await expect(
+        listGitHubRepos({ signal: controller.signal })
+      ).rejects.toThrow();
     });
   });
 

--- a/src/lib/api/__tests__/gstack.test.ts
+++ b/src/lib/api/__tests__/gstack.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { getGstackStatus, enableGstack, disableGstack, syncGstack } from '../gstack';
+
+const API_BASE = 'http://localhost:9876';
+
+describe('lib/api/gstack', () => {
+  describe('getGstackStatus', () => {
+    it('returns status', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/gstack/status`, () =>
+          HttpResponse.json({
+            enabled: true,
+            version: '1.2.3',
+            lastSync: '2026-04-26T00:00:00Z',
+          })
+        )
+      );
+
+      const status = await getGstackStatus('ws-1');
+      expect(status.enabled).toBe(true);
+      expect(status.version).toBe('1.2.3');
+    });
+
+    it('returns disabled status with no version/lastSync', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/gstack/status`, () =>
+          HttpResponse.json({ enabled: false })
+        )
+      );
+
+      const status = await getGstackStatus('ws-1');
+      expect(status.enabled).toBe(false);
+      expect(status.version).toBeUndefined();
+    });
+  });
+
+  describe('enableGstack', () => {
+    it('POSTs and resolves on success', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/gstack/enable`, ({ request }) => {
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await enableGstack('ws-1');
+      expect(capturedMethod).toBe('POST');
+    });
+
+    it('throws ApiError with enable message on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/gstack/enable`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(enableGstack('ws-1')).rejects.toMatchObject({
+        message: 'Failed to enable gstack',
+      });
+    });
+  });
+
+  describe('disableGstack', () => {
+    it('POSTs and resolves', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/gstack/disable`, () =>
+          new HttpResponse(null, { status: 204 })
+        )
+      );
+
+      await expect(disableGstack('ws-1')).resolves.toBeUndefined();
+    });
+
+    it('throws ApiError with disable message on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/gstack/disable`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(disableGstack('ws-1')).rejects.toMatchObject({
+        message: 'Failed to disable gstack',
+      });
+    });
+  });
+
+  describe('syncGstack', () => {
+    it('POSTs and resolves', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/gstack/sync`, () =>
+          new HttpResponse(null, { status: 204 })
+        )
+      );
+
+      await expect(syncGstack('ws-1')).resolves.toBeUndefined();
+    });
+
+    it('throws ApiError with sync message on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/gstack/sync`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(syncGstack('ws-1')).rejects.toMatchObject({
+        message: 'Failed to sync gstack',
+      });
+    });
+  });
+});

--- a/src/lib/api/__tests__/health.test.ts
+++ b/src/lib/api/__tests__/health.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { checkHealth, checkHealthWithRetry } from '../health';
+
+const API_BASE = 'http://localhost:9876';
+
+describe('lib/api/health', () => {
+  describe('checkHealth', () => {
+    it('returns true on 200 OK', async () => {
+      server.use(
+        http.get(`${API_BASE}/health`, () => HttpResponse.json({ status: 'ok' }))
+      );
+
+      expect(await checkHealth()).toBe(true);
+    });
+
+    it('returns false on non-OK status', async () => {
+      server.use(
+        http.get(`${API_BASE}/health`, () =>
+          HttpResponse.text('down', { status: 503 })
+        )
+      );
+
+      expect(await checkHealth()).toBe(false);
+    });
+
+    it('returns false when fetch throws (network error)', async () => {
+      server.use(
+        http.get(`${API_BASE}/health`, () => HttpResponse.error())
+      );
+
+      expect(await checkHealth()).toBe(false);
+    });
+  });
+
+  describe('checkHealthWithRetry', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('succeeds on first attempt without delay', async () => {
+      server.use(
+        http.get(`${API_BASE}/health`, () => HttpResponse.json({ status: 'ok' }))
+      );
+
+      const onAttempt = vi.fn();
+      const result = await checkHealthWithRetry(3, 100, onAttempt);
+
+      expect(result.success).toBe(true);
+      expect(result.attempts).toBe(1);
+      expect(onAttempt).toHaveBeenCalledTimes(1);
+      expect(onAttempt).toHaveBeenCalledWith(1);
+    });
+
+    it('reports failure with attempt count after exhausting retries', async () => {
+      server.use(
+        http.get(`${API_BASE}/health`, () =>
+          HttpResponse.text('down', { status: 503 })
+        )
+      );
+
+      const onAttempt = vi.fn();
+      const result = await checkHealthWithRetry(3, 1, onAttempt);
+
+      expect(result.success).toBe(false);
+      expect(result.attempts).toBe(3);
+      expect(result.error).toBe('Backend service did not respond after multiple attempts');
+      expect(onAttempt).toHaveBeenCalledTimes(3);
+    });
+
+    it('recovers if a later attempt succeeds', async () => {
+      let callCount = 0;
+      server.use(
+        http.get(`${API_BASE}/health`, () => {
+          callCount++;
+          if (callCount < 2) {
+            return HttpResponse.text('down', { status: 503 });
+          }
+          return HttpResponse.json({ status: 'ok' });
+        })
+      );
+
+      const result = await checkHealthWithRetry(5, 1);
+      expect(result.success).toBe(true);
+      expect(result.attempts).toBe(2);
+    });
+  });
+});

--- a/src/lib/api/__tests__/linear.test.ts
+++ b/src/lib/api/__tests__/linear.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { listMyLinearIssues, searchLinearIssues, type LinearIssueDTO } from '../linear';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockIssue: LinearIssueDTO = {
+  id: 'issue-1',
+  identifier: 'ENG-42',
+  title: 'Add login flow',
+  description: 'OAuth login.',
+  stateName: 'In Progress',
+  labels: ['feature'],
+  assignee: 'alice',
+  project: 'Authentication',
+};
+
+describe('lib/api/linear', () => {
+  describe('listMyLinearIssues', () => {
+    it('returns assigned issues', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/auth/linear/issues`, () =>
+          HttpResponse.json([mockIssue])
+        )
+      );
+
+      const issues = await listMyLinearIssues();
+      expect(issues).toHaveLength(1);
+      expect(issues[0].identifier).toBe('ENG-42');
+    });
+  });
+
+  describe('searchLinearIssues', () => {
+    it('returns matching issues and encodes query', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/auth/linear/issues/search`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json([mockIssue]);
+        })
+      );
+
+      const issues = await searchLinearIssues('login flow');
+      expect(issues).toHaveLength(1);
+      expect(new URLSearchParams(capturedSearch).get('q')).toBe('login flow');
+    });
+
+    it('returns empty array when no matches', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/auth/linear/issues/search`, () =>
+          HttpResponse.json([])
+        )
+      );
+
+      expect(await searchLinearIssues('nope')).toEqual([]);
+    });
+  });
+});

--- a/src/lib/api/__tests__/mcp.test.ts
+++ b/src/lib/api/__tests__/mcp.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { getNeverLoadDotMcp, setNeverLoadDotMcp } from '../mcp';
+
+const API_BASE = 'http://localhost:9876';
+
+// getMcpServers / setMcpServers are covered by src/lib/__tests__/api.mcp.test.ts.
+// getDotMcpInfo / getDotMcpTrust / setDotMcpTrust are covered by api.dotMcpTrust.test.ts.
+// This file fills the remaining gap: never-load-dot-mcp toggle.
+
+describe('lib/api/mcp — never-load-dot-mcp', () => {
+  describe('getNeverLoadDotMcp', () => {
+    it('unwraps enabled field from response envelope (true)', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/never-load-dot-mcp`, () =>
+          HttpResponse.json({ enabled: true })
+        )
+      );
+
+      expect(await getNeverLoadDotMcp()).toBe(true);
+    });
+
+    it('unwraps enabled field (false)', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/never-load-dot-mcp`, () =>
+          HttpResponse.json({ enabled: false })
+        )
+      );
+
+      expect(await getNeverLoadDotMcp()).toBe(false);
+    });
+  });
+
+  describe('setNeverLoadDotMcp', () => {
+    it('PUTs enabled flag', async () => {
+      let capturedBody: unknown;
+      let capturedMethod = '';
+      server.use(
+        http.put(`${API_BASE}/api/settings/never-load-dot-mcp`, async ({ request }) => {
+          capturedMethod = request.method;
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await setNeverLoadDotMcp(true);
+      expect(capturedMethod).toBe('PUT');
+      expect(capturedBody).toEqual({ enabled: true });
+    });
+
+    it('PUTs enabled=false', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/api/settings/never-load-dot-mcp`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await setNeverLoadDotMcp(false);
+      expect(capturedBody).toEqual({ enabled: false });
+    });
+  });
+});

--- a/src/lib/api/__tests__/memory.test.ts
+++ b/src/lib/api/__tests__/memory.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  listMemoryFiles,
+  getMemoryFile,
+  saveMemoryFile,
+  deleteMemoryFile,
+} from '../memory';
+
+const API_BASE = 'http://localhost:9876';
+
+describe('lib/api/memory', () => {
+  describe('listMemoryFiles', () => {
+    it('returns memory file infos', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/memory`, () =>
+          HttpResponse.json([
+            { name: 'CLAUDE.md', size: 1024 },
+            { name: 'notes.md', size: 512 },
+          ])
+        )
+      );
+
+      const files = await listMemoryFiles('ws-1');
+      expect(files).toHaveLength(2);
+      expect(files[0].name).toBe('CLAUDE.md');
+      expect(files[0].size).toBe(1024);
+    });
+  });
+
+  describe('getMemoryFile', () => {
+    it('returns file content', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/memory/file`, () =>
+          HttpResponse.json({
+            name: 'CLAUDE.md',
+            content: '# Project notes',
+            size: 15,
+          })
+        )
+      );
+
+      const file = await getMemoryFile('ws-1', 'CLAUDE.md');
+      expect(file.content).toBe('# Project notes');
+    });
+
+    it('encodes file names with special characters', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/memory/file`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ name: 'a', content: '', size: 0 });
+        })
+      );
+
+      await getMemoryFile('ws-1', 'foo bar.md');
+      expect(capturedUrl).toContain('name=foo%20bar.md');
+    });
+  });
+
+  describe('saveMemoryFile', () => {
+    it('PUTs name + content and resolves', async () => {
+      let capturedMethod = '';
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/memory/file`, async ({ request }) => {
+          capturedMethod = request.method;
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await saveMemoryFile('ws-1', 'CLAUDE.md', '# updated');
+
+      expect(capturedMethod).toBe('PUT');
+      expect(capturedBody).toEqual({ name: 'CLAUDE.md', content: '# updated' });
+    });
+
+    it('throws ApiError with save message on failure', async () => {
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/memory/file`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(saveMemoryFile('ws-1', 'CLAUDE.md', '')).rejects.toMatchObject({
+        message: 'Failed to save memory file',
+      });
+    });
+  });
+
+  describe('deleteMemoryFile', () => {
+    it('DELETEs with name query param and resolves', async () => {
+      let capturedSearch = '';
+      let capturedMethod = '';
+      server.use(
+        http.delete(`${API_BASE}/api/repos/:workspaceId/memory/file`, ({ request }) => {
+          capturedMethod = request.method;
+          capturedSearch = new URL(request.url).search;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await deleteMemoryFile('ws-1', 'old.md');
+      expect(capturedMethod).toBe('DELETE');
+      expect(new URLSearchParams(capturedSearch).get('name')).toBe('old.md');
+    });
+
+    it('throws ApiError with delete message on failure', async () => {
+      server.use(
+        http.delete(`${API_BASE}/api/repos/:workspaceId/memory/file`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(deleteMemoryFile('ws-1', 'old.md')).rejects.toMatchObject({
+        message: 'Failed to delete memory file',
+      });
+    });
+  });
+});

--- a/src/lib/api/__tests__/pr.test.ts
+++ b/src/lib/api/__tests__/pr.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  getPRStatus,
+  refreshPRStatus,
+  unlinkPR,
+  getPRs,
+  postCommitStatus,
+  getCommitStatuses,
+  type PRDetails,
+  type PRDashboardItem,
+} from '../pr';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockPR: PRDetails = {
+  number: 42,
+  state: 'open',
+  title: 'Add login flow',
+  body: 'Adds OAuth.',
+  htmlUrl: 'https://github.com/x/y/pull/42',
+  merged: false,
+  mergeable: true,
+  mergeableState: 'clean',
+  checkStatus: 'success',
+  checkDetails: [
+    { name: 'CI / test', status: 'completed', conclusion: 'success', durationSeconds: 90 },
+  ],
+  reviewDecision: 'approved',
+  requestedReviewers: 0,
+};
+
+describe('lib/api/pr', () => {
+  describe('getPRStatus', () => {
+    it('returns PR details on success', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () =>
+          HttpResponse.json(mockPR)
+        )
+      );
+
+      const pr = await getPRStatus('ws-1', 'session-1');
+      expect(pr?.number).toBe(42);
+      expect(pr?.checkStatus).toBe('success');
+    });
+
+    it('returns null on 404 (no PR linked)', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () =>
+          HttpResponse.text('', { status: 404 })
+        )
+      );
+
+      const pr = await getPRStatus('ws-1', 'session-1');
+      expect(pr).toBeNull();
+    });
+
+    it('throws ApiError on 500 (not silently null)', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-status`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(getPRStatus('ws-1', 'session-1')).rejects.toMatchObject({ status: 500 });
+    });
+  });
+
+  describe('refreshPRStatus', () => {
+    it('POSTs and resolves regardless of status (fire-and-forget)', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-refresh`, ({ request }) => {
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 202 });
+        })
+      );
+
+      await refreshPRStatus('ws-1', 'session-1');
+      expect(capturedMethod).toBe('POST');
+    });
+  });
+
+  describe('unlinkPR', () => {
+    it('POSTs and resolves on success', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr/unlink`,
+          ({ request }) => {
+            capturedMethod = request.method;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await unlinkPR('ws-1', 'session-1');
+      expect(capturedMethod).toBe('POST');
+    });
+
+    it('throws ApiError with custom message on failure', async () => {
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr/unlink`,
+          () => HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(unlinkPR('ws-1', 'session-1')).rejects.toMatchObject({
+        message: 'Failed to unlink pull request',
+      });
+    });
+  });
+
+  describe('getPRs', () => {
+    const mockDashboardItem: PRDashboardItem = {
+      number: 42,
+      title: 'Add login',
+      state: 'open',
+      htmlUrl: 'https://github.com/x/y/pull/42',
+      isDraft: false,
+      mergeable: true,
+      mergeableState: 'clean',
+      checkStatus: 'success',
+      checkDetails: [],
+      labels: [{ name: 'enhancement', color: '00ff00' }],
+      branch: 'feature/login',
+      baseBranch: 'main',
+      sessionId: 'session-1',
+      sessionName: 'Login flow',
+      workspaceId: 'ws-1',
+      workspaceName: 'My Project',
+      repoOwner: 'anthropics',
+      repoName: 'claude-code',
+      checksTotal: 3,
+      checksPassed: 3,
+      checksFailed: 0,
+    };
+
+    it('returns dashboard items without workspace filter', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/prs`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([mockDashboardItem]);
+        })
+      );
+
+      const prs = await getPRs();
+      expect(prs).toHaveLength(1);
+      expect(capturedUrl).toBe(`${API_BASE}/api/prs`);
+    });
+
+    it('appends ?workspaceId when provided', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/prs`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await getPRs('ws-1');
+      expect(capturedUrl).toContain('?workspaceId=ws-1');
+    });
+  });
+
+  describe('postCommitStatus', () => {
+    it('POSTs status payload and returns response', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/status`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({
+              id: 1,
+              state: 'success',
+              description: 'all good',
+              context: 'ci/test',
+              targetUrl: 'https://ci/run/1',
+              createdAt: '2026-04-26T00:00:00Z',
+              creator: { login: 'bot', avatarUrl: 'https://avatars/bot' },
+            });
+          }
+        )
+      );
+
+      const result = await postCommitStatus('ws-1', 'session-1', {
+        state: 'success',
+        description: 'all good',
+        context: 'ci/test',
+        targetUrl: 'https://ci/run/1',
+      });
+
+      expect(capturedBody).toEqual({
+        state: 'success',
+        description: 'all good',
+        context: 'ci/test',
+        targetUrl: 'https://ci/run/1',
+      });
+      expect(result.id).toBe(1);
+      expect(result.state).toBe('success');
+      expect(result.creator?.login).toBe('bot');
+    });
+  });
+
+  describe('getCommitStatuses', () => {
+    it('returns combined status with all status entries', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/statuses`,
+          () =>
+            HttpResponse.json({
+              state: 'success',
+              totalCount: 2,
+              statuses: [
+                {
+                  id: 1,
+                  state: 'success',
+                  description: 'tests pass',
+                  context: 'ci/test',
+                  createdAt: '2026-04-26T00:00:00Z',
+                },
+                {
+                  id: 2,
+                  state: 'success',
+                  description: 'lint pass',
+                  context: 'ci/lint',
+                  createdAt: '2026-04-26T00:01:00Z',
+                },
+              ],
+            })
+        )
+      );
+
+      const result = await getCommitStatuses('ws-1', 'session-1');
+      expect(result.state).toBe('success');
+      expect(result.totalCount).toBe(2);
+      expect(result.statuses).toHaveLength(2);
+    });
+  });
+});

--- a/src/lib/api/__tests__/repositories.test.ts
+++ b/src/lib/api/__tests__/repositories.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  listRepos,
+  addRepo,
+  deleteRepo,
+  getRepoDetails,
+  updateRepoSettings,
+  getRepoRemotes,
+  listRepoFiles,
+  getRepoFileContent,
+  type RepoDTO,
+} from '../repositories';
+import { ApiError } from '../base';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockRepo: RepoDTO = {
+  id: 'r-1',
+  name: 'claude-code',
+  path: '/Users/foo/code',
+  branch: 'main',
+  remote: 'origin',
+  branchPrefix: 'github',
+  customPrefix: '',
+  createdAt: '2026-04-26T00:00:00Z',
+};
+
+describe('lib/api/repositories', () => {
+  describe('listRepos', () => {
+    it('returns repos', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos`, () => HttpResponse.json([mockRepo]))
+      );
+
+      const repos = await listRepos();
+      expect(repos).toHaveLength(1);
+      expect(repos[0].id).toBe('r-1');
+    });
+  });
+
+  describe('addRepo', () => {
+    it('POSTs path and returns the created repo', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/repos`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(mockRepo);
+        })
+      );
+
+      const repo = await addRepo('/Users/foo/code');
+      expect(capturedBody).toEqual({ path: '/Users/foo/code' });
+      expect(repo.id).toBe('r-1');
+    });
+
+    it('throws ApiError on backend failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/repos`, () =>
+          HttpResponse.json({ error: 'not a git repo' }, { status: 400 })
+        )
+      );
+
+      await expect(addRepo('/tmp/not-a-repo')).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('deleteRepo', () => {
+    it('DELETEs by id and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.delete(`${API_BASE}/api/repos/:id`, ({ request }) => {
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await deleteRepo('r-1');
+      expect(capturedMethod).toBe('DELETE');
+    });
+
+    it('throws ApiError with custom message on failure', async () => {
+      server.use(
+        http.delete(`${API_BASE}/api/repos/:id`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(deleteRepo('r-1')).rejects.toMatchObject({
+        status: 500,
+        message: 'Failed to delete workspace',
+      });
+    });
+  });
+
+  describe('getRepoDetails', () => {
+    it('returns details with optional GitHub fields', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:id/details`, () =>
+          HttpResponse.json({
+            ...mockRepo,
+            remoteUrl: 'https://github.com/anthropics/claude-code.git',
+            githubOwner: 'anthropics',
+            githubRepo: 'claude-code',
+            workspacesPath: '/Users/foo/code/.worktrees',
+          })
+        )
+      );
+
+      const details = await getRepoDetails('r-1');
+      expect(details.githubOwner).toBe('anthropics');
+      expect(details.workspacesPath).toBe('/Users/foo/code/.worktrees');
+    });
+
+    it('returns details without GitHub fields when not a GitHub repo', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:id/details`, () => HttpResponse.json(mockRepo))
+      );
+
+      const details = await getRepoDetails('r-1');
+      expect(details.githubOwner).toBeUndefined();
+      expect(details.remoteUrl).toBeUndefined();
+    });
+  });
+
+  describe('updateRepoSettings', () => {
+    it('PATCHes the settings and returns the updated repo', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.patch(`${API_BASE}/api/repos/:id`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ ...mockRepo, branchPrefix: 'custom' });
+        })
+      );
+
+      const updated = await updateRepoSettings('r-1', {
+        branchPrefix: 'custom',
+        customPrefix: 'jira',
+      });
+
+      expect(capturedBody).toEqual({ branchPrefix: 'custom', customPrefix: 'jira' });
+      expect(updated.branchPrefix).toBe('custom');
+    });
+  });
+
+  describe('getRepoRemotes', () => {
+    it('returns remotes and per-remote branches', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:id/remotes`, () =>
+          HttpResponse.json({
+            remotes: ['origin', 'upstream'],
+            branches: {
+              origin: ['main', 'develop'],
+              upstream: ['main'],
+            },
+          })
+        )
+      );
+
+      const remotes = await getRepoRemotes('r-1');
+      expect(remotes.remotes).toEqual(['origin', 'upstream']);
+      expect(remotes.branches.origin).toEqual(['main', 'develop']);
+    });
+  });
+
+  describe('listRepoFiles', () => {
+    it('lists files at default depth=1', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:repoId/files`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json([
+            { name: 'src', path: 'src', isDir: true, children: [] },
+          ]);
+        })
+      );
+
+      const nodes = await listRepoFiles('r-1');
+      expect(nodes).toHaveLength(1);
+      expect(new URLSearchParams(capturedSearch).get('depth')).toBe('1');
+    });
+
+    it("forwards depth='all'", async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:repoId/files`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await listRepoFiles('r-1', 'all');
+      expect(new URLSearchParams(capturedSearch).get('depth')).toBe('all');
+    });
+  });
+
+  describe('getRepoFileContent', () => {
+    it('returns file content', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:repoId/file`, () =>
+          HttpResponse.json({
+            path: 'src/app.tsx',
+            name: 'app.tsx',
+            content: 'export const x = 1;',
+            size: 19,
+          })
+        )
+      );
+
+      const file = await getRepoFileContent('r-1', 'src/app.tsx');
+      expect(file.content).toBe('export const x = 1;');
+    });
+
+    it('encodes file paths with special characters', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:repoId/file`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ path: 'a', name: 'a', content: '', size: 0 });
+        })
+      );
+
+      await getRepoFileContent('r-1', 'src/foo bar/baz.ts');
+      expect(capturedUrl).toContain('path=src%2Ffoo%20bar%2Fbaz.ts');
+    });
+  });
+});

--- a/src/lib/api/__tests__/scheduled-tasks.test.ts
+++ b/src/lib/api/__tests__/scheduled-tasks.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  listAllScheduledTasks,
+  listScheduledTasks,
+  createScheduledTask,
+  getScheduledTask,
+  updateScheduledTask,
+  deleteScheduledTask,
+  listScheduledTaskRuns,
+  triggerScheduledTask,
+} from '../scheduled-tasks';
+import type { ScheduledTask, ScheduledTaskRun } from '@/lib/types';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockTask = {
+  id: 'task-1',
+  workspaceId: 'ws-1',
+  name: 'Nightly review',
+  prompt: 'Review the latest changes',
+  frequency: 'daily',
+  scheduleHour: 23,
+  scheduleMinute: 0,
+  createdAt: '2026-04-26T00:00:00Z',
+  updatedAt: '2026-04-26T00:00:00Z',
+} as unknown as ScheduledTask;
+
+const mockTaskRun = {
+  id: 'run-1',
+  taskId: 'task-1',
+  status: 'completed',
+  startedAt: '2026-04-26T23:00:00Z',
+  completedAt: '2026-04-26T23:05:00Z',
+} as unknown as ScheduledTaskRun;
+
+describe('lib/api/scheduled-tasks', () => {
+  describe('listAllScheduledTasks', () => {
+    it('returns all scheduled tasks across workspaces', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/scheduled-tasks`, () =>
+          HttpResponse.json([mockTask])
+        )
+      );
+
+      const tasks = await listAllScheduledTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].id).toBe('task-1');
+    });
+  });
+
+  describe('listScheduledTasks', () => {
+    it('returns tasks for a workspace', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/scheduled-tasks`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([mockTask]);
+        })
+      );
+
+      const tasks = await listScheduledTasks('ws-1');
+      expect(tasks).toHaveLength(1);
+      expect(capturedUrl).toContain('/repos/ws-1/scheduled-tasks');
+    });
+  });
+
+  describe('createScheduledTask', () => {
+    it('POSTs task data and returns created task', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/scheduled-tasks`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(mockTask);
+        })
+      );
+
+      const result = await createScheduledTask('ws-1', {
+        name: 'Nightly review',
+        prompt: 'Review the latest changes',
+        frequency: 'daily',
+        scheduleHour: 23,
+        scheduleMinute: 0,
+      });
+
+      expect(capturedBody).toEqual({
+        name: 'Nightly review',
+        prompt: 'Review the latest changes',
+        frequency: 'daily',
+        scheduleHour: 23,
+        scheduleMinute: 0,
+      });
+      expect(result.id).toBe('task-1');
+    });
+  });
+
+  describe('getScheduledTask', () => {
+    it('returns a single task by id', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/scheduled-tasks/:taskId`, () =>
+          HttpResponse.json(mockTask)
+        )
+      );
+
+      const task = await getScheduledTask('task-1');
+      expect(task.id).toBe('task-1');
+    });
+  });
+
+  describe('updateScheduledTask', () => {
+    it('PATCHes partial updates and returns updated task', async () => {
+      let capturedBody: unknown;
+      let capturedMethod = '';
+      server.use(
+        http.patch(`${API_BASE}/api/scheduled-tasks/:taskId`, async ({ request }) => {
+          capturedMethod = request.method;
+          capturedBody = await request.json();
+          return HttpResponse.json({ ...mockTask, name: 'Updated' });
+        })
+      );
+
+      const result = await updateScheduledTask('task-1', { name: 'Updated' });
+      expect(capturedMethod).toBe('PATCH');
+      expect(capturedBody).toEqual({ name: 'Updated' });
+      expect((result as { name?: string }).name).toBe('Updated');
+    });
+  });
+
+  describe('deleteScheduledTask', () => {
+    it('DELETEs and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.delete(`${API_BASE}/api/scheduled-tasks/:taskId`, ({ request }) => {
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await deleteScheduledTask('task-1');
+      expect(capturedMethod).toBe('DELETE');
+    });
+  });
+
+  describe('listScheduledTaskRuns', () => {
+    it('returns runs without limit param', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/scheduled-tasks/:taskId/runs`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([mockTaskRun]);
+        })
+      );
+
+      const runs = await listScheduledTaskRuns('task-1');
+      expect(runs).toHaveLength(1);
+      expect(capturedUrl).toBe(`${API_BASE}/api/scheduled-tasks/task-1/runs`);
+    });
+
+    it('appends ?limit when provided', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/scheduled-tasks/:taskId/runs`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await listScheduledTaskRuns('task-1', 25);
+      expect(new URLSearchParams(capturedSearch).get('limit')).toBe('25');
+    });
+  });
+
+  describe('triggerScheduledTask', () => {
+    it('POSTs to /trigger and returns the new run', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(`${API_BASE}/api/scheduled-tasks/:taskId/trigger`, ({ request }) => {
+          capturedMethod = request.method;
+          return HttpResponse.json(mockTaskRun);
+        })
+      );
+
+      const run = await triggerScheduledTask('task-1');
+      expect(capturedMethod).toBe('POST');
+      expect(run.id).toBe('run-1');
+    });
+  });
+});

--- a/src/lib/api/__tests__/scripts.test.ts
+++ b/src/lib/api/__tests__/scripts.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  getWorkspaceConfig,
+  updateWorkspaceConfig,
+  detectWorkspaceConfig,
+  runScript,
+  rerunSetupScripts,
+  stopScript,
+  getScriptRuns,
+} from '../scripts';
+import type { ChatMLConfig, ScriptRun } from '@/lib/types';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockConfig = {
+  scripts: {
+    setup: [{ key: 'install', command: 'pnpm install' }],
+    dev: { key: 'dev', command: 'pnpm dev' },
+  },
+} as unknown as ChatMLConfig;
+
+const mockRun = {
+  id: 'run-1',
+  scriptKey: 'install',
+  status: 'completed',
+  startedAt: '2026-04-26T10:00:00Z',
+  completedAt: '2026-04-26T10:01:00Z',
+} as unknown as ScriptRun;
+
+describe('lib/api/scripts', () => {
+  describe('getWorkspaceConfig', () => {
+    it('returns workspace config', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/config`, () =>
+          HttpResponse.json(mockConfig)
+        )
+      );
+
+      const config = await getWorkspaceConfig('ws-1');
+      expect(config).toEqual(mockConfig);
+    });
+  });
+
+  describe('updateWorkspaceConfig', () => {
+    it('PUTs config and returns updated', async () => {
+      let capturedBody: unknown;
+      let capturedMethod = '';
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/config`, async ({ request }) => {
+          capturedMethod = request.method;
+          capturedBody = await request.json();
+          return HttpResponse.json(mockConfig);
+        })
+      );
+
+      await updateWorkspaceConfig('ws-1', mockConfig);
+      expect(capturedMethod).toBe('PUT');
+      expect(capturedBody).toEqual(mockConfig);
+    });
+  });
+
+  describe('detectWorkspaceConfig', () => {
+    it('returns auto-detected config', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/config/detect`, () =>
+          HttpResponse.json(mockConfig)
+        )
+      );
+
+      const config = await detectWorkspaceConfig('ws-1');
+      expect(config).toEqual(mockConfig);
+    });
+  });
+
+  describe('runScript', () => {
+    it('POSTs scriptKey and returns runId', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/scripts/run`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({ runId: 'run-42' });
+          }
+        )
+      );
+
+      const result = await runScript('ws-1', 'session-1', 'install');
+      expect(capturedBody).toEqual({ scriptKey: 'install' });
+      expect(result.runId).toBe('run-42');
+    });
+  });
+
+  describe('rerunSetupScripts', () => {
+    it('POSTs and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/scripts/setup`,
+          ({ request }) => {
+            capturedMethod = request.method;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await rerunSetupScripts('ws-1', 'session-1');
+      expect(capturedMethod).toBe('POST');
+    });
+
+    it('throws ApiError with custom message on failure', async () => {
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/scripts/setup`,
+          () => HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(rerunSetupScripts('ws-1', 'session-1')).rejects.toMatchObject({
+        status: 500,
+        message: 'Failed to start setup scripts',
+      });
+    });
+  });
+
+  describe('stopScript', () => {
+    it('POSTs runId and resolves', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/scripts/stop`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await stopScript('ws-1', 'session-1', 'run-42');
+      expect(capturedBody).toEqual({ runId: 'run-42' });
+    });
+
+    it('throws ApiError with stop message on failure', async () => {
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/scripts/stop`,
+          () => HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(stopScript('ws-1', 'session-1', 'run-42')).rejects.toMatchObject({
+        message: 'Failed to stop script',
+      });
+    });
+  });
+
+  describe('getScriptRuns', () => {
+    it('returns script runs', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/scripts/runs`,
+          () => HttpResponse.json([mockRun])
+        )
+      );
+
+      const runs = await getScriptRuns('ws-1', 'session-1');
+      expect(runs).toHaveLength(1);
+      expect(runs[0].id).toBe('run-1');
+    });
+  });
+});

--- a/src/lib/api/__tests__/sessions.test.ts
+++ b/src/lib/api/__tests__/sessions.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  mapSessionDTO,
+  listSessions,
+  listAllSessions,
+  createSession,
+  updateSession,
+  deleteSession,
+  preflightCheck,
+  getCurrentBranch,
+  createBranch,
+  switchBranch,
+  deleteBranch,
+  listStashes,
+  createStash,
+  applyStash,
+  popStash,
+  dropStash,
+  sendSessionMessage,
+  listReviewScorecards,
+  type SessionDTO,
+  type StashEntry,
+  type ReviewScorecardDTO,
+} from '../sessions';
+import { ApiError } from '../base';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockSessionDTO: SessionDTO = {
+  id: 'session-1',
+  workspaceId: 'ws-1',
+  name: 'Test',
+  branch: 'feature/test',
+  worktreePath: '/tmp/wt',
+  task: 'Add login',
+  status: 'idle',
+  priority: 1,
+  taskStatus: 'in_progress',
+  agentId: 'agent-1',
+  stats: { additions: 10, deletions: 5 },
+  prStatus: 'open',
+  prNumber: 42,
+  sessionType: 'worktree',
+  pinned: false,
+  archived: false,
+  createdAt: '2026-04-26T00:00:00Z',
+  updatedAt: '2026-04-26T01:00:00Z',
+};
+
+describe('lib/api/sessions', () => {
+  describe('mapSessionDTO', () => {
+    it('maps full DTO into WorktreeSession with priority/taskStatus narrowed', () => {
+      const result = mapSessionDTO(mockSessionDTO);
+      expect(result.id).toBe('session-1');
+      expect(result.priority).toBe(1);
+      expect(result.taskStatus).toBe('in_progress');
+      expect(result.stats?.additions).toBe(10);
+      expect(result.archiveSummaryStatus).toBe('');
+    });
+
+    it('falls back to defaults when priority is missing', () => {
+      const dto = { ...mockSessionDTO, priority: undefined as unknown as number };
+      const result = mapSessionDTO(dto);
+      expect(result.priority).toBe(0);
+    });
+
+    it("falls back to 'backlog' when taskStatus is missing", () => {
+      const dto = { ...mockSessionDTO, taskStatus: undefined as unknown as string };
+      const result = mapSessionDTO(dto);
+      expect(result.taskStatus).toBe('backlog');
+    });
+
+    it('preserves archiveSummaryStatus when provided', () => {
+      const result = mapSessionDTO({ ...mockSessionDTO, archiveSummaryStatus: 'completed' });
+      expect(result.archiveSummaryStatus).toBe('completed');
+    });
+  });
+
+  describe('listAllSessions', () => {
+    it('returns all sessions across workspaces', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/sessions`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([mockSessionDTO]);
+        })
+      );
+
+      const sessions = await listAllSessions();
+      expect(sessions).toHaveLength(1);
+      expect(capturedUrl).toBe(`${API_BASE}/api/sessions`);
+    });
+
+    it('appends ?includeArchived=true', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/sessions`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await listAllSessions(true);
+      expect(capturedUrl).toContain('?includeArchived=true');
+    });
+  });
+
+  describe('createSession', () => {
+    it('POSTs default empty body', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(mockSessionDTO);
+        })
+      );
+
+      await createSession('ws-1');
+      expect(capturedBody).toEqual({});
+    });
+
+    it('POSTs all session fields when provided', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/repos/:workspaceId/sessions`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(mockSessionDTO);
+        })
+      );
+
+      await createSession('ws-1', {
+        name: 'Test',
+        branch: 'feature/test',
+        branchPrefix: 'feature',
+        task: 'Add login',
+        sessionType: 'worktree',
+      });
+
+      expect(capturedBody).toEqual({
+        name: 'Test',
+        branch: 'feature/test',
+        branchPrefix: 'feature',
+        task: 'Add login',
+        sessionType: 'worktree',
+      });
+    });
+  });
+
+  describe('listSessions', () => {
+    it('omits archived param by default', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await listSessions('ws-1');
+      expect(capturedUrl).not.toContain('includeArchived');
+    });
+
+    it('appends ?includeArchived=true', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await listSessions('ws-1', true);
+      expect(capturedUrl).toContain('?includeArchived=true');
+    });
+  });
+
+  describe('updateSession', () => {
+    it('returns null on 204 (session deleted)', async () => {
+      server.use(
+        http.patch(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId`, () =>
+          new HttpResponse(null, { status: 204 })
+        )
+      );
+
+      const result = await updateSession('ws-1', 'session-1', { archived: true });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteSession', () => {
+    it('DELETEs and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.delete(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId`, ({ request }) => {
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await deleteSession('ws-1', 'session-1');
+      expect(capturedMethod).toBe('DELETE');
+    });
+
+    it('throws ApiError with delete message on failure', async () => {
+      server.use(
+        http.delete(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(deleteSession('ws-1', 'session-1')).rejects.toMatchObject({
+        message: 'Failed to delete session',
+      });
+    });
+  });
+
+  describe('preflightCheck', () => {
+    it('returns ok=true for clean workspace', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/preflight`, () =>
+          HttpResponse.json({ ok: true })
+        )
+      );
+
+      const result = await preflightCheck('ws-1', 'session-1');
+      expect(result.ok).toBe(true);
+    });
+
+    it('reports active rebase + corruption flags', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/preflight`, () =>
+          HttpResponse.json({
+            ok: false,
+            activeRebase: true,
+            corruptedIndex: true,
+            errorMessage: 'rebase in progress',
+          })
+        )
+      );
+
+      const result = await preflightCheck('ws-1', 'session-1');
+      expect(result.ok).toBe(false);
+      expect(result.activeRebase).toBe(true);
+      expect(result.errorMessage).toBe('rebase in progress');
+    });
+  });
+
+  describe('getCurrentBranch', () => {
+    it('returns current branch name', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/current-branch`,
+          () => HttpResponse.json({ branch: 'feature/test' })
+        )
+      );
+
+      const result = await getCurrentBranch('ws-1', 'session-1');
+      expect(result.branch).toBe('feature/test');
+    });
+  });
+
+  describe('createBranch', () => {
+    it('POSTs name + startPoint', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branches/create`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({ branch: 'feature/new' });
+          }
+        )
+      );
+
+      await createBranch('ws-1', 'session-1', 'feature/new', 'main');
+      expect(capturedBody).toEqual({ name: 'feature/new', startPoint: 'main' });
+    });
+
+    it('omits startPoint when not provided', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branches/create`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({ branch: 'feature/new' });
+          }
+        )
+      );
+
+      await createBranch('ws-1', 'session-1', 'feature/new');
+      expect(capturedBody).toEqual({ name: 'feature/new' });
+    });
+  });
+
+  describe('switchBranch', () => {
+    it('POSTs branch name and returns confirmed branch', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branches/switch`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({ branch: 'main' });
+          }
+        )
+      );
+
+      const result = await switchBranch('ws-1', 'session-1', 'main');
+      expect(capturedBody).toEqual({ branch: 'main' });
+      expect(result.branch).toBe('main');
+    });
+  });
+
+  describe('deleteBranch', () => {
+    it('encodes branch names with slashes', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.delete(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branches/:branchName`,
+          ({ request }) => {
+            capturedUrl = request.url;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await deleteBranch('ws-1', 'session-1', 'feature/test');
+      expect(capturedUrl).toContain('/branches/feature%2Ftest');
+    });
+
+    it('throws ApiError with delete-branch message on failure', async () => {
+      server.use(
+        http.delete(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/branches/:branchName`,
+          () => HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(deleteBranch('ws-1', 'session-1', 'feature/test')).rejects.toMatchObject({
+        message: 'Failed to delete branch',
+      });
+    });
+  });
+
+  describe('stashes', () => {
+    const mockStash: StashEntry = { index: 0, branch: 'main', message: 'WIP' };
+
+    it('listStashes returns stash entries', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/stashes`,
+          () => HttpResponse.json([mockStash])
+        )
+      );
+
+      const stashes = await listStashes('ws-1', 'session-1');
+      expect(stashes).toHaveLength(1);
+      expect(stashes[0].message).toBe('WIP');
+    });
+
+    it('createStash POSTs message + includeUntracked', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/stashes`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await createStash('ws-1', 'session-1', 'WIP', true);
+      expect(capturedBody).toEqual({ message: 'WIP', includeUntracked: true });
+    });
+
+    it('createStash throws ApiError on failure', async () => {
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/stashes`,
+          () => HttpResponse.text('cannot stash', { status: 500 })
+        )
+      );
+
+      await expect(createStash('ws-1', 'session-1')).rejects.toBeInstanceOf(ApiError);
+    });
+
+    it('applyStash POSTs to /apply at given index', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/stashes/:index/apply`,
+          ({ request }) => {
+            capturedUrl = request.url;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await applyStash('ws-1', 'session-1', 2);
+      expect(capturedUrl).toContain('/stashes/2/apply');
+    });
+
+    it('popStash POSTs to /pop at given index', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/stashes/:index/pop`,
+          ({ request }) => {
+            capturedUrl = request.url;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await popStash('ws-1', 'session-1', 0);
+      expect(capturedUrl).toContain('/stashes/0/pop');
+    });
+
+    it('dropStash DELETEs at given index', async () => {
+      let capturedMethod = '';
+      let capturedUrl = '';
+      server.use(
+        http.delete(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/stashes/:index`,
+          ({ request }) => {
+            capturedMethod = request.method;
+            capturedUrl = request.url;
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await dropStash('ws-1', 'session-1', 1);
+      expect(capturedMethod).toBe('DELETE');
+      expect(capturedUrl).toContain('/stashes/1');
+    });
+  });
+
+  describe('sendSessionMessage', () => {
+    it('POSTs content', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/message`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      await sendSessionMessage('ws-1', 'session-1', 'hello');
+      expect(capturedBody).toEqual({ content: 'hello' });
+    });
+
+    it('throws ApiError on failure', async () => {
+      server.use(
+        http.post(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/message`,
+          () => HttpResponse.text('busy', { status: 503 })
+        )
+      );
+
+      await expect(sendSessionMessage('ws-1', 'session-1', 'hi')).rejects.toBeInstanceOf(
+        ApiError
+      );
+    });
+  });
+
+  describe('listReviewScorecards', () => {
+    it('returns scorecards', async () => {
+      const scorecard: ReviewScorecardDTO = {
+        id: 'sc-1',
+        sessionId: 'session-1',
+        reviewType: 'code-review',
+        scores: '[]',
+        summary: 'LGTM',
+        createdAt: '2026-04-26T00:00:00Z',
+      };
+
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/review-scorecards`,
+          () => HttpResponse.json([scorecard])
+        )
+      );
+
+      const scorecards = await listReviewScorecards('ws-1', 'session-1');
+      expect(scorecards).toHaveLength(1);
+      expect(scorecards[0].summary).toBe('LGTM');
+    });
+  });
+});

--- a/src/lib/api/__tests__/settings.test.ts
+++ b/src/lib/api/__tests__/settings.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  getEnvSettings,
+  getClaudeEnv,
+  setEnvSettings,
+  getAnthropicApiKey,
+  getClaudeAuthStatus,
+  setAnthropicApiKey,
+  getGitHubPersonalToken,
+  setGitHubPersonalToken,
+  refreshAWSCredentials,
+  getAWSSSOTokenStatus,
+  startRelayPairing,
+  cancelRelayPairing,
+  getRelayStatus,
+  disconnectRelay,
+} from '../settings';
+
+const API_BASE = 'http://localhost:9876';
+
+describe('lib/api/settings', () => {
+  describe('getEnvSettings', () => {
+    it('unwraps envVars from response envelope', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/env`, () =>
+          HttpResponse.json({ envVars: 'FOO=bar\nBAZ=qux' })
+        )
+      );
+
+      const result = await getEnvSettings();
+      expect(result).toBe('FOO=bar\nBAZ=qux');
+    });
+  });
+
+  describe('getClaudeEnv', () => {
+    it('unwraps env record from response envelope', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/claude-env`, () =>
+          HttpResponse.json({ env: { FOO: 'bar', BAZ: 'qux' } })
+        )
+      );
+
+      const result = await getClaudeEnv();
+      expect(result).toEqual({ FOO: 'bar', BAZ: 'qux' });
+    });
+  });
+
+  describe('setEnvSettings', () => {
+    it('PUTs envVars and resolves', async () => {
+      let capturedBody: unknown;
+      let capturedMethod = '';
+      server.use(
+        http.put(`${API_BASE}/api/settings/env`, async ({ request }) => {
+          capturedMethod = request.method;
+          capturedBody = await request.json();
+          return HttpResponse.json({});
+        })
+      );
+
+      await setEnvSettings('FOO=bar');
+      expect(capturedMethod).toBe('PUT');
+      expect(capturedBody).toEqual({ envVars: 'FOO=bar' });
+    });
+  });
+
+  describe('Anthropic API key', () => {
+    it('getAnthropicApiKey returns configured + maskedKey', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/anthropic-api-key`, () =>
+          HttpResponse.json({ configured: true, maskedKey: 'sk-...abc' })
+        )
+      );
+
+      const result = await getAnthropicApiKey();
+      expect(result.configured).toBe(true);
+      expect(result.maskedKey).toBe('sk-...abc');
+    });
+
+    it('setAnthropicApiKey PUTs apiKey and returns updated mask', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/api/settings/anthropic-api-key`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ configured: true, maskedKey: 'sk-...new' });
+        })
+      );
+
+      const result = await setAnthropicApiKey('sk-real-key');
+      expect(capturedBody).toEqual({ apiKey: 'sk-real-key' });
+      expect(result.maskedKey).toBe('sk-...new');
+    });
+  });
+
+  describe('getClaudeAuthStatus', () => {
+    it('returns auth status across credential sources', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/claude-auth-status`, () =>
+          HttpResponse.json({
+            configured: true,
+            hasStoredKey: false,
+            hasEnvKey: true,
+            hasCliCredentials: false,
+            hasBedrock: false,
+            credentialSource: 'env',
+          })
+        )
+      );
+
+      const status = await getClaudeAuthStatus();
+      expect(status.configured).toBe(true);
+      expect(status.credentialSource).toBe('env');
+      expect(status.hasEnvKey).toBe(true);
+    });
+  });
+
+  describe('GitHub personal token', () => {
+    it('getGitHubPersonalToken returns configured + maskedToken + username', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/github-personal-token`, () =>
+          HttpResponse.json({ configured: true, maskedToken: 'ghp_...xyz', username: 'alice' })
+        )
+      );
+
+      const result = await getGitHubPersonalToken();
+      expect(result.username).toBe('alice');
+    });
+
+    it('setGitHubPersonalToken PUTs token and returns updated info', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/api/settings/github-personal-token`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            configured: true,
+            maskedToken: 'ghp_...new',
+            username: 'alice',
+          });
+        })
+      );
+
+      await setGitHubPersonalToken('ghp_real');
+      expect(capturedBody).toEqual({ token: 'ghp_real' });
+    });
+  });
+
+  describe('AWS SSO', () => {
+    it('refreshAWSCredentials POSTs and returns status', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(`${API_BASE}/api/settings/aws-auth-refresh`, ({ request }) => {
+          capturedMethod = request.method;
+          return HttpResponse.json({ status: 'refreshed' });
+        })
+      );
+
+      const result = await refreshAWSCredentials();
+      expect(capturedMethod).toBe('POST');
+      expect(result.status).toBe('refreshed');
+    });
+
+    it('getAWSSSOTokenStatus returns full status', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/aws-sso-token-status`, () =>
+          HttpResponse.json({
+            applicable: true,
+            valid: true,
+            expiresAt: '2026-04-26T12:00:00Z',
+            expiresInMinutes: 30,
+          })
+        )
+      );
+
+      const status = await getAWSSSOTokenStatus();
+      expect(status.applicable).toBe(true);
+      expect(status.valid).toBe(true);
+      expect(status.expiresInMinutes).toBe(30);
+    });
+
+    it('getAWSSSOTokenStatus handles non-applicable case', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/aws-sso-token-status`, () =>
+          HttpResponse.json({ applicable: false, valid: null })
+        )
+      );
+
+      const status = await getAWSSSOTokenStatus();
+      expect(status.applicable).toBe(false);
+      expect(status.valid).toBeNull();
+    });
+  });
+
+  describe('Relay pairing', () => {
+    it('startRelayPairing POSTs relayUrl and returns token + qrData', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`${API_BASE}/api/relay/pair/start`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ token: 'tok-1', qrData: 'data:image/...' });
+        })
+      );
+
+      const result = await startRelayPairing('https://relay.example.com');
+      expect(capturedBody).toEqual({ relayUrl: 'https://relay.example.com' });
+      expect(result.token).toBe('tok-1');
+    });
+
+    it('cancelRelayPairing POSTs and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(`${API_BASE}/api/relay/pair/cancel`, ({ request }) => {
+          capturedMethod = request.method;
+          return HttpResponse.json({});
+        })
+      );
+
+      await cancelRelayPairing();
+      expect(capturedMethod).toBe('POST');
+    });
+
+    it('getRelayStatus returns connection details', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/relay/status`, () =>
+          HttpResponse.json({
+            connected: true,
+            paired: true,
+            relayUrl: 'https://relay.example.com',
+          })
+        )
+      );
+
+      const status = await getRelayStatus();
+      expect(status.connected).toBe(true);
+      expect(status.relayUrl).toBe('https://relay.example.com');
+    });
+
+    it('disconnectRelay POSTs and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(`${API_BASE}/api/relay/disconnect`, ({ request }) => {
+          capturedMethod = request.method;
+          return HttpResponse.json({});
+        })
+      );
+
+      await disconnectRelay();
+      expect(capturedMethod).toBe('POST');
+    });
+  });
+});

--- a/src/lib/api/__tests__/skills.test.ts
+++ b/src/lib/api/__tests__/skills.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  listSkills,
+  listInstalledSkills,
+  installSkill,
+  uninstallSkill,
+  getSkillContent,
+  listUserCommands,
+  getAvailableAgents,
+  getEnabledAgents,
+  setEnabledAgents,
+  type SkillDTO,
+  type AvailableAgentDTO,
+} from '../skills';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockSkill: SkillDTO = {
+  id: 'skill-1',
+  name: 'Code Review',
+  description: 'Reviews code for best practices.',
+  category: 'quality',
+  author: 'anthropic',
+  version: '1.0.0',
+  preview: 'Use when reviewing code...',
+  skillPath: 'plugins/code-review',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+  installed: false,
+};
+
+describe('lib/api/skills', () => {
+  describe('listSkills', () => {
+    it('returns all skills with no params (no query string)', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/skills`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([mockSkill]);
+        })
+      );
+
+      const skills = await listSkills();
+      expect(skills).toHaveLength(1);
+      expect(capturedUrl).toBe(`${API_BASE}/api/skills`);
+    });
+
+    it('appends category and search params', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/skills`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await listSkills({ category: 'quality', search: 'review' });
+      const params = new URLSearchParams(capturedSearch);
+      expect(params.get('category')).toBe('quality');
+      expect(params.get('search')).toBe('review');
+    });
+
+    it('forwards AbortSignal', async () => {
+      const controller = new AbortController();
+      server.use(
+        http.get(`${API_BASE}/api/skills`, async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return HttpResponse.json([]);
+        })
+      );
+
+      const promise = listSkills(undefined, controller.signal);
+      controller.abort();
+      await expect(promise).rejects.toThrow();
+    });
+  });
+
+  describe('listInstalledSkills', () => {
+    it('returns installed skills', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/skills/installed`, () =>
+          HttpResponse.json([{ ...mockSkill, installed: true, installedAt: '2026-04-01T00:00:00Z' }])
+        )
+      );
+
+      const skills = await listInstalledSkills();
+      expect(skills[0].installed).toBe(true);
+      expect(skills[0].installedAt).toBe('2026-04-01T00:00:00Z');
+    });
+  });
+
+  describe('installSkill', () => {
+    it('POSTs to /install and resolves', async () => {
+      let capturedUrl = '';
+      let capturedMethod = '';
+      server.use(
+        http.post(`${API_BASE}/api/skills/:skillId/install`, ({ request }) => {
+          capturedUrl = request.url;
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await installSkill('skill-1');
+      expect(capturedMethod).toBe('POST');
+      expect(capturedUrl).toContain('/skills/skill-1/install');
+    });
+
+    it('throws ApiError with install message on failure', async () => {
+      server.use(
+        http.post(`${API_BASE}/api/skills/:skillId/install`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(installSkill('skill-1')).rejects.toMatchObject({
+        status: 500,
+        message: 'Failed to install skill',
+      });
+    });
+  });
+
+  describe('uninstallSkill', () => {
+    it('DELETEs and resolves', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.delete(`${API_BASE}/api/skills/:skillId/uninstall`, ({ request }) => {
+          capturedMethod = request.method;
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await uninstallSkill('skill-1');
+      expect(capturedMethod).toBe('DELETE');
+    });
+
+    it('throws ApiError with uninstall message on failure', async () => {
+      server.use(
+        http.delete(`${API_BASE}/api/skills/:skillId/uninstall`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(uninstallSkill('skill-1')).rejects.toMatchObject({
+        status: 500,
+        message: 'Failed to uninstall skill',
+      });
+    });
+  });
+
+  describe('getSkillContent', () => {
+    it('returns skill markdown content', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/skills/:skillId/content`, () =>
+          HttpResponse.json({
+            id: 'skill-1',
+            name: 'Code Review',
+            skillPath: 'plugins/code-review',
+            content: '# Code Review\n\nUse this when reviewing code.',
+          })
+        )
+      );
+
+      const content = await getSkillContent('skill-1');
+      expect(content.id).toBe('skill-1');
+      expect(content.content).toContain('# Code Review');
+    });
+  });
+
+  describe('listUserCommands', () => {
+    it('returns user commands for a session', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/commands`,
+          ({ request }) => {
+            capturedUrl = request.url;
+            return HttpResponse.json([
+              {
+                name: 'deploy',
+                description: 'Deploy to production',
+                filePath: '.claude/commands/deploy.md',
+                content: 'Run the deploy script',
+              },
+            ]);
+          }
+        )
+      );
+
+      const commands = await listUserCommands('ws-1', 'session-1');
+      expect(commands).toHaveLength(1);
+      expect(commands[0].name).toBe('deploy');
+      expect(capturedUrl).toContain('/sessions/session-1/commands');
+    });
+  });
+
+  describe('getAvailableAgents', () => {
+    it('returns available agents', async () => {
+      const agent: AvailableAgentDTO = {
+        name: 'code-reviewer',
+        description: 'Reviews code',
+        model: 'claude-sonnet-4-6',
+        tools: ['Read', 'Grep'],
+        enabledDefault: true,
+      };
+      server.use(
+        http.get(`${API_BASE}/api/settings/available-agents`, () =>
+          HttpResponse.json([agent])
+        )
+      );
+
+      const agents = await getAvailableAgents();
+      expect(agents).toHaveLength(1);
+      expect(agents[0].name).toBe('code-reviewer');
+      expect(agents[0].tools).toEqual(['Read', 'Grep']);
+    });
+  });
+
+  describe('getEnabledAgents', () => {
+    it('returns array of enabled agent names', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/settings/enabled-agents`, () =>
+          HttpResponse.json(['code-reviewer', 'security-audit'])
+        )
+      );
+
+      const enabled = await getEnabledAgents('ws-1');
+      expect(enabled).toEqual(['code-reviewer', 'security-audit']);
+    });
+  });
+
+  describe('setEnabledAgents', () => {
+    it('PUTs the array and returns the saved list', async () => {
+      let capturedBody: unknown;
+      let capturedMethod = '';
+      server.use(
+        http.put(
+          `${API_BASE}/api/repos/:workspaceId/settings/enabled-agents`,
+          async ({ request }) => {
+            capturedMethod = request.method;
+            capturedBody = await request.json();
+            return HttpResponse.json(['code-reviewer']);
+          }
+        )
+      );
+
+      const result = await setEnabledAgents('ws-1', ['code-reviewer']);
+      expect(capturedMethod).toBe('PUT');
+      expect(capturedBody).toEqual(['code-reviewer']);
+      expect(result).toEqual(['code-reviewer']);
+    });
+  });
+});

--- a/src/lib/api/__tests__/skills.test.ts
+++ b/src/lib/api/__tests__/skills.test.ts
@@ -63,17 +63,13 @@ describe('lib/api/skills', () => {
     });
 
     it('forwards AbortSignal', async () => {
+      // Abort BEFORE invoking so the implementation sees an already-aborted
+      // signal — no real-time race against MSW.
       const controller = new AbortController();
-      server.use(
-        http.get(`${API_BASE}/api/skills`, async () => {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return HttpResponse.json([]);
-        })
-      );
-
-      const promise = listSkills(undefined, controller.signal);
       controller.abort();
-      await expect(promise).rejects.toThrow();
+      await expect(
+        listSkills(undefined, controller.signal)
+      ).rejects.toThrow();
     });
   });
 

--- a/src/lib/api/__tests__/stats.test.ts
+++ b/src/lib/api/__tests__/stats.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { getSpendStats } from '../stats';
+import type { SpendStats } from '@/lib/types';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockStats = {
+  totalSpend: 12.34,
+  byModel: { 'claude-sonnet-4-6': 10.0, 'claude-haiku-4-5': 2.34 },
+  byDay: [{ date: '2026-04-25', amount: 5.0 }],
+} as unknown as SpendStats;
+
+describe('lib/api/stats', () => {
+  describe('getSpendStats', () => {
+    it('returns spend stats with no day filter (no query string)', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(`${API_BASE}/api/stats/spend`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(mockStats);
+        })
+      );
+
+      const stats = await getSpendStats();
+      expect(stats).toEqual(mockStats);
+      expect(capturedUrl).toBe(`${API_BASE}/api/stats/spend`);
+    });
+
+    it('appends ?days when provided', async () => {
+      let capturedSearch = '';
+      server.use(
+        http.get(`${API_BASE}/api/stats/spend`, ({ request }) => {
+          capturedSearch = new URL(request.url).search;
+          return HttpResponse.json(mockStats);
+        })
+      );
+
+      await getSpendStats(7);
+      expect(new URLSearchParams(capturedSearch).get('days')).toBe('7');
+    });
+  });
+});

--- a/src/lib/api/__tests__/summaries.test.ts
+++ b/src/lib/api/__tests__/summaries.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  generateSummary,
+  getConversationSummary,
+  listSessionSummaries,
+  type SummaryDTO,
+} from '../summaries';
+
+const API_BASE = 'http://localhost:9876';
+
+const mockSummary: SummaryDTO = {
+  id: 'sum-1',
+  conversationId: 'conv-1',
+  sessionId: 'session-1',
+  conversationName: 'Login flow',
+  content: 'Implemented OAuth login with Google.',
+  status: 'completed',
+  messageCount: 24,
+  createdAt: '2026-04-26T00:00:00Z',
+};
+
+describe('lib/api/summaries', () => {
+  describe('generateSummary', () => {
+    it('POSTs to conversation summary endpoint and returns generated summary', async () => {
+      let capturedMethod = '';
+      server.use(
+        http.post(`${API_BASE}/api/conversations/:convId/summary`, ({ request }) => {
+          capturedMethod = request.method;
+          return HttpResponse.json({ ...mockSummary, status: 'generating' });
+        })
+      );
+
+      const summary = await generateSummary('conv-1');
+      expect(capturedMethod).toBe('POST');
+      expect(summary.status).toBe('generating');
+    });
+  });
+
+  describe('getConversationSummary', () => {
+    it('returns existing summary', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/summary`, () =>
+          HttpResponse.json(mockSummary)
+        )
+      );
+
+      const summary = await getConversationSummary('conv-1');
+      expect(summary?.content).toContain('OAuth');
+    });
+
+    it('returns null on 404 (no summary yet)', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/summary`, () =>
+          HttpResponse.text('', { status: 404 })
+        )
+      );
+
+      const summary = await getConversationSummary('conv-1');
+      expect(summary).toBeNull();
+    });
+
+    it('throws ApiError on 500 (not silently returns null)', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/conversations/:convId/summary`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(getConversationSummary('conv-1')).rejects.toMatchObject({ status: 500 });
+    });
+  });
+
+  describe('listSessionSummaries', () => {
+    it('returns summaries for a session', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/summaries`,
+          () => HttpResponse.json([mockSummary])
+        )
+      );
+
+      const summaries = await listSessionSummaries('ws-1', 'session-1');
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0].id).toBe('sum-1');
+    });
+
+    it('returns empty array when no summaries exist', async () => {
+      server.use(
+        http.get(
+          `${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/summaries`,
+          () => HttpResponse.json([])
+        )
+      );
+
+      expect(await listSessionSummaries('ws-1', 'session-1')).toEqual([]);
+    });
+  });
+});

--- a/src/lib/api/__tests__/templates.test.ts
+++ b/src/lib/api/__tests__/templates.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import {
+  getPRTemplate,
+  setPRTemplate,
+  getGlobalPRTemplate,
+  setGlobalPRTemplate,
+  getGlobalReviewPrompts,
+  setGlobalReviewPrompts,
+  getWorkspaceReviewPrompts,
+  setWorkspaceReviewPrompts,
+  getGlobalActionTemplates,
+  setGlobalActionTemplates,
+  getWorkspaceActionTemplates,
+  setWorkspaceActionTemplates,
+  getCustomInstructions,
+  setCustomInstructions,
+} from '../templates';
+
+const API_BASE = 'http://localhost:9876';
+
+describe('lib/api/templates', () => {
+  describe('PR template (workspace-scoped)', () => {
+    it('getPRTemplate unwraps template field', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/settings/pr-template`, () =>
+          HttpResponse.json({ template: '## Summary\n\n...' })
+        )
+      );
+
+      expect(await getPRTemplate('ws-1')).toBe('## Summary\n\n...');
+    });
+
+    it('setPRTemplate PUTs template and resolves', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/settings/pr-template`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await setPRTemplate('ws-1', '## new');
+      expect(capturedBody).toEqual({ template: '## new' });
+    });
+
+    it('setPRTemplate throws ApiError with custom message on failure', async () => {
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/settings/pr-template`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(setPRTemplate('ws-1', '')).rejects.toMatchObject({
+        message: 'Failed to save PR template',
+      });
+    });
+  });
+
+  describe('PR template (global)', () => {
+    it('getGlobalPRTemplate unwraps template field', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/pr-template`, () =>
+          HttpResponse.json({ template: 'global ## summary' })
+        )
+      );
+
+      expect(await getGlobalPRTemplate()).toBe('global ## summary');
+    });
+
+    it('setGlobalPRTemplate PUTs template', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/api/settings/pr-template`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await setGlobalPRTemplate('## g');
+      expect(capturedBody).toEqual({ template: '## g' });
+    });
+  });
+
+  describe('Review prompts', () => {
+    const mockPrompts = { 'code-review': 'Review code...', security: 'Audit...' };
+
+    it('getGlobalReviewPrompts unwraps prompts record', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/review-prompts`, () =>
+          HttpResponse.json({ prompts: mockPrompts })
+        )
+      );
+
+      expect(await getGlobalReviewPrompts()).toEqual(mockPrompts);
+    });
+
+    it('setGlobalReviewPrompts PUTs prompts record', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/api/settings/review-prompts`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await setGlobalReviewPrompts(mockPrompts);
+      expect(capturedBody).toEqual({ prompts: mockPrompts });
+    });
+
+    it('getWorkspaceReviewPrompts unwraps prompts record', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/settings/review-prompts`, () =>
+          HttpResponse.json({ prompts: mockPrompts })
+        )
+      );
+
+      expect(await getWorkspaceReviewPrompts('ws-1')).toEqual(mockPrompts);
+    });
+
+    it('setWorkspaceReviewPrompts PUTs prompts and throws ApiError on failure', async () => {
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/settings/review-prompts`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(setWorkspaceReviewPrompts('ws-1', {})).rejects.toMatchObject({
+        message: 'Failed to save workspace review prompts',
+      });
+    });
+  });
+
+  describe('Action templates', () => {
+    const mockTemplates = { commit: 'Commit msg...', pr: 'PR template...' };
+
+    it('getGlobalActionTemplates unwraps templates record', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/action-templates`, () =>
+          HttpResponse.json({ templates: mockTemplates })
+        )
+      );
+
+      expect(await getGlobalActionTemplates()).toEqual(mockTemplates);
+    });
+
+    it('setGlobalActionTemplates PUTs templates record', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/api/settings/action-templates`, async ({ request }) => {
+          capturedBody = await request.json();
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await setGlobalActionTemplates(mockTemplates);
+      expect(capturedBody).toEqual({ templates: mockTemplates });
+    });
+
+    it('getWorkspaceActionTemplates unwraps templates record', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/repos/:workspaceId/settings/action-templates`, () =>
+          HttpResponse.json({ templates: mockTemplates })
+        )
+      );
+
+      expect(await getWorkspaceActionTemplates('ws-1')).toEqual(mockTemplates);
+    });
+
+    it('setWorkspaceActionTemplates throws ApiError on failure', async () => {
+      server.use(
+        http.put(`${API_BASE}/api/repos/:workspaceId/settings/action-templates`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(setWorkspaceActionTemplates('ws-1', {})).rejects.toMatchObject({
+        message: 'Failed to save workspace action templates',
+      });
+    });
+  });
+
+  describe('Custom instructions', () => {
+    it('getCustomInstructions unwraps instructions field', async () => {
+      server.use(
+        http.get(`${API_BASE}/api/settings/custom-instructions`, () =>
+          HttpResponse.json({ instructions: 'Always use TS strict mode.' })
+        )
+      );
+
+      expect(await getCustomInstructions()).toBe('Always use TS strict mode.');
+    });
+
+    it('setCustomInstructions PUTs instructions and throws ApiError on failure', async () => {
+      server.use(
+        http.put(`${API_BASE}/api/settings/custom-instructions`, () =>
+          HttpResponse.text('', { status: 500 })
+        )
+      );
+
+      await expect(setCustomInstructions('hi')).rejects.toMatchObject({
+        message: 'Failed to save custom instructions',
+      });
+    });
+  });
+});

--- a/src/lib/plate-content.ts
+++ b/src/lib/plate-content.ts
@@ -16,8 +16,14 @@ export function extractContent(value: Value): {
   const parts: string[] = [];
   const mentionedFiles: string[] = [];
 
+  // Defensive depth cap. Plate's own pipeline limits depth, but content can
+  // arrive from external clipboard / drag-drop sources, and an unbounded
+  // recursion would blow the stack on a pathological / cyclic Value.
+  const MAX_DEPTH = 200;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plate nodes have dynamic structure
-  const processNode = (node: any) => {
+  const processNode = (node: any, depth: number = 0) => {
+    if (depth > MAX_DEPTH) return;
     if (node.text !== undefined) {
       parts.push(node.text);
     } else if (node.type === 'mention') {
@@ -26,7 +32,8 @@ export function extractContent(value: Value): {
         mentionedFiles.push(node.value);
       }
     } else if (node.children) {
-      node.children.forEach(processNode);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plate nodes have dynamic structure
+      node.children.forEach((child: any) => processNode(child, depth + 1));
     }
   };
 

--- a/src/lib/plate-content.ts
+++ b/src/lib/plate-content.ts
@@ -1,0 +1,42 @@
+import type { Value } from 'platejs';
+
+/**
+ * Extract plain text and mentioned file IDs from a Plate.js value tree.
+ *
+ * Walks the node tree, concatenating text content and capturing mention values
+ * separately so the caller can attach mentioned files to outgoing messages.
+ *
+ * Performance: uses array-join instead of string concatenation, which keeps
+ * deeply-nested or large pasted content from quadratic copy cost.
+ */
+export function extractContent(value: Value): {
+  text: string;
+  mentionedFiles: string[];
+} {
+  const parts: string[] = [];
+  const mentionedFiles: string[] = [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plate nodes have dynamic structure
+  const processNode = (node: any) => {
+    if (node.text !== undefined) {
+      parts.push(node.text);
+    } else if (node.type === 'mention') {
+      parts.push(`@${node.value}`);
+      if (node.value) {
+        mentionedFiles.push(node.value);
+      }
+    } else if (node.children) {
+      node.children.forEach(processNode);
+    }
+  };
+
+  value.forEach((node, index) => {
+    processNode(node);
+    // Add newline between paragraphs (except after last one)
+    if (index < value.length - 1) {
+      parts.push('\n');
+    }
+  });
+
+  return { text: parts.join('').trim(), mentionedFiles };
+}

--- a/src/stores/__tests__/appStore.activeTools.test.ts
+++ b/src/stores/__tests__/appStore.activeTools.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAppStore } from '../appStore';
+import type { ActiveTool, SubAgent, BackgroundTask } from '@/lib/types';
+
+const CONV = 'conv-1';
+
+function makeTool(overrides: Partial<ActiveTool> = {}): ActiveTool {
+  return {
+    id: `t-${Math.random().toString(36).slice(2, 7)}`,
+    tool: 'Read',
+    startTime: Date.now(),
+    ...overrides,
+  } as ActiveTool;
+}
+
+function makeSubAgent(overrides: Partial<SubAgent> = {}): SubAgent {
+  return {
+    agentId: `a-${Math.random().toString(36).slice(2, 7)}`,
+    agentType: 'general-purpose',
+    parentToolUseId: 'parent-1',
+    tools: [],
+    startTime: Date.now(),
+    completed: false,
+    ...overrides,
+  } as SubAgent;
+}
+
+function makeBgTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    taskId: `task-${Math.random().toString(36).slice(2, 7)}`,
+    description: 'Run thing',
+    status: 'running',
+    startTime: Date.now(),
+    ...overrides,
+  } as BackgroundTask;
+}
+
+describe('appStore — active tools, sub-agents, background tasks', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      activeTools: {},
+      subAgents: {},
+      backgroundTasks: {},
+      streamingState: {},
+    });
+  });
+
+  // ---- Active tools -----------------------------------------------------------
+
+  describe('addActiveTool', () => {
+    it('appends a tool to the conversation array', () => {
+      const tool = makeTool({ id: 't1', tool: 'Read' });
+      useAppStore.getState().addActiveTool(CONV, tool);
+      expect(useAppStore.getState().activeTools[CONV]).toEqual([tool]);
+    });
+
+    it('deduplicates tools with the same id', () => {
+      const tool = makeTool({ id: 't1' });
+      useAppStore.getState().addActiveTool(CONV, tool);
+      useAppStore.getState().addActiveTool(CONV, tool);
+      expect(useAppStore.getState().activeTools[CONV]).toHaveLength(1);
+    });
+
+    it('isolates tools across conversations', () => {
+      useAppStore.getState().addActiveTool('conv-a', makeTool({ id: 't1' }));
+      useAppStore.getState().addActiveTool('conv-b', makeTool({ id: 't2' }));
+      expect(useAppStore.getState().activeTools['conv-a']).toHaveLength(1);
+      expect(useAppStore.getState().activeTools['conv-b']).toHaveLength(1);
+    });
+  });
+
+  describe('completeActiveTool', () => {
+    it('sets endTime, success, summary, stdout, stderr, metadata', () => {
+      const tool = makeTool({ id: 't1' });
+      useAppStore.setState({ activeTools: { [CONV]: [tool] } });
+
+      useAppStore.getState().completeActiveTool(
+        CONV,
+        't1',
+        true,
+        'done',
+        'out',
+        'err',
+        { key: 'value' } as never,
+      );
+
+      const updated = useAppStore.getState().activeTools[CONV][0];
+      expect(updated.endTime).toBeDefined();
+      expect(updated.success).toBe(true);
+      expect(updated.summary).toBe('done');
+      expect(updated.stdout).toBe('out');
+      expect(updated.stderr).toBe('err');
+      expect(updated.metadata).toEqual({ key: 'value' });
+    });
+
+    it('is idempotent when tool is not present', () => {
+      const before = useAppStore.getState().activeTools;
+      useAppStore.getState().completeActiveTool(CONV, 'missing', true);
+      expect(useAppStore.getState().activeTools).toBe(before);
+    });
+  });
+
+  describe('updateToolProgress', () => {
+    it('updates elapsedSeconds for an in-flight tool', () => {
+      const tool = makeTool({ id: 't1' });
+      useAppStore.setState({ activeTools: { [CONV]: [tool] } });
+
+      useAppStore.getState().updateToolProgress(CONV, 't1', { elapsedTimeSeconds: 5 } as never);
+
+      expect(useAppStore.getState().activeTools[CONV][0].elapsedSeconds).toBe(5);
+    });
+
+    it('is a no-op when tool already completed (has endTime)', () => {
+      const tool = makeTool({ id: 't1', endTime: Date.now() });
+      useAppStore.setState({ activeTools: { [CONV]: [tool] } });
+      const before = useAppStore.getState().activeTools[CONV][0];
+
+      useAppStore.getState().updateToolProgress(CONV, 't1', { elapsedTimeSeconds: 99 } as never);
+      expect(useAppStore.getState().activeTools[CONV][0]).toBe(before);
+    });
+
+    it('is a no-op when tool not found', () => {
+      useAppStore.setState({ activeTools: { [CONV]: [] } });
+      useAppStore.getState().updateToolProgress(CONV, 'missing', { elapsedTimeSeconds: 5 } as never);
+      expect(useAppStore.getState().activeTools[CONV]).toEqual([]);
+    });
+  });
+
+  describe('updateToolProgressBatch', () => {
+    it('updates multiple tools in one batch', () => {
+      const t1 = makeTool({ id: 't1' });
+      const t2 = makeTool({ id: 't2' });
+      useAppStore.setState({ activeTools: { [CONV]: [t1, t2] } });
+
+      useAppStore.getState().updateToolProgressBatch([
+        { conversationId: CONV, toolId: 't1', progress: { elapsedTimeSeconds: 1 } as never },
+        { conversationId: CONV, toolId: 't2', progress: { elapsedTimeSeconds: 2 } as never },
+      ]);
+
+      const tools = useAppStore.getState().activeTools[CONV];
+      expect(tools.find((t) => t.id === 't1')?.elapsedSeconds).toBe(1);
+      expect(tools.find((t) => t.id === 't2')?.elapsedSeconds).toBe(2);
+    });
+
+    it('is a no-op when no updates have a matching active tool', () => {
+      useAppStore.setState({ activeTools: { [CONV]: [] } });
+      const before = useAppStore.getState().activeTools;
+
+      useAppStore.getState().updateToolProgressBatch([
+        { conversationId: CONV, toolId: 'missing', progress: { elapsedTimeSeconds: 5 } as never },
+      ]);
+      expect(useAppStore.getState().activeTools).toBe(before);
+    });
+
+    it('returns state unchanged when updates array is empty', () => {
+      useAppStore.setState({ activeTools: { [CONV]: [makeTool({ id: 't1' })] } });
+      const before = useAppStore.getState().activeTools;
+      useAppStore.getState().updateToolProgressBatch([]);
+      expect(useAppStore.getState().activeTools).toBe(before);
+    });
+  });
+
+  describe('clearActiveTools', () => {
+    it('replaces the conversation\'s active tools with an empty array', () => {
+      useAppStore.setState({ activeTools: { [CONV]: [makeTool(), makeTool()] } });
+      useAppStore.getState().clearActiveTools(CONV);
+      expect(useAppStore.getState().activeTools[CONV]).toEqual([]);
+    });
+  });
+
+  // ---- Sub agents -------------------------------------------------------------
+
+  describe('addSubAgent', () => {
+    it('adds a sub-agent', () => {
+      const agent = makeSubAgent({ agentId: 'a1' });
+      useAppStore.getState().addSubAgent(CONV, agent);
+      expect(useAppStore.getState().subAgents[CONV]).toEqual([agent]);
+    });
+
+    it('deduplicates sub-agents with the same id', () => {
+      const agent = makeSubAgent({ agentId: 'a1' });
+      useAppStore.getState().addSubAgent(CONV, agent);
+      useAppStore.getState().addSubAgent(CONV, agent);
+      expect(useAppStore.getState().subAgents[CONV]).toHaveLength(1);
+    });
+  });
+
+  describe('completeSubAgent', () => {
+    it('marks completed=true and sets endTime', () => {
+      const agent = makeSubAgent({ agentId: 'a1' });
+      useAppStore.setState({ subAgents: { [CONV]: [agent] } });
+
+      useAppStore.getState().completeSubAgent(CONV, 'a1');
+      const updated = useAppStore.getState().subAgents[CONV][0];
+      expect(updated.completed).toBe(true);
+      expect(updated.endTime).toBeDefined();
+    });
+  });
+
+  describe('addSubAgentTool', () => {
+    it('appends tool to the named sub-agent', () => {
+      const agent = makeSubAgent({ agentId: 'a1', tools: [] });
+      useAppStore.setState({ subAgents: { [CONV]: [agent] } });
+
+      const tool = makeTool({ id: 'sub-t1' });
+      useAppStore.getState().addSubAgentTool(CONV, 'a1', tool);
+
+      const updated = useAppStore.getState().subAgents[CONV][0];
+      expect(updated.tools).toEqual([tool]);
+    });
+
+    it('warns and drops tool when sub-agent does not exist', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      useAppStore.setState({ subAgents: { [CONV]: [] } });
+
+      useAppStore.getState().addSubAgentTool(CONV, 'missing', makeTool({ id: 't1' }));
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(useAppStore.getState().subAgents[CONV]).toEqual([]);
+      warnSpy.mockRestore();
+    });
+
+    it('deduplicates tools within the same sub-agent', () => {
+      const tool = makeTool({ id: 't1' });
+      const agent = makeSubAgent({ agentId: 'a1', tools: [tool] });
+      useAppStore.setState({ subAgents: { [CONV]: [agent] } });
+
+      useAppStore.getState().addSubAgentTool(CONV, 'a1', tool);
+      expect(useAppStore.getState().subAgents[CONV][0].tools).toHaveLength(1);
+    });
+  });
+
+  describe('completeSubAgentTool', () => {
+    it('finalizes a tool inside a sub-agent', () => {
+      const tool = makeTool({ id: 't1' });
+      const agent = makeSubAgent({ agentId: 'a1', tools: [tool] });
+      useAppStore.setState({ subAgents: { [CONV]: [agent] } });
+
+      useAppStore.getState().completeSubAgentTool(CONV, 'a1', 't1', true, 'ok', 'so', 'se');
+      const finalized = useAppStore.getState().subAgents[CONV][0].tools[0];
+      expect(finalized.endTime).toBeDefined();
+      expect(finalized.success).toBe(true);
+      expect(finalized.summary).toBe('ok');
+      expect(finalized.stdout).toBe('so');
+      expect(finalized.stderr).toBe('se');
+    });
+  });
+
+  describe('setSubAgentOutput / setSubAgentUsage', () => {
+    it('setSubAgentOutput updates output for matching agent', () => {
+      const agent = makeSubAgent({ agentId: 'a1', output: undefined });
+      useAppStore.setState({ subAgents: { [CONV]: [agent] } });
+
+      useAppStore.getState().setSubAgentOutput(CONV, 'a1', 'hello world');
+      expect(useAppStore.getState().subAgents[CONV][0].output).toBe('hello world');
+    });
+
+    it('setSubAgentUsage matches by parentToolUseId', () => {
+      const agent = makeSubAgent({ agentId: 'a1', parentToolUseId: 'parent-1' });
+      useAppStore.setState({ subAgents: { [CONV]: [agent] } });
+
+      useAppStore.getState().setSubAgentUsage(CONV, 'parent-1', { inputTokens: 100, outputTokens: 50 } as never);
+      expect((useAppStore.getState().subAgents[CONV][0] as SubAgent & { usage?: { inputTokens: number; outputTokens: number } }).usage).toEqual({ inputTokens: 100, outputTokens: 50 });
+    });
+
+    it('setSubAgentUsage is a no-op when no agent has matching parentToolUseId', () => {
+      const agent = makeSubAgent({ agentId: 'a1', parentToolUseId: 'parent-1' });
+      useAppStore.setState({ subAgents: { [CONV]: [agent] } });
+
+      useAppStore.getState().setSubAgentUsage(CONV, 'other', { inputTokens: 1, outputTokens: 1 } as never);
+      expect((useAppStore.getState().subAgents[CONV][0] as SubAgent & { usage?: unknown }).usage).toBeUndefined();
+    });
+  });
+
+  describe('clearSubAgents', () => {
+    it('clears the conversation\'s sub-agents', () => {
+      useAppStore.setState({ subAgents: { [CONV]: [makeSubAgent(), makeSubAgent()] } });
+      useAppStore.getState().clearSubAgents(CONV);
+      expect(useAppStore.getState().subAgents[CONV]).toEqual([]);
+    });
+  });
+
+  // ---- Background tasks ------------------------------------------------------
+
+  describe('addBackgroundTask', () => {
+    it('appends task to the conversation array', () => {
+      const task = makeBgTask({ taskId: 'task-1' });
+      useAppStore.getState().addBackgroundTask(CONV, task);
+      expect(useAppStore.getState().backgroundTasks[CONV]).toEqual([task]);
+    });
+
+    it('deduplicates by taskId', () => {
+      const task = makeBgTask({ taskId: 'task-1' });
+      useAppStore.getState().addBackgroundTask(CONV, task);
+      useAppStore.getState().addBackgroundTask(CONV, task);
+      expect(useAppStore.getState().backgroundTasks[CONV]).toHaveLength(1);
+    });
+  });
+
+  describe('updateBackgroundTask', () => {
+    it('merges partial updates', () => {
+      const task = makeBgTask({ taskId: 'task-1', status: 'running' });
+      useAppStore.setState({ backgroundTasks: { [CONV]: [task] } });
+
+      useAppStore.getState().updateBackgroundTask(CONV, 'task-1', { status: 'completed' });
+      expect(useAppStore.getState().backgroundTasks[CONV][0].status).toBe('completed');
+    });
+  });
+
+  describe('stopBackgroundTask', () => {
+    it('marks status=stopped and sets endTime', () => {
+      const task = makeBgTask({ taskId: 'task-1', status: 'running' });
+      useAppStore.setState({ backgroundTasks: { [CONV]: [task] } });
+
+      useAppStore.getState().stopBackgroundTask(CONV, 'task-1');
+      const stopped = useAppStore.getState().backgroundTasks[CONV][0] as BackgroundTask & { endTime: number };
+      expect(stopped.status).toBe('stopped');
+      expect(stopped.endTime).toBeDefined();
+    });
+  });
+
+  describe('clearBackgroundTasks', () => {
+    it('clears all tasks for the conversation', () => {
+      useAppStore.setState({ backgroundTasks: { [CONV]: [makeBgTask(), makeBgTask()] } });
+      useAppStore.getState().clearBackgroundTasks(CONV);
+      expect(useAppStore.getState().backgroundTasks[CONV]).toEqual([]);
+    });
+  });
+
+  describe('clearStoppedBackgroundTasks', () => {
+    it('removes only stopped tasks, keeps running ones', () => {
+      const running = makeBgTask({ taskId: 't-running', status: 'running' });
+      const stopped = makeBgTask({ taskId: 't-stopped', status: 'stopped' });
+      useAppStore.setState({ backgroundTasks: { [CONV]: [running, stopped] } });
+
+      useAppStore.getState().clearStoppedBackgroundTasks(CONV);
+      const tasks = useAppStore.getState().backgroundTasks[CONV];
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].taskId).toBe('t-running');
+    });
+  });
+
+  describe('removeBackgroundTask', () => {
+    it('removes a specific task by id', () => {
+      const t1 = makeBgTask({ taskId: 't1' });
+      const t2 = makeBgTask({ taskId: 't2' });
+      useAppStore.setState({ backgroundTasks: { [CONV]: [t1, t2] } });
+
+      useAppStore.getState().removeBackgroundTask(CONV, 't1');
+      expect(useAppStore.getState().backgroundTasks[CONV].map((t) => t.taskId)).toEqual(['t2']);
+    });
+
+    it('is a no-op when task does not exist', () => {
+      const t1 = makeBgTask({ taskId: 't1' });
+      useAppStore.setState({ backgroundTasks: { [CONV]: [t1] } });
+      const before = useAppStore.getState().backgroundTasks;
+
+      useAppStore.getState().removeBackgroundTask(CONV, 'missing');
+      expect(useAppStore.getState().backgroundTasks).toBe(before);
+    });
+  });
+});

--- a/src/stores/__tests__/appStore.conversations.test.ts
+++ b/src/stores/__tests__/appStore.conversations.test.ts
@@ -1,0 +1,501 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAppStore } from '../appStore';
+import {
+  createMockConversation,
+  createMockMessage,
+} from '@/test-utils/store-utils';
+import type { Conversation, Message } from '@/lib/types';
+
+const c1 = createMockConversation({ id: 'c1', sessionId: 's1' }) as Conversation;
+const c2 = createMockConversation({ id: 'c2', sessionId: 's1' }) as Conversation;
+const c3 = createMockConversation({ id: 'c3', sessionId: 's2' }) as Conversation;
+
+const m1 = createMockMessage({ id: 'm1', conversationId: 'c1' }) as Message;
+const m2 = createMockMessage({ id: 'm2', conversationId: 'c1' }) as Message;
+
+describe('appStore — conversation actions', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      conversations: [],
+      conversationIds: new Set(),
+      conversationsBySession: {},
+      messagesByConversation: {},
+      messagePagination: {},
+      messagesLoading: {},
+      streamingState: {},
+      activeTools: {},
+      agentTodos: {},
+      pendingUserQuestion: {},
+      pendingQAHandoff: {},
+      interruptedState: {},
+      contextUsage: {},
+      queuedMessages: {},
+      lastActiveConversationPerSession: {},
+      summaries: {},
+      inputSuggestions: {},
+      promptSuggestions: {},
+      toolUseSummaries: {},
+      checkpoints: [],
+      conversationsVersion: 0,
+      selectedConversationId: null,
+      selectedSessionId: null,
+    });
+  });
+
+  // ---- setConversations -------------------------------------------------------
+
+  describe('setConversations', () => {
+    it('replaces the array and rebuilds the conversationIds set', () => {
+      useAppStore.getState().setConversations([c1, c2]);
+      const state = useAppStore.getState();
+      expect(state.conversations).toHaveLength(2);
+      expect(state.conversationIds.has('c1')).toBe(true);
+      expect(state.conversationIds.has('c2')).toBe(true);
+    });
+
+    it('rebuilds conversationsBySession index', () => {
+      useAppStore.getState().setConversations([c1, c2, c3]);
+      const idx = useAppStore.getState().conversationsBySession;
+      expect(idx['s1']?.map((c) => c.id).sort()).toEqual(['c1', 'c2']);
+      expect(idx['s2']?.map((c) => c.id)).toEqual(['c3']);
+    });
+
+    it('bumps conversationsVersion', () => {
+      const before = useAppStore.getState().conversationsVersion;
+      useAppStore.getState().setConversations([c1]);
+      expect(useAppStore.getState().conversationsVersion).toBe(before + 1);
+    });
+  });
+
+  // ---- addConversation --------------------------------------------------------
+
+  describe('addConversation', () => {
+    it('appends and updates the index', () => {
+      useAppStore.getState().setConversations([c1]);
+      useAppStore.getState().addConversation(c2);
+      expect(useAppStore.getState().conversations.map((c) => c.id)).toEqual(['c1', 'c2']);
+      expect(useAppStore.getState().conversationsBySession['s1']?.map((c) => c.id)).toEqual(['c1', 'c2']);
+    });
+
+    it('is a no-op when the id already exists (deduplication)', () => {
+      useAppStore.getState().setConversations([c1]);
+      useAppStore.getState().addConversation(c1);
+      expect(useAppStore.getState().conversations).toHaveLength(1);
+    });
+
+    it('seeds messagesByConversation when the new conversation has initial messages', () => {
+      const conv = { ...c1, messages: [m1, m2] };
+      useAppStore.getState().addConversation(conv);
+      expect(useAppStore.getState().messagesByConversation['c1']).toHaveLength(2);
+    });
+
+    it('does not touch messagesByConversation when no initial messages', () => {
+      useAppStore.getState().addConversation({ ...c1, messages: [] });
+      expect(useAppStore.getState().messagesByConversation['c1']).toBeUndefined();
+    });
+
+    it('appends to existing messagesByConversation entries', () => {
+      useAppStore.setState({ messagesByConversation: { c1: [m1] } });
+      useAppStore.getState().addConversation({ ...c1, messages: [m2] });
+      expect(useAppStore.getState().messagesByConversation['c1']?.map((m) => m.id)).toEqual([
+        'm1', 'm2',
+      ]);
+    });
+  });
+
+  // ---- updateConversation -----------------------------------------------------
+
+  describe('updateConversation', () => {
+    it('merges partial updates onto matching conversation', () => {
+      useAppStore.getState().setConversations([c1, c2]);
+      useAppStore.getState().updateConversation('c1', { name: 'Renamed' });
+      expect(useAppStore.getState().conversations.find((c) => c.id === 'c1')?.name).toBe('Renamed');
+    });
+
+    it('keeps the conversationsBySession index in sync', () => {
+      useAppStore.getState().setConversations([c1]);
+      useAppStore.getState().updateConversation('c1', { name: 'Renamed' });
+      expect(useAppStore.getState().conversationsBySession['s1']?.[0].name).toBe('Renamed');
+    });
+
+    it('rebuilds the index when sessionId changes', () => {
+      useAppStore.getState().setConversations([c1]);
+      useAppStore.getState().updateConversation('c1', { sessionId: 's2' });
+      // After moving c1 from s1 to s2, s1 has no conversations so its key is gone.
+      expect(useAppStore.getState().conversationsBySession['s1']).toBeUndefined();
+      expect(useAppStore.getState().conversationsBySession['s2']?.[0].id).toBe('c1');
+    });
+  });
+
+  // ---- removeConversation -----------------------------------------------------
+
+  describe('removeConversation', () => {
+    it('removes the conversation and its messages', () => {
+      useAppStore.setState({
+        conversations: [c1, c2],
+        conversationIds: new Set(['c1', 'c2']),
+        conversationsBySession: { s1: [c1, c2] },
+        messagesByConversation: { c1: [m1], c2: [] },
+      });
+      useAppStore.getState().removeConversation('c1');
+      const state = useAppStore.getState();
+      expect(state.conversations.map((c) => c.id)).toEqual(['c2']);
+      expect(state.conversationIds.has('c1')).toBe(false);
+      expect(state.messagesByConversation['c1']).toBeUndefined();
+    });
+
+    it('cleans up per-conversation slices', () => {
+      useAppStore.setState({
+        conversations: [c1],
+        conversationIds: new Set(['c1']),
+        conversationsBySession: { s1: [c1] },
+        streamingState: { c1: {} as never, other: {} as never },
+        activeTools: { c1: [] as never },
+        agentTodos: { c1: [] as never },
+        pendingUserQuestion: { c1: {} as never },
+        pendingQAHandoff: { c1: {} as never },
+        interruptedState: { c1: {} as never },
+        contextUsage: { c1: {} as never },
+        queuedMessages: { c1: [] as never },
+        messagePagination: { c1: {} as never },
+        messagesLoading: { c1: true },
+      });
+      useAppStore.getState().removeConversation('c1');
+      const state = useAppStore.getState();
+      expect(state.streamingState['c1']).toBeUndefined();
+      expect(state.streamingState['other']).toBeDefined();
+      expect(state.activeTools['c1']).toBeUndefined();
+      expect(state.agentTodos['c1']).toBeUndefined();
+      expect(state.pendingUserQuestion['c1']).toBeUndefined();
+      expect(state.pendingQAHandoff['c1']).toBeUndefined();
+      expect(state.interruptedState['c1']).toBeUndefined();
+      expect(state.contextUsage['c1']).toBeUndefined();
+      expect(state.queuedMessages['c1']).toBeUndefined();
+      expect(state.messagePagination['c1']).toBeUndefined();
+      expect(state.messagesLoading['c1']).toBeUndefined();
+    });
+
+    it('selects an adjacent conversation when removing the selected one', () => {
+      // c1, c2, c3 — but c3 is in s2. Remove c1, expect c2 selected.
+      const c1a = createMockConversation({ id: 'c1', sessionId: 's1' }) as Conversation;
+      const c2a = createMockConversation({ id: 'c2', sessionId: 's1' }) as Conversation;
+      useAppStore.setState({
+        conversations: [c1a, c2a],
+        conversationIds: new Set(['c1', 'c2']),
+        conversationsBySession: { s1: [c1a, c2a] },
+        selectedConversationId: 'c1',
+      });
+      useAppStore.getState().removeConversation('c1');
+      expect(useAppStore.getState().selectedConversationId).toBe('c2');
+    });
+
+    it('selects the previous conversation when removing the last one', () => {
+      const c1a = createMockConversation({ id: 'c1', sessionId: 's1' }) as Conversation;
+      const c2a = createMockConversation({ id: 'c2', sessionId: 's1' }) as Conversation;
+      useAppStore.setState({
+        conversations: [c1a, c2a],
+        conversationIds: new Set(['c1', 'c2']),
+        conversationsBySession: { s1: [c1a, c2a] },
+        selectedConversationId: 'c2',
+      });
+      useAppStore.getState().removeConversation('c2');
+      expect(useAppStore.getState().selectedConversationId).toBe('c1');
+    });
+
+    it('clears selection when removing the only conversation in the session', () => {
+      useAppStore.setState({
+        conversations: [c1],
+        conversationIds: new Set(['c1']),
+        conversationsBySession: { s1: [c1] },
+        selectedConversationId: 'c1',
+      });
+      useAppStore.getState().removeConversation('c1');
+      expect(useAppStore.getState().selectedConversationId).toBeNull();
+    });
+
+    it('clears lastActiveConversationPerSession when the removed conv was the remembered one', () => {
+      useAppStore.setState({
+        conversations: [c1, c2],
+        conversationIds: new Set(['c1', 'c2']),
+        conversationsBySession: { s1: [c1, c2] },
+        lastActiveConversationPerSession: { s1: 'c1' },
+      });
+      useAppStore.getState().removeConversation('c1');
+      expect(useAppStore.getState().lastActiveConversationPerSession['s1']).toBeUndefined();
+    });
+
+    it('preserves lastActiveConversationPerSession when removing a non-remembered conv', () => {
+      useAppStore.setState({
+        conversations: [c1, c2],
+        conversationIds: new Set(['c1', 'c2']),
+        conversationsBySession: { s1: [c1, c2] },
+        lastActiveConversationPerSession: { s1: 'c2' },
+      });
+      useAppStore.getState().removeConversation('c1');
+      expect(useAppStore.getState().lastActiveConversationPerSession['s1']).toBe('c2');
+    });
+  });
+
+  // ---- selectConversation -----------------------------------------------------
+
+  describe('selectConversation', () => {
+    it('updates selectedConversationId', () => {
+      useAppStore.setState({ conversations: [c1] });
+      useAppStore.getState().selectConversation('c1');
+      expect(useAppStore.getState().selectedConversationId).toBe('c1');
+    });
+
+    it('persists last active conversation per session', () => {
+      useAppStore.setState({ conversations: [c1, c2] });
+      useAppStore.getState().selectConversation('c1');
+      expect(useAppStore.getState().lastActiveConversationPerSession['s1']).toBe('c1');
+
+      useAppStore.getState().selectConversation('c2');
+      expect(useAppStore.getState().lastActiveConversationPerSession['s1']).toBe('c2');
+    });
+
+    it('clears checkpoints when changing conversation', () => {
+      useAppStore.setState({
+        conversations: [c1],
+        checkpoints: [{ uuid: 'cp-1' } as never, { uuid: 'cp-2' } as never],
+      });
+      useAppStore.getState().selectConversation('c1');
+      expect(useAppStore.getState().checkpoints).toEqual([]);
+    });
+
+    it('handles null id (deselect)', () => {
+      useAppStore.setState({
+        conversations: [c1],
+        selectedConversationId: 'c1',
+      });
+      useAppStore.getState().selectConversation(null);
+      expect(useAppStore.getState().selectedConversationId).toBeNull();
+    });
+  });
+
+  // ---- Summary actions --------------------------------------------------------
+
+  describe('setSummary / updateSummary', () => {
+    it('setSummary stores summary by conversationId', () => {
+      const summary = { id: 'sum-1', content: 'Hello', status: 'completed' } as never;
+      useAppStore.getState().setSummary('c1', summary);
+      expect(useAppStore.getState().summaries['c1']).toEqual(summary);
+    });
+
+    it('setSummary overwrites existing summary', () => {
+      useAppStore.getState().setSummary('c1', { content: 'first' } as never);
+      useAppStore.getState().setSummary('c1', { content: 'second' } as never);
+      expect((useAppStore.getState().summaries['c1'] as { content: string }).content).toBe('second');
+    });
+
+    it('updateSummary merges into existing summary', () => {
+      useAppStore.getState().setSummary('c1', { content: 'a', status: 'generating' } as never);
+      useAppStore.getState().updateSummary('c1', { status: 'completed' } as never);
+      const result = useAppStore.getState().summaries['c1'] as { content: string; status: string };
+      expect(result.content).toBe('a');
+      expect(result.status).toBe('completed');
+    });
+
+    it('updateSummary is a no-op when no summary exists', () => {
+      useAppStore.getState().updateSummary('c1', { status: 'completed' } as never);
+      expect(useAppStore.getState().summaries['c1']).toBeUndefined();
+    });
+  });
+
+  // ---- Input suggestions ------------------------------------------------------
+
+  describe('setInputSuggestion / clearInputSuggestion', () => {
+    it('stores suggestion with timestamp', () => {
+      useAppStore.getState().setInputSuggestion('c1', { text: 'hint' } as never);
+      const result = useAppStore.getState().inputSuggestions['c1'] as { text: string; timestamp: number };
+      expect(result.text).toBe('hint');
+      expect(typeof result.timestamp).toBe('number');
+    });
+
+    it('clearInputSuggestion removes entry', () => {
+      useAppStore.getState().setInputSuggestion('c1', { text: 'hint' } as never);
+      useAppStore.getState().clearInputSuggestion('c1');
+      expect(useAppStore.getState().inputSuggestions['c1']).toBeUndefined();
+    });
+
+    it('clearInputSuggestion is a no-op when no suggestion exists', () => {
+      const before = useAppStore.getState().inputSuggestions;
+      useAppStore.getState().clearInputSuggestion('c1');
+      expect(useAppStore.getState().inputSuggestions).toBe(before);
+    });
+  });
+
+  // ---- Prompt suggestions ----------------------------------------------------
+
+  describe('addPromptSuggestion / clearPromptSuggestions', () => {
+    it('appends a new suggestion', () => {
+      useAppStore.getState().addPromptSuggestion('c1', 'first');
+      expect(useAppStore.getState().promptSuggestions['c1']).toEqual(['first']);
+    });
+
+    it('deduplicates within the same conversation', () => {
+      useAppStore.getState().addPromptSuggestion('c1', 'first');
+      useAppStore.getState().addPromptSuggestion('c1', 'first');
+      expect(useAppStore.getState().promptSuggestions['c1']).toEqual(['first']);
+    });
+
+    it('caps at 3 entries (keeps the most recent)', () => {
+      useAppStore.getState().addPromptSuggestion('c1', 'a');
+      useAppStore.getState().addPromptSuggestion('c1', 'b');
+      useAppStore.getState().addPromptSuggestion('c1', 'c');
+      useAppStore.getState().addPromptSuggestion('c1', 'd');
+      expect(useAppStore.getState().promptSuggestions['c1']).toEqual(['b', 'c', 'd']);
+    });
+
+    it('clearPromptSuggestions removes the entry', () => {
+      useAppStore.getState().addPromptSuggestion('c1', 'a');
+      useAppStore.getState().clearPromptSuggestions('c1');
+      expect(useAppStore.getState().promptSuggestions['c1']).toBeUndefined();
+    });
+
+    it('isolates suggestions across conversations', () => {
+      useAppStore.getState().addPromptSuggestion('c1', 'a');
+      useAppStore.getState().addPromptSuggestion('c2', 'b');
+      useAppStore.getState().clearPromptSuggestions('c1');
+      expect(useAppStore.getState().promptSuggestions['c2']).toEqual(['b']);
+    });
+  });
+
+  // ---- Tool use summaries ----------------------------------------------------
+
+  describe('addToolUseSummary / clearToolUseSummaries', () => {
+    it('accumulates tool use summaries', () => {
+      useAppStore.getState().addToolUseSummary('c1', { summary: 'a', toolUseIds: ['t1'] });
+      useAppStore.getState().addToolUseSummary('c1', { summary: 'b', toolUseIds: ['t2'] });
+      const list = useAppStore.getState().toolUseSummaries['c1'];
+      expect(list).toHaveLength(2);
+    });
+
+    it('clearToolUseSummaries removes the entry', () => {
+      useAppStore.getState().addToolUseSummary('c1', { summary: 's', toolUseIds: [] });
+      useAppStore.getState().clearToolUseSummaries('c1');
+      expect(useAppStore.getState().toolUseSummaries['c1']).toBeUndefined();
+    });
+  });
+
+  // ---- Messages ---------------------------------------------------------------
+
+  describe('addMessage', () => {
+    it('appends message to conversation messagesByConversation', () => {
+      useAppStore.getState().addMessage(m1);
+      expect(useAppStore.getState().messagesByConversation['c1']).toEqual([m1]);
+
+      useAppStore.getState().addMessage(m2);
+      expect(useAppStore.getState().messagesByConversation['c1']).toHaveLength(2);
+    });
+
+    it('keeps pagination totalCount in sync', () => {
+      useAppStore.setState({
+        messagePagination: {
+          c1: { hasMore: false, totalCount: 5, oldestPosition: 0, isLoadingMore: false } as never,
+        },
+      });
+      useAppStore.getState().addMessage(m1);
+      expect((useAppStore.getState().messagePagination['c1'] as { totalCount: number }).totalCount).toBe(6);
+    });
+
+    it('does not create pagination entry when none existed', () => {
+      useAppStore.getState().addMessage(m1);
+      expect(useAppStore.getState().messagePagination['c1']).toBeUndefined();
+    });
+  });
+
+  describe('updateMessage', () => {
+    it('merges updates onto matching message', () => {
+      useAppStore.setState({ messagesByConversation: { c1: [m1, m2] } });
+      useAppStore.getState().updateMessage('c1', 'm1', { content: 'updated' });
+      expect(useAppStore.getState().messagesByConversation['c1']?.[0].content).toBe('updated');
+      expect(useAppStore.getState().messagesByConversation['c1']?.[1].content).toBe('Test message');
+    });
+
+    it('is a no-op when conversation has no messages map entry', () => {
+      const before = useAppStore.getState().messagesByConversation;
+      useAppStore.getState().updateMessage('missing-conv', 'm1', { content: 'x' });
+      expect(useAppStore.getState().messagesByConversation).toBe(before);
+    });
+  });
+
+  describe('setMessagePage', () => {
+    it('replaces messages and writes pagination metadata', () => {
+      useAppStore.getState().setMessagePage('c1', [m1, m2], true, 0, 50);
+      const state = useAppStore.getState();
+      expect(state.messagesByConversation['c1']).toHaveLength(2);
+      expect(state.messagePagination['c1']).toEqual({
+        hasMore: true,
+        oldestPosition: 0,
+        isLoadingMore: false,
+        totalCount: 50,
+      });
+      expect(state.messagesLoading['c1']).toBe(false);
+    });
+  });
+
+  describe('prependMessages', () => {
+    it('prepends new messages and de-duplicates against existing IDs', () => {
+      useAppStore.setState({
+        messagesByConversation: { c1: [m2] },
+        messagePagination: {
+          c1: { hasMore: true, oldestPosition: 5, isLoadingMore: true, totalCount: 10 } as never,
+        },
+      });
+      const m0 = createMockMessage({ id: 'm0', conversationId: 'c1' }) as Message;
+      useAppStore.getState().prependMessages('c1', [m0, m2], false, 0);
+
+      const state = useAppStore.getState();
+      expect(state.messagesByConversation['c1']?.map((m) => m.id)).toEqual(['m0', 'm2']);
+      expect((state.messagePagination['c1'] as { hasMore: boolean; oldestPosition: number; isLoadingMore: boolean }).hasMore).toBe(false);
+      expect((state.messagePagination['c1'] as { hasMore: boolean; oldestPosition: number; isLoadingMore: boolean }).oldestPosition).toBe(0);
+      expect((state.messagePagination['c1'] as { hasMore: boolean; oldestPosition: number; isLoadingMore: boolean }).isLoadingMore).toBe(false);
+    });
+  });
+
+  describe('setLoadingMoreMessages', () => {
+    it('updates the isLoadingMore flag in pagination', () => {
+      useAppStore.setState({
+        messagePagination: {
+          c1: { hasMore: true, oldestPosition: 0, isLoadingMore: false, totalCount: 0 } as never,
+        },
+      });
+      useAppStore.getState().setLoadingMoreMessages('c1', true);
+      expect((useAppStore.getState().messagePagination['c1'] as { isLoadingMore: boolean }).isLoadingMore).toBe(true);
+    });
+  });
+
+  describe('setMessagesLoading', () => {
+    it('toggles initial-load flag for a conversation', () => {
+      useAppStore.getState().setMessagesLoading('c1', true);
+      expect(useAppStore.getState().messagesLoading['c1']).toBe(true);
+
+      useAppStore.getState().setMessagesLoading('c1', false);
+      expect(useAppStore.getState().messagesLoading['c1']).toBe(false);
+    });
+  });
+
+  describe('hydrateMessage', () => {
+    it('replaces a message in place by id', () => {
+      useAppStore.setState({ messagesByConversation: { c1: [m1, m2] } });
+      const hydrated = { ...m1, content: 'fully-hydrated', toolUsage: [] } as Message;
+      useAppStore.getState().hydrateMessage('c1', 'm1', hydrated);
+
+      const messages = useAppStore.getState().messagesByConversation['c1']!;
+      expect(messages[0].content).toBe('fully-hydrated');
+      expect(messages[1]).toBe(m2);
+    });
+
+    it('is a no-op when conversation has no messages', () => {
+      useAppStore.getState().hydrateMessage('c-missing', 'm1', m1);
+      expect(useAppStore.getState().messagesByConversation['c-missing']).toBeUndefined();
+    });
+
+    it('is a no-op when message id is not found in conversation', () => {
+      useAppStore.setState({ messagesByConversation: { c1: [m1] } });
+      useAppStore.getState().hydrateMessage('c1', 'missing', m1);
+      expect(useAppStore.getState().messagesByConversation['c1']).toEqual([m1]);
+    });
+  });
+});

--- a/src/stores/__tests__/appStore.fileTabs.test.ts
+++ b/src/stores/__tests__/appStore.fileTabs.test.ts
@@ -1,0 +1,473 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAppStore } from '../appStore';
+import { createMockConversation } from '@/test-utils/store-utils';
+import type { FileTab, Conversation } from '@/lib/types';
+
+const MAX_FILE_TABS = 10;
+
+function makeTab(overrides: Partial<FileTab> = {}): FileTab {
+  return {
+    id: `tab-${Math.random().toString(36).slice(2, 8)}`,
+    sessionId: 's1',
+    workspaceId: 'ws-1',
+    path: 'src/file.ts',
+    viewMode: 'file',
+    isPinned: false,
+    isDirty: false,
+    isPreview: false,
+    position: 0,
+    openedAt: '2026-04-26T10:00:00Z',
+    lastAccessedAt: '2026-04-26T10:00:00Z',
+    ...overrides,
+  } as FileTab;
+}
+
+describe('appStore — file tab actions', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      fileTabs: [],
+      selectedFileTabId: null,
+      pendingCloseFileTabId: null,
+      conversations: [],
+      conversationIds: new Set(),
+      conversationsBySession: {},
+      checkpoints: [],
+      selectedSessionId: null,
+      selectedConversationId: null,
+      lastActiveConversationPerSession: {},
+    });
+  });
+
+  describe('setFileTabs', () => {
+    it('replaces the tabs array', () => {
+      const t1 = makeTab({ id: 't1' });
+      useAppStore.getState().setFileTabs([t1]);
+      expect(useAppStore.getState().fileTabs).toEqual([t1]);
+    });
+  });
+
+  describe('openFileTab', () => {
+    it('opens a new tab and selects it', () => {
+      const t = makeTab({ id: 't1', path: 'a.ts' });
+      useAppStore.getState().openFileTab(t);
+      expect(useAppStore.getState().fileTabs.map((x) => x.id)).toEqual(['t1']);
+      expect(useAppStore.getState().selectedFileTabId).toBe('t1');
+    });
+
+    it('updates lastAccessedAt and selects when re-opening an existing tab', () => {
+      const t = makeTab({ id: 't1', lastAccessedAt: '2025-01-01T00:00:00Z' });
+      useAppStore.setState({ fileTabs: [t] });
+      useAppStore.getState().openFileTab(t);
+      const updated = useAppStore.getState().fileTabs[0];
+      expect(updated.lastAccessedAt).not.toBe('2025-01-01T00:00:00Z');
+      expect(useAppStore.getState().selectedFileTabId).toBe('t1');
+    });
+
+    it('promotes preview tab to persistent when re-opened without isPreview', () => {
+      const previewTab = makeTab({ id: 't1', isPreview: true });
+      useAppStore.setState({ fileTabs: [previewTab] });
+      useAppStore.getState().openFileTab({ ...previewTab, isPreview: undefined as never });
+      expect(useAppStore.getState().fileTabs[0].isPreview).toBe(false);
+    });
+
+    it('preview tabs replace the existing preview in the same session', () => {
+      const oldPreview = makeTab({ id: 't1', isPreview: true, path: 'a.ts' });
+      useAppStore.setState({ fileTabs: [oldPreview] });
+
+      const newPreview = makeTab({ id: 't2', isPreview: true, path: 'b.ts' });
+      useAppStore.getState().openFileTab(newPreview);
+
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].id).toBe('t2');
+    });
+
+    it('appends new persistent tab when no preview exists', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      useAppStore.getState().openFileTab(t1);
+      useAppStore.getState().openFileTab(t2);
+      expect(useAppStore.getState().fileTabs).toHaveLength(2);
+    });
+
+    it('evicts the oldest unpinned non-dirty tab when over MAX_FILE_TABS', () => {
+      const initial = Array.from({ length: MAX_FILE_TABS }, (_, i) =>
+        makeTab({
+          id: `t${i}`,
+          path: `f${i}.ts`,
+          lastAccessedAt: `2025-01-01T00:00:0${i}Z`,
+        })
+      );
+      useAppStore.setState({ fileTabs: initial });
+
+      const newTab = makeTab({ id: 'new', path: 'new.ts' });
+      useAppStore.getState().openFileTab(newTab);
+
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs).toHaveLength(MAX_FILE_TABS);
+      expect(tabs.find((t) => t.id === 'new')).toBeDefined();
+      // Oldest accessed (t0) should be the one evicted
+      expect(tabs.find((t) => t.id === 't0')).toBeUndefined();
+    });
+
+    it('skips eviction of pinned and dirty tabs even if oldest', () => {
+      const pinned = makeTab({
+        id: 'pinned',
+        isPinned: true,
+        lastAccessedAt: '2024-01-01T00:00:00Z',
+      });
+      const dirty = makeTab({
+        id: 'dirty',
+        isDirty: true,
+        lastAccessedAt: '2024-01-01T00:00:01Z',
+      });
+      const evictable = Array.from({ length: MAX_FILE_TABS - 2 }, (_, i) =>
+        makeTab({
+          id: `e${i}`,
+          lastAccessedAt: `2025-01-01T00:00:0${i}Z`,
+        })
+      );
+      useAppStore.setState({ fileTabs: [pinned, dirty, ...evictable] });
+
+      const newTab = makeTab({ id: 'new' });
+      useAppStore.getState().openFileTab(newTab);
+
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs.find((t) => t.id === 'pinned')).toBeDefined();
+      expect(tabs.find((t) => t.id === 'dirty')).toBeDefined();
+      expect(tabs.find((t) => t.id === 'new')).toBeDefined();
+      // First evictable should have been removed
+      expect(tabs.find((t) => t.id === 'e0')).toBeUndefined();
+    });
+
+    it('exceeds MAX_FILE_TABS when all tabs are pinned/dirty (data safety)', () => {
+      const tabs = Array.from({ length: MAX_FILE_TABS }, (_, i) =>
+        makeTab({ id: `t${i}`, isPinned: true })
+      );
+      useAppStore.setState({ fileTabs: tabs });
+
+      useAppStore.getState().openFileTab(makeTab({ id: 'extra' }));
+      expect(useAppStore.getState().fileTabs).toHaveLength(MAX_FILE_TABS + 1);
+    });
+  });
+
+  describe('closeFileTab', () => {
+    it('removes the tab from the array', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      useAppStore.setState({ fileTabs: [t1, t2], selectedFileTabId: 't2' });
+      useAppStore.getState().closeFileTab('t1');
+      expect(useAppStore.getState().fileTabs.map((t) => t.id)).toEqual(['t2']);
+    });
+
+    it('preserves selection when closing a non-selected tab', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      useAppStore.setState({ fileTabs: [t1, t2], selectedFileTabId: 't2' });
+      useAppStore.getState().closeFileTab('t1');
+      expect(useAppStore.getState().selectedFileTabId).toBe('t2');
+    });
+
+    it('selects next tab when closing the selected one', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      const t3 = makeTab({ id: 't3' });
+      useAppStore.setState({ fileTabs: [t1, t2, t3], selectedFileTabId: 't2' });
+      useAppStore.getState().closeFileTab('t2');
+      expect(useAppStore.getState().selectedFileTabId).toBe('t3');
+    });
+
+    it('selects previous tab when closing the last tab', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      useAppStore.setState({ fileTabs: [t1, t2], selectedFileTabId: 't2' });
+      useAppStore.getState().closeFileTab('t2');
+      expect(useAppStore.getState().selectedFileTabId).toBe('t1');
+    });
+
+    it('clears selection when closing the only tab', () => {
+      const t1 = makeTab({ id: 't1' });
+      useAppStore.setState({ fileTabs: [t1], selectedFileTabId: 't1' });
+      useAppStore.getState().closeFileTab('t1');
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+    });
+  });
+
+  describe('selectFileTab', () => {
+    it('updates selectedFileTabId and refreshes lastAccessedAt', () => {
+      const t1 = makeTab({ id: 't1', lastAccessedAt: '2025-01-01T00:00:00Z' });
+      useAppStore.setState({ fileTabs: [t1] });
+      useAppStore.getState().selectFileTab('t1');
+      expect(useAppStore.getState().selectedFileTabId).toBe('t1');
+      expect(useAppStore.getState().fileTabs[0].lastAccessedAt).not.toBe('2025-01-01T00:00:00Z');
+    });
+
+    it('handles null id (deselect)', () => {
+      useAppStore.setState({ fileTabs: [makeTab({ id: 't1' })], selectedFileTabId: 't1' });
+      useAppStore.getState().selectFileTab(null);
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+    });
+  });
+
+  describe('updateFileTab', () => {
+    it('merges partial updates', () => {
+      const t1 = makeTab({ id: 't1', isPinned: false });
+      useAppStore.setState({ fileTabs: [t1] });
+      useAppStore.getState().updateFileTab('t1', { isPinned: true });
+      expect(useAppStore.getState().fileTabs[0].isPinned).toBe(true);
+    });
+
+    it('is a no-op when id does not match', () => {
+      const t1 = makeTab({ id: 't1' });
+      useAppStore.setState({ fileTabs: [t1] });
+      useAppStore.getState().updateFileTab('missing', { isPinned: true });
+      expect(useAppStore.getState().fileTabs[0].isPinned).toBe(false);
+    });
+  });
+
+  describe('updateFileTabContent', () => {
+    it('marks tab dirty when content differs from originalContent', () => {
+      const t1 = makeTab({
+        id: 't1',
+        content: 'orig',
+        originalContent: 'orig',
+        isDirty: false,
+      } as never);
+      useAppStore.setState({ fileTabs: [t1] });
+
+      useAppStore.getState().updateFileTabContent('t1', 'modified');
+
+      const updated = useAppStore.getState().fileTabs[0];
+      expect((updated as { content: string }).content).toBe('modified');
+      expect(updated.isDirty).toBe(true);
+    });
+
+    it('clears isDirty when content matches originalContent (revert)', () => {
+      const t1 = makeTab({
+        id: 't1',
+        content: 'modified',
+        originalContent: 'orig',
+        isDirty: true,
+      } as never);
+      useAppStore.setState({ fileTabs: [t1] });
+
+      useAppStore.getState().updateFileTabContent('t1', 'orig');
+      expect(useAppStore.getState().fileTabs[0].isDirty).toBe(false);
+    });
+
+    it('promotes preview tab to persistent on edit', () => {
+      const t1 = makeTab({
+        id: 't1',
+        isPreview: true,
+        content: 'orig',
+        originalContent: 'orig',
+      } as never);
+      useAppStore.setState({ fileTabs: [t1] });
+
+      useAppStore.getState().updateFileTabContent('t1', 'changed');
+      expect(useAppStore.getState().fileTabs[0].isPreview).toBe(false);
+    });
+  });
+
+  describe('reorderFileTabs', () => {
+    it('moves tab from old index to new index', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      const t3 = makeTab({ id: 't3' });
+      useAppStore.setState({ fileTabs: [t1, t2, t3] });
+
+      useAppStore.getState().reorderFileTabs('t3', 't1');
+      expect(useAppStore.getState().fileTabs.map((t) => t.id)).toEqual(['t3', 't1', 't2']);
+    });
+
+    it('is a no-op when activeId is missing', () => {
+      const t1 = makeTab({ id: 't1' });
+      useAppStore.setState({ fileTabs: [t1] });
+      useAppStore.getState().reorderFileTabs('missing', 't1');
+      expect(useAppStore.getState().fileTabs.map((t) => t.id)).toEqual(['t1']);
+    });
+
+    it('is a no-op when overId is missing', () => {
+      const t1 = makeTab({ id: 't1' });
+      useAppStore.setState({ fileTabs: [t1] });
+      useAppStore.getState().reorderFileTabs('t1', 'missing');
+      expect(useAppStore.getState().fileTabs.map((t) => t.id)).toEqual(['t1']);
+    });
+  });
+
+  describe('pinFileTab', () => {
+    it('toggles pin flag', () => {
+      const t1 = makeTab({ id: 't1', isPinned: false });
+      useAppStore.setState({ fileTabs: [t1] });
+      useAppStore.getState().pinFileTab('t1', true);
+      expect(useAppStore.getState().fileTabs[0].isPinned).toBe(true);
+
+      useAppStore.getState().pinFileTab('t1', false);
+      expect(useAppStore.getState().fileTabs[0].isPinned).toBe(false);
+    });
+  });
+
+  describe('closeOtherTabs', () => {
+    it('keeps only the specified tab', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      const t3 = makeTab({ id: 't3' });
+      useAppStore.setState({ fileTabs: [t1, t2, t3] });
+
+      useAppStore.getState().closeOtherTabs('t2');
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs.map((t) => t.id)).toEqual(['t2']);
+      expect(useAppStore.getState().selectedFileTabId).toBe('t2');
+    });
+  });
+
+  describe('closeTabsToRight', () => {
+    it('removes tabs after the specified one', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      const t3 = makeTab({ id: 't3' });
+      useAppStore.setState({ fileTabs: [t1, t2, t3] });
+
+      useAppStore.getState().closeTabsToRight('t2');
+      expect(useAppStore.getState().fileTabs.map((t) => t.id)).toEqual(['t1', 't2']);
+    });
+
+    it('selects the anchor tab when the previously-selected tab was closed', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      const t3 = makeTab({ id: 't3' });
+      useAppStore.setState({ fileTabs: [t1, t2, t3], selectedFileTabId: 't3' });
+
+      useAppStore.getState().closeTabsToRight('t2');
+      expect(useAppStore.getState().selectedFileTabId).toBe('t2');
+    });
+
+    it('preserves selection when previously-selected tab is still present', () => {
+      const t1 = makeTab({ id: 't1' });
+      const t2 = makeTab({ id: 't2' });
+      const t3 = makeTab({ id: 't3' });
+      useAppStore.setState({ fileTabs: [t1, t2, t3], selectedFileTabId: 't1' });
+
+      useAppStore.getState().closeTabsToRight('t2');
+      expect(useAppStore.getState().selectedFileTabId).toBe('t1');
+    });
+
+    it('is a no-op when id does not exist', () => {
+      const t1 = makeTab({ id: 't1' });
+      useAppStore.setState({ fileTabs: [t1] });
+      useAppStore.getState().closeTabsToRight('missing');
+      expect(useAppStore.getState().fileTabs).toEqual([t1]);
+    });
+  });
+
+  describe('setPendingCloseFileTabId', () => {
+    it('sets and clears the pending id', () => {
+      useAppStore.getState().setPendingCloseFileTabId('t1');
+      expect(useAppStore.getState().pendingCloseFileTabId).toBe('t1');
+
+      useAppStore.getState().setPendingCloseFileTabId(null);
+      expect(useAppStore.getState().pendingCloseFileTabId).toBeNull();
+    });
+  });
+
+  // ---- selectNextTab / selectPreviousTab (unified file tab + conversation cycling) ----
+
+  describe('selectNextTab / selectPreviousTab', () => {
+    function setupSession() {
+      const t1 = makeTab({ id: 't1', sessionId: 's1' });
+      const t2 = makeTab({ id: 't2', sessionId: 's1' });
+      const c1 = createMockConversation({ id: 'c1', sessionId: 's1' }) as Conversation;
+      const c2 = createMockConversation({ id: 'c2', sessionId: 's1' }) as Conversation;
+      useAppStore.setState({
+        fileTabs: [t1, t2],
+        conversations: [c1, c2],
+        selectedSessionId: 's1',
+        selectedFileTabId: 't1',
+        selectedConversationId: null,
+      });
+    }
+
+    it('selectNextTab cycles through file tabs first, then conversations', () => {
+      setupSession();
+
+      useAppStore.getState().selectNextTab();
+      expect(useAppStore.getState().selectedFileTabId).toBe('t2');
+
+      useAppStore.getState().selectNextTab();
+      // Now into conversation territory
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+      expect(useAppStore.getState().selectedConversationId).toBe('c1');
+    });
+
+    it('selectNextTab wraps from end back to first', () => {
+      setupSession();
+      useAppStore.setState({
+        selectedFileTabId: null,
+        selectedConversationId: 'c2',
+      });
+
+      useAppStore.getState().selectNextTab();
+      expect(useAppStore.getState().selectedFileTabId).toBe('t1');
+    });
+
+    it('selectPreviousTab cycles backwards', () => {
+      setupSession();
+      // Start at t2
+      useAppStore.setState({ selectedFileTabId: 't2', selectedConversationId: null });
+
+      useAppStore.getState().selectPreviousTab();
+      expect(useAppStore.getState().selectedFileTabId).toBe('t1');
+    });
+
+    it('selectPreviousTab wraps from first back to last conversation', () => {
+      setupSession();
+      // Currently at t1 (first)
+      useAppStore.getState().selectPreviousTab();
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+      expect(useAppStore.getState().selectedConversationId).toBe('c2');
+    });
+
+    it('selectNextTab updates lastActiveConversationPerSession when navigating to conversation', () => {
+      setupSession();
+      // From t2 → c1
+      useAppStore.setState({ selectedFileTabId: 't2', selectedConversationId: null });
+      useAppStore.getState().selectNextTab();
+      expect(useAppStore.getState().lastActiveConversationPerSession['s1']).toBe('c1');
+    });
+
+    it('selectNextTab clears checkpoints when navigating to a conversation', () => {
+      setupSession();
+      useAppStore.setState({ checkpoints: [{ uuid: 'cp1' } as never] });
+
+      useAppStore.setState({ selectedFileTabId: 't2', selectedConversationId: null });
+      useAppStore.getState().selectNextTab();
+      expect(useAppStore.getState().checkpoints).toEqual([]);
+    });
+
+    it('is a no-op when no session is selected', () => {
+      useAppStore.setState({
+        selectedSessionId: null,
+        fileTabs: [makeTab({ id: 't1' })],
+        selectedFileTabId: null,
+      });
+      useAppStore.getState().selectNextTab();
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+
+      useAppStore.getState().selectPreviousTab();
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+    });
+
+    it('is a no-op when session has no tabs or conversations', () => {
+      useAppStore.setState({
+        selectedSessionId: 's1',
+        fileTabs: [],
+        conversations: [],
+        selectedFileTabId: null,
+        selectedConversationId: null,
+      });
+      useAppStore.getState().selectNextTab();
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+      expect(useAppStore.getState().selectedConversationId).toBeNull();
+    });
+  });
+});

--- a/src/stores/__tests__/appStore.fileTabs.test.ts
+++ b/src/stores/__tests__/appStore.fileTabs.test.ts
@@ -82,6 +82,21 @@ describe('appStore — file tab actions', () => {
       expect(tabs[0].id).toBe('t2');
     });
 
+    it('preview tabs from different sessions do not replace each other', () => {
+      // Cross-session scoping invariant: a preview belongs to a single
+      // session, and opening a preview in session B should not evict the
+      // preview that's still in session A.
+      const s1Preview = makeTab({ id: 't1', isPreview: true, sessionId: 's1', path: 'a.ts' });
+      useAppStore.setState({ fileTabs: [s1Preview] });
+
+      const s2Preview = makeTab({ id: 't2', isPreview: true, sessionId: 's2', path: 'b.ts' });
+      useAppStore.getState().openFileTab(s2Preview);
+
+      const tabs = useAppStore.getState().fileTabs;
+      expect(tabs).toHaveLength(2);
+      expect(tabs.map((t) => t.id).sort()).toEqual(['t1', 't2']);
+    });
+
     it('appends new persistent tab when no preview exists', () => {
       const t1 = makeTab({ id: 't1' });
       const t2 = makeTab({ id: 't2' });

--- a/src/stores/__tests__/appStore.sessions.test.ts
+++ b/src/stores/__tests__/appStore.sessions.test.ts
@@ -45,8 +45,6 @@ describe('appStore — session actions', () => {
       terminalInstances: {},
       activeTerminalId: {},
       terminalPanelVisible: {},
-      claudeTerminals: {},
-      activeClaudeTerminalId: {},
       scriptOutputVersions: {},
       selectedSessionId: null,
       selectedConversationId: null,
@@ -157,8 +155,6 @@ describe('appStore — session actions', () => {
         terminalInstances: { s1: {} as never },
         activeTerminalId: { s1: 't1' },
         terminalPanelVisible: { s1: true },
-        claudeTerminals: { s1: {} as never },
-        activeClaudeTerminalId: { s1: 'ct1' },
       });
 
       useAppStore.getState().removeSession('s1');
@@ -173,8 +169,6 @@ describe('appStore — session actions', () => {
       expect(state.terminalInstances['s1']).toBeUndefined();
       expect(state.activeTerminalId['s1']).toBeUndefined();
       expect(state.terminalPanelVisible['s1']).toBeUndefined();
-      expect(state.claudeTerminals['s1']).toBeUndefined();
-      expect(state.activeClaudeTerminalId['s1']).toBeUndefined();
     });
 
     it('clears selectedSessionId / selectedConversationId when removing the selected session', () => {
@@ -374,8 +368,6 @@ describe('appStore — session actions', () => {
         terminalInstances: { s1: {} as never, s2: {} as never },
         activeTerminalId: { s1: 't1', s2: 't2' },
         terminalPanelVisible: { s1: true, s2: false },
-        claudeTerminals: { s1: {} as never, s2: {} as never },
-        activeClaudeTerminalId: { s1: 'c1', s2: 'c2' },
       });
 
       useAppStore.getState().archiveSession('s1');
@@ -385,8 +377,6 @@ describe('appStore — session actions', () => {
       expect(state.terminalInstances['s2']).toBeDefined();
       expect(state.activeTerminalId['s1']).toBeUndefined();
       expect(state.terminalPanelVisible['s1']).toBeUndefined();
-      expect(state.claudeTerminals['s1']).toBeUndefined();
-      expect(state.activeClaudeTerminalId['s1']).toBeUndefined();
     });
   });
 

--- a/src/stores/__tests__/appStore.sessions.test.ts
+++ b/src/stores/__tests__/appStore.sessions.test.ts
@@ -1,0 +1,440 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { useAppStore } from '../appStore';
+import { useSettingsStore } from '../settingsStore';
+import { server } from '@/__mocks__/server';
+import {
+  createMockSession,
+  createMockConversation,
+} from '@/test-utils/store-utils';
+import type { WorktreeSession } from '@/lib/types';
+
+// selectSession triggers a background refreshPRStatus POST. MSW config is set to
+// `onUnhandledRequest: 'error'`, so we install a no-op handler at the suite level.
+const API_BASE = 'http://localhost:9876';
+
+const s1 = createMockSession({ id: 's1', workspaceId: 'ws-1' }) as WorktreeSession;
+const s2 = createMockSession({ id: 's2', workspaceId: 'ws-1' }) as WorktreeSession;
+const s3 = createMockSession({ id: 's3', workspaceId: 'ws-2' }) as WorktreeSession;
+
+describe('appStore — session actions', () => {
+  beforeEach(() => {
+    server.use(
+      http.post(`${API_BASE}/api/repos/:workspaceId/sessions/:sessionId/pr-refresh`, () =>
+        new HttpResponse(null, { status: 202 })
+      )
+    );
+    useAppStore.setState({
+      sessions: [],
+      conversations: [],
+      conversationIds: new Set(),
+      conversationsBySession: {},
+      messagesByConversation: {},
+      streamingState: {},
+      activeTools: {},
+      agentTodos: {},
+      contextUsage: {},
+      queuedMessages: {},
+      messagePagination: {},
+      customTodos: {},
+      sessionOutputs: {},
+      reviewComments: {},
+      lastActiveConversationPerSession: {},
+      sessionToggleState: {},
+      draftInputs: {},
+      terminalInstances: {},
+      activeTerminalId: {},
+      terminalPanelVisible: {},
+      claudeTerminals: {},
+      activeClaudeTerminalId: {},
+      scriptOutputVersions: {},
+      selectedSessionId: null,
+      selectedConversationId: null,
+      selectedFileTabId: null,
+      fileTabs: [],
+    });
+    useSettingsStore.setState({
+      markSessionRead: vi.fn(),
+      markSessionUnread: vi.fn(),
+      showBaseBranchSessions: false,
+    } as never);
+  });
+
+  // ---- Basic CRUD --------------------------------------------------------------
+
+  describe('setSessions', () => {
+    it('replaces the sessions array', () => {
+      useAppStore.getState().setSessions([s1, s2]);
+      expect(useAppStore.getState().sessions).toHaveLength(2);
+
+      useAppStore.getState().setSessions([s3]);
+      expect(useAppStore.getState().sessions).toEqual([s3]);
+    });
+  });
+
+  describe('addSession', () => {
+    it('prepends to the sessions array', () => {
+      useAppStore.getState().setSessions([s1]);
+      useAppStore.getState().addSession(s2);
+      expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(['s2', 's1']);
+    });
+  });
+
+  describe('updateSession', () => {
+    it('merges partial updates onto matching session', () => {
+      useAppStore.getState().setSessions([s1, s2]);
+      useAppStore.getState().updateSession('s1', { name: 'Renamed' });
+      expect(useAppStore.getState().sessions.find((s) => s.id === 's1')?.name).toBe('Renamed');
+      expect(useAppStore.getState().sessions.find((s) => s.id === 's2')?.name).toBe('Test Session');
+    });
+
+    it('is a no-op when id does not match', () => {
+      useAppStore.getState().setSessions([s1]);
+      useAppStore.getState().updateSession('missing', { name: 'x' } as never);
+      expect(useAppStore.getState().sessions).toEqual([s1]);
+    });
+  });
+
+  // ---- removeSession cascade ----------------------------------------------------
+
+  describe('removeSession cascade', () => {
+    it('removes the session and its conversations + messages', () => {
+      const conv = createMockConversation({ id: 'c1', sessionId: 's1' });
+      const otherConv = createMockConversation({ id: 'c2', sessionId: 's2' });
+
+      useAppStore.setState({
+        sessions: [s1, s2],
+        conversations: [conv as never, otherConv as never],
+        conversationIds: new Set(['c1', 'c2']),
+        conversationsBySession: { s1: [conv as never], s2: [otherConv as never] },
+        messagesByConversation: { c1: [{ id: 'm1' }] as never, c2: [] },
+      });
+
+      useAppStore.getState().removeSession('s1');
+
+      const state = useAppStore.getState();
+      expect(state.sessions.map((s) => s.id)).toEqual(['s2']);
+      expect(state.conversations.map((c) => c.id)).toEqual(['c2']);
+      expect(state.conversationIds.has('c1')).toBe(false);
+      expect(state.messagesByConversation['c1']).toBeUndefined();
+      expect(state.conversationsBySession['s1']).toBeUndefined();
+    });
+
+    it('clears per-conversation maps for removed session', () => {
+      const conv = createMockConversation({ id: 'c1', sessionId: 's1' });
+      useAppStore.setState({
+        sessions: [s1],
+        conversations: [conv as never],
+        conversationIds: new Set(['c1']),
+        conversationsBySession: { s1: [conv as never] },
+        streamingState: { c1: {} as never },
+        activeTools: { c1: [] as never },
+        agentTodos: { c1: [] as never },
+        contextUsage: { c1: {} as never },
+        queuedMessages: { c1: [] as never },
+        messagePagination: { c1: { hasMore: true } as never },
+      });
+
+      useAppStore.getState().removeSession('s1');
+
+      const state = useAppStore.getState();
+      expect(state.streamingState['c1']).toBeUndefined();
+      expect(state.activeTools['c1']).toBeUndefined();
+      expect(state.agentTodos['c1']).toBeUndefined();
+      expect(state.contextUsage['c1']).toBeUndefined();
+      expect(state.queuedMessages['c1']).toBeUndefined();
+      expect(state.messagePagination['c1']).toBeUndefined();
+    });
+
+    it('clears session-keyed slices', () => {
+      useAppStore.setState({
+        sessions: [s1],
+        customTodos: { s1: [] as never, s2: [] as never },
+        sessionOutputs: { s1: [] as never },
+        reviewComments: { s1: [] as never },
+        sessionToggleState: { s1: {} as never },
+        draftInputs: { s1: { text: 'x', attachments: [] } },
+        terminalInstances: { s1: {} as never },
+        activeTerminalId: { s1: 't1' },
+        terminalPanelVisible: { s1: true },
+        claudeTerminals: { s1: {} as never },
+        activeClaudeTerminalId: { s1: 'ct1' },
+      });
+
+      useAppStore.getState().removeSession('s1');
+
+      const state = useAppStore.getState();
+      expect(state.customTodos['s1']).toBeUndefined();
+      expect(state.customTodos['s2']).toBeDefined();
+      expect(state.sessionOutputs['s1']).toBeUndefined();
+      expect(state.reviewComments['s1']).toBeUndefined();
+      expect(state.sessionToggleState['s1']).toBeUndefined();
+      expect(state.draftInputs['s1']).toBeUndefined();
+      expect(state.terminalInstances['s1']).toBeUndefined();
+      expect(state.activeTerminalId['s1']).toBeUndefined();
+      expect(state.terminalPanelVisible['s1']).toBeUndefined();
+      expect(state.claudeTerminals['s1']).toBeUndefined();
+      expect(state.activeClaudeTerminalId['s1']).toBeUndefined();
+    });
+
+    it('clears selectedSessionId / selectedConversationId when removing the selected session', () => {
+      const conv = createMockConversation({ id: 'c1', sessionId: 's1' });
+      useAppStore.setState({
+        sessions: [s1],
+        conversations: [conv as never],
+        conversationIds: new Set(['c1']),
+        selectedSessionId: 's1',
+        selectedConversationId: 'c1',
+        selectedFileTabId: 'tab-1',
+        fileTabs: [{ id: 'tab-1', sessionId: 's1' }] as never,
+      });
+
+      useAppStore.getState().removeSession('s1');
+
+      const state = useAppStore.getState();
+      expect(state.selectedSessionId).toBeNull();
+      expect(state.selectedConversationId).toBeNull();
+      expect(state.selectedFileTabId).toBeNull();
+      expect(state.fileTabs).toEqual([]);
+    });
+
+    it('preserves selectedSessionId when removing an unrelated session', () => {
+      useAppStore.setState({
+        sessions: [s1, s2],
+        selectedSessionId: 's2',
+      });
+      useAppStore.getState().removeSession('s1');
+      expect(useAppStore.getState().selectedSessionId).toBe('s2');
+    });
+  });
+
+  // ---- selectSession ----------------------------------------------------------
+
+  describe('selectSession', () => {
+    it('updates selectedSessionId', () => {
+      useAppStore.setState({ sessions: [s1, s2] });
+      useAppStore.getState().selectSession('s1');
+      expect(useAppStore.getState().selectedSessionId).toBe('s1');
+    });
+
+    it("auto-selects the first conversation in the session", () => {
+      const c1 = createMockConversation({ id: 'c1', sessionId: 's1' });
+      const c2 = createMockConversation({ id: 'c2', sessionId: 's1' });
+      useAppStore.setState({
+        sessions: [s1],
+        conversations: [c1 as never, c2 as never],
+        conversationIds: new Set(['c1', 'c2']),
+      });
+
+      useAppStore.getState().selectSession('s1');
+      expect(useAppStore.getState().selectedConversationId).toBe('c1');
+    });
+
+    it('restores last active conversation when one was remembered', () => {
+      const c1 = createMockConversation({ id: 'c1', sessionId: 's1' });
+      const c2 = createMockConversation({ id: 'c2', sessionId: 's1' });
+      useAppStore.setState({
+        sessions: [s1],
+        conversations: [c1 as never, c2 as never],
+        conversationIds: new Set(['c1', 'c2']),
+        lastActiveConversationPerSession: { s1: 'c2' },
+      });
+
+      useAppStore.getState().selectSession('s1');
+      expect(useAppStore.getState().selectedConversationId).toBe('c2');
+    });
+
+    it('falls back to first conversation when last-active id no longer exists', () => {
+      const c1 = createMockConversation({ id: 'c1', sessionId: 's1' });
+      useAppStore.setState({
+        sessions: [s1],
+        conversations: [c1 as never],
+        conversationIds: new Set(['c1']),
+        lastActiveConversationPerSession: { s1: 'c-missing' },
+      });
+
+      useAppStore.getState().selectSession('s1');
+      expect(useAppStore.getState().selectedConversationId).toBe('c1');
+    });
+
+    it("scopes file tabs to the selected session", () => {
+      const tabA = { id: 'ta', sessionId: 's1' } as never;
+      const tabB = { id: 'tb', sessionId: 's2' } as never;
+      useAppStore.setState({
+        sessions: [s1, s2],
+        fileTabs: [tabA, tabB],
+        selectedFileTabId: 'tb', // currently selected tab belongs to s2
+      });
+
+      useAppStore.getState().selectSession('s1');
+      expect(useAppStore.getState().selectedFileTabId).toBe('ta');
+    });
+
+    it('clears selectedFileTabId when no tabs match the session', () => {
+      useAppStore.setState({
+        sessions: [s1],
+        fileTabs: [],
+        selectedFileTabId: 'tab-x',
+      });
+
+      useAppStore.getState().selectSession('s1');
+      expect(useAppStore.getState().selectedFileTabId).toBeNull();
+    });
+
+    it('marks session as read in settings store', () => {
+      const markSessionRead = vi.fn();
+      useSettingsStore.setState({
+        markSessionRead,
+        markSessionUnread: vi.fn(),
+      } as never);
+
+      useAppStore.setState({ sessions: [s1] });
+      useAppStore.getState().selectSession('s1');
+
+      expect(markSessionRead).toHaveBeenCalledWith('s1');
+    });
+
+    it('does not call markSessionRead when id is null', () => {
+      const markSessionRead = vi.fn();
+      useSettingsStore.setState({
+        markSessionRead,
+        markSessionUnread: vi.fn(),
+      } as never);
+
+      useAppStore.getState().selectSession(null);
+      expect(markSessionRead).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- setSessionToggleState --------------------------------------------------
+
+  describe('setSessionToggleState', () => {
+    it('sets toggle state for a session', () => {
+      useAppStore.getState().setSessionToggleState('s1', { expanded: true } as never);
+      expect((useAppStore.getState().sessionToggleState as Record<string, unknown>)['s1']).toEqual({ expanded: true });
+    });
+
+    it('does not affect other sessions', () => {
+      useAppStore.getState().setSessionToggleState('s1', { expanded: true } as never);
+      useAppStore.getState().setSessionToggleState('s2', { expanded: false } as never);
+      const state = useAppStore.getState().sessionToggleState as Record<string, { expanded: boolean }>;
+      expect(state.s1.expanded).toBe(true);
+      expect(state.s2.expanded).toBe(false);
+    });
+  });
+
+  // ---- archiveSession --------------------------------------------------------
+
+  describe('archiveSession', () => {
+    it('marks session as archived', () => {
+      useAppStore.setState({ sessions: [s1, s2] });
+      useAppStore.getState().archiveSession('s1');
+      const archived = useAppStore.getState().sessions.find((s) => s.id === 's1');
+      expect(archived?.archived).toBe(true);
+    });
+
+    it('is a no-op when session does not exist', () => {
+      useAppStore.setState({ sessions: [s1] });
+      useAppStore.getState().archiveSession('missing');
+      expect(useAppStore.getState().sessions[0].archived).toBeFalsy();
+    });
+
+    it('selects another non-archived session in the same workspace when archiving the selected one', () => {
+      useAppStore.setState({
+        sessions: [s1, s2],
+        selectedSessionId: 's1',
+      });
+      useAppStore.getState().archiveSession('s1');
+      expect(useAppStore.getState().selectedSessionId).toBe('s2');
+    });
+
+    it('clears selection when no other sessions remain in the workspace', () => {
+      useAppStore.setState({
+        sessions: [s1, s3], // s3 is in different workspace
+        selectedSessionId: 's1',
+      });
+      useAppStore.getState().archiveSession('s1');
+      expect(useAppStore.getState().selectedSessionId).toBeNull();
+      expect(useAppStore.getState().selectedConversationId).toBeNull();
+    });
+
+    it('skips already-archived sessions when picking next selection', () => {
+      const s2archived = { ...s2, archived: true };
+      useAppStore.setState({
+        sessions: [s1, s2archived],
+        selectedSessionId: 's1',
+      });
+      useAppStore.getState().archiveSession('s1');
+      expect(useAppStore.getState().selectedSessionId).toBeNull();
+    });
+
+    it('cleans up terminal slices for the archived session', () => {
+      useAppStore.setState({
+        sessions: [s1, s2],
+        terminalInstances: { s1: {} as never, s2: {} as never },
+        activeTerminalId: { s1: 't1', s2: 't2' },
+        terminalPanelVisible: { s1: true, s2: false },
+        claudeTerminals: { s1: {} as never, s2: {} as never },
+        activeClaudeTerminalId: { s1: 'c1', s2: 'c2' },
+      });
+
+      useAppStore.getState().archiveSession('s1');
+
+      const state = useAppStore.getState();
+      expect(state.terminalInstances['s1']).toBeUndefined();
+      expect(state.terminalInstances['s2']).toBeDefined();
+      expect(state.activeTerminalId['s1']).toBeUndefined();
+      expect(state.terminalPanelVisible['s1']).toBeUndefined();
+      expect(state.claudeTerminals['s1']).toBeUndefined();
+      expect(state.activeClaudeTerminalId['s1']).toBeUndefined();
+    });
+  });
+
+  describe('unarchiveSession', () => {
+    it('clears the archived flag', () => {
+      useAppStore.setState({ sessions: [{ ...s1, archived: true }] });
+      useAppStore.getState().unarchiveSession('s1');
+      expect(useAppStore.getState().sessions[0].archived).toBe(false);
+    });
+
+    it('is a no-op when session does not exist', () => {
+      useAppStore.setState({ sessions: [s1] });
+      useAppStore.getState().unarchiveSession('missing');
+      expect(useAppStore.getState().sessions).toEqual([s1]);
+    });
+  });
+
+  // ---- Drafts -----------------------------------------------------------------
+
+  describe('setDraftInput / clearDraftInput', () => {
+    it('stores a draft for a session', () => {
+      useAppStore.getState().setDraftInput('s1', { text: 'hello', attachments: [] });
+      expect(useAppStore.getState().draftInputs['s1']).toEqual({ text: 'hello', attachments: [] });
+    });
+
+    it('replaces an existing draft', () => {
+      useAppStore.getState().setDraftInput('s1', { text: 'first', attachments: [] });
+      useAppStore.getState().setDraftInput('s1', { text: 'second', attachments: [] });
+      expect(useAppStore.getState().draftInputs['s1']?.text).toBe('second');
+    });
+
+    it('clearDraftInput removes the entry', () => {
+      useAppStore.getState().setDraftInput('s1', { text: 'hi', attachments: [] });
+      useAppStore.getState().clearDraftInput('s1');
+      expect(useAppStore.getState().draftInputs['s1']).toBeUndefined();
+    });
+
+    it('clearDraftInput is safe when no draft exists', () => {
+      expect(() => useAppStore.getState().clearDraftInput('s1')).not.toThrow();
+    });
+
+    it('isolates drafts across sessions', () => {
+      useAppStore.getState().setDraftInput('s1', { text: 'a', attachments: [] });
+      useAppStore.getState().setDraftInput('s2', { text: 'b', attachments: [] });
+
+      useAppStore.getState().clearDraftInput('s1');
+      expect(useAppStore.getState().draftInputs['s1']).toBeUndefined();
+      expect(useAppStore.getState().draftInputs['s2']?.text).toBe('b');
+    });
+  });
+});

--- a/src/stores/__tests__/appStore.workspaces.test.ts
+++ b/src/stores/__tests__/appStore.workspaces.test.ts
@@ -32,8 +32,6 @@ describe('appStore — workspace actions', () => {
       terminalPanelVisible: {},
       terminalSessions: {},
       lastActiveConversationPerSession: {},
-      claudeTerminals: {},
-      activeClaudeTerminalId: {},
       selectedWorkspaceId: null,
       selectedSessionId: null,
       selectedConversationId: null,

--- a/src/stores/__tests__/appStore.workspaces.test.ts
+++ b/src/stores/__tests__/appStore.workspaces.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAppStore } from '../appStore';
+import { useSettingsStore } from '../settingsStore';
+import {
+  createMockWorkspace,
+  createMockSession,
+  createMockConversation,
+} from '@/test-utils/store-utils';
+import type { Workspace } from '@/lib/types';
+
+const w1 = createMockWorkspace({ id: 'ws-1', name: 'Alpha' }) as Workspace;
+const w2 = createMockWorkspace({ id: 'ws-2', name: 'Beta' }) as Workspace;
+const w3 = createMockWorkspace({ id: 'ws-3', name: 'Gamma' }) as Workspace;
+
+describe('appStore — workspace actions', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [],
+      sessions: [],
+      conversations: [],
+      conversationIds: new Set(),
+      conversationsBySession: {},
+      messagesByConversation: {},
+      streamingState: {},
+      activeTools: {},
+      agentTodos: {},
+      messagePagination: {},
+      customTodos: {},
+      sessionOutputs: {},
+      terminalInstances: {},
+      activeTerminalId: {},
+      terminalPanelVisible: {},
+      terminalSessions: {},
+      lastActiveConversationPerSession: {},
+      claudeTerminals: {},
+      activeClaudeTerminalId: {},
+      selectedWorkspaceId: null,
+      selectedSessionId: null,
+      selectedConversationId: null,
+      selectedFileTabId: null,
+      fileTabs: [],
+    });
+    useSettingsStore.setState({ workspaceOrder: [] } as never);
+  });
+
+  describe('setWorkspaces', () => {
+    it('replaces the workspaces array wholesale', () => {
+      useAppStore.getState().setWorkspaces([w1, w2]);
+      expect(useAppStore.getState().workspaces).toHaveLength(2);
+
+      useAppStore.getState().setWorkspaces([w3]);
+      expect(useAppStore.getState().workspaces).toEqual([w3]);
+    });
+
+    it('accepts empty array', () => {
+      useAppStore.getState().setWorkspaces([w1]);
+      useAppStore.getState().setWorkspaces([]);
+      expect(useAppStore.getState().workspaces).toEqual([]);
+    });
+  });
+
+  describe('addWorkspace', () => {
+    it('appends to the end of the list', () => {
+      useAppStore.getState().setWorkspaces([w1]);
+      useAppStore.getState().addWorkspace(w2);
+      expect(useAppStore.getState().workspaces.map((w) => w.id)).toEqual(['ws-1', 'ws-2']);
+    });
+  });
+
+  describe('updateWorkspace', () => {
+    it('merges partial updates onto matching workspace by id', () => {
+      useAppStore.getState().setWorkspaces([w1, w2]);
+      useAppStore.getState().updateWorkspace('ws-1', { name: 'Renamed' });
+
+      const ws = useAppStore.getState().workspaces;
+      expect(ws.find((w) => w.id === 'ws-1')?.name).toBe('Renamed');
+      expect(ws.find((w) => w.id === 'ws-2')?.name).toBe('Beta');
+    });
+
+    it('is a no-op when id does not match', () => {
+      useAppStore.getState().setWorkspaces([w1]);
+      useAppStore.getState().updateWorkspace('nonexistent', { name: 'x' } as never);
+      expect(useAppStore.getState().workspaces).toEqual([w1]);
+    });
+  });
+
+  describe('selectWorkspace', () => {
+    it('updates selectedWorkspaceId', () => {
+      useAppStore.getState().selectWorkspace('ws-1');
+      expect(useAppStore.getState().selectedWorkspaceId).toBe('ws-1');
+
+      useAppStore.getState().selectWorkspace(null);
+      expect(useAppStore.getState().selectedWorkspaceId).toBeNull();
+    });
+  });
+
+  describe('reorderWorkspaces', () => {
+    it('moves activeId before overId', () => {
+      useAppStore.getState().setWorkspaces([w1, w2, w3]);
+      useAppStore.getState().reorderWorkspaces('ws-3', 'ws-1');
+      expect(useAppStore.getState().workspaces.map((w) => w.id)).toEqual(['ws-3', 'ws-1', 'ws-2']);
+    });
+
+    it('persists new order to settingsStore', () => {
+      const setWorkspaceOrder = vi.fn();
+      useSettingsStore.setState({ setWorkspaceOrder, workspaceOrder: [] } as never);
+
+      useAppStore.getState().setWorkspaces([w1, w2, w3]);
+      useAppStore.getState().reorderWorkspaces('ws-2', 'ws-1');
+
+      expect(setWorkspaceOrder).toHaveBeenCalledWith(['ws-2', 'ws-1', 'ws-3']);
+    });
+
+    it('returns state unchanged when activeId is missing', () => {
+      useAppStore.getState().setWorkspaces([w1, w2]);
+      useAppStore.getState().reorderWorkspaces('missing', 'ws-1');
+      expect(useAppStore.getState().workspaces.map((w) => w.id)).toEqual(['ws-1', 'ws-2']);
+    });
+
+    it('returns state unchanged when overId is missing', () => {
+      useAppStore.getState().setWorkspaces([w1, w2]);
+      useAppStore.getState().reorderWorkspaces('ws-1', 'missing');
+      expect(useAppStore.getState().workspaces.map((w) => w.id)).toEqual(['ws-1', 'ws-2']);
+    });
+  });
+
+  describe('removeWorkspace cascade', () => {
+    it('removes the workspace from the list', () => {
+      useAppStore.getState().setWorkspaces([w1, w2]);
+      useAppStore.getState().removeWorkspace('ws-1');
+      expect(useAppStore.getState().workspaces.map((w) => w.id)).toEqual(['ws-2']);
+    });
+
+    it('cascades to sessions, conversations, and messages of the removed workspace', () => {
+      const session = createMockSession({ id: 'session-1', workspaceId: 'ws-1' });
+      const otherSession = createMockSession({ id: 'session-2', workspaceId: 'ws-2' });
+      const conversation = createMockConversation({ id: 'conv-1', sessionId: 'session-1' });
+      const otherConv = createMockConversation({ id: 'conv-2', sessionId: 'session-2' });
+
+      useAppStore.setState({
+        workspaces: [w1, w2],
+        sessions: [session as never, otherSession as never],
+        conversations: [conversation as never, otherConv as never],
+        conversationIds: new Set(['conv-1', 'conv-2']),
+        conversationsBySession: {
+          'session-1': [conversation as never],
+          'session-2': [otherConv as never],
+        },
+        messagesByConversation: {
+          'conv-1': [{ id: 'm1' }] as never,
+          'conv-2': [{ id: 'm2' }] as never,
+        },
+        streamingState: { 'conv-1': {} as never, 'conv-2': {} as never },
+        activeTools: { 'conv-1': [] as never, 'conv-2': [] as never },
+        agentTodos: { 'conv-1': [] as never, 'conv-2': [] as never },
+      });
+
+      useAppStore.getState().removeWorkspace('ws-1');
+
+      const state = useAppStore.getState();
+      expect(state.sessions.map((s) => s.id)).toEqual(['session-2']);
+      expect(state.conversations.map((c) => c.id)).toEqual(['conv-2']);
+      expect(state.conversationIds.has('conv-1')).toBe(false);
+      expect(state.conversationIds.has('conv-2')).toBe(true);
+      expect(state.conversationsBySession['session-1']).toBeUndefined();
+      expect(state.conversationsBySession['session-2']).toBeDefined();
+      expect(state.messagesByConversation['conv-1']).toBeUndefined();
+      expect(state.messagesByConversation['conv-2']).toBeDefined();
+      expect(state.streamingState['conv-1']).toBeUndefined();
+      expect(state.activeTools['conv-1']).toBeUndefined();
+      expect(state.agentTodos['conv-1']).toBeUndefined();
+    });
+
+    it('clears selectedWorkspaceId when removing the selected workspace', () => {
+      useAppStore.setState({
+        workspaces: [w1, w2],
+        selectedWorkspaceId: 'ws-1',
+      });
+      useAppStore.getState().removeWorkspace('ws-1');
+      expect(useAppStore.getState().selectedWorkspaceId).toBeNull();
+    });
+
+    it('preserves selectedWorkspaceId when removing a different workspace', () => {
+      useAppStore.setState({
+        workspaces: [w1, w2],
+        selectedWorkspaceId: 'ws-2',
+      });
+      useAppStore.getState().removeWorkspace('ws-1');
+      expect(useAppStore.getState().selectedWorkspaceId).toBe('ws-2');
+    });
+
+    it('clears selectedSessionId/conversationId when they belong to removed workspace', () => {
+      const session = createMockSession({ id: 'session-1', workspaceId: 'ws-1' });
+      const conversation = createMockConversation({ id: 'conv-1', sessionId: 'session-1' });
+
+      useAppStore.setState({
+        workspaces: [w1],
+        sessions: [session as never],
+        conversations: [conversation as never],
+        conversationIds: new Set(['conv-1']),
+        selectedSessionId: 'session-1',
+        selectedConversationId: 'conv-1',
+        selectedFileTabId: 'tab-1',
+        fileTabs: [{ id: 'tab-1', sessionId: 'session-1' }] as never,
+      });
+
+      useAppStore.getState().removeWorkspace('ws-1');
+
+      const state = useAppStore.getState();
+      expect(state.selectedSessionId).toBeNull();
+      expect(state.selectedConversationId).toBeNull();
+      expect(state.selectedFileTabId).toBeNull();
+      expect(state.fileTabs).toEqual([]);
+    });
+
+    it('removes the workspace id from settingsStore.workspaceOrder', () => {
+      const setWorkspaceOrder = vi.fn();
+      useSettingsStore.setState({
+        setWorkspaceOrder,
+        workspaceOrder: ['ws-1', 'ws-2', 'ws-3'],
+      } as never);
+      useAppStore.setState({ workspaces: [w1, w2, w3] });
+
+      useAppStore.getState().removeWorkspace('ws-2');
+
+      expect(setWorkspaceOrder).toHaveBeenCalledWith(['ws-1', 'ws-3']);
+    });
+
+    it('does not call setWorkspaceOrder when the workspace was not in the order', () => {
+      const setWorkspaceOrder = vi.fn();
+      useSettingsStore.setState({
+        setWorkspaceOrder,
+        workspaceOrder: ['ws-2'],
+      } as never);
+      useAppStore.setState({ workspaces: [w1, w2] });
+
+      useAppStore.getState().removeWorkspace('ws-1');
+      expect(setWorkspaceOrder).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/test-utils/async.ts
+++ b/src/test-utils/async.ts
@@ -1,0 +1,14 @@
+/**
+ * Async test helpers.
+ *
+ * `flushAsync` advances the microtask queue a fixed number of ticks. Use it
+ * instead of `await new Promise((r) => setTimeout(r, N))` for *negative*
+ * assertions ("nothing happens within X") — those macrotask waits are
+ * race-prone on slow CI runners (audit F-3). For waiting on a *condition*,
+ * prefer `@testing-library/react`'s `waitFor` instead.
+ */
+export async function flushAsync(ticks: number = 3): Promise<void> {
+  for (let i = 0; i < ticks; i++) {
+    await Promise.resolve();
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,11 +23,29 @@ export default defineConfig({
         'src/app/**/loading.tsx',
         'src/app/**/error.tsx',
       ],
+      // Coverage gate, calibrated to current measured values minus ~2 pts of headroom.
+      // Per-glob thresholds lock in the well-tested directories (lib/api/, lib/, stores/)
+      // so future PRs cannot silently regress them while the global average stays acceptable.
+      // Ratchet upward as new tests land.
       thresholds: {
-        statements: 20,
-        branches: 20,
-        functions: 20,
-        lines: 20,
+        // Global gate (catches regressions outside the explicitly-cared-for directories)
+        statements: 22,
+        branches: 19,
+        functions: 22,
+        lines: 22,
+        // High-coverage directories: hold them near current values
+        'src/lib/api/**': {
+          statements: 85,
+          branches: 68,
+          functions: 85,
+          lines: 85,
+        },
+        'src/stores/**': {
+          statements: 60,
+          branches: 51,
+          functions: 53,
+          lines: 61,
+        },
       },
     },
     alias: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,21 +24,30 @@ export default defineConfig({
         'src/app/**/error.tsx',
       ],
       // Coverage gate, calibrated to current measured values minus ~2 pts of headroom.
-      // Per-glob thresholds lock in the well-tested directories (lib/api/, lib/, stores/)
-      // so future PRs cannot silently regress them while the global average stays acceptable.
-      // Ratchet upward as new tests land.
+      // Per-glob thresholds lock in the well-tested directories (lib/, lib/api/, stores/)
+      // so future PRs cannot silently regress them while the global average stays
+      // acceptable. Ratchet upward as new tests land.
       thresholds: {
         // Global gate (catches regressions outside the explicitly-cared-for directories)
         statements: 22,
         branches: 19,
         functions: 22,
         lines: 22,
-        // High-coverage directories: hold them near current values
+        // High-coverage directories: hold them near current values.
+        // src/lib/api/** is matched first (more specific glob) so its higher floor
+        // applies to the API clients; everything else under src/lib/** falls back
+        // to the broader floor below.
         'src/lib/api/**': {
           statements: 85,
           branches: 68,
           functions: 85,
           lines: 85,
+        },
+        'src/lib/**': {
+          statements: 55,
+          branches: 55,
+          functions: 55,
+          lines: 58,
         },
         'src/stores/**': {
           statements: 60,


### PR DESCRIPTION
## Summary

Two-commit branch that lifts frontend coverage from a 20% floor to a calibrated, per-directory gate, and fixes a real mount-race in `usePRStatus` uncovered while writing the new tests.

**Commit 1 — expand suite (1760 → 2510 tests, +750)**
- `lib/api/`: 21.8% → 97.3% statements (every API client function exercised through MSW handlers)
- `appStore.ts`: 29.2% → 73% (workspace/session/conversation CRUD with cascade cleanup, file tabs, active tools, sub-agents, background tasks)
- `useWebSocket.ts`: 0.25% → 13.9% via a `MockWebSocket` integration test (mitigates audit P0 — the existing 7 `*.test.ts` files only drove store actions, not the hook itself)
- 11 hooks lifted from 0% to 90%+ (useShortcut, useApprovalPrompt, useFontSize, useResolvedThemeType, useAttentionCount, useAvatars, useExternalLinkGuard, useGlobalShortcuts, usePRStatus, useMenuHandlers, etc.)
- `PlateInput.tsx`: 0% → 96.3% via smoke render
- CI: `pnpm run test:coverage` (was `test:run`); coverage report uploaded as a 14-day artifact
- `vitest.config.ts` thresholds: global 22/19/22/22 plus per-dir floors for `src/lib/api/**` (85/68/85/85), `src/lib/**` (55/55/55/58), and `src/stores/**` (60/51/53/61)

**Commit 2 — stabilize async assertions and fix `usePRStatus` mount race**
- **Production fix**: `usePRStatus` now skips its clear-stale-data effect on initial mount via a `previousSessionRef`. Without this guard the clear's `setTimeout(0)` raced the fetch effect, wiping freshly-loaded `prDetails` on a fast resolver (jsdom + MSW, or hot-cached responses in production).
- **`flushAsync` test helper** (`src/test-utils/async.ts`) replaces ad-hoc `setTimeout(r, N)` macrotask waits in hook/api/store tests — kills CI flakes from timing guesses.
- Drops the MSW response-delay workaround in `usePRStatus` tests (no longer needed once the production race is fixed).
- Defensive `MAX_DEPTH=200` cap on `extractContent` (Plate value walker) for pathological clipboard input.

## Test plan

- [x] `pnpm run test:coverage` passes locally with the calibrated thresholds
- [x] `pnpm run lint` clean
- [ ] CI green (frontend job runs `test:coverage` + lint in parallel and uploads the coverage artifact)
- [ ] Verify `frontend-coverage` artifact is downloadable from the Actions run
- [ ] Smoke-test `usePRStatus` in the running app: switch sessions repeatedly and confirm PR details load on the first paint without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)