### PR TITLE
fix(sessions): keep base sessions out of selection when hidden

### DIFF
--- a/src/components/navigation/BrowserTabBar.tsx
+++ b/src/components/navigation/BrowserTabBar.tsx
@@ -32,8 +32,35 @@ import { useNavigationStore } from '@/stores/navigationStore';
 import { useAppStore } from '@/stores/appStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { buildNavigationLabel } from '@/lib/navigation';
+import { isSelectableSession } from '@/lib/sessionFilters';
 import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 import { cn } from '@/lib/utils';
+
+/**
+ * Apply a tab's persisted state to the global stores. Skips stale or hidden
+ * (e.g. base when disabled) session ids so persisted tabs can't sneak a base
+ * session back in after the setting was turned off.
+ */
+function applyTabState(tab: BrowserTab) {
+  const appStore = useAppStore.getState();
+  const settingsStore = useSettingsStore.getState();
+  appStore.selectWorkspace(tab.selectedWorkspaceId);
+  const candidate = tab.selectedSessionId
+    ? appStore.sessions.find((s) => s.id === tab.selectedSessionId)
+    : undefined;
+  const sessionToSelect =
+    candidate && isSelectableSession(candidate, settingsStore.showBaseBranchSessions)
+      ? candidate.id
+      : null;
+  appStore.selectSession(sessionToSelect);
+  if (sessionToSelect && tab.selectedConversationId) {
+    appStore.selectConversation(tab.selectedConversationId);
+  }
+  settingsStore.setContentView(tab.contentView);
+  if (sessionToSelect && candidate) {
+    expandGroupsForSession(candidate);
+  }
+}
 
 /**
  * Save current global state into the specified tab, then activate a new tab
@@ -61,21 +88,7 @@ export function switchToTab(tabId: string) {
   // Restore the new tab's state to globals
   const newTab = tabStore.tabs[tabId];
   if (newTab) {
-    startTransition(() => {
-      const appStore = useAppStore.getState();
-      const settingsStore = useSettingsStore.getState();
-      appStore.selectWorkspace(newTab.selectedWorkspaceId);
-      appStore.selectSession(newTab.selectedSessionId);
-      if (newTab.selectedConversationId) {
-        appStore.selectConversation(newTab.selectedConversationId);
-      }
-      settingsStore.setContentView(newTab.contentView);
-      // Auto-expand collapsed sidebar groups so the selected session is visible
-      if (newTab.selectedSessionId) {
-        const session = appStore.sessions.find(s => s.id === newTab.selectedSessionId && !s.archived);
-        if (session) expandGroupsForSession(session);
-      }
-    });
+    startTransition(() => applyTabState(newTab));
     useNavigationStore.getState().setActiveTabId(tabId);
   }
 }
@@ -276,16 +289,7 @@ export const BrowserTabStrip = memo(function BrowserTabStrip() {
       const tabStore = useTabStore.getState();
       const newTab = tabStore.tabs[tabStore.activeTabId];
       if (newTab) {
-        startTransition(() => {
-          const appStore = useAppStore.getState();
-          const settingsStore = useSettingsStore.getState();
-          appStore.selectWorkspace(newTab.selectedWorkspaceId);
-          appStore.selectSession(newTab.selectedSessionId);
-          if (newTab.selectedConversationId) {
-            appStore.selectConversation(newTab.selectedConversationId);
-          }
-          settingsStore.setContentView(newTab.contentView);
-        });
+        startTransition(() => applyTabState(newTab));
         useNavigationStore.getState().setActiveTabId(tabStore.activeTabId);
       }
     }

--- a/src/components/settings/sections/GitSettings.tsx
+++ b/src/components/settings/sections/GitSettings.tsx
@@ -3,9 +3,11 @@
 import { Switch } from '@/components/ui/switch';
 import { useSettingsStore, SETTINGS_DEFAULTS } from '@/stores/settingsStore';
 import { useAuthStore } from '@/stores/authStore';
+import { useAppStore } from '@/stores/appStore';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { SettingsRow } from '../shared/SettingsRow';
 import { SettingsGroup } from '../shared/SettingsGroup';
+import { findSelectableSession, isSelectableSession } from '@/lib/sessionFilters';
 
 function OverridableBadge() {
   return (
@@ -32,6 +34,21 @@ export function GitSettings() {
   const user = useAuthStore((s) => s.user);
   const githubUsername = user?.login || 'username';
 
+  // Toggle the setting and, when turning visibility off, replace any
+  // currently-selected base session so the conversation pane doesn't keep
+  // rendering a session the sidebar just hid.
+  const handleToggleBaseBranchSessions = (value: boolean) => {
+    setShowBaseBranchSessions(value);
+    if (!value) {
+      const app = useAppStore.getState();
+      const selected = app.sessions.find((s) => s.id === app.selectedSessionId);
+      if (selected && !isSelectableSession(selected, false)) {
+        const fallback = findSelectableSession(app.sessions, selected.workspaceId, false);
+        app.selectSession(fallback?.id ?? null);
+      }
+    }
+  };
+
   return (
     <div>
       <h2 className="text-xl font-semibold mb-5">Git</h2>
@@ -42,11 +59,11 @@ export function GitSettings() {
           title="Base branch sessions"
           description="Show a session for the base branch in the sidebar, allowing you to work directly on the main repo without a worktree"
           isModified={showBaseBranchSessions !== SETTINGS_DEFAULTS.showBaseBranchSessions}
-          onReset={() => setShowBaseBranchSessions(SETTINGS_DEFAULTS.showBaseBranchSessions)}
+          onReset={() => handleToggleBaseBranchSessions(SETTINGS_DEFAULTS.showBaseBranchSessions)}
         >
           <Switch
             checked={showBaseBranchSessions}
-            onCheckedChange={setShowBaseBranchSessions}
+            onCheckedChange={handleToggleBaseBranchSessions}
             aria-label="Base branch sessions"
           />
         </SettingsRow>

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -14,6 +14,7 @@ import { initAuth, listenForOAuthCallback, validateStoredToken, OAUTH_TIMEOUT_MS
 import { getLinearAuthStatus } from '@/lib/linearAuth';
 import { registerSession, getSessionDirName } from '@/lib/tauri';
 import { navigate } from '@/lib/navigation';
+import { findSelectableSession, isSelectableSession } from '@/lib/sessionFilters';
 import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 import { useToast } from '@/components/ui/toast';
 import {
@@ -263,12 +264,19 @@ export function useAppInitialization() {
           ? activeTab.selectedWorkspaceId
           : mappedWorkspaces[0]?.id ?? null;
 
+        // Hidden base sessions must never be auto-selected via fallback paths;
+        // the sidebar already filters them out, so the conversation view should match.
+        const { showBaseBranchSessions } = useSettingsStore.getState();
+
         // Determine target session before fetching conversations (only need active session's convs)
         const sessionValid = hasPersistedTab && activeTab.selectedSessionId &&
-          allSessions.some(s => s.id === activeTab.selectedSessionId && !s.archived);
+          allSessions.some(s =>
+            s.id === activeTab.selectedSessionId &&
+            isSelectableSession(s, showBaseBranchSessions)
+          );
         const targetSessionId = sessionValid
           ? activeTab.selectedSessionId
-          : allSessions.find(s => s.workspaceId === targetWorkspaceId && !s.archived)?.id ?? null;
+          : findSelectableSession(allSessions, targetWorkspaceId, showBaseBranchSessions)?.id ?? null;
 
         const contentViewWorkspaceId = activeTab?.contentView &&
           'workspaceId' in activeTab.contentView
@@ -285,7 +293,11 @@ export function useAppInitialization() {
           if (workspaceValid) {
             selectWorkspace(activeTab.selectedWorkspaceId);
             if (!sessionValid) {
-              const fallbackSession = allSessions.find(s => s.workspaceId === activeTab.selectedWorkspaceId && !s.archived);
+              const fallbackSession = findSelectableSession(
+                allSessions,
+                activeTab.selectedWorkspaceId,
+                showBaseBranchSessions,
+              );
               if (fallbackSession) selectSession(fallbackSession.id);
             }
           }
@@ -302,7 +314,9 @@ export function useAppInitialization() {
         // Auto-expand collapsed sidebar groups so the restored session is visible
         const selectedId = useAppStore.getState().selectedSessionId;
         if (selectedId) {
-          const selectedSession = allSessions.find(s => s.id === selectedId && !s.archived);
+          const selectedSession = allSessions.find(
+            (s) => s.id === selectedId && isSelectableSession(s, showBaseBranchSessions),
+          );
           if (selectedSession) expandGroupsForSession(selectedSession);
         }
 

--- a/src/lib/__tests__/navigation.test.ts
+++ b/src/lib/__tests__/navigation.test.ts
@@ -10,7 +10,26 @@ const mockSelectSession = vi.fn();
 const mockSelectConversation = vi.fn();
 const mockSetContentView = vi.fn();
 
-const mockAppState = {
+type MockSession = {
+  id: string;
+  name: string;
+  branch: string;
+  workspaceId: string;
+  sessionType?: 'worktree' | 'base';
+  archived?: boolean;
+};
+
+const mockAppState: {
+  selectedWorkspaceId: string | null;
+  selectedSessionId: string | null;
+  selectedConversationId: string | null;
+  workspaces: { id: string; name: string }[];
+  sessions: MockSession[];
+  conversations: { id: string; name: string; sessionId: string }[];
+  selectWorkspace: typeof mockSelectWorkspace;
+  selectSession: typeof mockSelectSession;
+  selectConversation: typeof mockSelectConversation;
+} = {
   selectedWorkspaceId: 'ws-1',
   selectedSessionId: 'sess-1',
   selectedConversationId: 'conv-1',
@@ -27,6 +46,7 @@ const mockSettingsState = {
   setContentView: mockSetContentView,
   markWorkspaceRead: vi.fn(),
   markSessionRead: vi.fn(),
+  showBaseBranchSessions: false,
 };
 
 vi.mock('@/stores/appStore', () => ({
@@ -93,8 +113,13 @@ describe('navigation helpers', () => {
     mockAppState.selectedSessionId = 'sess-1';
     mockAppState.selectedConversationId = 'conv-1';
     mockSettingsState.contentView = { type: 'conversation' };
+    mockSettingsState.showBaseBranchSessions = false;
     mockAppState.workspaces = [{ id: 'ws-1', name: 'My Repo' }];
-    mockAppState.sessions = [{ id: 'sess-1', name: 'boston', branch: 'main', workspaceId: 'ws-1' }];
+    mockAppState.sessions = [
+      { id: 'sess-1', name: 'boston', branch: 'main', workspaceId: 'ws-1' },
+      { id: 'sess-2', name: 'denver', branch: 'feat', workspaceId: 'ws-1' },
+      { id: 'sess-prev', name: 'prev', branch: 'feat', workspaceId: 'ws-1' },
+    ];
     mockAppState.conversations = [{ id: 'conv-1', name: 'Task Chat', sessionId: 'sess-1' }];
     mockTabStoreState.activeTabId = 'default';
   });
@@ -201,6 +226,46 @@ describe('navigation helpers', () => {
       expect(mockSelectWorkspace).toHaveBeenCalledWith(null);
       expect(mockSelectSession).toHaveBeenCalledWith(null);
     });
+
+    it('drops a hidden base sessionId to null when the visibility flag is off', () => {
+      mockAppState.sessions = [
+        { id: 'sess-1', name: 'boston', branch: 'main', workspaceId: 'ws-1' },
+        { id: 'base-1', name: 'main', branch: 'main', workspaceId: 'ws-1', sessionType: 'base' },
+      ];
+      mockSettingsState.showBaseBranchSessions = false;
+
+      // navigate() debounces consecutive sessionId calls via a module-scoped timer;
+      // run any pending timer so this assertion isn't subject to test order.
+      vi.useFakeTimers();
+      try {
+        navigate({ sessionId: 'base-1', conversationId: 'conv-1' });
+        vi.runAllTimers();
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(mockSelectSession).toHaveBeenCalledWith(null);
+      // Conversation must not be applied either, since the session was nulled.
+      expect(mockSelectConversation).not.toHaveBeenCalled();
+    });
+
+    it('keeps a base sessionId when the visibility flag is on', () => {
+      mockAppState.sessions = [
+        { id: 'sess-1', name: 'boston', branch: 'main', workspaceId: 'ws-1' },
+        { id: 'base-1', name: 'main', branch: 'main', workspaceId: 'ws-1', sessionType: 'base' },
+      ];
+      mockSettingsState.showBaseBranchSessions = true;
+
+      vi.useFakeTimers();
+      try {
+        navigate({ sessionId: 'base-1' });
+        vi.runAllTimers();
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(mockSelectSession).toHaveBeenCalledWith('base-1');
+    });
   });
 
   // ---------- goBack ----------
@@ -269,6 +334,26 @@ describe('navigation helpers', () => {
       const tab = getTab();
       const forwardLabels = tab.forwardStack.map((e) => e.label);
       expect(forwardLabels).not.toContain('invalid');
+    });
+
+    it('skips entries pointing at a hidden base session and discards them', () => {
+      mockAppState.sessions = [
+        { id: 'sess-1', name: 'boston', branch: 'main', workspaceId: 'ws-1' },
+        { id: 'base-1', name: 'main', branch: 'main', workspaceId: 'ws-1', sessionType: 'base' },
+      ];
+      mockSettingsState.showBaseBranchSessions = false;
+      const hiddenBaseEntry = makeEntry({ sessionId: 'base-1', label: 'hidden-base' });
+      const validEntry = makeEntry({ sessionId: 'sess-1', label: 'valid' });
+      useNavigationStore.setState({
+        tabs: { default: { backStack: [validEntry, hiddenBaseEntry], forwardStack: [] } },
+      });
+
+      goBack();
+
+      expect(mockSelectSession).toHaveBeenCalledWith('sess-1');
+      const tab = getTab();
+      const forwardLabels = tab.forwardStack.map((e) => e.label);
+      expect(forwardLabels).not.toContain('hidden-base');
     });
 
     it('sets and clears isRestoring during apply', () => {

--- a/src/lib/__tests__/sessionFilters.test.ts
+++ b/src/lib/__tests__/sessionFilters.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { isSelectableSession, findSelectableSession } from '../sessionFilters';
+import type { WorktreeSession } from '@/lib/types';
+
+function makeSession(overrides: Partial<WorktreeSession>): WorktreeSession {
+  return {
+    id: 'sess-1',
+    workspaceId: 'ws-1',
+    name: 'session',
+    branch: 'feature/branch',
+    worktreePath: '/tmp/path',
+    status: 'idle',
+    priority: 0,
+    taskStatus: 'in_progress',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('isSelectableSession', () => {
+  it('rejects archived sessions regardless of flag', () => {
+    const archived = makeSession({ archived: true, sessionType: 'worktree' });
+    expect(isSelectableSession(archived, true)).toBe(false);
+    expect(isSelectableSession(archived, false)).toBe(false);
+  });
+
+  it('rejects base sessions when showBaseBranchSessions is false', () => {
+    const base = makeSession({ sessionType: 'base' });
+    expect(isSelectableSession(base, false)).toBe(false);
+  });
+
+  it('accepts base sessions when showBaseBranchSessions is true', () => {
+    const base = makeSession({ sessionType: 'base' });
+    expect(isSelectableSession(base, true)).toBe(true);
+  });
+
+  it('accepts non-archived worktree sessions in either mode', () => {
+    const worktree = makeSession({ sessionType: 'worktree' });
+    expect(isSelectableSession(worktree, true)).toBe(true);
+    expect(isSelectableSession(worktree, false)).toBe(true);
+  });
+
+  it('treats undefined sessionType (legacy rows) as worktree', () => {
+    const legacy = makeSession({ sessionType: undefined });
+    expect(isSelectableSession(legacy, false)).toBe(true);
+  });
+});
+
+describe('findSelectableSession', () => {
+  const baseChat = makeSession({
+    id: 'base-chat',
+    workspaceId: 'ws-chat',
+    sessionType: 'base',
+  });
+  const worktreeChat = makeSession({
+    id: 'wt-chat',
+    workspaceId: 'ws-chat',
+    sessionType: 'worktree',
+  });
+  const worktreeChatArchived = makeSession({
+    id: 'wt-chat-old',
+    workspaceId: 'ws-chat',
+    sessionType: 'worktree',
+    archived: true,
+  });
+  const baseOther = makeSession({
+    id: 'base-other',
+    workspaceId: 'ws-other',
+    sessionType: 'base',
+  });
+
+  it('skips base sessions in the same workspace when flag is off', () => {
+    const sessions = [baseChat, worktreeChatArchived, worktreeChat];
+    expect(
+      findSelectableSession(sessions, 'ws-chat', false)?.id,
+    ).toBe('wt-chat');
+  });
+
+  it('returns undefined when only a base session remains and flag is off', () => {
+    const sessions = [baseChat, worktreeChatArchived];
+    expect(
+      findSelectableSession(sessions, 'ws-chat', false),
+    ).toBeUndefined();
+  });
+
+  it('returns the base session when flag is on and no worktrees remain', () => {
+    const sessions = [baseChat, worktreeChatArchived];
+    expect(
+      findSelectableSession(sessions, 'ws-chat', true)?.id,
+    ).toBe('base-chat');
+  });
+
+  it('scopes search to the requested workspace', () => {
+    const sessions = [baseOther, worktreeChat];
+    expect(
+      findSelectableSession(sessions, 'ws-chat', false)?.id,
+    ).toBe('wt-chat');
+  });
+
+  it('searches across all workspaces when workspaceId is null', () => {
+    const sessions = [baseOther, worktreeChatArchived, worktreeChat];
+    expect(
+      findSelectableSession(sessions, null, false)?.id,
+    ).toBe('wt-chat');
+  });
+});

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -14,6 +14,7 @@ import { useTabStore } from '@/stores/tabStore';
 import { ENABLE_BROWSER_TABS, SHOW_UNRELEASED } from '@/lib/constants';
 import { expandGroupsForSession } from '@/hooks/useSidebarSessions';
 import { useScheduledTaskStore } from '@/stores/scheduledTaskStore';
+import { isSelectableSession } from '@/lib/sessionFilters';
 
 /**
  * Check if a session's target conversation has messages cached in the store.
@@ -195,9 +196,13 @@ function isEntryValid(entry: NavigationEntry): boolean {
       break;
   }
 
-  // For conversation views, check referenced entities still exist
-  if (entry.sessionId && !sessions.some((s) => s.id === entry.sessionId)) {
-    return false;
+  // For conversation views, check referenced entities still exist and are selectable
+  // (a hidden base session counts as invalid so back/forward can't sneak it back in).
+  if (entry.sessionId) {
+    const session = sessions.find((s) => s.id === entry.sessionId);
+    if (!session) return false;
+    const { showBaseBranchSessions } = useSettingsStore.getState();
+    if (!isSelectableSession(session, showBaseBranchSessions)) return false;
   }
   if (entry.workspaceId && !workspaces.some((w) => w.id === entry.workspaceId)) {
     return false;
@@ -206,6 +211,19 @@ function isEntryValid(entry: NavigationEntry): boolean {
     return false;
   }
   return true;
+}
+
+/**
+ * Resolve a requested sessionId to one safe to select right now. Returns null
+ * if the id refers to a session that's been removed or is currently hidden by
+ * the showBaseBranchSessions setting (i.e. shouldn't be visible in the UI).
+ */
+function resolveSelectableSessionId(sessionId: string | null | undefined): string | null {
+  if (!sessionId) return null;
+  const session = useAppStore.getState().sessions.find((s) => s.id === sessionId);
+  if (!session) return null;
+  const { showBaseBranchSessions } = useSettingsStore.getState();
+  return isSelectableSession(session, showBaseBranchSessions) ? sessionId : null;
 }
 
 /** Apply a navigation entry to the app and tab state */
@@ -220,10 +238,13 @@ function applyEntry(entry: NavigationEntry): void {
     // Use selectSession for session changes (it auto-selects first conversation)
     // But if we have a specific conversationId, override after
     if (entry.sessionId !== undefined) {
-      appStore.selectSession(entry.sessionId);
+      const safeId = resolveSelectableSessionId(entry.sessionId);
+      appStore.selectSession(safeId);
       // Auto-expand collapsed sidebar groups so the selected session is visible
-      const session = appStore.sessions.find(s => s.id === entry.sessionId && !s.archived);
-      if (session) expandGroupsForSession(session);
+      if (safeId) {
+        const session = appStore.sessions.find((s) => s.id === safeId);
+        if (session) expandGroupsForSession(session);
+      }
     }
     if (entry.conversationId !== undefined) {
       appStore.selectConversation(entry.conversationId);
@@ -284,6 +305,12 @@ export function navigate(params: NavigateParams): void {
       useSettingsStore.getState().markWorkspaceRead(params.workspaceId);
     }
 
+    // Resolve the requested session id once: a hidden base session (or a stale
+    // id) collapses to null so it can't slip into selection or the active tab.
+    const safeSessionId = params.sessionId !== undefined
+      ? resolveSelectableSessionId(params.sessionId)
+      : undefined;
+
     const applyMutations = () => {
       const appStore = useAppStore.getState();
       const settingsStore = useSettingsStore.getState();
@@ -291,10 +318,10 @@ export function navigate(params: NavigateParams): void {
       if (params.workspaceId !== undefined) {
         appStore.selectWorkspace(params.workspaceId);
       }
-      if (params.sessionId !== undefined) {
-        appStore.selectSession(params.sessionId);
+      if (safeSessionId !== undefined) {
+        appStore.selectSession(safeSessionId);
       }
-      if (params.conversationId !== undefined) {
+      if (params.conversationId !== undefined && safeSessionId !== null) {
         appStore.selectConversation(params.conversationId);
       }
       if (params.contentView !== undefined) {
@@ -305,8 +332,10 @@ export function navigate(params: NavigateParams): void {
       if (ENABLE_BROWSER_TABS) {
         useTabStore.getState().updateActiveTab({
           ...(params.workspaceId !== undefined && { selectedWorkspaceId: params.workspaceId }),
-          ...(params.sessionId !== undefined && { selectedSessionId: params.sessionId }),
-          ...(params.conversationId !== undefined && { selectedConversationId: params.conversationId }),
+          ...(safeSessionId !== undefined && { selectedSessionId: safeSessionId }),
+          ...(params.conversationId !== undefined && safeSessionId !== null && {
+            selectedConversationId: params.conversationId,
+          }),
           ...(params.contentView !== undefined && { contentView: params.contentView }),
           label: params.label ?? buildLabelForParams(params),
         });

--- a/src/lib/sessionFilters.ts
+++ b/src/lib/sessionFilters.ts
@@ -1,0 +1,36 @@
+import type { WorktreeSession } from '@/lib/types';
+
+/**
+ * Returns true when a session should be visible/selectable in the UI: not
+ * archived, and either non-base or base-with-the-setting-on. This is the
+ * single source of truth for "should the conversation pane / sidebar / tab
+ * restoration touch this session?".
+ */
+export function isSelectableSession(
+  session: WorktreeSession,
+  showBaseBranchSessions: boolean,
+): boolean {
+  if (session.archived) return false;
+  if (session.sessionType === 'base' && !showBaseBranchSessions) return false;
+  return true;
+}
+
+/**
+ * Find the first selectable session in a workspace.
+ *
+ * When `workspaceId` is `null` or `undefined` the workspace filter is dropped
+ * and the search runs across **all** workspaces — useful for fallbacks during
+ * app boot when no workspace is selected yet. Pass an explicit string id when
+ * results must be scoped to a single workspace.
+ */
+export function findSelectableSession(
+  sessions: WorktreeSession[],
+  workspaceId: string | null | undefined,
+  showBaseBranchSessions: boolean,
+): WorktreeSession | undefined {
+  return sessions.find(
+    (s) =>
+      (!workspaceId || s.workspaceId === workspaceId) &&
+      isSelectableSession(s, showBaseBranchSessions),
+  );
+}

--- a/src/stores/__tests__/appStore.sessions.test.ts
+++ b/src/stores/__tests__/appStore.sessions.test.ts
@@ -362,6 +362,48 @@ describe('appStore — session actions', () => {
       expect(useAppStore.getState().selectedSessionId).toBeNull();
     });
 
+    it('skips base sessions when picking next selection if showBaseBranchSessions is false', () => {
+      const baseSess = createMockSession({
+        id: 'base-1',
+        workspaceId: 'ws-1',
+        sessionType: 'base',
+      }) as WorktreeSession;
+      const worktree = { ...s1, sessionType: 'worktree' } as WorktreeSession;
+      useAppStore.setState({
+        sessions: [baseSess, worktree],
+        selectedSessionId: 's1',
+        selectedConversationId: 'c1',
+      });
+      useSettingsStore.setState({ showBaseBranchSessions: false } as never);
+
+      useAppStore.getState().archiveSession('s1');
+
+      expect(useAppStore.getState().selectedSessionId).toBeNull();
+      expect(useAppStore.getState().selectedConversationId).toBeNull();
+    });
+
+    it('selects the base session when showBaseBranchSessions is true and only base remains', () => {
+      const baseSess = createMockSession({
+        id: 'base-1',
+        workspaceId: 'ws-1',
+        sessionType: 'base',
+      }) as WorktreeSession;
+      const worktree = { ...s1, sessionType: 'worktree' } as WorktreeSession;
+      useAppStore.setState({
+        sessions: [baseSess, worktree],
+        selectedSessionId: 's1',
+      });
+      useSettingsStore.setState({ showBaseBranchSessions: true } as never);
+
+      try {
+        useAppStore.getState().archiveSession('s1');
+        expect(useAppStore.getState().selectedSessionId).toBe('base-1');
+      } finally {
+        // Reset locally so the suite isn't load-bearing on beforeEach for this flag.
+        useSettingsStore.setState({ showBaseBranchSessions: false } as never);
+      }
+    });
+
     it('cleans up terminal slices for the archived session', () => {
       useAppStore.setState({
         sessions: [s1, s2],

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -35,6 +35,7 @@ import { useSettingsStore } from './settingsStore';
 import { refreshPRStatus } from '@/lib/api';
 import { buildTurnConfigLabel, supportsExtendedContext } from '@/lib/models';
 import { omitKey } from '@/lib/utils';
+import { isSelectableSession } from '@/lib/sessionFilters';
 import { cleanupConversationState } from '@/hooks/useWebSocket';
 
 // Throttle on-select PR refresh to avoid excessive API calls.
@@ -1084,8 +1085,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const otherSessions = updatedSessions.filter(
         (s) =>
           s.workspaceId === session.workspaceId &&
-          !s.archived &&
-          (s.sessionType !== 'base' || showBaseBranchSessions)
+          isSelectableSession(s, showBaseBranchSessions)
       );
       newSelectedSessionId = otherSessions[0]?.id || null;
 


### PR DESCRIPTION
## Summary

Fixes the UX bug where the conversation pane could keep rendering a base session that the sidebar had hidden. Adds a single source of truth (`src/lib/sessionFilters.ts`) for *"is this session selectable right now?"* and routes every selection path through it.

- `useAppInitialization` filters persisted tab/session state through `isSelectableSession` on boot.
- `BrowserTabBar` factors tab-state restoration into a shared `applyTabState` helper used by both `switchToTab` and `handleCloseTab`. Both paths now drop a stale or hidden base id to null and expand the matching sidebar group.
- `appStore.archiveSession` picks the next selection through the helper.
- `navigation.ts` adds a `resolveSelectableSessionId` gate so `navigate()` and `applyEntry()` (browser back/forward, deep links, notifications) can't reintroduce a hidden base session. `isEntryValid` rejects entries that point at one.
- `GitSettings`: toggling the switch off (or hitting Reset) immediately swaps a stale base selection for a worktree fallback — no refresh/tab switch required.

## Test plan

- [x] New unit tests for `isSelectableSession` / `findSelectableSession` (`src/lib/__tests__/sessionFilters.test.ts`).
- [x] New tests in `appStore.sessions.test.ts` for `archiveSession` picking through the helper, including the showBaseBranchSessions=true case.
- [x] New tests in `navigation.test.ts` for `navigate()` dropping a hidden base id and `goBack` discarding entries that point at one.
- [x] Targeted suites: `npm run test:run -- src/lib/__tests__/navigation.test.ts src/lib/__tests__/sessionFilters.test.ts src/stores/__tests__/appStore.sessions.test.ts` — 77/77 passing.
- [x] Full frontend suite: 2550/2551 (one pre-existing slate-react failure in `PlateInput.test.tsx`, unrelated).
- [x] `npx tsc --noEmit`: no new errors in changed files.
- [x] `npm run lint`: no new errors in changed files.

### Manual verification suggestions

1. Enable **Settings → Git → Base branch sessions**, select a base session, then disable the toggle. The conversation pane should switch to a worktree session (or empty state) immediately.
2. Open multiple browser tabs, select a base session in one tab, disable the toggle, then switch back to that tab. The tab should not re-show the base session.
3. Navigate into a base session, disable the toggle, then press the back button. History should skip the hidden entry.
4. Archive your last worktree with the toggle off — selection should clear (not fall back to the base session). Toggle on then archive — selection should fall back to the base session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)