### PR TITLE
fix(ci): stop falsely reporting 'no failures' on empty snapshot

### DIFF
--- a/backend/server/ci_handlers.go
+++ b/backend/server/ci_handlers.go
@@ -284,12 +284,31 @@ func (h *Handlers) AnalyzeCIFailure(w http.ResponseWriter, r *http.Request) {
 }
 
 // CIFailureContext holds aggregated CI failure information for all failing jobs.
+//
+// Status describes the snapshot so the frontend (and the agent) can tell apart
+// the four reasons FailedRuns can be empty:
+//   - "has_failures" — FailedRuns is non-empty.
+//   - "all_passed"   — runs exist on the latest SHA and all completed without
+//                       a failure-equivalent conclusion.
+//   - "in_progress"  — runs exist on the latest SHA but at least one is still
+//                       queued/in-progress and no failed jobs have surfaced yet.
+//   - "no_runs"      — no workflow runs were returned for the branch.
 type CIFailureContext struct {
 	Branch      string             `json:"branch"`
+	Status      string             `json:"status"`
 	FailedRuns  []FailedRunContext `json:"failedRuns"`
 	TotalFailed int                `json:"totalFailed"`
 	Truncated   bool               `json:"truncated"`
 }
+
+// CI status values for CIFailureContext.Status. Kept as constants so callers
+// can reference them without typo risk.
+const (
+	CIStatusHasFailures = "has_failures"
+	CIStatusAllPassed   = "all_passed"
+	CIStatusInProgress  = "in_progress"
+	CIStatusNoRuns      = "no_runs"
+)
 
 // FailedRunContext holds failure details for a single workflow run.
 type FailedRunContext struct {
@@ -359,6 +378,7 @@ func (h *Handlers) GetCIFailureContext(w http.ResponseWriter, r *http.Request) {
 	if latestSHA == "" {
 		writeJSON(w, CIFailureContext{
 			Branch:      branch,
+			Status:      CIStatusNoRuns,
 			FailedRuns:  []FailedRunContext{},
 			TotalFailed: 0,
 		})
@@ -369,15 +389,26 @@ func (h *Handlers) GetCIFailureContext(w http.ResponseWriter, r *http.Request) {
 	// Include both fully-completed failed runs and in-progress runs (their
 	// individual jobs may already be completed with a failure conclusion).
 	// Skip runs that are still queued/waiting and have no jobs to inspect yet.
+	//
+	// hasPendingOnLatestSHA tracks whether any latest-SHA run is still queued
+	// or in-progress, so we can distinguish "still running" from "all passed"
+	// when no failures surface.
 	var eligibleRuns []github.WorkflowRun
+	hasPendingOnLatestSHA := false
 	for _, run := range runs {
 		if run.HeadSHA != latestSHA {
 			continue
 		}
+		if run.Status != "completed" {
+			hasPendingOnLatestSHA = true
+		}
 		if run.Status == "queued" || run.Status == "waiting" || run.Status == "pending" || run.Status == "requested" {
 			continue
 		}
-		if run.Status == "completed" && run.Conclusion != "failure" && run.Conclusion != "timed_out" {
+		if run.Status == "completed" &&
+			run.Conclusion != "failure" &&
+			run.Conclusion != "timed_out" &&
+			run.Conclusion != "action_required" {
 			continue
 		}
 		eligibleRuns = append(eligibleRuns, run)
@@ -417,7 +448,19 @@ func (h *Handlers) GetCIFailureContext(w http.ResponseWriter, r *http.Request) {
 
 		var failedJobs []FailedJobContext
 		for _, job := range jobResults[i].jobs {
-			if job.Conclusion != "failure" && job.Conclusion != "timed_out" {
+			if job.Status != "completed" {
+				// Defensive: GitHub usually completes all jobs before
+				// flipping run.Status, so the run-level pending check
+				// above already covers this. Keep the per-job set in
+				// case a straggler job appears under a "completed" run.
+				hasPendingOnLatestSHA = true
+			}
+			// action_required is a failure-equivalent: GitHub flags the run
+			// red and the Checks panel surfaces it the same way. Stay
+			// consistent with frontend and pr_status filters.
+			if job.Conclusion != "failure" &&
+				job.Conclusion != "timed_out" &&
+				job.Conclusion != "action_required" {
 				continue
 			}
 
@@ -482,8 +525,18 @@ func (h *Handlers) GetCIFailureContext(w http.ResponseWriter, r *http.Request) {
 	}
 	wg.Wait()
 
+	status := CIStatusHasFailures
+	if len(failedRuns) == 0 {
+		if hasPendingOnLatestSHA {
+			status = CIStatusInProgress
+		} else {
+			status = CIStatusAllPassed
+		}
+	}
+
 	result := CIFailureContext{
 		Branch:      branch,
+		Status:      status,
 		FailedRuns:  failedRuns,
 		TotalFailed: totalFailed,
 		Truncated:   truncatedOverall,

--- a/backend/server/ci_handlers_test.go
+++ b/backend/server/ci_handlers_test.go
@@ -2,11 +2,14 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/chatml/chatml-backend/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -243,4 +246,225 @@ func TestResolveGitHubContext_NotGitHubRepo(t *testing.T) {
 	assert.Nil(t, ghCtx)
 	// GetGitHubRemote fails because the remote is a local path, not a GitHub URL
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ============================================================================
+// GetCIFailureContext — happy-path / status-field tests
+//
+// These tests guard the regression that caused "Fix Issues" to falsely report
+// "No CI failures found" — a discrepancy between the panel (which surfaces
+// action_required as a failure) and this handler (which used to drop it),
+// plus the fact that an empty failedRuns array could mean "all passed",
+// "still in progress", or "no runs" — ambiguity the frontend had to invent
+// a hardcoded reply for.
+// ============================================================================
+
+// setupCIFailureContextTest wires together a mock GitHub server, a real git
+// repo with a github.com remote, a workspace, and a session on a feature
+// branch — i.e. the minimum to drive GetCIFailureContext end-to-end.
+func setupCIFailureContextTest(t *testing.T, ghServer *httptest.Server) (*Handlers, *http.Request, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	h, s := setupTestHandlersWithGitHub(t, ghServer)
+
+	repoPath := createTestGitRepo(t)
+	runGit(t, repoPath, "remote", "set-url", "origin", "https://github.com/owner/repo.git")
+	createTestRepo(t, s, "ws-ci", repoPath)
+
+	// Create a session on a feature branch — the handler reads
+	// session.Branch when calling ListWorkflowRuns.
+	require.NoError(t, s.AddSession(context.Background(), &models.Session{
+		ID:          "sess-ci",
+		WorkspaceID: "ws-ci",
+		Name:        "CI Test Session",
+		Status:      "idle",
+		Branch:      "feature/test",
+	}))
+
+	req := httptest.NewRequest("GET", "/api/repos/ws-ci/sessions/sess-ci/ci/failure-context", nil)
+	req = withChiContext(req, map[string]string{"id": "ws-ci", "sessionId": "sess-ci"})
+	w := httptest.NewRecorder()
+
+	return h, req, w
+}
+
+// TestGetCIFailureContext_NoRuns asserts that when GitHub returns no workflow
+// runs, the response carries Status="no_runs" so the frontend can craft an
+// honest message instead of the misleading "no failures found."
+func TestGetCIFailureContext_NoRuns(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.True(t, strings.HasPrefix(r.URL.Path, "/repos/owner/repo/actions/runs"))
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"total_count":   0,
+			"workflow_runs": []interface{}{},
+		})
+	}))
+	defer ghServer.Close()
+
+	h, req, w := setupCIFailureContextTest(t, ghServer)
+	h.GetCIFailureContext(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp CIFailureContext
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, CIStatusNoRuns, resp.Status)
+	assert.Empty(t, resp.FailedRuns)
+	assert.Equal(t, 0, resp.TotalFailed)
+}
+
+// TestGetCIFailureContext_AllPassed asserts that when all latest-SHA runs
+// completed successfully, Status="all_passed" and failedRuns is empty.
+func TestGetCIFailureContext_AllPassed(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only the runs listing is hit here — no eligible runs means jobs
+		// are never fetched.
+		require.Contains(t, r.URL.Path, "/actions/runs")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"total_count": 1,
+			"workflow_runs": []map[string]interface{}{
+				{
+					"id":          int64(1),
+					"name":        "ci",
+					"status":      "completed",
+					"conclusion":  "success",
+					"head_sha":    "sha-1",
+					"head_branch": "feature/test",
+				},
+			},
+		})
+	}))
+	defer ghServer.Close()
+
+	h, req, w := setupCIFailureContextTest(t, ghServer)
+	h.GetCIFailureContext(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp CIFailureContext
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, CIStatusAllPassed, resp.Status)
+	assert.Empty(t, resp.FailedRuns)
+}
+
+// TestGetCIFailureContext_InProgress asserts that when latest-SHA runs are
+// still queued or in-progress with no failed jobs surfaced, Status reports
+// "in_progress" — the frontend must NOT mislabel this as "all passed."
+func TestGetCIFailureContext_InProgress(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/actions/runs/1/jobs"):
+			// One in-progress job, no failures yet.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 1,
+				"jobs": []map[string]interface{}{
+					{
+						"id":         int64(11),
+						"run_id":     int64(1),
+						"name":       "build",
+						"status":     "in_progress",
+						"conclusion": nil,
+						"steps":      []interface{}{},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/actions/runs"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 1,
+				"workflow_runs": []map[string]interface{}{
+					{
+						"id":          int64(1),
+						"name":        "ci",
+						"status":      "in_progress",
+						"conclusion":  nil,
+						"head_sha":    "sha-1",
+						"head_branch": "feature/test",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected GH path: %s", r.URL.Path)
+		}
+	}))
+	defer ghServer.Close()
+
+	h, req, w := setupCIFailureContextTest(t, ghServer)
+	h.GetCIFailureContext(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp CIFailureContext
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, CIStatusInProgress, resp.Status)
+	assert.Empty(t, resp.FailedRuns)
+}
+
+// TestGetCIFailureContext_ActionRequired asserts that a run/job concluded as
+// "action_required" surfaces in failedRuns. The Checks panel,
+// PRHoverCard, and pr_status.go all treat action_required as a failure;
+// this handler must agree, otherwise users see red checks in the panel
+// while Fix Issues silently sees nothing.
+func TestGetCIFailureContext_ActionRequired(t *testing.T) {
+	// Declare ghServer up front so the handler can build a Location header
+	// pointing back at this same test server (avoids any real network I/O).
+	var ghServer *httptest.Server
+	ghServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/logs/job-11":
+			// Body served at the redirect target — keeps the log fetch
+			// inside the test server.
+			_, _ = w.Write([]byte("error: deploy step failed\n"))
+		case strings.Contains(r.URL.Path, "/actions/jobs/11/logs"):
+			// 302 → redirect target on this same server so we never
+			// hit the network.
+			w.Header().Set("Location", ghServer.URL+"/logs/job-11")
+			w.WriteHeader(http.StatusFound)
+		case strings.Contains(r.URL.Path, "/actions/runs/1/jobs"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 1,
+				"jobs": []map[string]interface{}{
+					{
+						"id":         int64(11),
+						"run_id":     int64(1),
+						"name":       "deploy",
+						"status":     "completed",
+						"conclusion": "action_required",
+						"html_url":   "https://github.com/owner/repo/actions/runs/1/job/11",
+						"steps":      []interface{}{},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/actions/runs"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"total_count": 1,
+				"workflow_runs": []map[string]interface{}{
+					{
+						"id":          int64(1),
+						"name":        "deploy",
+						"status":      "completed",
+						"conclusion":  "action_required",
+						"head_sha":    "sha-1",
+						"head_branch": "feature/test",
+						"html_url":    "https://github.com/owner/repo/actions/runs/1",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected GH path: %s", r.URL.Path)
+		}
+	}))
+	defer ghServer.Close()
+
+	h, req, w := setupCIFailureContextTest(t, ghServer)
+	h.GetCIFailureContext(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp CIFailureContext
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, CIStatusHasFailures, resp.Status)
+	require.Len(t, resp.FailedRuns, 1)
+	require.Len(t, resp.FailedRuns[0].FailedJobs, 1)
+	assert.Equal(t, "deploy", resp.FailedRuns[0].FailedJobs[0].JobName)
+	assert.Equal(t, 1, resp.TotalFailed)
+	// Verify the log-fetch path actually executed end-to-end and the body
+	// from the redirect target landed on the job. Without this, a regression
+	// that breaks log fetching would still let the test pass.
+	assert.Contains(t, resp.FailedRuns[0].FailedJobs[0].Logs, "deploy step failed")
 }

--- a/src/components/navigation/SessionToolbarContent.tsx
+++ b/src/components/navigation/SessionToolbarContent.tsx
@@ -20,7 +20,7 @@ import {
 import { ACTION_TEMPLATES, ACTION_TEMPLATE_NAMES, fetchMergedActionTemplates } from '@/lib/action-templates';
 import type { ActionTemplateKey } from '@/lib/action-templates';
 import { dispatchAppEvent, useAppEventListener } from '@/lib/custom-events';
-import { formatCIFailureMessage } from '@/lib/check-utils';
+import { buildCIStatusNote, formatCIFailureMessage, getCIStatusToast } from '@/lib/check-utils';
 import { useToast } from '@/components/ui/toast';
 import { copyToClipboard, openInApp } from '@/lib/tauri';
 import { cn, toBase64 } from '@/lib/utils';
@@ -347,38 +347,51 @@ export function SessionToolbarContent() {
       return;
     }
 
-    // Step 2: handle no-failures case
-    if (context.failedRuns.length === 0) {
-      setStreaming(selectedConversationId, false);
-      updateConversation(selectedConversationId, { status: 'idle' });
-      addMessage({
-        id: crypto.randomUUID(),
-        conversationId: selectedConversationId,
-        role: 'assistant',
-        content: 'No CI failures found. All checks may have passed.',
-        timestamp: new Date().toISOString(),
-      });
-      showWarning('No CI failures found. Checks may have passed.');
-      setFixIssuesLoading(false);
-      return;
+    // Step 2: build a second attachment.
+    //  - has_failures → "CI Failure Details" with the formatted log excerpts.
+    //  - empty snapshot → "Backend CI snapshot" status note that explains what
+    //    the backend saw and tells the agent to verify with `gh` before
+    //    concluding there is nothing to fix. We *always* send to the agent —
+    //    silently faking an assistant reply hid real failures (e.g. when the
+    //    snapshot's filters dropped them) and broke user trust.
+    let secondaryContent: string;
+    let secondaryName: string;
+    if (context.failedRuns.length > 0) {
+      secondaryContent = formatCIFailureMessage(context);
+      secondaryName = 'CI Failure Details';
+    } else {
+      // Runtime invariant: failedRuns is empty in this branch, so status
+      // can't be 'has_failures'. Narrow defensively for the type system —
+      // a misreporting backend gets coerced to 'no_runs' rather than
+      // generating a self-contradicting note.
+      const emptyStatus = context.status === 'has_failures' ? 'no_runs' : context.status;
+      secondaryContent = buildCIStatusNote(emptyStatus, context.branch);
+      secondaryName = 'Backend CI snapshot';
     }
-
-    // Step 3: send with failure details attached
-    const failureContent = formatCIFailureMessage(context);
-    const failureAttachment: AttachmentDTO = {
+    const secondaryAttachment: AttachmentDTO = {
       id: crypto.randomUUID(),
       type: 'file',
-      name: 'CI Failure Details',
+      name: secondaryName,
       mimeType: 'text/markdown',
-      size: new Blob([failureContent]).size,
-      lineCount: failureContent.split('\n').length,
-      base64Data: toBase64(failureContent),
-      preview: failureContent.slice(0, 200),
+      size: new Blob([secondaryContent]).size,
+      lineCount: secondaryContent.split('\n').length,
+      base64Data: toBase64(secondaryContent),
+      preview: secondaryContent.slice(0, 200),
       isInstruction: false,
     };
+
+    // Step 3: send to agent with both attachments and surface a non-blocking
+    // toast when the snapshot was empty so the user knows what was forwarded.
     try {
-      await sendConversationMessage(selectedConversationId, 'Fix the failing CI checks', { attachments: [templateAttachment, failureAttachment] });
-    } catch {
+      await sendConversationMessage(
+        selectedConversationId,
+        'Fix the failing CI checks',
+        { attachments: [templateAttachment, secondaryAttachment] }
+      );
+      const toast = getCIStatusToast(context.status);
+      if (toast) showWarning(toast);
+    } catch (error) {
+      console.error('Failed to send Fix Issues message:', error);
       setStreaming(selectedConversationId, false);
       updateConversation(selectedConversationId, { status: 'idle' });
       showWarning('Failed to send message to agent.');

--- a/src/lib/__tests__/check-utils.test.ts
+++ b/src/lib/__tests__/check-utils.test.ts
@@ -4,8 +4,11 @@ import {
   formatDuration,
   computeJobDuration,
   formatCIFailureMessage,
+  buildCIStatusNote,
+  getCIStatusToast,
+  type EmptyCISnapshotStatus,
 } from '../check-utils';
-import type { CIFailureContextDTO } from '@/lib/api';
+import type { CIFailureContextDTO, CIFailureContextStatus } from '@/lib/api';
 
 // ============================================================================
 // getCheckStatusInfo
@@ -191,6 +194,7 @@ describe('formatCIFailureMessage', () => {
   it('formats a single failed run with a single failed job', () => {
     const context: CIFailureContextDTO = {
       branch: 'main',
+      status: 'has_failures',
       failedRuns: [{
         runId: 1,
         runName: 'CI',
@@ -222,6 +226,7 @@ describe('formatCIFailureMessage', () => {
   it('shows truncation notice for log output', () => {
     const context: CIFailureContextDTO = {
       branch: 'main',
+      status: 'has_failures',
       failedRuns: [{
         runId: 1,
         runName: 'CI',
@@ -247,6 +252,7 @@ describe('formatCIFailureMessage', () => {
   it('shows unavailable message when logs are missing', () => {
     const context: CIFailureContextDTO = {
       branch: 'main',
+      status: 'has_failures',
       failedRuns: [{
         runId: 1,
         runName: 'CI',
@@ -273,6 +279,7 @@ describe('formatCIFailureMessage', () => {
   it('shows truncation note when total failures are truncated', () => {
     const context: CIFailureContextDTO = {
       branch: 'main',
+      status: 'has_failures',
       failedRuns: [{
         runId: 1,
         runName: 'CI',
@@ -299,6 +306,7 @@ describe('formatCIFailureMessage', () => {
   it('handles multiple failed steps', () => {
     const context: CIFailureContextDTO = {
       branch: 'main',
+      status: 'has_failures',
       failedRuns: [{
         runId: 1,
         runName: 'CI',
@@ -324,6 +332,7 @@ describe('formatCIFailureMessage', () => {
   it('omits failed steps line when no steps provided', () => {
     const context: CIFailureContextDTO = {
       branch: 'main',
+      status: 'has_failures',
       failedRuns: [{
         runId: 1,
         runName: 'CI',
@@ -344,5 +353,57 @@ describe('formatCIFailureMessage', () => {
 
     const msg = formatCIFailureMessage(context);
     expect(msg).not.toContain('Failed steps:');
+  });
+});
+
+// ============================================================================
+// buildCIStatusNote / getCIStatusToast
+//
+// These guard the "Fix Issues" handler regression — when the backend snapshot
+// was empty, the UI used to fake a hardcoded assistant reply. The handler now
+// always sends to the agent, but uses these helpers to give the agent and the
+// user an honest status note instead of "no failures found."
+// ============================================================================
+
+describe('buildCIStatusNote', () => {
+  // has_failures is intentionally excluded by the `EmptyCISnapshotStatus`
+  // type — buildCIStatusNote is only called when the snapshot has no failed
+  // jobs, so testing the failure case here would assert against a code path
+  // that is structurally unreachable.
+  const emptyStatuses: EmptyCISnapshotStatus[] = ['all_passed', 'in_progress', 'no_runs'];
+
+  it.each(emptyStatuses)('includes branch and verification commands for status "%s"', (status) => {
+    const note = buildCIStatusNote(status, 'feature/x');
+    expect(note).toContain('feature/x');
+    // Always tells the agent how to verify with `gh`, regardless of status.
+    expect(note).toContain('gh run list');
+    expect(note).toContain('gh run view');
+  });
+
+  it('falls back to (unknown) when branch is empty', () => {
+    const note = buildCIStatusNote('all_passed', '');
+    expect(note).toContain('(unknown)');
+  });
+
+  it('uses a status-specific headline so the agent can tell snapshots apart', () => {
+    expect(buildCIStatusNote('all_passed', 'b')).toContain('all checks');
+    expect(buildCIStatusNote('in_progress', 'b')).toContain('in progress');
+    expect(buildCIStatusNote('no_runs', 'b')).toContain('no workflow runs');
+  });
+});
+
+describe('getCIStatusToast', () => {
+  it('returns null for has_failures so the failure attachment speaks for itself', () => {
+    expect(getCIStatusToast('has_failures')).toBeNull();
+  });
+
+  it.each<[CIFailureContextStatus, string]>([
+    ['all_passed', 'passed'],
+    ['in_progress', 'still running'],
+    ['no_runs', 'No workflow runs'],
+  ])('returns a non-null toast describing status "%s"', (status, fragment) => {
+    const toast = getCIStatusToast(status);
+    expect(toast).not.toBeNull();
+    expect(toast).toContain(fragment);
   });
 });

--- a/src/lib/action-templates.ts
+++ b/src/lib/action-templates.ts
@@ -72,6 +72,8 @@ export const ACTION_TEMPLATES: Record<ActionTemplateKey, string> = {
 
   'fix-issues': `## Fix CI Failures
 
+If the attached "CI Failure Details" lists failing jobs, focus on those. If instead the attachment is "Backend CI snapshot" with no failed jobs, the snapshot may be stale, filtered, or pre-completion — verify with \`gh run list --branch <branch>\` and \`gh run view <run-id> --log-failed\` before concluding there is nothing to fix. If checks really did pass, say so to the user clearly.
+
 1. Analyze the failing checks and their error output carefully. Categorize each failure:
    - **Code failures**: build errors, type errors, test failures, lint errors
    - **Infrastructure failures**: timeouts, OOM, Docker issues, dependency resolution — these are not code problems

--- a/src/lib/api/ci.ts
+++ b/src/lib/api/ci.ts
@@ -140,8 +140,18 @@ export interface FailedRunContext {
   failedJobs: FailedJobContext[];
 }
 
+// Snapshot status from GetCIFailureContext. Lets callers tell apart the
+// reasons failedRuns can be empty so the UX (and the agent) can react
+// honestly instead of always saying "no failures."
+export type CIFailureContextStatus =
+  | 'has_failures'
+  | 'all_passed'
+  | 'in_progress'
+  | 'no_runs';
+
 export interface CIFailureContextDTO {
   branch: string;
+  status: CIFailureContextStatus;
   failedRuns: FailedRunContext[];
   totalFailed: number;
   truncated: boolean;

--- a/src/lib/check-utils.ts
+++ b/src/lib/check-utils.ts
@@ -8,7 +8,7 @@ import {
   Play,
   type LucideIcon,
 } from 'lucide-react';
-import type { CIFailureContextDTO } from '@/lib/api';
+import type { CIFailureContextDTO, CIFailureContextStatus } from '@/lib/api';
 
 export interface StatusInfo {
   icon: LucideIcon;
@@ -118,4 +118,68 @@ export function formatCIFailureMessage(context: CIFailureContextDTO): string {
   }
 
   return parts.join('\n');
+}
+
+/**
+ * The empty-snapshot statuses — `has_failures` is intentionally excluded
+ * because `buildCIStatusNote` is only meaningful when there are no failed
+ * jobs to attach. The type prevents callers from generating a self-
+ * contradicting note.
+ */
+export type EmptyCISnapshotStatus = Exclude<CIFailureContextStatus, 'has_failures'>;
+
+/**
+ * Markdown attachment content sent to the agent when the backend's CI snapshot
+ * came back without failed jobs. The snapshot can be empty for several
+ * non-equivalent reasons (all-passed, in-progress, no runs at all), and any of
+ * them can also be a false negative — so the note tells the agent to verify
+ * with `gh` before concluding there is nothing to fix.
+ */
+export function buildCIStatusNote(
+  status: EmptyCISnapshotStatus,
+  branch: string
+): string {
+  const headline: Record<EmptyCISnapshotStatus, string> = {
+    all_passed: 'Backend CI snapshot: all checks on the latest commit appear to have passed.',
+    in_progress: 'Backend CI snapshot: workflow runs on the latest commit are still queued or in progress.',
+    no_runs: 'Backend CI snapshot: no workflow runs were found for this branch yet.',
+  };
+
+  return [
+    headline[status],
+    '',
+    `Branch: ${branch || '(unknown)'}`,
+    '',
+    'No failed jobs are pre-loaded for you. Possible reasons:',
+    '- All checks have passed on the latest commit.',
+    '- Workflow runs are still queued or in progress.',
+    '- No workflow runs exist for this branch yet.',
+    '- The snapshot only inspects the latest commit\'s SHA; older runs are excluded.',
+    '- The snapshot may have missed something the live API would reflect.',
+    '',
+    'Verify before concluding there is nothing to fix:',
+    '- `gh run list --branch <branch> --limit 20` to list recent runs.',
+    '- `gh run view <run-id> --log-failed` for any run that looks failed or pending.',
+    '',
+    'If checks really did pass, say so to the user clearly. If checks are still running, offer to wait or summarize what is pending. If the snapshot is wrong, fix the failures you find.',
+  ].join('\n');
+}
+
+/**
+ * Short user-facing toast message for the CI snapshot status. Returns null
+ * when the status doesn't warrant a warning (i.e., real failures were found
+ * and the failure attachment will speak for itself).
+ */
+export function getCIStatusToast(status: CIFailureContextStatus): string | null {
+  switch (status) {
+    case 'all_passed':
+      return 'Latest commit\'s checks all passed — agent will verify.';
+    case 'in_progress':
+      return 'CI is still running — agent will verify.';
+    case 'no_runs':
+      return 'No workflow runs for this branch yet — agent will check.';
+    case 'has_failures':
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
## Summary

The **Fix Issues** toolbar action would silently respond *"No CI failures found. All checks may have passed."* any time the backend snapshot came back without failed jobs — conflating four very different states (no runs yet, runs in progress, all passed, a real failure the snapshot filtered out) and blocking users from getting agent help when CI was actually broken.

This change disambiguates the snapshot status, brings the failure filter in line with the rest of the codebase, and makes the toolbar always forward an honest status note to the agent.

### Backend (`GetCIFailureContext`)
- Add a `Status` field on `CIFailureContext` with four constants — `has_failures`, `all_passed`, `in_progress`, `no_runs` — so callers can tell apart the reasons `failedRuns` can be empty.
- Track `hasPendingOnLatestSHA` at run-level (defensively also per-job) to distinguish "still running" from "all passed".
- Treat `action_required` as a failure-equivalent at both run and job level, matching `backend/github/pr_status.go`, `ChecksPanel.tsx`, and `PRHoverCard.tsx`.
- New tests cover all four status branches plus the `action_required` regression. The log-fetch test redirects back to the same `httptest` server so no real network I/O is performed.

### Frontend (Fix Issues)
- Always forward to the agent. When the snapshot is empty, attach a *"Backend CI snapshot"* status note instead of faking an assistant reply, and tell the agent to verify with `gh run list` / `gh run view --log-failed` before concluding there is nothing to fix.
- Show a non-blocking warning toast describing what was forwarded.
- Update the `fix-issues` action template so the agent knows how to handle the new status attachment.
- Type the empty-snapshot helper as `EmptyCISnapshotStatus` (= `Exclude<CIFailureContextStatus, 'has_failures'>`) so callers can't generate a self-contradicting note.
- Log send failures via `console.error` instead of swallowing them in an empty `catch`.

## Test plan

- [x] `cd backend && go test -race -run 'TestGetCIFailureContext' ./server/...` — covers `NoRuns`, `AllPassed`, `InProgress`, `ActionRequired` plus the existing `resolveGitHubContext` paths.
- [x] `npm run test:run -- src/lib/__tests__/check-utils.test.ts` — 41 tests covering `buildCIStatusNote` (per-status headlines, branch fallback, verification commands) and `getCIStatusToast`.
- [x] `npx tsc --noEmit` — no new errors on changed files.
- [x] `npm run lint` — no new warnings on changed files.
- [ ] Manual: in a session whose latest SHA has **no runs**, click *Fix Issues* → user message + template attachment + "Backend CI snapshot" attachment + toast "*No workflow runs for this branch yet — agent will check.*"
- [ ] Manual: in a session whose latest SHA is still **in progress**, click *Fix Issues* → toast "*CI is still running — agent will verify.*"
- [ ] Manual: in a session with a real **failed run**, click *Fix Issues* → "CI Failure Details" attachment with logs, no extra toast.
- [ ] Manual: trigger a workflow that ends in `action_required` (or simulate via mock) → it now appears in the Checks panel **and** is forwarded to the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)