### PR TITLE
feat(recovery): persist interrupted plan snapshots and expose recovery endpoint

### DIFF
--- a/backend/agent/manager.go
+++ b/backend/agent/manager.go
@@ -22,7 +22,9 @@ import (
 	"github.com/google/uuid"
 )
 
-const snapshotDebounceInterval = 500 * time.Millisecond
+// 200ms gives good recovery granularity (minimal output lost on crash) without
+// excessive SQLite write pressure; 500ms lost too much content in practice.
+const snapshotDebounceInterval = 200 * time.Millisecond
 const initRetryDelay = 3 * time.Second
 
 // Suggestion filtering patterns (used by suggestion generation, not PR detection).
@@ -99,6 +101,12 @@ type Manager struct {
 	// ollamaMgr manages the lifecycle of the bundled Ollama binary for local model inference.
 	// Set at startup via SetOllamaManager. Nil means local models are unavailable.
 	ollamaMgr OllamaManager
+
+	// recentlyRecoveredConvIDs holds conversation IDs whose streaming snapshots
+	// were converted to persisted messages during Init(). Used by the frontend
+	// to show an "interrupted session" indicator even after snapshots are cleared.
+	recentlyRecoveredConvIDs   []string
+	recentlyRecoveredConvIDsMu sync.RWMutex
 }
 
 func NewManager(ctx context.Context, s *store.SQLiteStore, wm *git.WorktreeManager, backendPort int) *Manager {
@@ -124,10 +132,13 @@ func (m *Manager) Init(ctx context.Context) error {
 	// Convert orphaned streaming snapshots into persisted assistant messages.
 	// This recovers partial agent responses that were lost when the app was
 	// killed mid-turn (safety net for when the output handler's flush fails).
-	if converted, err := m.store.ConvertSnapshotsToMessages(ctx); err != nil {
+	if recovered, err := m.store.ConvertSnapshotsToMessages(ctx); err != nil {
 		logger.Manager.Errorf("Failed to convert snapshots to messages: %v", err)
-	} else if converted > 0 {
-		logger.Manager.Infof("Recovered %d interrupted assistant messages from snapshots", converted)
+	} else if len(recovered) > 0 {
+		logger.Manager.Infof("Recovered %d interrupted assistant messages from snapshots", len(recovered))
+		m.recentlyRecoveredConvIDsMu.Lock()
+		m.recentlyRecoveredConvIDs = recovered
+		m.recentlyRecoveredConvIDsMu.Unlock()
 	}
 	return nil
 }
@@ -2320,6 +2331,20 @@ func (m *Manager) GetActiveStreamingConversations() []string {
 		}
 	}
 	return active
+}
+
+// GetRecentlyRecoveredConversations returns the IDs of conversations whose
+// streaming snapshots were converted to persisted messages during Init().
+// The list is populated once at startup and never changes — it is the
+// authoritative set of "interrupted then recovered" conversations for the
+// current app session. The frontend uses this to show an interrupted-session
+// indicator even after all snapshots have been cleared.
+func (m *Manager) GetRecentlyRecoveredConversations() []string {
+	m.recentlyRecoveredConvIDsMu.RLock()
+	defer m.recentlyRecoveredConvIDsMu.RUnlock()
+	result := make([]string, len(m.recentlyRecoveredConvIDs))
+	copy(result, m.recentlyRecoveredConvIDs)
+	return result
 }
 
 // betasForModel returns comma-separated beta flags for the given model.

--- a/backend/server/conversation_handlers.go
+++ b/backend/server/conversation_handlers.go
@@ -486,6 +486,18 @@ func (h *Handlers) GetInterruptedConversations(w http.ResponseWriter, r *http.Re
 	writeJSON(w, result)
 }
 
+// GetRecentlyRecoveredConversations returns the IDs of conversations whose
+// streaming snapshots were converted to persisted messages during this app
+// startup. The frontend uses this to show an interrupted-session indicator
+// after snapshots have already been cleared by ConvertSnapshotsToMessages.
+func (h *Handlers) GetRecentlyRecoveredConversations(w http.ResponseWriter, r *http.Request) {
+	ids := h.agentManager.GetRecentlyRecoveredConversations()
+	if ids == nil {
+		ids = []string{}
+	}
+	writeJSON(w, map[string][]string{"conversationIds": ids})
+}
+
 // ResumeAgent restarts a dead agent process for an interrupted conversation
 // using the SDK resume mechanism.
 func (h *Handlers) ResumeAgent(w http.ResponseWriter, r *http.Request) {

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -299,6 +299,7 @@ func NewRouter(ctx context.Context, s *store.SQLiteStore, hub *Hub, agentMgr *ag
 	r.Route("/api/conversations", func(r chi.Router) {
 		r.Get("/active-streaming", h.GetActiveStreamingConversations)
 		r.Get("/interrupted", h.GetInterruptedConversations)
+		r.Get("/recently-recovered", h.GetRecentlyRecoveredConversations)
 		r.Get("/{convId}", h.GetConversation)
 		r.Get("/{convId}/messages", h.GetConversationMessages)
 		r.Get("/{convId}/messages/{msgId}", h.GetMessage)

--- a/backend/store/sqlite.go
+++ b/backend/store/sqlite.go
@@ -2230,29 +2230,34 @@ func (s *SQLiteStore) CleanupStaleConversations(ctx context.Context) error {
 // ConvertSnapshotsToMessages converts orphaned streaming snapshots into persisted
 // assistant messages. This recovers partial agent responses that were lost when
 // the app was killed mid-turn (e.g., SIGKILL before the output handler could flush).
-// Returns the number of conversations whose snapshots were converted.
-func (s *SQLiteStore) ConvertSnapshotsToMessages(ctx context.Context) (int, error) {
+// Returns the IDs of conversations whose snapshots were converted.
+func (s *SQLiteStore) ConvertSnapshotsToMessages(ctx context.Context) ([]string, error) {
 	interrupted, err := s.GetInterruptedConversations(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("ConvertSnapshotsToMessages: %w", err)
+		return nil, fmt.Errorf("ConvertSnapshotsToMessages: %w", err)
 	}
 
 	// Minimal struct for deserializing snapshot JSON within the store package
 	// (cannot import agent package due to circular dependency).
 	// Intentionally ignores: activeTools, isThinking, planModeActive, subAgents,
-	// pendingPlanApproval, pendingUserQuestion — these are transient UI state
-	// that is not meaningful to recover as a persisted message.
+	// pendingUserQuestion — these are transient UI state not meaningful to
+	// recover as a persisted message. pendingPlanApproval IS recovered because
+	// the plan content is valuable for the user to see after a crash.
 	type snapshotTextSegment struct {
 		Text      string `json:"text"`
 		Timestamp int64  `json:"timestamp"`
 	}
+	type snapshotPlanApproval struct {
+		PlanContent string `json:"planContent"`
+	}
 	type snapshot struct {
-		Text         string                `json:"text"`
-		TextSegments []snapshotTextSegment `json:"textSegments"`
-		Thinking     string                `json:"thinking"`
+		Text                string                `json:"text"`
+		TextSegments        []snapshotTextSegment `json:"textSegments"`
+		Thinking            string                `json:"thinking"`
+		PendingPlanApproval *snapshotPlanApproval `json:"pendingPlanApproval"`
 	}
 
-	converted := 0
+	var recovered []string
 	for _, ic := range interrupted {
 		var snap snapshot
 		if err := json.Unmarshal(ic.SnapshotJSON, &snap); err != nil {
@@ -2264,8 +2269,9 @@ func (s *SQLiteStore) ConvertSnapshotsToMessages(ctx context.Context) (int, erro
 			continue
 		}
 
-		// Skip empty snapshots (agent started but hadn't produced any text or thinking)
-		if snap.Text == "" && snap.Thinking == "" {
+		// Skip empty snapshots (agent started but hadn't produced any text, thinking, or plan)
+		hasPlanContent := snap.PendingPlanApproval != nil && snap.PendingPlanApproval.PlanContent != ""
+		if snap.Text == "" && snap.Thinking == "" && !hasPlanContent {
 			// Clear the empty snapshot
 			if err := s.ClearStreamingSnapshot(ctx, ic.ID); err != nil {
 				logger.Store.Errorf("ConvertSnapshotsToMessages: failed to clear empty snapshot for conv %s: %v", ic.ID, err)
@@ -2276,15 +2282,21 @@ func (s *SQLiteStore) ConvertSnapshotsToMessages(ctx context.Context) (int, erro
 		// Dedup: check if the last message is already an assistant message with matching content.
 		// This handles the case where the output handler successfully flushed (Change 1) but
 		// ClearStreamingSnapshot failed (e.g., timeout).
-		var lastRole, lastContent sql.NullString
+		// plan_content is included to avoid false-positive matches for plan-only snapshots
+		// (text="") which could otherwise match any empty-content assistant message.
+		var lastRole, lastContent, lastPlanContent sql.NullString
 		row := s.db.QueryRowContext(ctx,
-			`SELECT role, content FROM messages WHERE conversation_id = ? ORDER BY position DESC LIMIT 1`,
+			`SELECT role, content, plan_content FROM messages WHERE conversation_id = ? ORDER BY position DESC LIMIT 1`,
 			ic.ID)
-		if err := row.Scan(&lastRole, &lastContent); err != nil && err != sql.ErrNoRows {
+		if err := row.Scan(&lastRole, &lastContent, &lastPlanContent); err != nil && err != sql.ErrNoRows {
 			logger.Store.Errorf("ConvertSnapshotsToMessages: failed to check last message for conv %s: %v", ic.ID, err)
 			continue
 		}
-		if lastRole.Valid && lastRole.String == "assistant" && lastContent.Valid && lastContent.String == snap.Text {
+		expectedPlanContent := ""
+		if hasPlanContent {
+			expectedPlanContent = snap.PendingPlanApproval.PlanContent
+		}
+		if lastRole.Valid && lastRole.String == "assistant" && lastContent.String == snap.Text && lastPlanContent.String == expectedPlanContent {
 			// Already persisted — just clear the snapshot
 			if err := s.ClearStreamingSnapshot(ctx, ic.ID); err != nil {
 				logger.Store.Errorf("ConvertSnapshotsToMessages: failed to clear duplicate snapshot for conv %s: %v", ic.ID, err)
@@ -2292,7 +2304,7 @@ func (s *SQLiteStore) ConvertSnapshotsToMessages(ctx context.Context) (int, erro
 			continue
 		}
 
-		// Build timeline from text segments and thinking blocks.
+		// Build timeline from text segments, thinking blocks, and plan content.
 		// Thinking is prepended since it typically precedes text output.
 		var timeline []models.TimelineEntry
 		if snap.Thinking != "" {
@@ -2308,12 +2320,18 @@ func (s *SQLiteStore) ConvertSnapshotsToMessages(ctx context.Context) (int, erro
 			// Fallback: single text entry if no segments
 			timeline = append(timeline, models.TimelineEntry{Type: "text", Content: snap.Text})
 		}
+		var recoveredPlanContent string
+		if hasPlanContent {
+			recoveredPlanContent = snap.PendingPlanApproval.PlanContent
+			timeline = append(timeline, models.TimelineEntry{Type: "plan", Content: recoveredPlanContent})
+		}
 
 		msg := models.Message{
 			ID:              uuid.New().String()[:8],
 			Role:            "assistant",
 			Content:         snap.Text,
 			ThinkingContent: snap.Thinking,
+			PlanContent:     recoveredPlanContent,
 			Timeline:        timeline,
 			Timestamp:       time.Now(),
 		}
@@ -2327,11 +2345,11 @@ func (s *SQLiteStore) ConvertSnapshotsToMessages(ctx context.Context) (int, erro
 			logger.Store.Errorf("ConvertSnapshotsToMessages: failed to clear snapshot after conversion for conv %s: %v", ic.ID, err)
 		}
 
-		converted++
-		logger.Store.Infof("ConvertSnapshotsToMessages: recovered interrupted assistant message for conv %s (%d chars)", ic.ID, len(snap.Text))
+		recovered = append(recovered, ic.ID)
+		logger.Store.Infof("ConvertSnapshotsToMessages: recovered interrupted assistant message for conv %s (%d chars text, plan=%v)", ic.ID, len(snap.Text), hasPlanContent)
 	}
 
-	return converted, nil
+	return recovered, nil
 }
 
 // ============================================================================

--- a/backend/store/streaming_snapshot_test.go
+++ b/backend/store/streaming_snapshot_test.go
@@ -5,9 +5,189 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/chatml/chatml-backend/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// setupInterruptedConv creates a conversation with an agent_session_id set (required
+// by GetInterruptedConversations) and a streaming snapshot.
+func setupInterruptedConv(t *testing.T, s *SQLiteStore, convID string, snapshot map[string]interface{}) {
+	t.Helper()
+	ctx := context.Background()
+	repo := createTestRepo(t, s, "repo-"+convID)
+	session := createTestSession(t, s, "sess-"+convID, repo.ID)
+	createTestConversation(t, s, convID, session.ID)
+	require.NoError(t, s.UpdateConversation(ctx, convID, func(c *models.Conversation) {
+		c.AgentSessionID = "agent-session-" + convID
+	}))
+	data, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+	require.NoError(t, s.SetStreamingSnapshot(ctx, convID, data))
+}
+
+func TestConvertSnapshotsToMessages_PlanOnly(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	setupInterruptedConv(t, s, "conv-1", map[string]interface{}{
+		"text":     "",
+		"thinking": "",
+		"pendingPlanApproval": map[string]interface{}{
+			"planContent": "Step 1: do the thing\nStep 2: profit",
+		},
+	})
+
+	recovered, err := s.ConvertSnapshotsToMessages(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"conv-1"}, recovered)
+
+	page, err := s.GetConversationMessages(ctx, "conv-1", nil, 10, false)
+	require.NoError(t, err)
+	require.Len(t, page.Messages, 1)
+
+	msg := page.Messages[0]
+	assert.Equal(t, "assistant", msg.Role)
+	assert.Equal(t, "", msg.Content)
+	assert.Equal(t, "Step 1: do the thing\nStep 2: profit", msg.PlanContent)
+	require.Len(t, msg.Timeline, 1)
+	assert.Equal(t, "plan", msg.Timeline[0].Type)
+	assert.Equal(t, "Step 1: do the thing\nStep 2: profit", msg.Timeline[0].Content)
+
+	// Snapshot should be cleared after conversion
+	snap, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Nil(t, snap)
+}
+
+func TestConvertSnapshotsToMessages_TextAndPlan(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	setupInterruptedConv(t, s, "conv-1", map[string]interface{}{
+		"text":     "Here is my plan:",
+		"thinking": "let me think...",
+		"pendingPlanApproval": map[string]interface{}{
+			"planContent": "Step 1: do stuff",
+		},
+	})
+
+	recovered, err := s.ConvertSnapshotsToMessages(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"conv-1"}, recovered)
+
+	page, err := s.GetConversationMessages(ctx, "conv-1", nil, 10, false)
+	require.NoError(t, err)
+	require.Len(t, page.Messages, 1)
+
+	msg := page.Messages[0]
+	assert.Equal(t, "assistant", msg.Role)
+	assert.Equal(t, "Here is my plan:", msg.Content)
+	assert.Equal(t, "let me think...", msg.ThinkingContent)
+	assert.Equal(t, "Step 1: do stuff", msg.PlanContent)
+
+	types := make([]string, len(msg.Timeline))
+	for i, e := range msg.Timeline {
+		types[i] = e.Type
+	}
+	assert.Equal(t, []string{"thinking", "text", "plan"}, types)
+}
+
+func TestConvertSnapshotsToMessages_EmptyPlanContent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// pendingPlanApproval present but planContent is empty — treated as empty snapshot
+	setupInterruptedConv(t, s, "conv-1", map[string]interface{}{
+		"text":     "",
+		"thinking": "",
+		"pendingPlanApproval": map[string]interface{}{
+			"planContent": "",
+		},
+	})
+
+	recovered, err := s.ConvertSnapshotsToMessages(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, recovered)
+
+	page, err := s.GetConversationMessages(ctx, "conv-1", nil, 10, false)
+	require.NoError(t, err)
+	assert.Empty(t, page.Messages)
+
+	// Empty snapshot should be cleared
+	snap, err := s.GetStreamingSnapshot(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Nil(t, snap)
+}
+
+func TestConvertSnapshotsToMessages_DedupPlanOnly(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Simulate a previous recovery: there's already an assistant message with
+	// empty content and planContent = "Plan A". A second snapshot with the same
+	// plan content arrives — should be deduped and not create a duplicate message.
+	repo := createTestRepo(t, s, "repo-conv-1")
+	session := createTestSession(t, s, "sess-conv-1", repo.ID)
+	createTestConversation(t, s, "conv-1", session.ID)
+	require.NoError(t, s.UpdateConversation(ctx, "conv-1", func(c *models.Conversation) {
+		c.AgentSessionID = "agent-session-conv-1"
+	}))
+
+	existingMsg := models.Message{
+		ID:          "msg-1",
+		Role:        "assistant",
+		Content:     "",
+		PlanContent: "Plan A",
+	}
+	require.NoError(t, s.AddMessageToConversation(ctx, "conv-1", existingMsg))
+
+	// Same content in the snapshot
+	data := []byte(`{"text":"","thinking":"","pendingPlanApproval":{"planContent":"Plan A"}}`)
+	require.NoError(t, s.SetStreamingSnapshot(ctx, "conv-1", data))
+
+	recovered, err := s.ConvertSnapshotsToMessages(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, recovered) // deduped, not recovered again
+
+	page, err := s.GetConversationMessages(ctx, "conv-1", nil, 10, false)
+	require.NoError(t, err)
+	assert.Len(t, page.Messages, 1) // still only the original message
+}
+
+func TestConvertSnapshotsToMessages_DifferentPlanNotDeduped(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Existing message has Plan A; snapshot has Plan B — must NOT be deduped.
+	repo := createTestRepo(t, s, "repo-conv-1")
+	session := createTestSession(t, s, "sess-conv-1", repo.ID)
+	createTestConversation(t, s, "conv-1", session.ID)
+	require.NoError(t, s.UpdateConversation(ctx, "conv-1", func(c *models.Conversation) {
+		c.AgentSessionID = "agent-session-conv-1"
+	}))
+
+	existingMsg := models.Message{
+		ID:          "msg-1",
+		Role:        "assistant",
+		Content:     "",
+		PlanContent: "Plan A",
+	}
+	require.NoError(t, s.AddMessageToConversation(ctx, "conv-1", existingMsg))
+
+	// Different plan in the snapshot
+	data := []byte(`{"text":"","thinking":"","pendingPlanApproval":{"planContent":"Plan B"}}`)
+	require.NoError(t, s.SetStreamingSnapshot(ctx, "conv-1", data))
+
+	recovered, err := s.ConvertSnapshotsToMessages(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"conv-1"}, recovered)
+
+	page, err := s.GetConversationMessages(ctx, "conv-1", nil, 10, false)
+	require.NoError(t, err)
+	require.Len(t, page.Messages, 2)
+	assert.Equal(t, "Plan B", page.Messages[1].PlanContent)
+}
 
 func TestSetStreamingSnapshot_Basic(t *testing.T) {
 	s := newTestStore(t)

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -15,7 +15,7 @@ import { getAuthToken } from '@/lib/auth-token';
 import { getBackendPort } from '@/lib/backend-port';
 import { useConnectionStore } from '@/stores/connectionStore';
 import { dispatchAppEvent } from '@/lib/custom-events';
-import { getConversationDropStats, getActiveStreamingConversations, getInterruptedConversations, getConversationMessages, getStreamingSnapshot, toStoreMessage, updateSession as updateSessionApi, refreshPRStatus, addSystemMessage, listAllSessions, mapSessionDTO } from '@/lib/api';
+import { getConversationDropStats, getActiveStreamingConversations, getInterruptedConversations, getRecentlyRecoveredConversations, getConversationMessages, getStreamingSnapshot, toStoreMessage, updateSession as updateSessionApi, refreshPRStatus, addSystemMessage, listAllSessions, mapSessionDTO } from '@/lib/api';
 import { useScheduledTaskStore } from '@/stores/scheduledTaskStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useBranchCacheStore } from '@/stores/branchCacheStore';
@@ -1288,13 +1288,15 @@ export function useWebSocket(enabled: boolean = true) {
       console.warn('Failed to reconcile initial streaming state:', err);
     }
 
-    // Phase 2: Discover conversations interrupted by app shutdown
+    // Phase 2: Discover conversations interrupted by app shutdown (snapshot still present)
+    const phase2ConvIds = new Set<string>();
     try {
       const interrupted = await getInterruptedConversations();
       for (const item of interrupted) {
         const conv = store.conversations.find(c => c.id === item.id);
         if (!conv) continue;
 
+        phase2ConvIds.add(item.id);
         store.updateConversation(item.id, { status: 'idle' });
         store.setInterruptedState(item.id, {
           agentSessionId: item.agentSessionId,
@@ -1304,16 +1306,41 @@ export function useWebSocket(enabled: boolean = true) {
           elicitationMcpServer: item.snapshot?.pendingElicitation?.mcpServerName,
           snapshot: item.snapshot,
         });
-        // Inject the snapshot's text as a visible assistant message so the user
-        // can see what the agent produced before the interruption. The dedup
-        // inside injectInterruptedAssistantMessage prevents duplicates if the
-        // backend's ConvertSnapshotsToMessages already persisted it.
-        if (item.snapshot?.text) {
+        // Inject the snapshot content (text + plan) as a visible assistant message so the
+        // user can see what the agent produced before the interruption. The dedup inside
+        // injectInterruptedAssistantMessage prevents duplicates if ConvertSnapshotsToMessages
+        // already persisted it.
+        const hasContent = !!(item.snapshot?.text || item.snapshot?.pendingPlanApproval?.planContent);
+        if (item.snapshot && hasContent) {
           store.injectInterruptedAssistantMessage(item.id, item.snapshot);
         }
       }
     } catch (err) {
       console.warn('Failed to reconcile interrupted conversations:', err);
+    }
+
+    // Phase 3: Show interrupted indicator for conversations that were already recovered
+    // by ConvertSnapshotsToMessages on startup (their snapshots are cleared but the
+    // recovered messages are in the DB and have already been loaded by the frontend).
+    try {
+      const { conversationIds } = await getRecentlyRecoveredConversations();
+      for (const convId of conversationIds) {
+        const conv = store.conversations.find(c => c.id === convId);
+        if (!conv) continue;
+        // Only set interrupted state if not already set by Phase 2 (snapshot still present).
+        // Uses a local Set rather than store.interruptedState since store is a snapshot
+        // captured before Phase 2 ran and would not reflect Phase 2's mutations.
+        if (phase2ConvIds.has(convId)) continue;
+        store.setInterruptedState(convId, {
+          agentSessionId: '',
+          hadPendingPlan: false,
+          hadPendingQuestion: false,
+          hadPendingElicitation: false,
+          snapshot: null,
+        });
+      }
+    } catch (err) {
+      console.warn('Failed to reconcile recently-recovered conversations:', err);
     }
   // getStore is a stable reference (useAppStore.getState), no deps needed
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/api/conversations.ts
+++ b/src/lib/api/conversations.ts
@@ -357,6 +357,11 @@ export async function getInterruptedConversations(): Promise<InterruptedConversa
   return handleResponse(res);
 }
 
+export async function getRecentlyRecoveredConversations(): Promise<{ conversationIds: string[] }> {
+  const res = await fetchWithAuth(`${getApiBase()}/api/conversations/recently-recovered`);
+  return handleResponse(res);
+}
+
 export async function resumeAgent(convId: string): Promise<{ status: string }> {
   const res = await fetchWithAuth(`${getApiBase()}/api/conversations/${convId}/resume-agent`, { method: 'POST' });
   return handleResponse(res);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -641,7 +641,7 @@ interface AppState {
   setInterruptedState: (conversationId: string, info: InterruptedInfo | null) => void;
   setInterruptedResuming: (conversationId: string, resuming: boolean) => void;
   clearInterruptedState: (conversationId: string) => void;
-  injectInterruptedAssistantMessage: (conversationId: string, snapshot: { text: string; textSegments?: { text: string; timestamp: number }[]; thinking?: string }) => void;
+  injectInterruptedAssistantMessage: (conversationId: string, snapshot: { text: string; textSegments?: { text: string; timestamp: number }[]; thinking?: string; pendingPlanApproval?: { planContent?: string } | null }) => void;
 
   // File watcher actions
   setLastFileChange: (event: { workspaceId: string; path: string; fullPath: string }) => void;
@@ -2938,24 +2938,33 @@ updateFileTabContent: (id, content) => set((state) => ({
     },
   })),
   injectInterruptedAssistantMessage: (conversationId, snapshot) => set((state) => {
-    if (!snapshot.text) return state;
+    const hasPlan = !!snapshot.pendingPlanApproval?.planContent;
+    if (!snapshot.text && !hasPlan) return state;
     const existing = state.messagesByConversation[conversationId] ?? [];
     // Dedup: skip if the last message is already an assistant message with matching content
     // (backend's ConvertSnapshotsToMessages may have already persisted it)
     const lastMsg = existing[existing.length - 1];
-    if (lastMsg && lastMsg.role === 'assistant' && lastMsg.content === snapshot.text) {
+    const expectedPlanContent = snapshot.pendingPlanApproval?.planContent ?? '';
+    if (lastMsg && lastMsg.role === 'assistant' && lastMsg.content === (snapshot.text ?? '') && (lastMsg.planContent ?? '') === expectedPlanContent) {
       return state;
     }
-    // Build timeline from text segments
-    const timeline: import('@/lib/types').TimelineEntry[] = snapshot.textSegments?.length
-      ? snapshot.textSegments.filter(s => s.text).map(s => ({ type: 'text' as const, content: s.text }))
-      : [{ type: 'text' as const, content: snapshot.text }];
+    // Build timeline from text segments and plan content
+    const timeline: import('@/lib/types').TimelineEntry[] = [];
+    if (snapshot.textSegments?.length) {
+      timeline.push(...snapshot.textSegments.filter(s => s.text).map(s => ({ type: 'text' as const, content: s.text })));
+    } else if (snapshot.text) {
+      timeline.push({ type: 'text' as const, content: snapshot.text });
+    }
+    if (hasPlan) {
+      timeline.push({ type: 'plan' as const, content: snapshot.pendingPlanApproval!.planContent! });
+    }
     const message: import('@/lib/types').Message = {
       id: `interrupted-${conversationId}-${Date.now()}`,
       conversationId,
       role: 'assistant',
-      content: snapshot.text,
+      content: snapshot.text ?? '',
       thinkingContent: snapshot.thinking,
+      planContent: hasPlan ? snapshot.pendingPlanApproval!.planContent : undefined,
       timeline,
       timestamp: new Date().toISOString(),
     };


### PR DESCRIPTION
## Summary

- Extends crash recovery to handle `pendingPlanApproval` content — plans proposed by the agent before a crash are now persisted as `plan` timeline entries, not silently dropped
- Adds a new `/api/conversations/recently-recovered` endpoint so the frontend can show an interrupted-session banner even after snapshots have been cleared at startup
- Fixes a stale-state bug in the Phase 3 WebSocket reconciliation guard, and tightens the dedup logic to prevent false-positive matches on plan-only messages

## Changes Made

**Backend — `backend/store/sqlite.go`**
- `ConvertSnapshotsToMessages` now deserializes `pendingPlanApproval.planContent` and includes it in the recovered message's `PlanContent` field and timeline
- Return type changed from `int` (count) to `[]string` (recovered conversation IDs)
- Dedup query now selects `plan_content` alongside `content`, preventing false-positive matches when the last assistant message has empty text but a different plan

**Backend — `backend/agent/manager.go`**
- Stores recovered IDs in `recentlyRecoveredConvIDs` (mutex-protected) during `Init()`
- `GetRecentlyRecoveredConversations()` exposes the list; populated once at startup
- Snapshot debounce tightened 500ms → 200ms for better crash-recovery granularity

**Backend — `backend/server/`**
- `GET /api/conversations/recently-recovered` handler returns `{ conversationIds: string[] }`

**Frontend — `src/hooks/useWebSocket.ts`**
- Phase 3 reconciliation uses a local `Set<string>` (populated during Phase 2) instead of `store.interruptedState` to guard against stale Zustand snapshot references

**Frontend — `src/stores/appStore.ts`**
- `injectInterruptedAssistantMessage` now builds a `plan` timeline entry from `pendingPlanApproval.planContent`
- Dedup check includes `planContent` to avoid false positives on plan-only snapshots

**Frontend — `src/lib/api/conversations.ts`**
- `getRecentlyRecoveredConversations()` API function

**Tests — `backend/store/streaming_snapshot_test.go`**
- 5 new tests for `ConvertSnapshotsToMessages`: plan-only recovery, text+plan recovery, empty plan content, dedup on matching plan, and dedup not firing on different plan content

## Test Plan

- [ ] `cd backend && go test -race ./store/... -run TestConvert` — 5 new tests pass
- [ ] `make test` — full backend test suite passes
- [ ] Manual: kill the app mid-plan-proposal → restart → verify plan content appears in the interrupted conversation's message history
- [ ] Manual: interrupted banner shows for conversations recovered at startup (Phase 3 path), not just those still carrying a live snapshot (Phase 2)
- [ ] Manual: no duplicate messages when `ConvertSnapshotsToMessages` and Phase 2 snapshot injection both fire for the same conversation