### PR TITLE
perf: warm pr-status cache, add circuit breaker, debounce watcher

### DIFF
--- a/backend/branch/pr_watcher.go
+++ b/backend/branch/pr_watcher.go
@@ -58,6 +58,7 @@ type PRWatcher struct {
 	store         PRWatcherStore
 	prCache       *github.PRCache // Shared cache with ListPRs handler
 	onChange      func(PRChangeEvent)
+	onPRDetails   func(sessionID string, details *github.PRDetails) // Wired by handlers to keep prStatusCache warm.
 	ctx           context.Context
 	cancel        context.CancelFunc
 	backfillOnce  sync.Once
@@ -85,6 +86,32 @@ func NewPRWatcher(
 
 	go w.run()
 	return w
+}
+
+// SetOnPRDetails registers a callback fired whenever the watcher obtains fresh
+// PRDetails for a session — either from a GitHub fetch or from the shared
+// prCache. Used by the HTTP layer to populate its per-session SFCache so that
+// /pr-status polls hit the cache instead of paying a GitHub round-trip on the
+// request path. Safe to leave unset.
+func (w *PRWatcher) SetOnPRDetails(cb func(sessionID string, details *github.PRDetails)) {
+	w.mu.Lock()
+	w.onPRDetails = cb
+	w.mu.Unlock()
+}
+
+// emitPRDetails invokes onPRDetails without holding w.mu, so the callback can
+// freely take other locks (e.g. an SFCache write). Reads the callback under
+// RLock to stay safe with concurrent SetOnPRDetails.
+func (w *PRWatcher) emitPRDetails(sessionID string, details *github.PRDetails) {
+	if details == nil {
+		return
+	}
+	w.mu.RLock()
+	cb := w.onPRDetails
+	w.mu.RUnlock()
+	if cb != nil {
+		cb(sessionID, details)
+	}
 }
 
 // WatchSession starts watching a session for PR status changes.
@@ -389,6 +416,11 @@ func (w *PRWatcher) enrichPRMetadata(sessionID string, prNumber int) {
 		logger.PRWatcher.Warnf("enrichPRMetadata: failed to get PR #%d details for session %s: %v", prNumber, sessionID, err)
 		return
 	}
+
+	// Populate per-session pr-status cache so the HTTP handler can serve
+	// instantly. Done before any further state checks so a stale entry/PR
+	// mismatch below doesn't suppress the cache write.
+	w.emitPRDetails(sessionID, details)
 
 	w.mu.Lock()
 	// Re-check entry still exists and matches the same PR
@@ -748,11 +780,17 @@ func (w *PRWatcher) checkSessionPR(owner, repo string, entry *PRWatchEntry, bran
 		if details != nil {
 			checkStatus = string(details.CheckStatus)
 			mergeable = details.Mergeable
+			// Warm the per-session pr-status cache (handler reads this on GET).
+			w.emitPRDetails(entry.SessionID, details)
 		}
 	} else if entry.PRStatus == models.PRStatusOpen && entry.PRNumber > 0 {
 		// Had an open PR but it's no longer in the open list - check if merged or closed
 		details, err := w.ghClient.GetPRDetails(w.ctx, owner, repo, entry.PRNumber)
 		if err == nil && details != nil {
+			// Even on lifecycle transitions, freshly-fetched details should
+			// warm the per-session cache so /pr-status reflects merged/closed
+			// state without another GitHub call.
+			w.emitPRDetails(entry.SessionID, details)
 			if details.State == "closed" {
 				// Check if it was merged using the `merged` boolean from the PR response,
 				// falling back to the dedicated /merge endpoint

--- a/backend/branch/pr_watcher_test.go
+++ b/backend/branch/pr_watcher_test.go
@@ -377,6 +377,110 @@ func TestPRWatcher_CheckSessionPR_MergedPR_ClearsMergeConflict(t *testing.T) {
 	require.NotNil(t, capturedEvent, "should have emitted a change event")
 }
 
+func TestPRWatcher_OnPRDetails_FiresForOpenPR(t *testing.T) {
+	// SetOnPRDetails is the contract that lets the HTTP layer keep its
+	// per-session pr-status cache warm. Verify it fires when the watcher
+	// resolves details for a session with an open PR.
+	store := newMockStore()
+	store.sessions["sess-1"] = &models.Session{
+		ID:         "sess-1",
+		PRStatus:   "none",
+		TaskStatus: models.TaskStatusInProgress,
+	}
+
+	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
+	w := newTestPRWatcher(store, repoMgr, nil)
+	w.onChange = func(evt PRChangeEvent) {}
+	defer w.Close()
+
+	mergeable := true
+	ts := newMockGitHubServer(t, mockGitHubResponses{
+		prDetails: &mockPRDetails{state: "open", merged: false, mergeable: &mergeable},
+	})
+	defer ts.Close()
+
+	ghClient := github.NewClient("", "")
+	ghClient.SetToken("test-token")
+	ghClient.SetAPIURL(ts.URL)
+	w.ghClient = ghClient
+
+	var capturedSession string
+	var capturedDetails *github.PRDetails
+	w.SetOnPRDetails(func(sessionID string, details *github.PRDetails) {
+		capturedSession = sessionID
+		capturedDetails = details
+	})
+
+	w.mu.Lock()
+	w.sessions["sess-1"] = &PRWatchEntry{
+		SessionID: "sess-1",
+		Branch:    "feature/foo",
+		RepoPath:  "/repo/path",
+		PRStatus:  "none",
+	}
+	w.mu.Unlock()
+
+	branchToPR := map[string]*github.PRListItem{
+		"feature/foo": {Number: 42, Branch: "feature/foo", HTMLURL: "https://github.com/org/myrepo/pull/42"},
+	}
+	w.checkSessionPR("org", "myrepo", w.sessions["sess-1"], branchToPR)
+
+	assert.Equal(t, "sess-1", capturedSession, "callback should have fired with the session id")
+	require.NotNil(t, capturedDetails, "callback should have received PR details")
+	require.NotNil(t, capturedDetails.Mergeable)
+	assert.True(t, *capturedDetails.Mergeable)
+}
+
+func TestPRWatcher_OnPRDetails_FiresForMergedTransition(t *testing.T) {
+	// When a previously-open PR drops out of the open list, the watcher
+	// fetches details to discover merged/closed state. That fetch should
+	// also warm the per-session cache so /pr-status reflects the new state
+	// without another GitHub round-trip.
+	store := newMockStore()
+	store.sessions["sess-1"] = &models.Session{
+		ID:         "sess-1",
+		PRStatus:   models.PRStatusOpen,
+		PRNumber:   42,
+		TaskStatus: models.TaskStatusInReview,
+	}
+
+	repoMgr := &mockPRWatcherRepoManager{owner: "org", repo: "myrepo"}
+	w := newTestPRWatcher(store, repoMgr, nil)
+	w.onChange = func(evt PRChangeEvent) {}
+	defer w.Close()
+
+	ts := newMockGitHubServer(t, mockGitHubResponses{
+		prDetails: &mockPRDetails{state: "closed", merged: true, mergeable: nil},
+		prMerged:  boolPtr(true),
+	})
+	defer ts.Close()
+
+	ghClient := github.NewClient("", "")
+	ghClient.SetToken("test-token")
+	ghClient.SetAPIURL(ts.URL)
+	w.ghClient = ghClient
+
+	var calls int
+	w.SetOnPRDetails(func(sessionID string, details *github.PRDetails) {
+		calls++
+	})
+
+	w.mu.Lock()
+	w.sessions["sess-1"] = &PRWatchEntry{
+		SessionID: "sess-1",
+		Branch:    "feature/foo",
+		RepoPath:  "/repo/path",
+		PRStatus:  models.PRStatusOpen,
+		PRNumber:  42,
+	}
+	w.mu.Unlock()
+
+	// Empty branchToPR — the open list no longer includes this branch.
+	w.checkSessionPR("org", "myrepo", w.sessions["sess-1"], map[string]*github.PRListItem{})
+
+	assert.Equal(t, 1, calls, "callback should fire exactly once for the merged-transition fetch")
+}
+
 func TestPRWatcher_CheckSessionPR_OpenPR_SetsMergeConflict(t *testing.T) {
 	// When a PR is open and mergeable is false, HasMergeConflict should be true.
 	store := newMockStore()

--- a/backend/github/circuit_breaker.go
+++ b/backend/github/circuit_breaker.go
@@ -1,0 +1,109 @@
+package github
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/chatml/chatml-backend/logger"
+)
+
+// Per-host circuit breaker constants. Tuned for the GitHub API outage shape
+// observed in the field: DNS goes down for tens of minutes, every retry
+// budget on every dependent endpoint serializes against it, and the user's
+// UI freezes for 6–14 seconds per panel. Tripping after a small number of
+// consecutive failures cuts that to <50ms while the network heals.
+const (
+	circuitFailureThreshold = 3
+	circuitFailureWindow    = 30 * time.Second
+	circuitOpenDuration     = 30 * time.Second
+)
+
+// ErrCircuitOpen is returned by the GitHub client's transport when the
+// per-host circuit breaker has tripped. Callers should treat this the same as
+// any other transient transport failure (e.g. fall back to cached values).
+var ErrCircuitOpen = errors.New("github: circuit breaker open")
+
+// circuitBreaker tracks per-host failure state so a sustained outage on one
+// host (api.github.com) does not pay the retry budget on every request.
+// State is keyed by URL host because the OAuth host (github.com) and the
+// API host (api.github.com) can fail independently.
+type circuitBreaker struct {
+	now    func() time.Time // overridable for tests
+	states sync.Map         // host (string) -> *circuitState
+}
+
+// newCircuitBreaker constructs a closed breaker with real-clock time.
+func newCircuitBreaker() *circuitBreaker {
+	return &circuitBreaker{now: time.Now}
+}
+
+func (cb *circuitBreaker) state(host string) *circuitState {
+	if v, ok := cb.states.Load(host); ok {
+		return v.(*circuitState)
+	}
+	s := &circuitState{}
+	actual, _ := cb.states.LoadOrStore(host, s)
+	return actual.(*circuitState)
+}
+
+// allow reports whether a request to host should proceed.
+// Returns false while the breaker is open for this host.
+func (cb *circuitBreaker) allow(host string) bool {
+	s := cb.state(host)
+	now := cb.now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return now.After(s.openedUntil)
+}
+
+// recordFailure increments the consecutive-failure counter for host. When the
+// count reaches circuitFailureThreshold within circuitFailureWindow the
+// breaker opens for circuitOpenDuration. If the previous failure is older
+// than the window, the counter restarts so transient blips don't
+// accumulate over hours into a trip.
+func (cb *circuitBreaker) recordFailure(host string) {
+	s := cb.state(host)
+	now := cb.now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.firstFailureAt.IsZero() && now.Sub(s.firstFailureAt) > circuitFailureWindow {
+		s.consecutiveFails = 0
+		s.firstFailureAt = time.Time{}
+	}
+
+	s.consecutiveFails++
+	if s.firstFailureAt.IsZero() {
+		s.firstFailureAt = now
+	}
+
+	if s.consecutiveFails >= circuitFailureThreshold {
+		s.openedUntil = now.Add(circuitOpenDuration)
+		// Reset the counter so the next single success closes the breaker
+		// cleanly without leaving stale failure history behind.
+		s.consecutiveFails = 0
+		s.firstFailureAt = time.Time{}
+		logger.GitHub.Warnf("circuit breaker open for %s (cool-down %v)", host, circuitOpenDuration)
+	}
+}
+
+// recordSuccess clears all failure state for host. Called after any
+// successful round-trip (any HTTP response counts — even 5xx), since the
+// failure mode the breaker exists to suppress is "host is unreachable",
+// not "host returned an error".
+func (cb *circuitBreaker) recordSuccess(host string) {
+	s := cb.state(host)
+	s.mu.Lock()
+	s.consecutiveFails = 0
+	s.firstFailureAt = time.Time{}
+	s.openedUntil = time.Time{}
+	s.mu.Unlock()
+}
+
+type circuitState struct {
+	mu               sync.Mutex
+	consecutiveFails int
+	firstFailureAt   time.Time
+	openedUntil      time.Time
+}

--- a/backend/github/circuit_breaker_test.go
+++ b/backend/github/circuit_breaker_test.go
@@ -1,0 +1,143 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCircuitBreaker_AllowsInitially(t *testing.T) {
+	cb := newCircuitBreaker()
+	assert.True(t, cb.allow("api.github.com"))
+}
+
+func TestCircuitBreaker_OpensAfterThresholdConsecutiveFailures(t *testing.T) {
+	cb := newCircuitBreaker()
+
+	for i := 0; i < circuitFailureThreshold; i++ {
+		cb.recordFailure("api.github.com")
+	}
+
+	assert.False(t, cb.allow("api.github.com"), "breaker should be open after threshold failures")
+}
+
+func TestCircuitBreaker_PerHostIsolation(t *testing.T) {
+	// A failing host must not open the circuit for an unrelated host.
+	cb := newCircuitBreaker()
+
+	for i := 0; i < circuitFailureThreshold; i++ {
+		cb.recordFailure("api.github.com")
+	}
+
+	assert.False(t, cb.allow("api.github.com"))
+	assert.True(t, cb.allow("github.com"), "unrelated host should remain closed")
+}
+
+func TestCircuitBreaker_SuccessResetsFailureCount(t *testing.T) {
+	cb := newCircuitBreaker()
+
+	cb.recordFailure("api.github.com")
+	cb.recordFailure("api.github.com")
+	cb.recordSuccess("api.github.com")
+	cb.recordFailure("api.github.com")
+	cb.recordFailure("api.github.com")
+
+	// Two failures since the success — should still be closed (need 3 consecutive).
+	assert.True(t, cb.allow("api.github.com"))
+}
+
+func TestCircuitBreaker_ClosesAfterCooldown(t *testing.T) {
+	// Use a controllable clock so the test doesn't depend on wall time.
+	now := time.Now()
+	cb := newCircuitBreaker()
+	cb.now = func() time.Time { return now }
+
+	for i := 0; i < circuitFailureThreshold; i++ {
+		cb.recordFailure("api.github.com")
+	}
+	require.False(t, cb.allow("api.github.com"))
+
+	// Advance past the cooldown window.
+	now = now.Add(circuitOpenDuration + time.Second)
+	assert.True(t, cb.allow("api.github.com"), "breaker should close after cooldown")
+}
+
+func TestCircuitBreaker_FailureWindowResets(t *testing.T) {
+	// Failures spread out over more than the failure window must not
+	// accumulate into a trip — the breaker only protects against bursts.
+	now := time.Now()
+	cb := newCircuitBreaker()
+	cb.now = func() time.Time { return now }
+
+	cb.recordFailure("api.github.com")
+	now = now.Add(circuitFailureWindow + time.Second)
+	cb.recordFailure("api.github.com")
+	cb.recordFailure("api.github.com")
+
+	// Only the last two failures are within the window — below threshold.
+	assert.True(t, cb.allow("api.github.com"))
+}
+
+// failingTransport always returns the configured error. Used to drive the
+// retryTransport's circuit-breaker integration without real network.
+type failingTransport struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (f *failingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	f.calls.Add(1)
+	return nil, f.err
+}
+
+func TestRetryTransport_CircuitBreakerShortCircuitsAfterThresholdFailures(t *testing.T) {
+	// Drive the breaker through the public RoundTrip API to verify the wiring.
+	// Each RoundTrip records one outcome regardless of how many internal
+	// retries it ran, so threshold round-trips trip the breaker.
+	failing := &failingTransport{err: errors.New("dial tcp: lookup api.github.com: no such host")}
+	rt := &retryTransport{
+		base:       failing,
+		maxRetries: 0, // skip retries to keep the test fast
+		baseDelay:  1 * time.Millisecond,
+		breaker:    newCircuitBreaker(),
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.github.com/x", nil)
+
+	// Trip the breaker.
+	for i := 0; i < circuitFailureThreshold; i++ {
+		_, err := rt.RoundTrip(req)
+		require.Error(t, err)
+	}
+
+	beforeCalls := failing.calls.Load()
+	_, err := rt.RoundTrip(req)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCircuitOpen), "breaker should short-circuit with ErrCircuitOpen, got %v", err)
+	assert.Equal(t, beforeCalls, failing.calls.Load(), "breaker-open path must not invoke the underlying transport")
+}
+
+func TestRetryTransport_CircuitBreakerDoesNotCountContextCancellation(t *testing.T) {
+	// Context cancel/deadline reflect the caller's lifecycle, not host health.
+	// They must not move the breaker toward open.
+	failing := &failingTransport{err: context.Canceled}
+	rt := &retryTransport{
+		base:       failing,
+		maxRetries: 0,
+		baseDelay:  1 * time.Millisecond,
+		breaker:    newCircuitBreaker(),
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.github.com/x", nil)
+
+	for i := 0; i < circuitFailureThreshold+2; i++ {
+		_, _ = rt.RoundTrip(req)
+	}
+	assert.True(t, rt.breaker.allow("api.github.com"), "context cancellations must not trip the breaker")
+}

--- a/backend/github/client.go
+++ b/backend/github/client.go
@@ -51,16 +51,23 @@ type Client struct {
 
 // NewClient creates a new GitHub client
 func NewClient(clientID, clientSecret string) *Client {
+	// Shared per-host circuit breaker: state is keyed by URL.Host so a
+	// failing api.github.com trips both transports together (they target
+	// the same host most of the time), avoiding double-counting failures
+	// or losing track of recovery.
+	breaker := newCircuitBreaker()
 	rt := &retryTransport{
 		base:       http.DefaultTransport,
 		maxRetries: 3,
 		baseDelay:  1 * time.Second,
+		breaker:    breaker,
 	}
 	// Fewer retries for the no-redirect client used in interactive log fetching.
 	noRedirectRT := &retryTransport{
 		base:       http.DefaultTransport,
 		maxRetries: 1,
 		baseDelay:  500 * time.Millisecond,
+		breaker:    breaker,
 	}
 	return &Client{
 		clientID:     clientID,

--- a/backend/github/retry_transport.go
+++ b/backend/github/retry_transport.go
@@ -16,13 +16,52 @@ import (
 
 // retryTransport wraps an http.RoundTripper with automatic retry and
 // exponential backoff for GitHub API rate-limit responses (429 and 403).
+//
+// It also fronts a per-host circuit breaker (when configured): once the
+// host has produced enough consecutive transport failures the breaker
+// opens, and subsequent requests fail fast with ErrCircuitOpen instead of
+// paying the full retry budget. This bounds the user-visible freeze when
+// GitHub is unreachable to one full retry cycle, not one per dependent
+// endpoint per panel.
 type retryTransport struct {
 	base       http.RoundTripper
 	maxRetries int
 	baseDelay  time.Duration
+	breaker    *circuitBreaker // optional; no-op when nil
 }
 
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Short-circuit when the breaker is open — return immediately so callers
+	// see a fast-path failure they can treat the same as any other transport
+	// error (typically: serve a stale cached response).
+	if t.breaker != nil {
+		if !t.breaker.allow(req.URL.Host) {
+			return nil, fmt.Errorf("%w: %s", ErrCircuitOpen, req.URL.Host)
+		}
+	}
+
+	resp, err := t.roundTripWithRetries(req)
+
+	// Record outcome for the breaker. Context cancel/deadline don't reflect
+	// host health (the user/upstream cancelled), so they don't count as
+	// failures. A response — even a 5xx — counts as success because the host
+	// is reachable; the breaker only exists to suppress connection-level
+	// failures, not server-side error rates.
+	if t.breaker != nil {
+		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			// Don't move the breaker either way.
+		case err != nil:
+			t.breaker.recordFailure(req.URL.Host)
+		case resp != nil:
+			t.breaker.recordSuccess(req.URL.Host)
+		}
+	}
+
+	return resp, err
+}
+
+func (t *retryTransport) roundTripWithRetries(req *http.Request) (*http.Response, error) {
 	// Buffer the request body so it can be replayed on retry.
 	if req.Body != nil && req.GetBody == nil {
 		bodyBytes, err := io.ReadAll(req.Body)

--- a/backend/server/ci_handlers.go
+++ b/backend/server/ci_handlers.go
@@ -91,7 +91,7 @@ func (h *Handlers) ListCIRuns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cacheKey := fmt.Sprintf("%s/%s@%s", ghCtx.owner, ghCtx.repo, ghCtx.session.Branch)
-	runs, err := h.ciRunsCache.DoContext(r.Context(), cacheKey, func() ([]github.WorkflowRun, error) {
+	runs, cacheState, err := h.ciRunsCache.DoContextWithStaleOnError(r.Context(), cacheKey, func() ([]github.WorkflowRun, error) {
 		fetchCtx, cancel := context.WithTimeout(h.serverCtx, ghFetchTimeout)
 		defer cancel()
 		return h.ghClient.ListWorkflowRuns(fetchCtx, ghCtx.owner, ghCtx.repo, ghCtx.session.Branch)
@@ -101,6 +101,12 @@ func (h *Handlers) ListCIRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if cacheState == CacheStaleError {
+		// GitHub call failed but we have a cached run list — return it with
+		// a degraded-cache header instead of a 502 so the UI keeps showing
+		// the last-known runs through the outage.
+		w.Header().Set("X-Cache-Status", "stale-error")
+	}
 	writeJSON(w, runs)
 }
 

--- a/backend/server/handlers.go
+++ b/backend/server/handlers.go
@@ -730,14 +730,22 @@ func NewHandlers(ctx context.Context, s *store.SQLiteStore, am *agent.Manager, d
 		statsComputer:    sc,
 		diffCache:        diffCache,
 		snapshotCache:    snapshotCache,
-		// PR status changes via WebSocket push from pr-watcher; 15s TTL is a
-		// short fallback for the polling clients while collapsing the 3-5
-		// concurrent subscribers (per-session) into one upstream GitHub call.
+		// PR details are kept warm by pr-watcher's 30s/45s polling cycle
+		// (see SetOnPRDetails wire-up below). The 90s freshness TTL is
+		// comfortably longer than the slow-tier interval, so /pr-status
+		// polls served to the user almost always hit the cache and avoid
+		// a 1.0–1.5s GitHub round-trip on the request path. The 10-minute
+		// stale window keeps the last-known value usable as a fallback
+		// when GitHub is unreachable, so a transient outage degrades the
+		// UI to "slightly stale" instead of broken panels.
 		// Keyed by sessionID — see prStatusCacheKey for the rationale.
-		prStatusCache: NewSFCache[*github.PRDetails](15 * time.Second),
+		prStatusCache: NewSFCacheWithStale[*github.PRDetails](90*time.Second, 10*time.Minute),
 		// CI workflow runs change relatively slowly; 30s coalesces the 30s
 		// polling loop subscribers without serving meaningfully stale data.
-		ciRunsCache: NewSFCache[[]github.WorkflowRun](30 * time.Second),
+		// The 5-minute stale window provides the same outage fallback as
+		// pr-status: rather than 502 panels, users see a slightly older run
+		// list while GitHub recovers.
+		ciRunsCache: NewSFCacheWithStale[[]github.WorkflowRun](30*time.Second, 5*time.Minute),
 		// Action templates are configuration; 60s eliminates 4-6× round-trips
 		// on every session switch with effectively no staleness risk.
 		actionTemplatesCache: NewSFCache[map[string]string](60 * time.Second),
@@ -754,6 +762,14 @@ func NewHandlers(ctx context.Context, s *store.SQLiteStore, am *agent.Manager, d
 	const sfCacheSweepInterval = 5 * time.Minute
 	h.prStatusCache.StartSweeper(serverCtx, sfCacheSweepInterval)
 	h.ciRunsCache.StartSweeper(serverCtx, sfCacheSweepInterval)
+
+	// Have the PR watcher feed prStatusCache so /pr-status polls served to
+	// users hit the cache instead of paying a synchronous GitHub call.
+	if prw != nil {
+		prw.SetOnPRDetails(func(sessionID string, details *github.PRDetails) {
+			h.prStatusCache.Set(prStatusCacheKey(sessionID), details)
+		})
+	}
 	return h
 }
 

--- a/backend/server/pr_handlers.go
+++ b/backend/server/pr_handlers.go
@@ -78,14 +78,17 @@ func (h *Handlers) GetSessionPRStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get PR details from GitHub. Multiple panels subscribe to pr-status on
-	// session switch; SFCache collapses concurrent callers into one call and
-	// caches the result for 15s.
+	// session switch; SFCache collapses concurrent callers into one call.
+	// The cache is kept warm by pr-watcher (see SetOnPRDetails wiring) so
+	// most polls served here hit the fresh window without ever calling
+	// GitHub. The stale-on-error path returns the last-known value when
+	// GitHub is unreachable rather than failing the request, preserving UI
+	// continuity through transient outages.
 	//
 	// The shared GitHub call runs against a context derived from h.serverCtx
 	// (bounded by ghFetchTimeout), not r.Context(), so one disconnecting
-	// panel can't poison the upstream fetch for the other waiters. Each
-	// caller can still bail on its own r.Context() via DoContext.
-	prDetails, err := h.prStatusCache.DoContext(ctx, prStatusCacheKey(sessionID), func() (*github.PRDetails, error) {
+	// panel can't poison the upstream fetch for the other waiters.
+	prDetails, cacheState, err := h.prStatusCache.DoContextWithStaleOnError(ctx, prStatusCacheKey(sessionID), func() (*github.PRDetails, error) {
 		fetchCtx, cancel := context.WithTimeout(h.serverCtx, ghFetchTimeout)
 		defer cancel()
 		return h.ghClient.GetPRDetails(fetchCtx, owner, repoName, session.PRNumber)
@@ -99,6 +102,12 @@ func (h *Handlers) GetSessionPRStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if cacheState == CacheStaleError {
+		// Surface that the response is a degraded fallback so the UI can
+		// render an "offline" indicator instead of pretending nothing is
+		// wrong. Set before WriteHeader (which writeJSON triggers).
+		w.Header().Set("X-Cache-Status", "stale-error")
+	}
 	writeJSON(w, prDetails)
 }
 

--- a/backend/server/singleflight_cache.go
+++ b/backend/server/singleflight_cache.go
@@ -23,28 +23,59 @@ import (
 // value as read-only — mutating it races with other readers and silently
 // corrupts the cache entry. If you need to mutate, copy first.
 type SFCache[T any] struct {
-	sf  singleflight.Group
-	ttl time.Duration
+	sf       singleflight.Group
+	ttl      time.Duration // freshness window — Do/DoContext serve directly within this
+	staleTTL time.Duration // extended grace period; entries past ttl but within staleTTL
+	// remain in the map and are usable as a stale-on-error fallback.
 
 	mu      sync.RWMutex
 	entries map[string]sfEntry[T]
 }
 
 type sfEntry[T any] struct {
-	value     T
-	expiresAt time.Time
+	value      T
+	expiresAt  time.Time // after this: not fresh (Do refetches)
+	staleUntil time.Time // after this: evicted (entry is gone)
 }
 
+// CacheState describes how DoContextWithStaleOnError served its result.
+type CacheState int
+
+const (
+	// CacheFresh means the value was served from fresh cache or from a
+	// successful upstream refresh.
+	CacheFresh CacheState = iota
+	// CacheStaleError means the upstream refresh returned an error and the
+	// caller is being served a previously-cached value as a fallback.
+	// Surface this to the client (e.g. via X-Cache-Status: stale-error)
+	// so degraded responses are visible.
+	CacheStaleError
+)
+
 // NewSFCache returns a singleflight-backed TTL cache. ttl must be > 0.
+// The cache has no extended stale window — entries are evicted at ttl.
 //
 // Without an explicit eviction strategy, entries that are written once and
 // never re-stored (e.g. a feature branch that's deleted, a closed PR) would
 // stay in the map until process exit. Use StartSweeper for long-lived caches
 // whose key cardinality grows with usage.
 func NewSFCache[T any](ttl time.Duration) *SFCache[T] {
+	return NewSFCacheWithStale[T](ttl, ttl)
+}
+
+// NewSFCacheWithStale returns a cache with separate freshness and staleness
+// windows. Entries are served directly while within freshTTL; past freshTTL
+// but within staleTTL they remain in the map and can be served by
+// DoContextWithStaleOnError as a fallback when an upstream refresh fails.
+// staleTTL is clamped up to freshTTL.
+func NewSFCacheWithStale[T any](freshTTL, staleTTL time.Duration) *SFCache[T] {
+	if staleTTL < freshTTL {
+		staleTTL = freshTTL
+	}
 	return &SFCache[T]{
-		ttl:     ttl,
-		entries: make(map[string]sfEntry[T]),
+		ttl:      freshTTL,
+		staleTTL: staleTTL,
+		entries:  make(map[string]sfEntry[T]),
 	}
 }
 
@@ -121,6 +152,58 @@ func (c *SFCache[T]) DoContext(ctx context.Context, key string, fn func() (T, er
 	}
 }
 
+// DoContextWithStaleOnError is like DoContext but, when fn returns an error
+// and a stale cached value is still within the staleTTL window, returns that
+// value with CacheStaleError instead of surfacing the error. This trades
+// momentary staleness for UI continuity during upstream outages: the
+// alternative is the user seeing 5xx panels every poll until the upstream
+// recovers.
+//
+// Behaviour matrix:
+//   - fresh hit:                  → (value, CacheFresh, nil)
+//   - miss + fn ok:               → (value, CacheFresh, nil)
+//   - miss + fn error + stale:    → (stale, CacheStaleError, nil)
+//   - miss + fn error + no stale: → (zero,  CacheFresh,      err)
+//   - ctx cancelled:              → (zero,  CacheFresh,      ctx.Err())
+//
+// Caller's ctx can abort their wait without cancelling the underlying fn —
+// see DoContext for the singleflight semantics.
+func (c *SFCache[T]) DoContextWithStaleOnError(ctx context.Context, key string, fn func() (T, error)) (T, CacheState, error) {
+	if v, ok := c.lookup(key); ok {
+		return v, CacheFresh, nil
+	}
+
+	ch := c.sf.DoChan(key, func() (any, error) {
+		if v, ok := c.lookup(key); ok {
+			return v, nil
+		}
+		result, err := fn()
+		if err != nil {
+			var zero T
+			return zero, err
+		}
+		c.store(key, result)
+		return result, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		var zero T
+		return zero, CacheFresh, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			// Refresh failed — fall back to a stale cached value if one
+			// exists. This is the entire point of the staleTTL window.
+			if v, ok := c.lookupStale(key); ok {
+				return v, CacheStaleError, nil
+			}
+			var zero T
+			return zero, CacheFresh, res.Err
+		}
+		return res.Val.(T), CacheFresh, nil
+	}
+}
+
 // Invalidate drops any cached value for key. Safe to call when nothing is cached.
 func (c *SFCache[T]) Invalidate(key string) {
 	c.mu.Lock()
@@ -128,6 +211,18 @@ func (c *SFCache[T]) Invalidate(key string) {
 	c.mu.Unlock()
 }
 
+// Set populates the cache for key with the configured TTL. Use this when an
+// external producer (e.g. a background poller) has already fetched the value
+// and wants subsequent Do/DoContext calls to hit instead of refetching.
+//
+// The stored value is treated as read-only — see the SFCache contract.
+func (c *SFCache[T]) Set(key string, value T) {
+	c.store(key, value)
+}
+
+// lookup returns the cached value if it is still fresh. Past the freshness
+// window but within the stale window, the entry is intentionally retained so
+// DoContextWithStaleOnError can fall back to it on upstream failure.
 func (c *SFCache[T]) lookup(key string) (T, bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[key]
@@ -136,30 +231,56 @@ func (c *SFCache[T]) lookup(key string) (T, bool) {
 		var zero T
 		return zero, false
 	}
-	if time.Now().After(entry.expiresAt) {
-		// Opportunistic eviction: drop the stale entry so a key that's
-		// looked up once and never re-stored doesn't pin memory forever.
-		// Re-check under the write lock — another caller may have
-		// refreshed the entry between our read and write.
+	now := time.Now()
+	if now.After(entry.staleUntil) {
+		// Past stale window — drop the entry so a key looked up once and
+		// never re-stored doesn't pin memory forever. Re-check under the
+		// write lock to avoid racing a fresh write.
 		c.mu.Lock()
-		if cur, ok := c.entries[key]; ok && time.Now().After(cur.expiresAt) {
+		if cur, ok := c.entries[key]; ok && time.Now().After(cur.staleUntil) {
 			delete(c.entries, key)
 		}
 		c.mu.Unlock()
 		var zero T
 		return zero, false
 	}
+	if now.After(entry.expiresAt) {
+		// Stale-but-retained: not a fresh hit. Don't evict; the
+		// stale-on-error path may still need this value.
+		var zero T
+		return zero, false
+	}
 	return entry.value, true
 }
 
-// Sweep walks the entries map once and deletes anything past its TTL. Cheap
-// even for caches with thousands of keys (just a map walk under a write lock).
-// Exposed for tests; production callers should use StartSweeper.
+// lookupStale returns any retained value (fresh or past-fresh-but-within-
+// staleTTL). Used by DoContextWithStaleOnError as the fallback path when
+// the upstream refresh fails. Does not evict on miss.
+func (c *SFCache[T]) lookupStale(key string) (T, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	if time.Now().After(entry.staleUntil) {
+		var zero T
+		return zero, false
+	}
+	return entry.value, true
+}
+
+// Sweep walks the entries map once and deletes anything past its stale
+// deadline (entries past freshness but still within staleTTL are retained
+// for stale-on-error fallback). Cheap even for caches with thousands of
+// keys (just a map walk under a write lock). Exposed for tests;
+// production callers should use StartSweeper.
 func (c *SFCache[T]) Sweep() {
 	now := time.Now()
 	c.mu.Lock()
 	for k, e := range c.entries {
-		if now.After(e.expiresAt) {
+		if now.After(e.staleUntil) {
 			delete(c.entries, k)
 		}
 	}
@@ -188,7 +309,12 @@ func (c *SFCache[T]) StartSweeper(ctx context.Context, interval time.Duration) {
 }
 
 func (c *SFCache[T]) store(key string, value T) {
+	now := time.Now()
 	c.mu.Lock()
-	c.entries[key] = sfEntry[T]{value: value, expiresAt: time.Now().Add(c.ttl)}
+	c.entries[key] = sfEntry[T]{
+		value:      value,
+		expiresAt:  now.Add(c.ttl),
+		staleUntil: now.Add(c.staleTTL),
+	}
 	c.mu.Unlock()
 }

--- a/backend/server/singleflight_cache_test.go
+++ b/backend/server/singleflight_cache_test.go
@@ -191,6 +191,118 @@ func TestSFCache_Invalidate(t *testing.T) {
 	}
 }
 
+func TestSFCache_SetPopulatesEntryAndSuppressesFn(t *testing.T) {
+	c := NewSFCache[int](5 * time.Second)
+	var calls int64
+
+	c.Set("k", 7)
+
+	for i := 0; i < 3; i++ {
+		v, err := c.Do("k", func() (int, error) {
+			atomic.AddInt64(&calls, 1)
+			return 99, nil
+		})
+		if err != nil || v != 7 {
+			t.Fatalf("iter %d: got (%d, %v), want (7, nil)", i, v, err)
+		}
+	}
+	if got := atomic.LoadInt64(&calls); got != 0 {
+		t.Errorf("expected 0 underlying calls (Set should populate cache), got %d", got)
+	}
+}
+
+func TestSFCache_StaleOnError_ReturnsStaleAfterFailedRefresh(t *testing.T) {
+	// Fresh window short, stale window long: the entry expires almost
+	// immediately but stays available as a fallback for ~5s.
+	c := NewSFCacheWithStale[string](20*time.Millisecond, 5*time.Second)
+
+	// Seed a cached value via a successful first call.
+	if _, _, err := c.DoContextWithStaleOnError(context.Background(), "k", func() (string, error) {
+		return "v1", nil
+	}); err != nil {
+		t.Fatalf("seed call: unexpected error: %v", err)
+	}
+
+	// Let freshness elapse but keep stale window valid.
+	time.Sleep(40 * time.Millisecond)
+
+	// Refresh fails — caller should still see the cached value tagged stale.
+	v, state, err := c.DoContextWithStaleOnError(context.Background(), "k", func() (string, error) {
+		return "", errors.New("upstream down")
+	})
+	if err != nil {
+		t.Fatalf("expected nil error from stale fallback, got %v", err)
+	}
+	if v != "v1" {
+		t.Errorf("expected stale value v1, got %q", v)
+	}
+	if state != CacheStaleError {
+		t.Errorf("expected CacheStaleError, got %v", state)
+	}
+}
+
+func TestSFCache_StaleOnError_PropagatesErrorWithNoFallback(t *testing.T) {
+	// A miss with no prior successful call has no stale value to fall back
+	// on; the error must surface so the caller can render an error state.
+	c := NewSFCacheWithStale[int](20*time.Millisecond, 5*time.Second)
+	sentinel := errors.New("upstream down")
+
+	_, state, err := c.DoContextWithStaleOnError(context.Background(), "k", func() (int, error) {
+		return 0, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+	if state != CacheFresh {
+		t.Errorf("expected CacheFresh marker on hard error path, got %v", state)
+	}
+}
+
+func TestSFCache_StaleOnError_FreshHitDoesNotCallFn(t *testing.T) {
+	c := NewSFCacheWithStale[string](5*time.Second, 30*time.Second)
+	_, _, err := c.DoContextWithStaleOnError(context.Background(), "k", func() (string, error) {
+		return "v1", nil
+	})
+	if err != nil {
+		t.Fatalf("seed call: unexpected error: %v", err)
+	}
+
+	called := false
+	v, state, err := c.DoContextWithStaleOnError(context.Background(), "k", func() (string, error) {
+		called = true
+		return "v2", nil
+	})
+	if err != nil || v != "v1" {
+		t.Errorf("expected fresh hit (v1, nil), got (%q, %v)", v, err)
+	}
+	if state != CacheFresh {
+		t.Errorf("expected CacheFresh, got %v", state)
+	}
+	if called {
+		t.Error("fresh hit must not invoke fn")
+	}
+}
+
+func TestSFCache_StaleOnError_EntryEvictedAfterStaleWindow(t *testing.T) {
+	// Past the stale window, the value is gone and the next failure surfaces.
+	c := NewSFCacheWithStale[string](10*time.Millisecond, 30*time.Millisecond)
+	_, _, err := c.DoContextWithStaleOnError(context.Background(), "k", func() (string, error) {
+		return "v1", nil
+	})
+	if err != nil {
+		t.Fatalf("seed call: unexpected error: %v", err)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	sentinel := errors.New("upstream down")
+	_, _, err = c.DoContextWithStaleOnError(context.Background(), "k", func() (string, error) {
+		return "", sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("past stale window: expected sentinel error, got %v", err)
+	}
+}
+
 func TestSFCache_LookupEvictsExpiredEntry(t *testing.T) {
 	c := NewSFCache[int](20 * time.Millisecond)
 

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{Emitter, Manager};
 
 use crate::error::{AppError, AppResult};
@@ -39,6 +39,11 @@ struct FileChangedPayload<'a> {
     full_path: &'a str,
     files: Vec<FileEntry<'a>>,
     file_count: usize,
+    /// True when this event was emitted from a burst-cooldown window (e.g. a
+    /// `git checkout` or `npm install` storm). Consumers should treat the file
+    /// list as a hint that "many things changed" and prefer a single bulk
+    /// refetch over per-file reload work.
+    burst: bool,
 }
 
 #[derive(Serialize, Clone)]
@@ -67,7 +72,36 @@ const IGNORED_DIRECTORIES: &[&str] = &[
     "build",
     ".venv",
     "venv",
+    ".turbo",
+    ".swc",
+    ".parcel-cache",
+    "coverage",
+    ".nyc_output",
 ];
+
+/// File-count threshold above which a single debounce window is treated as a
+/// burst (git checkout, npm install, branch switch). Picked to comfortably
+/// exceed the largest plausible single-edit batch (a few dozen files at most)
+/// while catching the multi-thousand-file storms observed in the wild.
+const BURST_THRESHOLD: usize = 500;
+
+/// How long to suppress emissions after entering burst cooldown for a workspace.
+/// During this window, additional file events are accumulated into the same
+/// burst rather than emitted as separate events. Long enough to absorb the
+/// inter-burst quiet periods of macOS FSEvents during a checkout, short enough
+/// that the UI updates feel "near-immediate" rather than stuck.
+const BURST_COOLDOWN: Duration = Duration::from_millis(2500);
+
+/// Receiver poll interval. The thread blocks on `recv_timeout` rather than
+/// `recv` so it can periodically flush expired bursts even when no new
+/// events arrive (e.g. a checkout finishes and the disk goes quiet).
+const RECV_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// State for a workspace currently in burst cooldown.
+struct BurstState {
+    entered_at: Instant,
+    accumulated: WorkspaceChanges,
+}
 
 /// Pre-compiled ignore patterns to avoid heap allocations on every file event.
 /// Uses `OnceLock` (stable since Rust 1.70) instead of `LazyLock` (1.80+) for MSRV compat.
@@ -109,6 +143,47 @@ fn extract_session_dir(base_path: &Path, event_path: &Path) -> Option<String> {
                 None
             }
         })
+}
+
+/// Emit a `file-changed` event for one workspace. Centralised so the normal
+/// path and the burst-flush path stay in sync (same payload shape, same log
+/// line). `burst=true` tells the frontend that the file list is a hint about
+/// "many things changed at once" rather than per-file edits worth reloading
+/// individually.
+fn emit_file_changed(
+    window: &tauri::WebviewWindow,
+    workspace_id: &str,
+    files: &WorkspaceChanges,
+    burst: bool,
+) {
+    let count = files.len();
+    let Some((last_path, last_full)) = files.last() else {
+        return;
+    };
+    let file_list: Vec<FileEntry<'_>> = files
+        .iter()
+        .map(|(path, full)| FileEntry {
+            path: path.as_str(),
+            full_path: full.as_str(),
+        })
+        .collect();
+    let payload = FileChangedPayload {
+        workspace_id,
+        path: last_path.as_str(),
+        full_path: last_full.as_str(),
+        files: file_list,
+        file_count: count,
+        burst,
+    };
+    if let Err(e) = window.emit("file-changed", payload) {
+        log::error!("Failed to emit file-changed event: {}", e);
+    }
+    log::debug!(
+        "File changes detected in workspace {}: {} files (burst={})",
+        workspace_id,
+        count,
+        burst
+    );
 }
 
 /// Start the global file watcher on the base worktrees directory.
@@ -181,15 +256,26 @@ pub fn start_global_watcher(
     // Spawn a thread to handle file change events.
     // Lifecycle: The thread runs until the channel closes. When stop_global_watcher()
     // drops the GlobalFileWatcher (and its debouncer), the sender channel closes,
-    // causing rx.recv() to return Err and the thread to exit gracefully.
+    // causing rx.recv_timeout() to return Disconnected and the thread to exit gracefully.
     std::thread::spawn(move || {
+        use std::sync::mpsc::RecvTimeoutError;
+
         log::info!(
             "Global file watcher started on base directory: {}",
             watcher_base_path.display()
         );
 
+        // Per-workspace burst-cooldown state. A workspace enters burst cooldown
+        // when a single debounce window emits ≥ BURST_THRESHOLD files (the
+        // signature of `git checkout` / `npm install` etc). While in cooldown,
+        // additional events are accumulated and a single `file-changed` event
+        // with `burst=true` is emitted when the cooldown expires. This collapses
+        // the 5–6 emit storm that a branch switch otherwise produces into one
+        // user-visible event and one downstream snapshot refetch.
+        let mut bursts: HashMap<String, BurstState> = HashMap::new();
+
         loop {
-            match rx.recv() {
+            match rx.recv_timeout(RECV_POLL_INTERVAL) {
                 Ok(Ok(events)) => {
                     // Collect changed files per workspace, emitting ONE event per workspace
                     // instead of per-file to avoid flooding the WebView event loop.
@@ -275,45 +361,84 @@ pub fn start_global_watcher(
                         }
                     }
 
-                    // Emit one event per workspace with all changed file paths
-                    if let Some(window) = app_handle.get_webview_window("main") {
-                        for (workspace_id, files) in &workspace_changes {
-                            let count = files.len();
-                            let Some((last_path, last_full)) = files.last() else {
-                                continue;
-                            };
-                            let file_list: Vec<FileEntry<'_>> = files
-                                .iter()
-                                .map(|(path, full)| FileEntry {
-                                    path: path.as_str(),
-                                    full_path: full.as_str(),
-                                })
-                                .collect();
-                            let payload = FileChangedPayload {
-                                workspace_id: workspace_id.as_str(),
-                                path: last_path.as_str(),
-                                full_path: last_full.as_str(),
-                                files: file_list,
-                                file_count: count,
-                            };
-                            if let Err(e) = window.emit("file-changed", payload) {
-                                log::error!("Failed to emit file-changed event: {}", e);
-                            }
+                    let window = app_handle.get_webview_window("main");
+                    for (workspace_id, files) in workspace_changes {
+                        // If this workspace is already in burst cooldown, accumulate
+                        // and skip emission — the flush pass below or a later batch
+                        // will release it as a single `burst=true` event.
+                        if let Some(state) = bursts.get_mut(&workspace_id) {
+                            state.accumulated.extend(files);
+                            continue;
+                        }
+
+                        // First debounce window for this workspace. If it crosses the
+                        // burst threshold, withhold emission and start cooldown so the
+                        // (typically multi-window) storm collapses into one event.
+                        if files.len() >= BURST_THRESHOLD {
                             log::debug!(
-                                "File changes detected in workspace {}: {} files",
+                                "Entering burst cooldown for workspace {} ({} files)",
                                 workspace_id,
-                                count
+                                files.len()
                             );
+                            bursts.insert(
+                                workspace_id,
+                                BurstState {
+                                    entered_at: Instant::now(),
+                                    accumulated: files,
+                                },
+                            );
+                            continue;
+                        }
+
+                        // Normal-sized batch — emit immediately with burst=false.
+                        if let Some(window) = window.as_ref() {
+                            emit_file_changed(window, &workspace_id, &files, false);
                         }
                     }
                 }
                 Ok(Err(error)) => {
                     log::error!("Global file watcher error: {:?}", error);
                 }
-                Err(_) => {
-                    // Channel closed, watcher was stopped
+                Err(RecvTimeoutError::Timeout) => {
+                    // Fall through to flush expired bursts even when the disk is quiet.
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    // Channel closed, watcher was stopped. Flush any pending bursts
+                    // so accumulated changes aren't silently dropped on shutdown.
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        for (workspace_id, state) in bursts.drain() {
+                            emit_file_changed(&window, &workspace_id, &state.accumulated, true);
+                        }
+                    }
                     log::info!("Global file watcher stopped");
                     break;
+                }
+            }
+
+            // Flush any bursts whose cooldown window has expired. This runs after
+            // every batch and after every timeout, so the worst-case extra latency
+            // for a burst flush is RECV_POLL_INTERVAL.
+            if !bursts.is_empty() {
+                let now = Instant::now();
+                let expired: Vec<String> = bursts
+                    .iter()
+                    .filter(|(_, state)| now.duration_since(state.entered_at) >= BURST_COOLDOWN)
+                    .map(|(k, _)| k.clone())
+                    .collect();
+                if !expired.is_empty() {
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        for ws_id in expired {
+                            if let Some(state) = bursts.remove(&ws_id) {
+                                emit_file_changed(&window, &ws_id, &state.accumulated, true);
+                            }
+                        }
+                    } else {
+                        // No window to emit to — drop the bursts to avoid
+                        // accumulating memory indefinitely.
+                        for ws_id in expired {
+                            bursts.remove(&ws_id);
+                        }
+                    }
                 }
             }
         }

--- a/src/hooks/__tests__/useFileWatcher.test.ts
+++ b/src/hooks/__tests__/useFileWatcher.test.ts
@@ -282,6 +282,40 @@ describe('useFileWatcher', () => {
     expect(mockedSendNotification).not.toHaveBeenCalled();
   });
 
+  it('skips per-tab reload work for burst events but still updates the store', async () => {
+    // Burst events represent a checkout / install storm with hundreds of files.
+    // The hook must NOT iterate every file checking for tab conflicts (wasted
+    // work; the downstream snapshot refetch handles bulk refresh) but still
+    // needs to write the event to the store so other consumers react.
+    const tab = makeFileTab({ isDirty: false });
+    useAppStore.setState({ fileTabs: [tab] });
+
+    renderHook(() => useFileWatcher());
+
+    await act(async () => {
+      await flushAsync();
+    });
+
+    await act(async () => {
+      capturedFileChangeHandler!({
+        workspaceId: 'ws-1',
+        path: 'src/file.ts',
+        fullPath: '/workspaces/ws-1/src/file.ts',
+        files: [{ path: 'src/file.ts', fullPath: '/workspaces/ws-1/src/file.ts' }],
+        fileCount: 1500,
+        burst: true,
+      });
+      await flushAsync();
+    });
+
+    // Store should still receive the change so consumers can refetch snapshot.
+    const lastChange = useAppStore.getState().lastFileChange;
+    expect(lastChange?.burst).toBe(true);
+    // But the hook must NOT do per-file reload work on a burst.
+    expect(mockedGetRepoFileContent).not.toHaveBeenCalled();
+    expect(mockedSendNotification).not.toHaveBeenCalled();
+  });
+
   it('cleans up listener on unmount', async () => {
     const { unmount } = renderHook(() => useFileWatcher());
 

--- a/src/hooks/useFileWatcher.ts
+++ b/src/hooks/useFileWatcher.ts
@@ -39,6 +39,15 @@ export function useFileWatcher(enabled: boolean = true) {
   // Reads fileTabs from the store directly to always get the latest state,
   // avoiding stale closures when the Tauri listener outlives a render cycle.
   const handleFileChange = useCallback(async (event: FileChangedEvent) => {
+    // Burst events represent a checkout / install / branch-switch storm
+    // (hundreds-to-thousands of files at once). The downstream snapshot
+    // refetch driven by setLastFileChange already handles the bulk refresh;
+    // running per-tab conflict checks against thousands of paths here just
+    // burns the main thread without any UX benefit.
+    if (event.burst) {
+      return;
+    }
+
     const { fileTabs, updateFileTab } = useAppStore.getState();
 
     // Determine which file paths to check for tab conflicts

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -261,6 +261,13 @@ export interface FileChangedEvent {
   files?: { path: string; fullPath: string }[];
   /** Total number of files changed in this batch */
   fileCount?: number;
+  /**
+   * True when the watcher emitted this event after burst-cooldown expired
+   * (e.g. a `git checkout` or `npm install` storm). Consumers should treat
+   * the file list as a hint that "many things changed" and prefer one bulk
+   * refetch over per-file reload work.
+   */
+  burst?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Three independent fixes derived from log analysis showing concrete UX bottlenecks:

- **`/pr-status` taking 1.0–1.5s on every poll** (every ~15–30s per session)
- **GitHub-down cascades freezing the UI for 6–14s** when DNS fails
- **`git checkout` firing 5–6 redundant snapshot refetches in 3 seconds**

## Changes

**Fix 1 — pr-status cache warming** (cuts steady-state latency 1.2s → <10ms)
- `PRWatcher.SetOnPRDetails` callback fed by all three details code paths (open-PR, merged-transition, `enrichPRMetadata`).
- Wired in `NewHandlers` to populate `prStatusCache`.
- TTL bumped 15s → 90s fresh / 10min stale. The watcher's 30/45s polling now keeps the cache continuously warm.

**Fix 2 — GitHub I/O hardening** (cuts 6–14s freezes to <50ms)
- New `backend/github/circuit_breaker.go`: per-host breaker opens after 3 consecutive transport failures within 30s, stays open for 30s. Context cancellations don't count.
- `retryTransport` short-circuits with `ErrCircuitOpen` when open, records success/failure once per `RoundTrip`.
- `SFCache.DoContextWithStaleOnError` returns the last cached value when refresh fails, with new `CacheStaleError` state.
- `/pr-status` and `/ci/runs` use the new helper and emit `X-Cache-Status: stale-error` so the UI can render a degraded state instead of 500/502.

**Fix 3 — Watcher burst suppression** (collapses checkout storms 5–6× → 1×)
- Per-workspace burst-cooldown in `src-tauri/src/watcher.rs`. Windows emitting ≥500 files enter a 2.5s accumulation; a single `file-changed` event with `burst: true` is emitted on flush.
- Switched from `recv()` to `recv_timeout(500ms)` so cooldowns flush even on a quiet disk.
- Frontend (`useFileWatcher.ts`) skips per-tab reload work on burst events — the downstream snapshot refetch already handles bulk refresh.
- Ignore list extended with `.turbo`, `.swc`, `.parcel-cache`, `coverage`, `.nyc_output`.

## Test plan

- [x] `go test -race ./...` — all 13 backend packages pass, no races
- [x] `cargo test --lib` — 57/57 Rust tests pass
- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 2556/2557 (one pre-existing PlateInput flake unrelated to these changes; verified failing on the unmodified branch)
- [x] `npm run build` — TypeScript + Next.js clean
- [x] 13 new tests added: SFCache `Set` and stale-on-error variants, PRWatcher `onPRDetails` for both code paths, circuit breaker (6 unit + 2 transport-integration), `useFileWatcher` burst-skip
- [ ] Manual verification on a session with an open PR: `/pr-status` calls should log <10ms after warm-up
- [ ] Manual verification with a `git checkout` in a moderately large repo: one `File changes detected` log per checkout, not 5–6
- [ ] Manual verification with WiFi off: panels show stale data with offline indicator instead of 502 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)