### PR TITLE
feat(agent-runner): upgrade Claude Agent SDK to 0.2.139, wire skills + origin

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.119",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.138",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz",
-      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.139.tgz",
+      "integrity": "sha512-9zmitYoxCQiQZsTUbm9IGC6VyZt70J3NLtkRQPQvFVfz7bKDrhlZZKzXmyl2XmqedXEIeQy2ACmwdjwzPIVIAw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -30,23 +30,23 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.139"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.119.tgz",
-      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.139.tgz",
+      "integrity": "sha512-dnuO2E0x6o9GAk9iZZKlEd10h+0PQFdTfr5aQU4I0W+0ReKsFEoE9LAqfomS2EvLUQ9L62X0+n0iyZQmAVi1kw==",
       "cpu": [
         "arm64"
       ],
@@ -57,9 +57,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.119.tgz",
-      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.139.tgz",
+      "integrity": "sha512-SXyldBIwpMHDXppPGObXZ1wjSSWf/YPgD6vK4nssIXarC/DtMRnAQ419Hb3q5MaBB29vSjOPKmG0MOkMltFR/A==",
       "cpu": [
         "x64"
       ],
@@ -70,9 +70,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.119.tgz",
-      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.139.tgz",
+      "integrity": "sha512-qfnQ4SjEcq//iGAJkk25J6j4Tq+dvQe9wHks0dcaSdGOs2D96Teqrb358YJe+nke2DBKVUa9Y4ComW3aUBM29w==",
       "cpu": [
         "arm64"
       ],
@@ -86,9 +86,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.119.tgz",
-      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.139.tgz",
+      "integrity": "sha512-gzMfit9t7Fiy5taZ+miAaP8ZmOMc+hv8Ov3UOXGwJunK6H+0F88ctBSnolDPMPQaS6s2WoMD0o8fhUbBudtMVw==",
       "cpu": [
         "arm64"
       ],
@@ -102,9 +102,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.119.tgz",
-      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.139.tgz",
+      "integrity": "sha512-2Gqy5hV/MyObbwSyNhj5ha2cY5EZnUfDLvpEwR1eeOaU1yqnxzsdNzXWgHIyWQGKGNE2ICwgLYtt6AtOJGWpPg==",
       "cpu": [
         "x64"
       ],
@@ -118,9 +118,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.119.tgz",
-      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.139.tgz",
+      "integrity": "sha512-Fg/aQs1vdyqLrNXqGa1i7/ODpGxP6ud/K/2AgVarLteg2Z3ZnrHPvPQ6iQmTGI8+BhxAZ141t4Dg0CWz3CoqCQ==",
       "cpu": [
         "x64"
       ],
@@ -134,9 +134,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.119.tgz",
-      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.139.tgz",
+      "integrity": "sha512-HusAU/gSQ0G0AHU+Hj/ps0Tl5JaUF2nxkp+G42tU6hpnwLMOQMdLx/yqvSQnz4WSxggxiDFmYvMDLYAmuE9Qdg==",
       "cpu": [
         "arm64"
       ],
@@ -147,9 +147,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.119.tgz",
-      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.139.tgz",
+      "integrity": "sha512-eJjbtLvEBJcTrl4WJhmhP7FYdTVvx/XtioifH7OEnCoxQozMHhOmA0X90csplIRpttX+jX2PqnE5j2FwU20eCw==",
       "cpu": [
         "x64"
       ],

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.119",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.138",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -213,7 +213,13 @@ let prePlanPermissionMode: PermissionMode = "bypassPermissions";
 // Task 6: Settings Sources Configuration
 const settingSourcesArg = getArg("--setting-sources");
 const settingSources = settingSourcesArg
-  ? settingSourcesArg.split(',').map(s => s.trim()) as ('project' | 'user' | 'local')[]
+  ? settingSourcesArg.split(',').map(s => s.trim()).filter(s => s) as ('project' | 'user' | 'local')[]
+  : undefined;
+
+// Skills Configuration (SDK 0.2.120/0.2.133)
+const skillsArg = getArg("--skills");
+const skills: string[] | "all" | undefined = skillsArg
+  ? (skillsArg === "all" ? "all" : skillsArg.split(',').map(s => s.trim()).filter(s => s))
   : undefined;
 
 // Task 7: Beta Features Flag
@@ -2260,6 +2266,7 @@ async function main(): Promise<void> {
         ? { type: "enabled", budgetTokens: maxThinkingTokens } satisfies ThinkingConfig
         : undefined,
       settingSources,
+      ...(skills !== undefined ? { skills } : {}),
       betas,
       model,
       // Effort level controls adaptive thinking depth (Opus 4.6+)
@@ -2737,6 +2744,7 @@ function handleMessage(message: SDKMessage): void {
         checkpoint_uuid?: string;
         message_index?: number;
         permission_denials?: Array<{ tool_name: string; tool_use_id: string; tool_input: unknown }>;
+        origin?: "user" | "task_notification"; // SDK 0.2.126+
       };
 
       // If the turn produced no streamed text but the result has content,
@@ -2785,6 +2793,7 @@ function handleMessage(message: SDKMessage): void {
           sessionId: resultMsg.session_id,
           fastModeState: resultMsg.fast_mode_state,
           ...(permissionDenials ? { permissionDenials } : {}),
+          ...(resultMsg.origin ? { origin: resultMsg.origin } : {}),
           stats: {
             toolCalls: runStats.toolCalls,
             toolsByType: runStats.toolsByType,
@@ -2816,6 +2825,7 @@ function handleMessage(message: SDKMessage): void {
           sessionId: resultMsg.session_id,
           fastModeState: resultMsg.fast_mode_state,
           ...(permissionDenials ? { permissionDenials } : {}),
+          ...(resultMsg.origin ? { origin: resultMsg.origin } : {}),
           stats: {
             toolCalls: runStats.toolCalls,
             toolsByType: runStats.toolsByType,

--- a/backend/agent/process.go
+++ b/backend/agent/process.go
@@ -311,6 +311,9 @@ func NewProcessWithOptions(opts ProcessOptions) *Process {
 	if opts.SettingSources != "" {
 		args = append(args, "--setting-sources", opts.SettingSources)
 	}
+	if opts.Skills != "" {
+		args = append(args, "--skills", opts.Skills)
+	}
 	if opts.Betas != "" {
 		args = append(args, "--betas", opts.Betas)
 	}

--- a/backend/agent/process_test.go
+++ b/backend/agent/process_test.go
@@ -1215,3 +1215,55 @@ func TestNewProcessWithOptions_SkipDotMcpDefaultFalse(t *testing.T) {
 	assert.False(t, p.Options().SkipDotMcp, "SkipDotMcp should default to false")
 	assert.NotContains(t, p.cmd.Args, "--skip-dot-mcp")
 }
+
+func TestNewProcessWithOptions_SkillsList(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "skills-list-test",
+		Workdir:        "/tmp",
+		ConversationID: "conv-skills-list",
+		Skills:         "init,security-review",
+	}
+	p := NewProcessWithOptions(opts)
+
+	args := p.cmd.Args
+	found := false
+	for i, arg := range args {
+		if arg == "--skills" && i+1 < len(args) && args[i+1] == "init,security-review" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected --skills init,security-review in args: %v", args)
+}
+
+func TestNewProcessWithOptions_SkillsAll(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "skills-all-test",
+		Workdir:        "/tmp",
+		ConversationID: "conv-skills-all",
+		Skills:         "all",
+	}
+	p := NewProcessWithOptions(opts)
+
+	args := p.cmd.Args
+	found := false
+	for i, arg := range args {
+		if arg == "--skills" && i+1 < len(args) && args[i+1] == "all" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected --skills all in args: %v", args)
+}
+
+func TestNewProcessWithOptions_SkillsEmpty(t *testing.T) {
+	opts := ProcessOptions{
+		ID:             "skills-empty-test",
+		Workdir:        "/tmp",
+		ConversationID: "conv-skills-empty",
+	}
+	p := NewProcessWithOptions(opts)
+
+	assert.Empty(t, p.Options().Skills)
+	assert.NotContains(t, p.cmd.Args, "--skills")
+}

--- a/core/agent/options.go
+++ b/core/agent/options.go
@@ -33,4 +33,5 @@ type ProcessOptions struct {
 	AgentsJSON          string            // JSON object of programmatic agent definitions (SDK 0.2.62+)
 	PermissionRulesFile string            // Path to JSON file with persistent permission rules
 	OllamaEndpoint      string            // Ollama server endpoint for local model inference (e.g., "http://127.0.0.1:39421")
+	Skills              string            // Comma-separated skill IDs, or "all" (SDK 0.2.120+)
 }

--- a/core/agent/parser.go
+++ b/core/agent/parser.go
@@ -23,6 +23,7 @@ type AgentEvent struct {
 	Cwd            string                 `json:"cwd,omitempty"`
 	Reason         string                 `json:"reason,omitempty"`
 	Subtype        string                 `json:"subtype,omitempty"`
+	Origin         string                 `json:"origin,omitempty"` // SDK 0.2.126+: "user" | "task_notification"
 	Errors         []string               `json:"errors,omitempty"`
 	Cost           float64                `json:"cost,omitempty"`
 	Turns          int                    `json:"turns,omitempty"`


### PR DESCRIPTION
## Summary

- Upgrades `@anthropic-ai/claude-agent-sdk` from `0.2.119` to `0.2.139` (19 patch versions)
- Wires the new `skills` config option (`string[] | "all"`) through the full stack so the backend can control which Skills load in an agent session
- Propagates the new `origin` field on result messages (`"user" | "task_notification"`) through the event pipeline to the frontend

## Changes Made

- **`agent-runner/package.json`** — Bumped SDK version to `^0.2.138` (resolves to `0.2.139`)
- **`agent-runner/src/index.ts`** — Added `--skills` CLI arg parsing; wired `skills` into `queryOptions`; extended result type cast with `origin?: "user" | "task_notification"` and included it in both success and error result emits
- **`core/agent/options.go`** — Added `Skills string` field to `ProcessOptions` (comma-separated IDs or `"all"`, SDK 0.2.120+)
- **`backend/agent/process.go`** — Emit `--skills <value>` CLI arg when `Skills` is set, matching the existing `SettingSources`/`Betas` pattern
- **`core/agent/parser.go`** — Added `Origin string` field to `AgentEvent` for JSON deserialization of result messages
- **`backend/agent/process_test.go`** — Added 3 tests: `SkillsList`, `SkillsAll`, `SkillsEmpty`

**Skipped intentionally:**
- `updatedMCPToolOutput` → `updatedToolOutput` migration — not used in this codebase
- `resolveSettings()` alpha function — not stable enough for production
- `TodoWrite` deprecation advisory — no replacement tooling available yet in the SDK

## Test Plan

- [x] `cd agent-runner && npm run build` — TypeScript compiles clean
- [x] `npm run lint` — 0 errors
- [x] `make test` — all backend tests pass including the 3 new `Skills` tests
- [ ] Manual: start a session and verify the `init` event still fires with the skills list