### PR TITLE
feat(auth): prefer OAuth subscription over API key in credential cascade

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -2382,11 +2382,13 @@ func formatSessionName(name string) string {
 
 // newAIClient creates a fresh AI client by checking multiple credential sources in order:
 // 0. AWS Bedrock via Claude Code settings.json or ChatML env vars
-// 1. Encrypted API key stored in SQLite settings
-// 2. ANTHROPIC_API_KEY environment variable
-// 3. Claude Code OAuth token from macOS Keychain
-// 4. Claude Code credentials file (~/.claude/.credentials.json)
-// 5. Cached OAuth token from agent-runner SDK
+// 1. Claude Code OAuth token from macOS Keychain
+// 2. Claude Code credentials file (~/.claude/.credentials.json)
+// 3. Cached OAuth token from agent-runner SDK
+// 4. Encrypted API key stored in SQLite settings
+// 5. ANTHROPIC_API_KEY environment variable
+// Subscription/OAuth sources are preferred over API keys so users on a Claude
+// Max/Pro plan don't unintentionally burn API quota when both are configured.
 // Returns nil if no credentials are available.
 func (m *Manager) newAIClient() ai.Provider {
 	// Read Claude Code settings once — shared by Bedrock check and env var merge.
@@ -2409,23 +2411,7 @@ func (m *Manager) newAIClient() ai.Provider {
 		return client
 	}
 
-	// Source 1: SQLite settings (explicit user-configured API key)
-	if envVars != nil {
-		if apiKey := envVars["ANTHROPIC_API_KEY"]; apiKey != "" {
-			logger.Manager.Debugf("AI client: using API key from settings")
-			m.signalCredentialsReady()
-			return ai.NewClient(apiKey)
-		}
-	}
-
-	// Source 2: Process environment variable
-	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
-		logger.Manager.Debugf("AI client: using API key from environment")
-		m.signalCredentialsReady()
-		return ai.NewClient(apiKey)
-	}
-
-	// Source 3: Claude Code OAuth token from OS keychain
+	// Source 1: Claude Code OAuth token from OS keychain
 	var keychainErr, credFileErr error
 	token, keychainErr := ai.ReadClaudeCodeOAuthToken()
 	if keychainErr == nil {
@@ -2434,7 +2420,7 @@ func (m *Manager) newAIClient() ai.Provider {
 		return ai.NewClientWithOAuth(token)
 	}
 
-	// Source 4: Credentials file fallback (~/.claude/.credentials.json)
+	// Source 2: Credentials file fallback (~/.claude/.credentials.json)
 	token, credFileErr = ai.ReadClaudeCodeCredentialsFile()
 	if credFileErr == nil {
 		logger.Manager.Debugf("AI client: using OAuth token from credentials file")
@@ -2442,13 +2428,29 @@ func (m *Manager) newAIClient() ai.Provider {
 		return ai.NewClientWithOAuth(token)
 	}
 
-	// Source 5: Cached OAuth token from agent-runner SDK
-	// In release builds, sources 1-4 often fail (no env var from Finder launch,
-	// keychain ACL blocks access). The SDK authenticates independently and we
-	// cache its credentials on the first init event.
+	// Source 3: Cached OAuth token from agent-runner SDK
+	// In release builds, the keychain/credfile sources often fail (no env var from
+	// Finder launch, keychain ACL blocks access). The SDK authenticates
+	// independently and we cache its credentials on the first init event.
 	if cached := m.getCachedOAuthToken(); cached != "" {
 		logger.Manager.Debugf("AI client: using cached OAuth token from SDK")
 		return ai.NewClientWithOAuth(cached)
+	}
+
+	// Source 4: SQLite settings (explicit user-configured API key)
+	if envVars != nil {
+		if apiKey := envVars["ANTHROPIC_API_KEY"]; apiKey != "" {
+			logger.Manager.Debugf("AI client: using API key from settings")
+			m.signalCredentialsReady()
+			return ai.NewClient(apiKey)
+		}
+	}
+
+	// Source 5: Process environment variable
+	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
+		logger.Manager.Debugf("AI client: using API key from environment")
+		m.signalCredentialsReady()
+		return ai.NewClient(apiKey)
 	}
 
 	logger.Manager.Warnf("AI client unavailable: no credentials found (keychain: %v, credfile: %v)", keychainErr, credFileErr)
@@ -2549,6 +2551,21 @@ func (m *Manager) setCachedOAuthToken(token string) {
 	defer m.cachedOAuthTokenMu.Unlock()
 	m.cachedOAuthToken = token
 	m.signalCredentialsReady()
+}
+
+// hasOAuthCredentials returns true when any OAuth/subscription source is available.
+// Used to suppress ANTHROPIC_API_KEY injection into the agent-runner subprocess env:
+// the Agent SDK prefers env vars over OAuth, which would defeat the subscription-first
+// priority established in newAIClient.
+func (m *Manager) hasOAuthCredentials() bool {
+	if m.getCachedOAuthToken() != "" {
+		return true
+	}
+	if _, err := ai.ReadClaudeCodeOAuthToken(); err == nil {
+		return true
+	}
+	_, err := ai.ReadClaudeCodeCredentialsFile()
+	return err == nil
 }
 
 // getCachedOAuthToken returns the cached OAuth token, if any.
@@ -3306,21 +3323,28 @@ func (m *Manager) loadEnvVars(ctx context.Context, claudeSettings *ai.ClaudeCode
 		}
 	}
 
-	// Load encrypted Anthropic API key if configured
-	encrypted, found, err := m.store.GetSetting(ctx, "anthropic-api-key")
-	if err != nil {
-		return envMap, nil // non-fatal: proceed without the key
-	}
-	if found && encrypted != "" {
-		decrypted, err := crypto.Decrypt(encrypted)
+	var encrypted string // reused across the encrypted-setting loads below
+
+	// Load encrypted Anthropic API key if configured.
+	// Skip when OAuth credentials are present: the Agent SDK picks up
+	// ANTHROPIC_API_KEY from env before checking keychain/credfile, which
+	// would bypass subscription auth and burn API quota unintentionally.
+	if !m.hasOAuthCredentials() {
+		encrypted, found, err = m.store.GetSetting(ctx, "anthropic-api-key")
 		if err != nil {
-			logger.Manager.Errorf("failed to decrypt Anthropic API key: %v", err)
-			return envMap, nil
+			return envMap, nil // non-fatal: proceed without the key
 		}
-		if envMap == nil {
-			envMap = make(map[string]string)
+		if found && encrypted != "" {
+			decrypted, err := crypto.Decrypt(encrypted)
+			if err != nil {
+				logger.Manager.Errorf("failed to decrypt Anthropic API key: %v", err)
+				return envMap, nil
+			}
+			if envMap == nil {
+				envMap = make(map[string]string)
+			}
+			envMap["ANTHROPIC_API_KEY"] = decrypted
 		}
-		envMap["ANTHROPIC_API_KEY"] = decrypted
 	}
 
 	// Load encrypted GitHub personal access token if configured.

--- a/backend/agent/manager_test.go
+++ b/backend/agent/manager_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -1094,11 +1095,11 @@ API_SECRET=topsecret
 // newAIClient Multi-Source Credential Tests
 // ============================================================================
 
-func TestNewAIClient_Source1_SQLiteApiKey(t *testing.T) {
+func TestNewAIClient_SqliteApiKey_WhenNoOAuth(t *testing.T) {
 	ctx := context.Background()
 	m, s := setupTestManager(t)
 
-	// Store an encrypted API key in SQLite settings
+	// Store an encrypted API key in SQLite settings (Source 4 in the cascade).
 	encrypted, err := crypto.Encrypt("sk-ant-api03-sqlite-test-key")
 	require.NoError(t, err)
 	require.NoError(t, s.SetSetting(ctx, "anthropic-api-key", encrypted))
@@ -1120,7 +1121,7 @@ func TestNewAIClient_Source1_SQLiteApiKey(t *testing.T) {
 	assert.Equal(t, "x-api-key", client.AuthHeader())
 }
 
-func TestNewAIClient_Source2_EnvVar(t *testing.T) {
+func TestNewAIClient_EnvVar_WhenNoOAuth(t *testing.T) {
 	m, _ := setupTestManager(t)
 
 	// No SQLite key configured, set env var instead
@@ -1141,11 +1142,11 @@ func TestNewAIClient_Source2_EnvVar(t *testing.T) {
 	assert.Equal(t, "x-api-key", client.AuthHeader())
 }
 
-func TestNewAIClient_Source1_TakesPriorityOverSource2(t *testing.T) {
+func TestNewAIClient_SqliteBeatsEnvVar(t *testing.T) {
 	ctx := context.Background()
 	m, s := setupTestManager(t)
 
-	// Set BOTH SQLite key and env var
+	// Set BOTH SQLite key and env var. SQLite (Source 4) wins over env var (Source 5).
 	encrypted, err := crypto.Encrypt("sk-sqlite-priority")
 	require.NoError(t, err)
 	require.NoError(t, s.SetSetting(ctx, "anthropic-api-key", encrypted))
@@ -1162,7 +1163,7 @@ func TestNewAIClient_Source1_TakesPriorityOverSource2(t *testing.T) {
 
 	provider := m.newAIClient()
 	require.NotNil(t, provider)
-	// Client should use SQLite key (source 1), not env var (source 2)
+	// Client should use SQLite key, not env var
 	client, ok := provider.(*ai.Client)
 	require.True(t, ok, "expected *ai.Client, got %T", provider)
 	assert.Equal(t, "x-api-key", client.AuthHeader())
@@ -1181,7 +1182,7 @@ func TestNewAIClient_NoSources_ReturnsNil(t *testing.T) {
 		}
 	}()
 
-	// No SQLite key, no env var. Source 3 (keychain) may or may not work
+	// No SQLite key, no env var. Sources 1-3 (OAuth) may or may not work
 	// depending on the machine, but we can at least verify it doesn't panic.
 	client := m.newAIClient()
 	// On CI/machines without Claude Code credentials, this should be nil.
@@ -1204,8 +1205,8 @@ func TestNewAIClient_EmptyEnvVar_SkipsToNextSource(t *testing.T) {
 		}
 	}()
 
-	// No SQLite key, empty env var — should fall through to source 3 (keychain)
-	// On CI this returns nil, on dev machines it might return OAuth client
+	// No SQLite key, empty env var — should fall through to OAuth sources (1-3).
+	// On CI without keychain access this returns nil; on dev machines OAuth may resolve.
 	client := m.newAIClient()
 	_ = client // just verifying no panic
 }
@@ -1225,8 +1226,9 @@ func TestNewAIClient_EnvVarsOnlyWithoutAnthropicKey(t *testing.T) {
 		}
 	}()
 
-	// loadEnvVars will return a map with DB_HOST and PORT but no ANTHROPIC_API_KEY
-	// Should fall through to source 2, then source 3
+	// loadEnvVars returns DB_HOST and PORT but no ANTHROPIC_API_KEY, so the
+	// SQLite-key path (Source 4) is skipped and the env-var path (Source 5) is empty.
+	// Falls through to OAuth sources, which on CI without keychain access return nil.
 	client := m.newAIClient()
 	// On CI: nil; on dev machine: might get OAuth client
 	_ = client
@@ -1284,6 +1286,40 @@ func TestNewAIClient_EncryptedKeyOverridesEnvVarsSetting(t *testing.T) {
 	client, ok := provider.(*ai.Client)
 	require.True(t, ok, "expected *ai.Client, got %T", provider)
 	assert.Equal(t, "sk-encrypted-wins", client.AuthValue())
+}
+
+// TestNewAIClient_OAuthBeatsApiKey verifies that when both an OAuth credentials file
+// and an API key (SQLite + env var) are present, the OAuth subscription wins. This
+// guards against regression of the "Subscription over API Key" priority change.
+func TestNewAIClient_OAuthBeatsApiKey(t *testing.T) {
+	ctx := context.Background()
+	m, s := setupTestManager(t)
+
+	// Stage a valid OAuth credentials file at $HOME/.claude/.credentials.json with a
+	// year-3000 expiry so the cascade picks it up on every machine, including CI.
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	credContent := []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-oauth-wins","expiresAt":32503680000000}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), credContent, 0o600))
+	t.Setenv("HOME", dir)
+
+	// Also configure both API-key paths — these MUST lose to the OAuth credentials file.
+	encrypted, err := crypto.Encrypt("sk-api-key-should-lose")
+	require.NoError(t, err)
+	require.NoError(t, s.SetSetting(ctx, "anthropic-api-key", encrypted))
+
+	t.Setenv("ANTHROPIC_API_KEY", "sk-env-should-also-lose")
+
+	provider := m.newAIClient()
+	require.NotNil(t, provider, "should create an OAuth client")
+	client, ok := provider.(*ai.Client)
+	require.True(t, ok, "expected *ai.Client, got %T", provider)
+	// OAuth clients use Authorization: Bearer; API-key clients use x-api-key.
+	// Don't assert the exact token value — the keychain (Source 1) may resolve to
+	// a real token on dev machines and beat the staged credentials file (Source 2).
+	assert.Equal(t, "Authorization", client.AuthHeader(),
+		"expected OAuth subscription to win over API key")
 }
 
 // ============================================================================

--- a/backend/server/settings_handlers.go
+++ b/backend/server/settings_handlers.go
@@ -569,31 +569,6 @@ func (h *Handlers) GetClaudeAuthStatus(w http.ResponseWriter, r *http.Request) {
 	// Check 2: ANTHROPIC_API_KEY environment variable
 	hasEnvKey := os.Getenv("ANTHROPIC_API_KEY") != ""
 
-	// Auto-import: if no stored key, discover ANTHROPIC_API_KEY from external
-	// sources and persist it into ChatML's encrypted settings store so the
-	// banner resolves and the key is available for non-agent tasks (e.g. title
-	// generation). This runs once — subsequent calls find the stored key above.
-	if !hasStoredKey {
-		discoveredKey := ""
-		if k := os.Getenv("ANTHROPIC_API_KEY"); k != "" {
-			discoveredKey = k
-		} else if claudeSettings != nil && claudeSettings.Env["ANTHROPIC_API_KEY"] != "" {
-			discoveredKey = claudeSettings.Env["ANTHROPIC_API_KEY"]
-		} else if chatmlEnvVars["ANTHROPIC_API_KEY"] != "" {
-			discoveredKey = chatmlEnvVars["ANTHROPIC_API_KEY"]
-		}
-
-		if discoveredKey != "" {
-			if enc, encErr := crypto.Encrypt(discoveredKey); encErr != nil {
-				log.Printf("WARN: auto-import ANTHROPIC_API_KEY encrypt failed: %v", encErr)
-			} else if setErr := h.store.SetSetting(ctx, settingKeyAnthropicAPIKey, enc); setErr != nil {
-				log.Printf("WARN: auto-import ANTHROPIC_API_KEY store failed: %v", setErr)
-			} else {
-				hasStoredKey = true
-			}
-		}
-	}
-
 	// Check 3: Claude Code CLI credentials via OS keychain (validates token contents + expiration)
 	_, cliErr := ai.ReadClaudeCodeOAuthToken()
 	hasCliCredentials := cliErr == nil
@@ -619,19 +594,49 @@ func (h *Handlers) GetClaudeAuthStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Auto-import: if no stored key and no higher-priority credential source (OAuth or
+	// Bedrock), discover ANTHROPIC_API_KEY from external sources and persist it into
+	// ChatML's encrypted settings store so the banner resolves and the key is available
+	// for non-agent tasks (e.g. title generation). This runs once — subsequent calls
+	// find the stored key above.
+	// Skip when OAuth or Bedrock is active: users on a subscription or Bedrock config
+	// should not have an unused API key silently persisted in their settings.
+	if !hasStoredKey && !hasCliCredentials && !hasBedrock {
+		discoveredKey := ""
+		if k := os.Getenv("ANTHROPIC_API_KEY"); k != "" {
+			discoveredKey = k
+		} else if claudeSettings != nil && claudeSettings.Env["ANTHROPIC_API_KEY"] != "" {
+			discoveredKey = claudeSettings.Env["ANTHROPIC_API_KEY"]
+		} else if chatmlEnvVars["ANTHROPIC_API_KEY"] != "" {
+			discoveredKey = chatmlEnvVars["ANTHROPIC_API_KEY"]
+		}
+
+		if discoveredKey != "" {
+			if enc, encErr := crypto.Encrypt(discoveredKey); encErr != nil {
+				log.Printf("WARN: auto-import ANTHROPIC_API_KEY encrypt failed: %v", encErr)
+			} else if setErr := h.store.SetSetting(ctx, settingKeyAnthropicAPIKey, enc); setErr != nil {
+				log.Printf("WARN: auto-import ANTHROPIC_API_KEY store failed: %v", setErr)
+			} else {
+				hasStoredKey = true
+			}
+		}
+	}
+
 	configured := hasStoredKey || hasEnvKey || hasCliCredentials || hasBedrock
 
 	// Determine the primary credential source for UI display.
-	// Order must match newAIClient() priority: Bedrock > stored key > env key > CLI credentials.
+	// Order must match newAIClient() priority: Bedrock > CLI credentials > stored key > env key.
+	// Subscription/OAuth wins over API key so users on a Claude Max/Pro plan don't burn API quota
+	// when both are configured.
 	credentialSource := ""
 	if hasBedrock {
 		credentialSource = "aws_bedrock"
+	} else if hasCliCredentials {
+		credentialSource = "claude_subscription"
 	} else if hasStoredKey {
 		credentialSource = "api_key"
 	} else if hasEnvKey {
 		credentialSource = "env_var"
-	} else if hasCliCredentials {
-		credentialSource = "claude_subscription"
 	}
 
 	writeJSON(w, map[string]interface{}{

--- a/backend/server/settings_handlers_test.go
+++ b/backend/server/settings_handlers_test.go
@@ -954,6 +954,45 @@ func TestGetClaudeAuthStatus_CliCredentialsFallbackToFile(t *testing.T) {
 	assert.Equal(t, "claude_subscription", result["credentialSource"])
 }
 
+// TestGetClaudeAuthStatus_CliCredentialsBeatsApiKey verifies that when both an
+// OAuth credentials file and an ANTHROPIC_API_KEY are configured, the reported
+// credentialSource is the subscription. Mirrors the priority enforced by
+// newAIClient — OAuth wins so users on a Max/Pro plan don't burn API quota.
+func TestGetClaudeAuthStatus_CliCredentialsBeatsApiKey(t *testing.T) {
+	h, st := setupTestHandlers(t)
+	defer st.Close()
+
+	// Stage a valid OAuth credentials file at $HOME/.claude/.credentials.json.
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	credContent := []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-test","expiresAt":32503680000000}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), credContent, 0o600))
+	t.Setenv("HOME", dir)
+
+	// Also set ANTHROPIC_API_KEY — with the new gating, it will NOT be auto-imported
+	// because OAuth credentials are already present.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-api-should-lose")
+
+	req := httptest.NewRequest("GET", "/api/settings/auth-status", nil)
+	w := httptest.NewRecorder()
+	h.GetClaudeAuthStatus(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	assert.Equal(t, true, result["configured"])
+	assert.Equal(t, true, result["hasCliCredentials"])
+	assert.Equal(t, true, result["hasEnvKey"])
+	// hasStoredKey stays false: auto-import is suppressed when OAuth is present
+	// so subscription users don't accumulate unused persisted API keys.
+	assert.Equal(t, false, result["hasStoredKey"])
+	assert.Equal(t, "claude_subscription", result["credentialSource"],
+		"OAuth subscription must beat both stored and env API keys")
+}
+
 func TestGetClaudeEnv_NoFile(t *testing.T) {
 	h, st := setupTestHandlers(t)
 	defer st.Close()


### PR DESCRIPTION
## Summary

- Reorder `newAIClient()` so Claude Code OAuth (keychain → credentials file → SDK cache) wins over any configured `ANTHROPIC_API_KEY`. Users on Claude Max/Pro plans no longer burn API quota when both credential types are present.
- Extend the same priority to the agent-runner subprocess by suppressing `ANTHROPIC_API_KEY` env injection when OAuth is active.
- Gate the `GetClaudeAuthStatus` auto-import of `ANTHROPIC_API_KEY` so subscription/Bedrock users don't silently accumulate unused persisted keys.

## Changes Made

- **`backend/agent/manager.go`** — Reordered `newAIClient()` sources: keychain (1) → credentials file (2) → cached SDK token (3) → stored API key (4) → env var (5). Added `hasOAuthCredentials()` helper. In `loadEnvVars`, skip `ANTHROPIC_API_KEY` injection into subprocess env when OAuth is available (fixes the agent-runner layer, not just the backend's own AI client).
- **`backend/server/settings_handlers.go`** — Moved CLI credential and Bedrock checks before the auto-import block. Auto-import is now gated on `!hasCliCredentials && !hasBedrock`. `credentialSource` priority order updated to match `newAIClient`.
- **`backend/agent/manager_test.go`** — Added `TestNewAIClient_OAuthBeatsApiKey` regression test. Fixed exact-token assertion that would flake on dev machines with a real Claude Code keychain entry (now asserts `AuthHeader == "Authorization"` only). Replaced manual `os.Setenv`/deferred-restore with `t.Setenv`.
- **`backend/server/settings_handlers_test.go`** — Added `TestGetClaudeAuthStatus_CliCredentialsBeatsApiKey`. Updated assertion to expect `hasStoredKey == false` when OAuth is present (auto-import no longer runs).

## Test Plan

- [ ] `cd backend && go test -race ./agent/... ./server/...` — all tests pass
- [ ] `cd backend && go build ./...` — builds clean
- [ ] Manual: configure Claude Code OAuth (sign in via CLI) + set `ANTHROPIC_API_KEY` in ChatML Settings → confirm dashboard shows "claude_subscription" and agent sessions run without hitting the API key
- [ ] Manual: configure only `ANTHROPIC_API_KEY` (no OAuth) → confirm agent sessions still work normally via API key fallback