### PR TITLE
fix(checks): harden CI runs against null payloads and surface panel errors

### DIFF
--- a/backend/github/actions.go
+++ b/backend/github/actions.go
@@ -118,7 +118,9 @@ func (c *Client) ListWorkflowRuns(ctx context.Context, owner, repo, branch strin
 		return nil, err
 	}
 
-	var runs []WorkflowRun
+	// Initialized as empty (non-nil) so a zero-result response serializes as
+	// `[]` not `null`, which the frontend treats as a hard contract violation.
+	runs := []WorkflowRun{}
 	for page := 1; page <= maxWorkflowRunPages; page++ {
 		q := url.Values{}
 		q.Set("per_page", strconv.Itoa(pagePerPage))
@@ -247,7 +249,9 @@ func (c *Client) ListWorkflowJobs(ctx context.Context, owner, repo string, runID
 		return nil, err
 	}
 
-	var jobs []WorkflowJob
+	// Initialized as empty (non-nil) so a zero-result response serializes as
+	// `[]` not `null`, which the frontend treats as a hard contract violation.
+	jobs := []WorkflowJob{}
 	for page := 1; page <= maxWorkflowJobPages; page++ {
 		q := url.Values{}
 		q.Set("per_page", strconv.Itoa(pagePerPage))

--- a/backend/github/actions_test.go
+++ b/backend/github/actions_test.go
@@ -416,6 +416,56 @@ func TestGetCombinedStatus_Success(t *testing.T) {
 	require.Equal(t, "chatml/ai-review", combined.Statuses[1].Context)
 }
 
+// Regression: a Go nil slice marshals to JSON `null`, which crashes the
+// frontend Checks panel when it does `runs.some(...)`. ListWorkflowRuns must
+// always return a non-nil slice when the API responds 200 with zero runs.
+func TestListWorkflowRuns_EmptyResultSerializesAsArray(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"total_count":   0,
+			"workflow_runs": []map[string]interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.SetToken("test_token")
+	client.SetAPIURL(server.URL)
+
+	runs, err := client.ListWorkflowRuns(context.Background(), "owner", "repo", "")
+	require.NoError(t, err)
+	require.NotNil(t, runs, "must be non-nil so JSON serializes as `[]` not `null`")
+	require.Len(t, runs, 0)
+
+	encoded, err := json.Marshal(runs)
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(encoded))
+}
+
+// Regression: same nil-slice pitfall as above, for ListWorkflowJobs.
+func TestListWorkflowJobs_EmptyResultSerializesAsArray(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"total_count": 0,
+			"jobs":        []map[string]interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("", "")
+	client.SetToken("test_token")
+	client.SetAPIURL(server.URL)
+
+	jobs, err := client.ListWorkflowJobs(context.Background(), "owner", "repo", 12345)
+	require.NoError(t, err)
+	require.NotNil(t, jobs, "must be non-nil so JSON serializes as `[]` not `null`")
+	require.Len(t, jobs, 0)
+
+	encoded, err := json.Marshal(jobs)
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(encoded))
+}
+
 func TestWorkflowRun_TimeFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/src/components/panels/ChangesPanel.tsx
+++ b/src/components/panels/ChangesPanel.tsx
@@ -76,7 +76,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
-import { InlineErrorFallback } from '@/components/shared/ErrorFallbacks';
+import { InlineErrorFallback, PanelErrorFallback } from '@/components/shared/ErrorFallbacks';
 import type { FileTab } from '@/lib/types';
 import { useShortcuts } from '@/hooks/useShortcut';
 import { getShortcutById, formatShortcutKeys } from '@/lib/shortcuts';
@@ -950,7 +950,11 @@ export function ChangesPanel() {
                   />
                 )}
                 <div className="flex-1 min-h-0 p-1">
-                  <ErrorBoundary section="FileTree" fallback={<InlineErrorFallback message="Unable to display file tree" />}>
+                  <ErrorBoundary
+                    section="FileTree"
+                    fallback={<InlineErrorFallback message="Unable to display file tree" />}
+                    resetKeys={[selectedWorkspaceId, selectedSessionId]}
+                  >
                     <FileTree
                       ref={fileTreeRef}
                       files={files}
@@ -1000,12 +1004,32 @@ export function ChangesPanel() {
             )}
           </div>
           <div className={cn("h-full", selectedTab !== 'review' && 'hidden')}>
-            <ErrorBoundary section="ReviewPanel" fallback={<InlineErrorFallback message="Unable to display review" />}>
+            <ErrorBoundary
+              section="ReviewPanel"
+              fallback={({ error, retry }) => (
+                <PanelErrorFallback
+                  title="Couldn't load review"
+                  error={error}
+                  onRetry={retry}
+                />
+              )}
+              resetKeys={[selectedWorkspaceId, selectedSessionId]}
+            >
               <ReviewPanel workspaceId={selectedWorkspaceId} sessionId={selectedSessionId} onFileSelect={handleReviewFileSelect} showResolved={showResolved} />
             </ErrorBoundary>
           </div>
           <div className={cn("h-full", selectedTab !== 'checks' && 'hidden')}>
-            <ErrorBoundary section="ChecksPanel" fallback={<InlineErrorFallback message="Unable to display checks" />}>
+            <ErrorBoundary
+              section="ChecksPanel"
+              fallback={({ error, retry }) => (
+                <PanelErrorFallback
+                  title="Couldn't load checks"
+                  error={error}
+                  onRetry={retry}
+                />
+              )}
+              resetKeys={[selectedWorkspaceId, selectedSessionId]}
+            >
               <ChecksPanel ref={checksPanelRef} onSendMessage={handleGitActionMessage} onPrUrlChange={setPrUrl} active={selectedTab === 'checks'} />
             </ErrorBoundary>
           </div>
@@ -1043,7 +1067,11 @@ export function ChangesPanel() {
             {/* Tab content — CSS visibility toggling prevents unmount/remount */}
             <div className="flex-1 min-h-0">
               <div className={cn("h-full", bottomTab !== 'todos' && 'hidden')}>
-                <ErrorBoundary section="TodoPanel" fallback={<InlineErrorFallback message="Unable to display tasks" />}>
+                <ErrorBoundary
+                  section="TodoPanel"
+                  fallback={<InlineErrorFallback message="Unable to display tasks" />}
+                  resetKeys={[selectedSessionId, selectedConversationId]}
+                >
                   <TodoPanel />
                 </ErrorBoundary>
               </div>
@@ -1059,12 +1087,20 @@ export function ChangesPanel() {
               </div>
               {/* CSS 'hidden' keeps the component mounted; isVisible gates network fetches */}
               <div className={cn("h-full", bottomTab !== 'file-history' && 'hidden')}>
-                <ErrorBoundary section="FileHistory" fallback={<InlineErrorFallback message="Unable to display file history" />}>
+                <ErrorBoundary
+                  section="FileHistory"
+                  fallback={<InlineErrorFallback message="Unable to display file history" />}
+                  resetKeys={[selectedWorkspaceId, selectedSessionId]}
+                >
                   <FileHistoryPanel isVisible={bottomTab === 'file-history'} />
                 </ErrorBoundary>
               </div>
               <div className={cn("h-full", bottomTab !== 'background' && 'hidden')}>
-                <ErrorBoundary section="BackgroundTasks" fallback={<InlineErrorFallback message="Unable to display background tasks" />}>
+                <ErrorBoundary
+                  section="BackgroundTasks"
+                  fallback={<InlineErrorFallback message="Unable to display background tasks" />}
+                  resetKeys={[selectedConversationId]}
+                >
                   <BackgroundTasksPanel conversationId={selectedConversationId} />
                 </ErrorBoundary>
               </div>

--- a/src/components/shared/ErrorFallbacks.tsx
+++ b/src/components/shared/ErrorFallbacks.tsx
@@ -1,8 +1,15 @@
 'use client';
 
-import { AlertTriangle } from 'lucide-react';
+import { useId, useState } from 'react';
+import { AlertTriangle, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 import type { LucideIcon } from 'lucide-react';
+
+// Cap rendered error messages so a stringified HTML error page or a giant
+// stack-as-message can't break the panel layout. The <pre> below also caps
+// vertical size; this is the horizontal/character-count guard.
+const MAX_ERROR_MESSAGE_CHARS = 1000;
 
 interface InlineErrorFallbackProps {
   message?: string;
@@ -58,6 +65,91 @@ export function BlockErrorFallback({
       <p className="text-sm font-medium">{title}</p>
       {description && (
         <p className="text-xs text-muted-foreground/70 mt-1">{description}</p>
+      )}
+    </div>
+  );
+}
+
+interface PanelErrorFallbackProps {
+  title?: string;
+  description?: string;
+  /** Underlying error to surface in the collapsible "Show details" section. */
+  error?: Error | null;
+  /** Retry handler — wired to ErrorBoundary's retry. Hides the button when omitted. */
+  onRetry?: () => void;
+  className?: string;
+}
+
+/**
+ * Panel-shaped error fallback for tab content (Checks, Review, Files…).
+ *
+ * Larger and more informative than `BlockErrorFallback`: includes a retry
+ * button (driven by the ErrorBoundary's retry callback) and a collapsible
+ * error-details section so users can self-serve when the panel crashes.
+ */
+export function PanelErrorFallback({
+  title = "Couldn't load this panel",
+  description = 'Something prevented this view from rendering.',
+  error,
+  onRetry,
+  className,
+}: PanelErrorFallbackProps) {
+  const [showDetails, setShowDetails] = useState(false);
+  const detailsId = useId();
+  const rawMessage = error?.message?.trim() ?? '';
+  const message =
+    rawMessage.length > MAX_ERROR_MESSAGE_CHARS
+      ? `${rawMessage.slice(0, MAX_ERROR_MESSAGE_CHARS)}…`
+      : rawMessage;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center h-full p-6 text-center',
+        className
+      )}
+    >
+      <AlertTriangle className="w-8 h-8 mb-2 text-destructive/50" />
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="text-xs text-muted-foreground/80 mt-1.5 max-w-xs">{description}</p>
+
+      {onRetry && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRetry}
+          className="gap-2 mt-4"
+        >
+          <RefreshCw />
+          Try again
+        </Button>
+      )}
+
+      {message && (
+        <div className="mt-5 w-full max-w-md flex flex-col items-center">
+          <button
+            type="button"
+            aria-expanded={showDetails}
+            aria-controls={detailsId}
+            onClick={() => setShowDetails((v) => !v)}
+            className="flex items-center gap-1 text-2xs text-muted-foreground/70 hover:text-muted-foreground transition-colors rounded-sm outline-none focus-visible:ring-1 focus-visible:ring-ring/30"
+          >
+            {showDetails ? (
+              <ChevronDown className="w-3 h-3" />
+            ) : (
+              <ChevronRight className="w-3 h-3" />
+            )}
+            <span>{showDetails ? 'Hide details' : 'Show details'}</span>
+          </button>
+          {showDetails && (
+            <pre
+              id={detailsId}
+              className="mt-2 p-2 rounded-md bg-muted/50 border border-border text-xs font-mono text-muted-foreground whitespace-pre-wrap break-words max-h-40 overflow-auto text-left w-full"
+            >
+              {message}
+            </pre>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/hooks/__tests__/useCIRuns.test.ts
+++ b/src/hooks/__tests__/useCIRuns.test.ts
@@ -211,6 +211,27 @@ describe('useCIRuns', () => {
       expect(mockedGetCIRuns).toHaveBeenCalledTimes(2);
       expect(mockedGetCIRuns).toHaveBeenLastCalledWith('ws-1', 'session-2');
     });
+
+    // Regression: Go's encoding/json marshals a nil slice as `null` rather than
+    // `[]`, so a backend that constructs its result with `var runs []WorkflowRun`
+    // and never appends will return JSON `null` to the client. Without this
+    // coercion the hook would call `setRuns(null)` and the next render would
+    // throw `runs.some is not a function` inside the ChecksPanel ErrorBoundary.
+    it('coerces a null payload from getCIRuns to an empty array', async () => {
+      mockedGetCIRuns.mockResolvedValue(
+        null as unknown as WorkflowRunDTO[]
+      );
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      expect(result.current.runs).toEqual([]);
+      expect(result.current.error).toBeNull();
+      expect(result.current.loading).toBe(false);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -596,6 +617,28 @@ describe('useCIRuns', () => {
           await result.current.getJobs(1);
         })
       ).rejects.toThrow('No active session');
+    });
+
+    // Regression: same nil-slice pitfall as `getCIRuns`. If the backend ever
+    // returns JSON `null` for jobs, the consumer's `[...jobs].sort()` would
+    // crash. Ensure getJobs hands back an array unconditionally.
+    it('coerces a null payload from getCIJobs to an empty array', async () => {
+      mockedGetCIJobs.mockResolvedValue(
+        null as unknown as WorkflowJobDTO[]
+      );
+
+      const { result } = renderHook(() =>
+        useCIRuns('ws-1', 'session-1')
+      );
+
+      await flushAndAdvance();
+
+      let returnedJobs: WorkflowJobDTO[];
+      await act(async () => {
+        returnedJobs = await result.current.getJobs(1);
+      });
+
+      expect(returnedJobs!).toEqual([]);
     });
   });
 

--- a/src/hooks/useCIRuns.ts
+++ b/src/hooks/useCIRuns.ts
@@ -79,10 +79,13 @@ export function useCIRuns(
 
     try {
       const data = await getCIRuns(wsId, sessId);
+      // Coerce nullish to []. A nil Go slice marshals as JSON `null`; without
+      // this guard, `setRuns(null)` would crash the next render at `runs.some`.
+      const safeData = data ?? [];
       if (!signal?.aborted) {
-        setRuns(data);
+        setRuns(safeData);
         setError(null);
-        setChecksData(wsId, sessId, { runs: data });
+        setChecksData(wsId, sessId, { runs: safeData });
       }
     } catch (err) {
       if (signal?.aborted) return;
@@ -110,13 +113,17 @@ export function useCIRuns(
     await fetchRuns();
   }, [fetchRuns]);
 
-  // Get jobs for a workflow run
+  // Get jobs for a workflow run.
+  // Coerces nullish to [] for the same reason as `fetchRuns` above: a nil Go
+  // slice marshals as JSON `null`, which would crash the consumer's
+  // `[...jobs].sort(...)` in ChecksPanel.
   const getJobs = useCallback(
     async (runId: number): Promise<WorkflowJobDTO[]> => {
       if (!workspaceId || !sessionId) {
         throw new Error('No active session');
       }
-      return getCIJobs(workspaceId, sessionId, runId);
+      const data = await getCIJobs(workspaceId, sessionId, runId);
+      return data ?? [];
     },
     [workspaceId, sessionId]
   );


### PR DESCRIPTION
## Summary

- **Root cause fix**: `ListWorkflowRuns` / `ListWorkflowJobs` constructed result slices with `var x []T`, so a zero-result API response was returned as a nil slice and JSON-encoded as `null`. The frontend's `runs.some(...)` then threw and took down the Checks panel. Both backend functions now initialize the slice as `[]T{}`.
- **Defense in depth on the frontend**: `useCIRuns` also coerces nullish payloads from `getCIRuns` / `getCIJobs` to `[]` so a future regression can't crash the UI.
- **Recovery, not just prevention**: when any panel does crash, Review and Checks now render a new `PanelErrorFallback` with a retry button and a collapsible "Show details" section. `ErrorBoundary` gets `resetKeys` so switching workspace/session auto-recovers without needing the retry button.

## Test plan

- [x] Backend regression tests: `TestListWorkflowRuns_EmptyResultSerializesAsArray` and `TestListWorkflowJobs_EmptyResultSerializesAsArray` (`backend/github/actions_test.go`) — assert `[]`, not `null`, on zero-result responses
- [x] Frontend regression tests: two new cases in `useCIRuns.test.ts` cover null payloads from both `getCIRuns` and `getCIJobs`
- [x] `npm run lint` clean on touched files
- [ ] Manual: trigger an artificial panel crash in Review/Checks and confirm the new fallback renders with retry + details disclosure
- [ ] Manual: with no CI runs on a branch, confirm Checks panel renders the empty state instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)